### PR TITLE
Markdown エディタ選択と AI サマリ生成機能を追加

### DIFF
--- a/Sources/Clover/Models/AppSettings.swift
+++ b/Sources/Clover/Models/AppSettings.swift
@@ -1,4 +1,71 @@
 import SwiftUI
+import AppKit
+
+/// Markdown ファイルを開くエディタの選択肢。
+enum MarkdownEditor: String, CaseIterable, Identifiable {
+    case system
+    case obsidian
+    case vscode
+    case cursor
+    case antigravity
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .system:      return L10n.systemDefault
+        case .obsidian:    return "Obsidian"
+        case .vscode:      return "Visual Studio Code"
+        case .cursor:      return "Cursor"
+        case .antigravity: return "Antigravity"
+        }
+    }
+
+    var bundleIdentifier: String? {
+        switch self {
+        case .system:      return nil
+        case .obsidian:    return "md.obsidian"
+        case .vscode:      return "com.microsoft.VSCode"
+        case .cursor:      return "com.todesktop.230313mzl4w4u92"
+        case .antigravity: return "com.google.antigravity"
+        }
+    }
+
+    var isInstalled: Bool {
+        guard let bid = bundleIdentifier else { return true }
+        return NSWorkspace.shared.urlForApplication(withBundleIdentifier: bid) != nil
+    }
+
+    static var availableEditors: [MarkdownEditor] {
+        allCases.filter(\.isInstalled)
+    }
+
+    func open(_ url: URL) {
+        // Obsidian は file:// URL を渡してもファイルを開けないため URI スキームを使う
+        if self == .obsidian {
+            var components = URLComponents()
+            components.scheme = "obsidian"
+            components.host = "open"
+            components.queryItems = [URLQueryItem(name: "path", value: url.path)]
+            if let obsidianURL = components.url {
+                NSWorkspace.shared.open(obsidianURL)
+                return
+            }
+        }
+
+        guard let bid = bundleIdentifier,
+              let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bid)
+        else {
+            NSWorkspace.shared.open(url)
+            return
+        }
+        NSWorkspace.shared.open(
+            [url],
+            withApplicationAt: appURL,
+            configuration: NSWorkspace.OpenConfiguration()
+        )
+    }
+}
 
 /// アプリ設定の一元管理。@AppStorage で UserDefaults に永続化。
 @MainActor
@@ -39,6 +106,14 @@ final class AppSettings: ObservableObject {
         return enabled.isEmpty || enabled.contains(identifier)
     }
 
+    // MARK: - Markdown エディタ設定
+    @AppStorage("markdownEditor") var markdownEditorRawValue: String = MarkdownEditor.system.rawValue
+
+    var markdownEditor: MarkdownEditor {
+        get { MarkdownEditor(rawValue: markdownEditorRawValue) ?? .system }
+        set { markdownEditorRawValue = newValue.rawValue }
+    }
+
     // MARK: - 保管庫設定
     @AppStorage("vaultPath") var vaultPath: String = AppSettings.defaultVaultPath
 
@@ -66,6 +141,78 @@ final class AppSettings: ObservableObject {
     @AppStorage("llmEndpointURL") var llmEndpointURL: String = ""
     @AppStorage("llmModelName") var llmModelName: String = ""
     @AppStorage("llmAutoSummaryEnabled") var llmAutoSummaryEnabled: Bool = false
+    @AppStorage("llmSummaryPrompt") var llmSummaryPrompt: String = AppSettings.defaultSummaryPrompt
+
+    // swiftlint:disable:next line_length
+    nonisolated static let defaultSummaryPrompt: String = """
+    以下の文字起こしを要約してください。
+
+    <context>
+    これは顧客とのミーティングです。目的は、顧客の業種、組織状況、利用中のプロジェクト、ニーズ、懸念点を把握し、適切なフォローアップにつなげることです。特に以下を重視してください。
+    - お客様の実利用量を増やすための示唆を拾うこと
+    - 進行中プロジェクトの進捗、課題、停滞要因を明確にすること
+    - 新しいユースケースや拡張機会を見つけること
+    - 担当アカウントチーム（営業、ソリューションアーキテクト）がプロアクティブに動けるよう、次の打ち手を整理すること
+    </context>
+
+    <summary_format>
+    ### 次のステップ
+    会話内容に基づいて、次に何を進めるべきかを簡潔に整理してください。
+    日付や期限が出ている場合は必ず含めてください。
+    顧客側の予定だけでなく、営業/SA 側が先回りして実施すべき内容も記載してください。
+
+    ### 要点・決定事項
+    議論の要点や決定事項を箇条書きで整理してください。特に以下を含めてください。
+    - 顧客の現状や背景
+    - 進行中プロジェクトの状況
+    - 顧客が重視していること
+    - 合意した内容、方向性、優先順位
+
+    ### プロジェクト進捗・課題
+    進行中の案件やプロジェクトについて、以下を整理してください。
+    - 現在の進捗状況
+    - 直近のマイルストーン
+    - 課題、ボトルネック、依存関係
+    - 停滞要因やリスク
+      - 進捗が不明な場合は、その旨を明記してください。
+
+    ### 利用拡大の機会
+    顧客の実利用量を増やす観点で、会話から読み取れる機会を整理してください。
+    - 現在利用中の領域
+    - 利用が限定的な領域
+    - 拡大余地がありそうなチーム、業務、ワークロード
+    - 導入・活用を広げるために必要そうな支援
+
+    ### 新規ユースケース候補
+    会話の中で明示的または示唆された新しいユースケース候補を整理してください。
+    まだ確定していないアイデアも、重要であれば「候補」として記載してください。
+
+    ### アクションアイテム
+    担当者が明確なものは担当者名も記載してください。
+    顧客側の宿題だけでなく、営業/SA 側のアクションも分けて整理してください。
+
+    ### 主な懸念点・未解決事項
+    ミーティング中に挙がった質問や懸念点、意思決定に必要な未解決事項を整理してください。
+    特に、契約前進や利用拡大の障害になりそうな内容を重点的に記載してください。
+    </summary_format>
+
+    <summary_style>
+    - 読みやすさを優先し、情報過多にしない
+    - パラグラフよりも見出しと箇条書きを優先する
+    - アクションアイテムはチェックボックス（- [ ]）を使用する
+    - カジュアルかつプロフェッショナルなトーンで書く
+    - 必要に応じて短い直接引用を使ってもよい
+    - 曖昧な点は断定せず、「示唆された」「可能性がある」と表現する
+    </summary_style>
+
+    <summary_rules>
+    - Markdown 形式で出力する
+    - 出力をコードブロック（```）で囲まない
+    - 情報が会話中に出ていない場合は、推測しすぎず「明示なし」と記載する
+    - 単なる議事録ではなく、次回アクションにつながる営業・SA向けサマリーにする
+    - 重要度が高いものから順に記載する
+    </summary_rules>
+    """
 
     /// API トークン（Keychain に保存）。
     var llmAPIToken: String {

--- a/Sources/Clover/Models/TranscriptStore.swift
+++ b/Sources/Clover/Models/TranscriptStore.swift
@@ -74,4 +74,12 @@ final class TranscriptStore: ObservableObject {
             return "[\(time)] \(speaker)\(segment.displayText)"
         }.joined(separator: "\n")
     }
+
+    /// LLM 要約用のテキスト。スピーカーラベルを含めない。
+    func exportForSummary() -> String {
+        segments.map { segment in
+            let time = Formatters.timeHHmmss.string(from: segment.startTime)
+            return "[\(time)] \(segment.displayText)"
+        }.joined(separator: "\n")
+    }
 }

--- a/Sources/Clover/Resources/en.lproj/Localizable.strings
+++ b/Sources/Clover/Resources/en.lproj/Localizable.strings
@@ -38,6 +38,11 @@
 "Display Languages" = "Display Languages";
 "Only selected languages will appear in the language picker. All languages are shown if none are selected." = "Only selected languages will appear in the language picker. All languages are shown if none are selected.";
 
+/* Settings - Markdown Editor */
+"Markdown Editor" = "Markdown Editor";
+"Editor used to open README and summary files." = "Editor used to open README and summary files.";
+"System Default" = "System Default";
+
 /* Settings - LLM */
 "LLM Settings" = "LLM Settings";
 "Endpoint URL" = "Endpoint URL";
@@ -54,6 +59,15 @@
 "Unexpected response from server" = "Unexpected response from server";
 "HTTP %lld: %@" = "HTTP %lld: %@";
 "Empty response from server" = "Empty response from server";
+
+/* Summary */
+"Generating summary..." = "Generating summary...";
+"Summary generated" = "Summary generated";
+"Open Summary" = "Open Summary";
+"Generate Summary" = "Generate Summary";
+"Summary Prompt" = "Summary Prompt";
+"Reset to Default" = "Reset to Default";
+"LLM configuration is incomplete. Please set endpoint, model, and API token in Settings." = "LLM configuration is incomplete. Please set endpoint, model, and API token in Settings.";
 
 /* Error Messages - Audio */
 "Screen recording access denied. Please allow it in System Settings > Privacy & Security > Screen Recording." = "Screen recording access denied. Please allow it in System Settings > Privacy & Security > Screen Recording.";

--- a/Sources/Clover/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Clover/Resources/ja.lproj/Localizable.strings
@@ -38,6 +38,11 @@
 "Display Languages" = "表示する言語";
 "Only selected languages will appear in the language picker. All languages are shown if none are selected." = "選択した言語のみが言語ピッカーに表示されます。未選択の場合はすべての言語が表示されます。";
 
+/* Settings - Markdown Editor */
+"Markdown Editor" = "Markdown エディタ";
+"Editor used to open README and summary files." = "README やサマリファイルを開く際に使用するエディタです。";
+"System Default" = "システムデフォルト";
+
 /* Settings - LLM */
 "LLM Settings" = "LLM 設定";
 "Endpoint URL" = "エンドポイント URL";
@@ -54,6 +59,15 @@
 "Unexpected response from server" = "サーバーから予期しないレスポンスが返されました";
 "HTTP %lld: %@" = "HTTP %lld: %@";
 "Empty response from server" = "サーバーから空のレスポンスが返されました";
+
+/* Summary */
+"Generating summary..." = "要約を生成中...";
+"Summary generated" = "要約が生成されました";
+"Open Summary" = "要約を開く";
+"Generate Summary" = "要約を生成";
+"Summary Prompt" = "要約プロンプト";
+"Reset to Default" = "デフォルトに戻す";
+"LLM configuration is incomplete. Please set endpoint, model, and API token in Settings." = "LLM の設定が不完全です。設定画面でエンドポイント、モデル、API トークンを設定してください。";
 
 /* Error Messages - Audio */
 "Screen recording access denied. Please allow it in System Settings > Privacy & Security > Screen Recording." = "画面収録のアクセスが拒否されました。システム設定 > プライバシーとセキュリティ > 画面収録 で許可してください";

--- a/Sources/Clover/Services/SummaryService.swift
+++ b/Sources/Clover/Services/SummaryService.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// 文字起こしテキストを LLM で要約し、Obsidian 互換の Markdown ファイルとして保存するサービス。
+enum SummaryService {
+    /// 要約を生成してプロジェクトフォルダに Markdown ファイルとして書き出す。
+    /// - Returns: 生成された `.md` ファイルの URL。
+    @MainActor
+    static func generateSummary(
+        projectURL: URL,
+        transcriptionId: UUID,
+        startedAt: Date,
+        transcriptText: String
+    ) async throws -> URL {
+        let settings = AppSettings.shared
+        let endpoint = settings.llmEndpointURL
+        let model = settings.llmModelName
+        let token = settings.llmAPIToken
+        let prompt = settings.llmSummaryPrompt
+
+        let userContent = "<transcription>\n\(transcriptText)\n</transcription>"
+
+        let messages: [LLMService.ChatMessage] = [
+            .init(role: "system", content: prompt),
+            .init(role: "user", content: userContent),
+        ]
+
+        let summary = try await LLMService.chatCompletion(
+            endpoint: endpoint,
+            model: model,
+            token: token,
+            messages: messages,
+            maxTokens: 4096
+        )
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let dateString = formatter.string(from: startedAt)
+        let frontmatter = """
+        ---
+        transcription_id: "\(transcriptionId.uuidString)"
+        date: "\(dateString)"
+        tags:
+          - transcription-summary
+        ---
+        """
+
+        let markdown = frontmatter + "\n\n" + summary + "\n"
+
+        let fileURL = projectURL.appendingPathComponent("summary_\(transcriptionId.uuidString).md")
+        try Data(markdown.utf8).write(to: fileURL, options: .atomic)
+
+        return fileURL
+    }
+}

--- a/Sources/Clover/Utilities/L10n.swift
+++ b/Sources/Clover/Utilities/L10n.swift
@@ -49,6 +49,12 @@ enum L10n {
     static var displayLanguages: String { String(localized: "Display Languages", bundle: bundle) }
     static var displayLanguagesDescription: String { String(localized: "Only selected languages will appear in the language picker. All languages are shown if none are selected.", bundle: bundle) }
 
+    // MARK: - Settings (Markdown Editor)
+
+    static var markdownEditor: String { String(localized: "Markdown Editor", bundle: bundle) }
+    static var markdownEditorDescription: String { String(localized: "Editor used to open README and summary files.", bundle: bundle) }
+    static var systemDefault: String { String(localized: "System Default", bundle: bundle) }
+
     // MARK: - Settings (LLM)
 
     static var llmSettings: String { String(localized: "LLM Settings", bundle: bundle) }
@@ -66,6 +72,16 @@ enum L10n {
     static var llmErrorUnexpectedResponse: String { String(localized: "Unexpected response from server", bundle: bundle) }
     static func llmErrorHTTP(_ code: Int, _ detail: String) -> String { String(localized: "HTTP \(code): \(detail)", bundle: bundle) }
     static var llmErrorEmptyResponse: String { String(localized: "Empty response from server", bundle: bundle) }
+
+    // MARK: - Summary
+
+    static var generatingSummary: String { String(localized: "Generating summary...", bundle: bundle) }
+    static var summaryGenerated: String { String(localized: "Summary generated", bundle: bundle) }
+    static var openSummary: String { String(localized: "Open Summary", bundle: bundle) }
+    static var generateSummary: String { String(localized: "Generate Summary", bundle: bundle) }
+    static var summaryPrompt: String { String(localized: "Summary Prompt", bundle: bundle) }
+    static var resetToDefault: String { String(localized: "Reset to Default", bundle: bundle) }
+    static var llmConfigIncomplete: String { String(localized: "LLM configuration is incomplete. Please set endpoint, model, and API token in Settings.", bundle: bundle) }
 
     // MARK: - Error Messages (Audio)
 

--- a/Sources/Clover/ViewModels/CaptionViewModel.swift
+++ b/Sources/Clover/ViewModels/CaptionViewModel.swift
@@ -21,6 +21,13 @@ final class CaptionViewModel: ObservableObject {
     // MARK: - Transcription State
 
     var currentTranscriptionId: UUID?
+    var currentProjectURL: URL?
+
+    // MARK: - Summary State
+
+    @Published var isSummaryGenerating: Bool = false
+    @Published var summaryError: String?
+    @Published var lastSummaryURL: URL?
 
     /// 録音中でなく、文字起こしを表示中の場合 true。
     var isViewingHistory: Bool {
@@ -182,16 +189,17 @@ final class CaptionViewModel: ObservableObject {
 
     // MARK: - Recording Control
 
-    func toggleListening(dbQueue: DatabaseQueue) {
+    func toggleListening(dbQueue: DatabaseQueue, projectURL: URL) {
         if isListening {
             stopListening()
         } else {
-            Task { await startListening(dbQueue: dbQueue) }
+            Task { await startListening(dbQueue: dbQueue, projectURL: projectURL) }
         }
     }
 
     /// 新規文字起こしで録音を開始する。
-    func startListening(dbQueue: DatabaseQueue, appendingTo existingTranscriptionId: UUID? = nil) async {
+    func startListening(dbQueue: DatabaseQueue, projectURL: URL, appendingTo existingTranscriptionId: UUID? = nil) async {
+        self.currentProjectURL = projectURL
         guard analyzerReady else {
             errorMessage = L10n.speechRecognitionNotReady
             return
@@ -261,6 +269,11 @@ final class CaptionViewModel: ObservableObject {
         systemAudioManager = nil
         isListening = false
 
+        let transcriptionId = currentTranscriptionId
+        let transcriptText = store.exportForSummary()
+        let projectURL = currentProjectURL
+        let recordingStart = store.recordingStartTime ?? Date()
+
         Task {
             for pipeline in pipelines {
                 pipeline.bridge.finish()
@@ -269,7 +282,55 @@ final class CaptionViewModel: ObservableObject {
             pipelines.removeAll()
             persistenceService?.stop()
             persistenceService = nil
+
+            if AppSettings.shared.llmAutoSummaryEnabled,
+               let transcriptionId,
+               let projectURL {
+                await generateSummary(
+                    transcriptionId: transcriptionId,
+                    transcriptText: transcriptText,
+                    projectURL: projectURL,
+                    startedAt: recordingStart
+                )
+            }
         }
+    }
+
+    // MARK: - Summary Generation
+
+    func generateSummary(
+        transcriptionId: UUID,
+        transcriptText: String,
+        projectURL: URL,
+        startedAt: Date
+    ) async {
+        guard !transcriptText.isEmpty else { return }
+
+        let settings = AppSettings.shared
+        guard !settings.llmEndpointURL.isEmpty,
+              !settings.llmModelName.isEmpty,
+              !settings.llmAPIToken.isEmpty else {
+            summaryError = L10n.llmConfigIncomplete
+            return
+        }
+
+        isSummaryGenerating = true
+        summaryError = nil
+        lastSummaryURL = nil
+
+        do {
+            let fileURL = try await SummaryService.generateSummary(
+                projectURL: projectURL,
+                transcriptionId: transcriptionId,
+                startedAt: startedAt,
+                transcriptText: transcriptText
+            )
+            lastSummaryURL = fileURL
+        } catch {
+            summaryError = error.localizedDescription
+        }
+
+        isSummaryGenerating = false
     }
 
     func clearText() {

--- a/Sources/Clover/ViewModels/SidebarViewModel.swift
+++ b/Sources/Clover/ViewModels/SidebarViewModel.swift
@@ -124,10 +124,10 @@ final class SidebarViewModel: ObservableObject {
         }
     }
 
-    /// README.md を作成（未存在の場合）し、デフォルトエディタで開く。
+    /// README.md を作成（未存在の場合）し、設定されたエディタで開く。
     func openReadme(for project: FolderProject) {
         guard let readmeURL = try? folderService.ensureReadmeExists(for: project) else { return }
-        NSWorkspace.shared.open(readmeURL)
+        AppSettings.shared.markdownEditor.open(readmeURL)
     }
 
     func deleteProject(_ project: FolderProject) {

--- a/Sources/Clover/Views/ControlPanelView.swift
+++ b/Sources/Clover/Views/ControlPanelView.swift
@@ -1,6 +1,57 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
+/// ホバー時に背景がハイライトされるアイコンボタンスタイル。
+struct ToolbarIconButtonStyle: ButtonStyle {
+    @State private var isHovered = false
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(6)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(configuration.isPressed
+                          ? Color.primary.opacity(0.15)
+                          : isHovered ? Color.primary.opacity(0.08) : Color.clear)
+            )
+            .onHover { hovering in
+                isHovered = hovering
+            }
+    }
+}
+
+/// 音声ソース選択ボタン（ホバー対応）。
+private struct AudioSourceButton: View {
+    let mode: AudioSourceMode
+    let isSelected: Bool
+    let action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Image(systemName: mode.iconName)
+                    .font(.caption2)
+                Text(mode.label)
+                    .font(.subheadline)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .frame(maxWidth: .infinity)
+            .background(
+                isSelected
+                    ? Color.accentColor
+                    : isHovered ? Color.primary.opacity(0.08) : Color.clear
+            )
+            .foregroundColor(isSelected ? .white : .primary)
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            isHovered = hovering
+        }
+    }
+}
+
 /// メインコントロールウィンドウ（議事録ビュー）。
 struct ControlPanelView: View {
     @ObservedObject var viewModel: CaptionViewModel
@@ -75,6 +126,44 @@ struct ControlPanelView: View {
                     Spacer()
                 }
             }
+
+            // 要約ステータス
+            if viewModel.isSummaryGenerating {
+                HStack(spacing: 6) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(L10n.generatingSummary)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Spacer()
+                }
+            }
+
+            if let summaryError = viewModel.summaryError {
+                HStack {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(.orange)
+                    Text(summaryError)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                    Spacer()
+                }
+            }
+
+            if let summaryURL = viewModel.lastSummaryURL {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(.green)
+                    Text(L10n.summaryGenerated)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Button(L10n.openSummary) {
+                        AppSettings.shared.markdownEditor.open(summaryURL)
+                    }
+                    .font(.caption)
+                    Spacer()
+                }
+            }
         }
         .padding()
         .frame(minWidth: 500, minHeight: 500)
@@ -89,8 +178,9 @@ struct ControlPanelView: View {
                 if viewModel.isViewingHistory {
                     resumeRecording()
                 } else {
-                    guard let dbQueue = sidebarViewModel.dbQueue else { return }
-                    viewModel.toggleListening(dbQueue: dbQueue)
+                    guard let dbQueue = sidebarViewModel.dbQueue,
+                          let projectURL = sidebarViewModel.selectedProject?.url else { return }
+                    viewModel.toggleListening(dbQueue: dbQueue, projectURL: projectURL)
                 }
             }) {
                 HStack(spacing: 4) {
@@ -112,22 +202,12 @@ struct ControlPanelView: View {
             // 音声ソース選択
             HStack(spacing: 0) {
                 ForEach(AudioSourceMode.allCases, id: \.self) { mode in
-                    Button {
+                    AudioSourceButton(
+                        mode: mode,
+                        isSelected: viewModel.audioSourceMode == mode
+                    ) {
                         viewModel.audioSourceMode = mode
-                    } label: {
-                        HStack(spacing: 4) {
-                            Image(systemName: mode.iconName)
-                                .font(.caption2)
-                            Text(mode.label)
-                                .font(.subheadline)
-                        }
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 5)
-                        .frame(maxWidth: .infinity)
-                        .background(viewModel.audioSourceMode == mode ? Color.accentColor : Color.clear)
-                        .foregroundColor(viewModel.audioSourceMode == mode ? .white : .primary)
                     }
-                    .buttonStyle(.plain)
                 }
             }
             .background(Color.secondary.opacity(0.12))
@@ -153,11 +233,31 @@ struct ControlPanelView: View {
 
             Spacer()
 
+            // 要約生成
+            Button(action: {
+                guard let transcriptionId = viewModel.currentTranscriptionId,
+                      let projectURL = sidebarViewModel.selectedProject?.url else { return }
+                let text = viewModel.store.exportForSummary()
+                Task {
+                    await viewModel.generateSummary(
+                        transcriptionId: transcriptionId,
+                        transcriptText: text,
+                        projectURL: projectURL,
+                        startedAt: viewModel.store.recordingStartTime ?? Date()
+                    )
+                }
+            }) {
+                Image(systemName: "sparkles")
+            }
+            .buttonStyle(ToolbarIconButtonStyle())
+            .disabled(viewModel.store.segments.isEmpty || viewModel.isSummaryGenerating || viewModel.isListening)
+            .help(L10n.generateSummary)
+
             // 書き出し
             Button(action: { viewModel.exportTranscript() }) {
                 Image(systemName: "square.and.arrow.up")
             }
-            .buttonStyle(.borderless)
+            .buttonStyle(ToolbarIconButtonStyle())
             .disabled(viewModel.store.segments.isEmpty)
             .help(L10n.export)
 
@@ -165,7 +265,7 @@ struct ControlPanelView: View {
             Button(action: { viewModel.clearText() }) {
                 Image(systemName: "trash")
             }
-            .buttonStyle(.borderless)
+            .buttonStyle(ToolbarIconButtonStyle())
             .disabled(viewModel.store.segments.isEmpty || !viewModel.isListening)
             .help(L10n.clearTranscription)
         }
@@ -175,9 +275,10 @@ struct ControlPanelView: View {
 
     private func resumeRecording() {
         guard let dbQueue = sidebarViewModel.dbQueue,
+              let projectURL = sidebarViewModel.selectedProject?.url,
               let transcriptionId = viewModel.currentTranscriptionId else { return }
         Task {
-            await viewModel.startListening(dbQueue: dbQueue, appendingTo: transcriptionId)
+            await viewModel.startListening(dbQueue: dbQueue, projectURL: projectURL, appendingTo: transcriptionId)
         }
     }
 

--- a/Sources/Clover/Views/SettingsView.swift
+++ b/Sources/Clover/Views/SettingsView.swift
@@ -35,6 +35,19 @@ struct SettingsView: View {
                 Text(L10n.vaultDescription)
                     .font(.caption)
                     .foregroundColor(.secondary)
+
+                Picker(L10n.markdownEditor, selection: Binding(
+                    get: { settings.markdownEditor },
+                    set: { settings.markdownEditor = $0 }
+                )) {
+                    ForEach(MarkdownEditor.availableEditors) { editor in
+                        Text(editor.displayName).tag(editor)
+                    }
+                }
+
+                Text(L10n.markdownEditorDescription)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
             }
 
             Section {
@@ -92,6 +105,23 @@ struct SettingsView: View {
                 Text(L10n.autoSummaryDescription)
                     .font(.caption)
                     .foregroundColor(.secondary)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(L10n.summaryPrompt)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    TextEditor(text: $settings.llmSummaryPrompt)
+                        .font(.body)
+                        .frame(height: 80)
+                        .border(Color.secondary.opacity(0.3))
+                    HStack {
+                        Spacer()
+                        Button(L10n.resetToDefault) {
+                            settings.llmSummaryPrompt = AppSettings.defaultSummaryPrompt
+                        }
+                        .font(.caption)
+                    }
+                }
             } header: {
                 Text(L10n.llmSettings)
             } footer: {
@@ -168,7 +198,7 @@ struct SettingsView: View {
             }
         }
         .formStyle(.grouped)
-        .frame(width: 560, height: 620)
+        .frame(width: 560, height: 760)
         .padding()
         .task {
             apiToken = settings.llmAPIToken

--- a/Sources/Clover/Views/SidebarView.swift
+++ b/Sources/Clover/Views/SidebarView.swift
@@ -108,47 +108,28 @@ struct SidebarView: View {
                     isRenameFocused = true
                 }
         } else {
-            HStack {
-                Image(systemName: isSelected ? "folder.fill" : "folder")
-                    .foregroundColor(isSelected ? .accentColor : .secondary)
-                Text(project.name)
-                    .font(.headline)
-                    .foregroundColor(isSelected ? .primary : .secondary)
-                Spacer()
-                if isSelected {
-                    Image(systemName: "chevron.down")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                }
-            }
-            .padding(.vertical, 8)
-            .padding(.horizontal, 4)
-            .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(isSelected ? Color.accentColor.opacity(0.12) : Color.clear)
-            )
-            .contentShape(Rectangle())
-            .onTapGesture(count: 2) {
-                editingName = project.name
-                editingProjectURL = project.url
-            }
-            .onTapGesture(count: 1) {
-                sidebarViewModel.selectProject(project)
-                viewModel.clearCurrentTranscription()
-            }
-            .contextMenu {
-                Button(L10n.rename) {
+            ProjectHeaderRow(
+                project: project,
+                isSelected: isSelected,
+                onSelect: {
+                    sidebarViewModel.selectProject(project)
+                    viewModel.clearCurrentTranscription()
+                },
+                onDoubleClick: {
                     editingName = project.name
                     editingProjectURL = project.url
-                }
-                Button(L10n.editReadme) {
+                },
+                onRename: {
+                    editingName = project.name
+                    editingProjectURL = project.url
+                },
+                onEditReadme: {
                     sidebarViewModel.openReadme(for: project)
-                }
-                Divider()
-                Button(L10n.delete, role: .destructive) {
+                },
+                onDelete: {
                     sidebarViewModel.deleteProject(project)
                 }
-            }
+            )
         }
     }
 
@@ -176,34 +157,12 @@ struct SidebarView: View {
                     isTranscriptionRenameFocused = true
                 }
         } else {
-            VStack(alignment: .leading, spacing: 2) {
-                HStack {
-                    Image(systemName: transcription.endedAt != nil ? "waveform" : "record.circle.fill")
-                        .font(.caption)
-                        .foregroundColor(transcription.endedAt != nil ? .secondary : .red)
-                    if transcription.title.isEmpty {
-                        Text(Self.dateFormatter.string(from: transcription.startedAt))
-                            .font(.subheadline)
-                    } else {
-                        Text(transcription.title)
-                            .font(.subheadline)
-                    }
-                }
-                HStack(spacing: 8) {
-                    if !transcription.title.isEmpty {
-                        Text(Self.dateFormatter.string(from: transcription.startedAt))
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                    }
-                    if let endedAt = transcription.endedAt {
-                        let duration = endedAt.timeIntervalSince(transcription.startedAt)
-                        Text(Self.durationFormatter.string(from: duration) ?? "")
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                    }
-                }
-            }
-            .padding(.vertical, 2)
+            TranscriptionListRow(
+                transcription: transcription,
+                isSelected: sidebarViewModel.selectedTranscriptionId == transcription.id,
+                dateFormatter: Self.dateFormatter,
+                durationFormatter: Self.durationFormatter
+            )
         }
     }
 
@@ -268,5 +227,103 @@ struct SidebarView: View {
 
         guard let dbQueue = sidebarViewModel.dbQueue else { return }
         viewModel.loadTranscription(transcriptionId, dbQueue: dbQueue)
+    }
+}
+
+// MARK: - Hoverable Sub-Views
+
+/// ホバー対応のプロジェクトヘッダー行。
+private struct ProjectHeaderRow: View {
+    let project: FolderProject
+    let isSelected: Bool
+    let onSelect: () -> Void
+    let onDoubleClick: () -> Void
+    let onRename: () -> Void
+    let onEditReadme: () -> Void
+    let onDelete: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        HStack {
+            Image(systemName: isSelected ? "folder.fill" : "folder")
+                .foregroundColor(isSelected ? .accentColor : .secondary)
+            Text(project.name)
+                .font(.headline)
+                .foregroundColor(isSelected ? .primary : isHovered ? .primary : .secondary)
+            Spacer()
+            if isSelected {
+                Image(systemName: "chevron.down")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(
+                    isSelected
+                        ? Color.accentColor.opacity(0.12)
+                        : isHovered ? Color.primary.opacity(0.06) : Color.clear
+                )
+        )
+        .contentShape(Rectangle())
+        .onHover { isHovered = $0 }
+        .onTapGesture(count: 2) { onDoubleClick() }
+        .onTapGesture(count: 1) { onSelect() }
+        .contextMenu {
+            Button(L10n.rename) { onRename() }
+            Button(L10n.editReadme) { onEditReadme() }
+            Divider()
+            Button(L10n.delete, role: .destructive) { onDelete() }
+        }
+    }
+}
+
+/// ホバー対応の文字起こし一覧行。
+private struct TranscriptionListRow: View {
+    let transcription: TranscriptionRecord
+    let isSelected: Bool
+    let dateFormatter: DateFormatter
+    let durationFormatter: DateComponentsFormatter
+    @State private var isHovered = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Image(systemName: transcription.endedAt != nil ? "waveform" : "record.circle.fill")
+                    .font(.caption)
+                    .foregroundColor(transcription.endedAt != nil ? .secondary : .red)
+                if transcription.title.isEmpty {
+                    Text(dateFormatter.string(from: transcription.startedAt))
+                        .font(.subheadline)
+                } else {
+                    Text(transcription.title)
+                        .font(.subheadline)
+                }
+            }
+            HStack(spacing: 8) {
+                if !transcription.title.isEmpty {
+                    Text(dateFormatter.string(from: transcription.startedAt))
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+                if let endedAt = transcription.endedAt {
+                    let duration = endedAt.timeIntervalSince(transcription.startedAt)
+                    Text(durationFormatter.string(from: duration) ?? "")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 2)
+        .padding(.horizontal, 4)
+        .contentShape(Rectangle())
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(isHovered && !isSelected ? Color.primary.opacity(0.06) : Color.clear)
+        )
+        .onHover { isHovered = $0 }
     }
 }


### PR DESCRIPTION
## Summary
- Markdown エディタ設定（Obsidian / VS Code / Cursor / Antigravity）を追加し、README やサマリファイルを指定エディタで開けるように
- Obsidian は `obsidian://open?path=` URI スキームで正しくファイルを開くよう対応
- 録音停止時に LLM で文字起こしサマリを自動生成し、Obsidian 互換の Markdown ファイルとして保存する機能を追加
- サイドバーとコントロールパネルのホバー UI を改善

## 変更内容
- `AppSettings.swift`: `MarkdownEditor` enum 追加、Obsidian URI スキーム対応、LLM サマリプロンプト設定
- `SummaryService.swift`: LLM 要約生成サービス（新規）
- `CaptionViewModel.swift`: サマリ生成ステート管理、録音停止時の自動要約
- `ControlPanelView.swift`: 要約ボタン・ステータス表示、`ToolbarIconButtonStyle` / `AudioSourceButton` 追加
- `SettingsView.swift`: Markdown エディタ選択ピッカー、サマリプロンプト編集 UI
- `SidebarView.swift`: `ProjectHeaderRow` / `TranscriptionListRow` のホバー対応サブビュー化
- `SidebarViewModel.swift`: README を設定エディタで開くよう変更
- `L10n.swift` / `Localizable.strings` (en/ja): 新規ローカライズキー追加

## Test plan
- [ ] `swift build` でビルド成功を確認
- [ ] 設定画面で Markdown エディタを Obsidian に変更し、サマリや README が Obsidian で正しく開かれることを確認
- [ ] 他のエディタ（VS Code, Cursor, System Default）でも同様にファイルが開かれることを確認
- [ ] LLM 設定（エンドポイント・モデル・API トークン）を入力し、録音停止後に自動サマリが生成されることを確認
- [ ] サマリ生成ボタンから手動でサマリを生成できることを確認
- [ ] サマリプロンプトの編集・デフォルト復元が動作することを確認
