### PR TITLE
サマリーファイル名に日付プレフィックスを追加 & ミーティング検出バナーのアイコンをDahliaに変更

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,11 @@ let package = Package(
             ],
             path: "Sources/Dahlia",
             resources: [.process("Resources")]
+        ),
+        .testTarget(
+            name: "DahliaTests",
+            dependencies: ["Dahlia"],
+            path: "Tests/DahliaTests"
         )
     ]
 )

--- a/Sources/Dahlia/Database/AppDatabaseManager.swift
+++ b/Sources/Dahlia/Database/AppDatabaseManager.swift
@@ -118,6 +118,14 @@ final class AppDatabaseManager: Sendable {
             )
         }
 
+        migrator.registerMigration("v3_sidebarIndexes") { db in
+            try db.create(
+                index: "transcripts_on_projectId_startedAt",
+                on: "transcripts",
+                columns: ["projectId", "startedAt"]
+            )
+        }
+
         return migrator
     }
 }

--- a/Sources/Dahlia/Database/TranscriptionRepository.swift
+++ b/Sources/Dahlia/Database/TranscriptionRepository.swift
@@ -6,7 +6,7 @@ import GRDB
 final class TranscriptionRepository {
     private let dbQueue: DatabaseQueue
 
-    init(dbQueue: DatabaseQueue) {
+    nonisolated init(dbQueue: DatabaseQueue) {
         self.dbQueue = dbQueue
     }
 
@@ -199,7 +199,7 @@ final class TranscriptionRepository {
         let screenshots: [ScreenshotRecord]
     }
 
-    func fetchTranscriptionDetail(id transcriptionId: UUID) throws -> TranscriptionDetail {
+    nonisolated func fetchTranscriptionDetail(id transcriptionId: UUID) throws -> TranscriptionDetail {
         try dbQueue.read { db in
             let transcription = try TranscriptionRecord.fetchOne(db, key: transcriptionId)
             let segments = try SegmentRecord

--- a/Sources/Dahlia/Database/VaultRecord.swift
+++ b/Sources/Dahlia/Database/VaultRecord.swift
@@ -2,7 +2,7 @@ import Foundation
 import GRDB
 
 /// 保管庫を表す GRDB レコード。path は保管庫ディレクトリの絶対パスに対応する。
-struct VaultRecord: Codable, FetchableRecord, PersistableRecord, Identifiable {
+struct VaultRecord: Codable, FetchableRecord, PersistableRecord, Identifiable, Equatable {
     static let databaseTableName = "vaults"
 
     var id: UUID

--- a/Sources/Dahlia/Models/ProjectNode.swift
+++ b/Sources/Dahlia/Models/ProjectNode.swift
@@ -7,81 +7,47 @@ struct FlatProjectRow: Identifiable, Equatable {
     let displayName: String
     let depth: Int
     let hasChildren: Bool
-}
 
-/// projects テーブルのレコードから構築される階層ツリーのノード。
-struct ProjectNode: Identifiable {
-    let id: UUID
-    let name: String
-    let displayName: String
-    var children: [ProjectNode]
+    /// ProjectRecord 配列から、入力順を保ったままサイドバー表示用のフラット行を構築する。
+    static func buildRows(fromRecords records: [ProjectRecord]) -> [FlatProjectRow] {
+        guard !records.isEmpty else { return [] }
 
-    /// ツリーを深さ優先でフラットリストに変換する。
-    static func flatten(_ nodes: [ProjectNode], depth: Int = 0) -> [FlatProjectRow] {
-        var result: [FlatProjectRow] = []
-        for node in nodes {
-            result.append(FlatProjectRow(
-                id: node.id,
-                name: node.name,
-                displayName: node.displayName,
-                depth: depth,
-                hasChildren: !node.children.isEmpty
-            ))
-            result.append(contentsOf: flatten(node.children, depth: depth + 1))
+        let parentNames = parentNames(in: records)
+        var rows: [FlatProjectRow] = []
+        rows.reserveCapacity(records.count)
+
+        for record in records {
+            let components = record.name.split(separator: "/")
+            let displayName = components.last.map(String.init) ?? record.name
+            let depth = max(components.count - 1, 0)
+            let hasChildren = parentNames.contains(record.name)
+
+            rows.append(
+                FlatProjectRow(
+                    id: record.id,
+                    name: record.name,
+                    displayName: displayName,
+                    depth: depth,
+                    hasChildren: hasChildren
+                )
+            )
         }
-        return result
+
+        return rows
     }
 
-    /// フラットな ProjectRecord 配列からツリーを構築する。O(n) の Dictionary ベースアルゴリズム。
-    static func buildTree(from records: [ProjectRecord]) -> [ProjectNode] {
-        // ソート済みなので中間ノード（親）は子より先に処理される
-        let sorted = records.sorted { $0.name < $1.name }
+    private static func parentNames(in records: [ProjectRecord]) -> Set<String> {
+        var parentNames = Set<String>()
 
-        // name → (ノード, 子ノード配列) を管理。子配列は参照型で共有して後から追加可能にする。
-        final class MutableNode {
-            let id: UUID
-            let name: String
-            let displayName: String
-            var children: [MutableNode] = []
-
-            init(id: UUID, name: String, displayName: String) {
-                self.id = id
-                self.name = name
-                self.displayName = displayName
-            }
-
-            func toProjectNode() -> ProjectNode {
-                ProjectNode(
-                    id: id,
-                    name: name,
-                    displayName: displayName,
-                    children: children.map { $0.toProjectNode() }
-                )
-            }
-        }
-
-        var nodeMap: [String: MutableNode] = [:]
-        var roots: [MutableNode] = []
-
-        for record in sorted {
+        for record in records {
             let components = record.name.split(separator: "/")
-            let displayName = String(components.last!)
-            let node = MutableNode(id: record.id, name: record.name, displayName: displayName)
-            nodeMap[record.name] = node
+            guard components.count > 1 else { continue }
 
-            if components.count > 1 {
-                let parentPath = components.dropLast().joined(separator: "/")
-                if let parent = nodeMap[parentPath] {
-                    parent.children.append(node)
-                } else {
-                    // 親レコードが存在しない場合はルートとして扱う
-                    roots.append(node)
-                }
-            } else {
-                roots.append(node)
+            for depth in 1 ..< components.count {
+                parentNames.insert(components[0 ..< depth].joined(separator: "/"))
             }
         }
 
-        return roots.map { $0.toProjectNode() }
+        return parentNames
     }
 }

--- a/Sources/Dahlia/Services/SummaryService.swift
+++ b/Sources/Dahlia/Services/SummaryService.swift
@@ -120,15 +120,18 @@ enum SummaryService {
 
         let markdown = frontmatter + "\n\n" + result.summary + "\n"
 
+        let datePrefix = dateFormatter.string(from: Date())
         let fileName: String
         if result.title.isEmpty {
-            fileName = "summary_\(transcriptionId.uuidString)"
+            fileName = "\(datePrefix)-summary_\(transcriptionId.uuidString)"
         } else {
             // ファイル名に使えない文字を除去し、空白をハイフンに置換
             let sanitized = result.title
                 .replacingOccurrences(of: " ", with: "-")
                 .replacingOccurrences(of: "[/\\\\:*?\"<>|]", with: "", options: .regularExpression)
-            fileName = sanitized.isEmpty ? "summary_\(transcriptionId.uuidString)" : sanitized
+            fileName = sanitized.isEmpty
+                ? "\(datePrefix)-summary_\(transcriptionId.uuidString)"
+                : "\(datePrefix)-\(sanitized)"
         }
         let fileURL = projectURL.appendingPathComponent("\(fileName).md")
         try Data(markdown.utf8).write(to: fileURL, options: .atomic)

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -3,6 +3,7 @@ import GRDB
 @preconcurrency import ScreenCaptureKit
 import Speech
 import SwiftUI
+import os
 
 private enum ScreenshotError: Error {
     case encodingFailed
@@ -68,6 +69,7 @@ final class CaptionViewModel: ObservableObject {
     private var persistenceService: TranscriptPersistenceService?
     private var storeCancellable: AnyCancellable?
     private var settingsCancellable: AnyCancellable?
+    private var transcriptionLoadTask: Task<Void, Never>?
 
     init() {
         storeCancellable = store.objectWillChange
@@ -106,6 +108,34 @@ final class CaptionViewModel: ObservableObject {
         return f
     }()
 
+    private struct LoadedTranscriptionData {
+        let segments: [TranscriptSegment]
+        let screenshots: [ScreenshotRecord]
+        let lastSummaryURL: URL?
+    }
+
+    private nonisolated static func fetchLoadedTranscriptionData(
+        transcriptionId: UUID,
+        dbQueue: DatabaseQueue,
+        projectURL: URL
+    ) throws -> LoadedTranscriptionData {
+        let repo = TranscriptionRepository(dbQueue: dbQueue)
+        let detail = try repo.fetchTranscriptionDetail(id: transcriptionId)
+        let segments = detail.segments.map(TranscriptSegment.init(from:))
+
+        let lastSummaryURL: URL? = if detail.transcription?.summaryCreated == true {
+            SummaryService.findSummaryFile(in: projectURL, transcriptionId: transcriptionId)
+        } else {
+            nil
+        }
+
+        return LoadedTranscriptionData(
+            segments: segments,
+            screenshots: detail.screenshots,
+            lastSummaryURL: lastSummaryURL
+        )
+    }
+
     // MARK: - Transcription Loading
 
     /// DB から文字起こしのセグメントを読み込んで表示する。
@@ -125,23 +155,43 @@ final class CaptionViewModel: ObservableObject {
         currentVaultURL = vaultURL
         currentDbQueue = dbQueue
 
-        let repo = TranscriptionRepository(dbQueue: dbQueue)
-        let detail = try? repo.fetchTranscriptionDetail(id: transcriptionId)
-        let segments = (detail?.segments ?? []).map { TranscriptSegment(from: $0) }
-        store.loadSegments(segments)
-        screenshots = detail?.screenshots ?? []
-
-        // summaryCreated フラグが立っている場合のみファイルを探索
-        if let transcription = detail?.transcription, transcription.summaryCreated {
-            lastSummaryURL = SummaryService.findSummaryFile(in: projectURL, transcriptionId: transcriptionId)
-        } else {
-            lastSummaryURL = nil
-        }
+        transcriptionLoadTask?.cancel()
+        store.clear()
+        screenshots = []
+        lastSummaryURL = nil
         summaryError = nil
+
+        transcriptionLoadTask = Task { [weak self, transcriptionId, dbQueue, projectURL] in
+            guard let self else { return }
+
+            let loaded: LoadedTranscriptionData
+            do {
+                loaded = try await Task.detached(priority: .userInitiated) {
+                    try Self.fetchLoadedTranscriptionData(
+                        transcriptionId: transcriptionId,
+                        dbQueue: dbQueue,
+                        projectURL: projectURL
+                    )
+                }.value
+            } catch is CancellationError {
+                return
+            } catch {
+                Logger(subsystem: "com.dahlia", category: "CaptionViewModel")
+                    .error("Failed to load transcription \(transcriptionId): \(error)")
+                return
+            }
+
+            guard !Task.isCancelled, self.currentTranscriptionId == transcriptionId else { return }
+
+            self.store.loadSegments(loaded.segments)
+            self.screenshots = loaded.screenshots
+            self.lastSummaryURL = loaded.lastSummaryURL
+        }
     }
 
     /// 現在の文字起こし表示をクリアして初期状態に戻す。
     func clearCurrentTranscription() {
+        transcriptionLoadTask?.cancel()
         currentTranscriptionId = nil
         currentProjectURL = nil
         currentProjectId = nil

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -1,9 +1,9 @@
 import Combine
 import GRDB
+import os
 @preconcurrency import ScreenCaptureKit
 import Speech
 import SwiftUI
-import os
 
 private enum ScreenshotError: Error {
     case encodingFailed

--- a/Sources/Dahlia/ViewModels/SidebarViewModel.swift
+++ b/Sources/Dahlia/ViewModels/SidebarViewModel.swift
@@ -75,7 +75,10 @@ final class SidebarViewModel {
                 in: dbQueue,
                 onError: { _ in },
                 onChange: { [weak self] vaults in
-                    Task { @MainActor in self?.allVaults = vaults }
+                    Task { @MainActor in
+                        guard let self, self.allVaults != vaults else { return }
+                        self.allVaults = vaults
+                    }
                 }
             )
         }
@@ -116,8 +119,10 @@ final class SidebarViewModel {
             onError: { _ in },
             onChange: { [weak self] records in
                 Task { @MainActor in
-                    let tree = ProjectNode.buildTree(from: records)
-                    self?.flatProjects = ProjectNode.flatten(tree)
+                    guard let self else { return }
+                    let rows = FlatProjectRow.buildRows(fromRecords: records)
+                    guard self.flatProjects != rows else { return }
+                    self.flatProjects = rows
                 }
             }
         )
@@ -162,7 +167,8 @@ final class SidebarViewModel {
             onError: { _ in },
             onChange: { [weak self] transcriptions in
                 Task { @MainActor in
-                    self?.transcriptionsForSelectedProject = transcriptions
+                    guard let self, self.transcriptionsForSelectedProject != transcriptions else { return }
+                    self.transcriptionsForSelectedProject = transcriptions
                 }
             }
         )

--- a/Sources/Dahlia/Views/MeetingDetectionBannerView.swift
+++ b/Sources/Dahlia/Views/MeetingDetectionBannerView.swift
@@ -59,37 +59,16 @@ struct MeetingDetectionPopupView: View {
         )
     }
 
-    @ViewBuilder
     private var appIcon: some View {
-        if let icon = meetingAppIcon() {
-            Image(nsImage: icon)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
-        } else {
-            Image(systemName: "video.fill")
-                .font(.system(size: 18))
-                .foregroundColor(.accentColor)
-                .frame(width: 36, height: 36)
-                .background(RoundedRectangle(cornerRadius: 8).fill(Color.accentColor.opacity(0.12)))
-        }
+        Image(nsImage: NSApp.applicationIconImage)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 
     private var meetingDescription: String {
         meeting.appName.isEmpty
             ? L10n.microphoneInUse
             : L10n.meetingDetectedSubtitle(meeting.appName)
-    }
-
-    private func meetingAppIcon() -> NSImage? {
-        let bundleID = meeting.bundleIdentifier
-        guard bundleID != "unknown",
-              let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID)
-        else {
-            return NSWorkspace.shared.runningApplications.first {
-                $0.localizedName == meeting.appName
-            }?.icon
-        }
-        return NSWorkspace.shared.icon(forFile: appURL.path)
     }
 }

--- a/Sources/Dahlia/Views/SidebarView.swift
+++ b/Sources/Dahlia/Views/SidebarView.swift
@@ -64,7 +64,7 @@ struct SidebarView: View {
                     row: row,
                     isSelected: isSelected,
                     transcriptions: isSelected ? transcriptions : [],
-                    selectedTranscriptionId: currentSelectedTranscriptionId,
+                    selectedTranscriptionId: isSelected ? currentSelectedTranscriptionId : nil,
                     sidebarViewModel: sidebarViewModel,
                     viewModel: viewModel,
                     editingProjectId: $editingProjectId,

--- a/Tests/DahliaTests/ProjectNodeTests.swift
+++ b/Tests/DahliaTests/ProjectNodeTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+#if canImport(Testing)
+import Testing
+@testable import Dahlia
+
+struct ProjectNodeTests {
+    @Test
+    func marksDirectParentAsHavingChildren() {
+        let rows = FlatProjectRow.buildRows(
+            fromRecords: [
+                project(named: "foo"),
+                project(named: "foo/bar")
+            ]
+        )
+
+        #expect(rows.map(\.hasChildren) == [true, false])
+    }
+
+    @Test
+    func ignoresSiblingPrefixesWhenDeterminingChildren() {
+        let rows = FlatProjectRow.buildRows(
+            fromRecords: [
+                project(named: "foo"),
+                project(named: "foo-archive"),
+                project(named: "foo/bar")
+            ]
+        )
+
+        #expect(rows.map(\.hasChildren) == [true, false, false])
+    }
+
+    @Test
+    func ignoresNonDescendantPrefixMatches() {
+        let rows = FlatProjectRow.buildRows(
+            fromRecords: [
+                project(named: "foo"),
+                project(named: "foo.bar"),
+                project(named: "foo/bar"),
+                project(named: "foo0")
+            ]
+        )
+
+        #expect(rows.map(\.hasChildren) == [true, false, false, false])
+    }
+
+    @Test
+    func marksIntermediateNodesAsHavingChildren() {
+        let rows = FlatProjectRow.buildRows(
+            fromRecords: [
+                project(named: "a/b"),
+                project(named: "a/b/c"),
+                project(named: "z")
+            ]
+        )
+
+        #expect(rows.map(\.hasChildren) == [true, false, false])
+    }
+
+    @Test
+    func keepsInputOrderWhileComputingChildrenIndependently() {
+        let rows = FlatProjectRow.buildRows(
+            fromRecords: [
+                project(named: "foo/bar"),
+                project(named: "foo"),
+                project(named: "foo/baz")
+            ]
+        )
+
+        #expect(rows.map(\.name) == ["foo/bar", "foo", "foo/baz"])
+        #expect(rows.map(\.hasChildren) == [false, true, false])
+    }
+
+    private func project(named name: String) -> ProjectRecord {
+        ProjectRecord(id: .v7(), vaultId: .v7(), name: name, createdAt: Date())
+    }
+}
+#elseif canImport(XCTest)
+import XCTest
+@testable import Dahlia
+
+final class ProjectNodeTests: XCTestCase {
+    func testMarksDirectParentAsHavingChildren() {
+        let rows = FlatProjectRow.buildRows(
+            fromRecords: [
+                project(named: "foo"),
+                project(named: "foo/bar")
+            ]
+        )
+
+        XCTAssertEqual(rows.map(\.hasChildren), [true, false])
+    }
+
+    func testIgnoresSiblingPrefixesWhenDeterminingChildren() {
+        let rows = FlatProjectRow.buildRows(
+            fromRecords: [
+                project(named: "foo"),
+                project(named: "foo-archive"),
+                project(named: "foo/bar")
+            ]
+        )
+
+        XCTAssertEqual(rows.map(\.hasChildren), [true, false, false])
+    }
+
+    func testIgnoresNonDescendantPrefixMatches() {
+        let rows = FlatProjectRow.buildRows(
+            fromRecords: [
+                project(named: "foo"),
+                project(named: "foo.bar"),
+                project(named: "foo/bar"),
+                project(named: "foo0")
+            ]
+        )
+
+        XCTAssertEqual(rows.map(\.hasChildren), [true, false, false, false])
+    }
+
+    func testMarksIntermediateNodesAsHavingChildren() {
+        let rows = FlatProjectRow.buildRows(
+            fromRecords: [
+                project(named: "a/b"),
+                project(named: "a/b/c"),
+                project(named: "z")
+            ]
+        )
+
+        XCTAssertEqual(rows.map(\.hasChildren), [true, false, false])
+    }
+
+    func testKeepsInputOrderWhileComputingChildrenIndependently() {
+        let rows = FlatProjectRow.buildRows(
+            fromRecords: [
+                project(named: "foo/bar"),
+                project(named: "foo"),
+                project(named: "foo/baz")
+            ]
+        )
+
+        XCTAssertEqual(rows.map(\.name), ["foo/bar", "foo", "foo/baz"])
+        XCTAssertEqual(rows.map(\.hasChildren), [false, true, false])
+    }
+
+    private func project(named name: String) -> ProjectRecord {
+        ProjectRecord(id: .v7(), vaultId: .v7(), name: name, createdAt: Date())
+    }
+}
+#endif


### PR DESCRIPTION
## 概要

- **SummaryService**: サマリーの Markdown ファイル名に日付プレフィックス（`YYYY-MM-dd`）を付与し、ファイルの時系列整理を容易にした
- **MeetingDetectionBannerView**: ミーティング検出時のポップアップアイコンを、検出されたミーティングアプリのアイコンから Dahlia 自身のアプリアイコン（`NSApp.applicationIconImage`）に変更。不要になった `meetingAppIcon()` メソッドと `@ViewBuilder` を削除

## テスト計画

- [ ] サマリー生成後、出力される `.md` ファイル名に日付プレフィックスが付いていることを確認
- [ ] タイトルが空の場合・タイトルありの場合の両方でファイル名が正しいことを確認
- [ ] ミーティング検出バナーに Dahlia のアプリアイコンが表示されることを確認

This pull request was AI-assisted by Isaac.