### PR TITLE
Agent をサイドバーに移動し、ツール表示・録音中ナビゲーションを改善

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+SENTRY_DSN=

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.app
 DerivedData/
 .DS_Store
+.env.local

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3c6b5201fd9001811228a23e221146f67a9619fd7da3856c9e3e5843902c4275",
+  "originHash" : "0b2d84814c5ca1d5cf4271aed0c298935a940ff4a261ada7513fb6cbcb319b3d",
   "pins" : [
     {
       "identity" : "grdb.swift",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "36e30a6f1ef10e4194f6af0cff90888526f0c115",
         "version" : "7.10.0"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "3a22ecd00ad1398747bfd587e44df82716908dd3",
+        "version" : "9.10.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -8,13 +8,15 @@ let package = Package(
         .macOS(.v26)
     ],
     dependencies: [
-        .package(url: "https://github.com/groue/GRDB.swift.git", from: "7.0.0")
+        .package(url: "https://github.com/groue/GRDB.swift.git", from: "7.0.0"),
+        .package(url: "https://github.com/getsentry/sentry-cocoa", from: "9.10.0"),
     ],
     targets: [
         .executableTarget(
             name: "Dahlia",
             dependencies: [
-                .product(name: "GRDB", package: "GRDB.swift")
+                .product(name: "GRDB", package: "GRDB.swift"),
+                .product(name: "Sentry", package: "sentry-cocoa"),
             ],
             path: "Sources/Dahlia",
             resources: [.process("Resources")]

--- a/Sources/Dahlia/DahliaApp.swift
+++ b/Sources/Dahlia/DahliaApp.swift
@@ -101,6 +101,7 @@ struct DahliaApp: App {
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_: Notification) {
+        ErrorReportingService.start()
         NSApplication.shared.setActivationPolicy(.regular)
     }
 

--- a/Sources/Dahlia/Models/SummaryProgressState.swift
+++ b/Sources/Dahlia/Models/SummaryProgressState.swift
@@ -3,7 +3,7 @@ import Foundation
 /// 要約生成の各ステップの進捗状態を管理する。
 @MainActor @Observable
 final class SummaryProgressState {
-    enum StepStatus: Sendable {
+    enum StepStatus {
         case pending
         case running
         case completed

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -34,9 +34,17 @@
 "Transcript" = "Transcript";
 "Agent" = "Agent";
 
+/* Agent */
+"Project Mode" = "Project Mode";
+"Transcript Mode" = "Transcript Mode";
+"Run Claude Code in the project directory." = "Run Claude Code in the project directory.";
+"Continuously feed transcript to Claude Code." = "Continuously feed transcript to Claude Code.";
+"Start Agent" = "Start";
+"Stop Agent" = "Stop";
+
 /* Settings (Agent) */
 "Enable Agent (Beta)" = "Enable Agent (Beta)";
-"Enable the Agent tab to interact with Claude during transcription. This is a beta feature." = "Enable the Agent tab to interact with Claude during transcription. This is a beta feature.";
+"Enable the Agent sidebar to interact with Claude. This is a beta feature." = "Enable the Agent sidebar to interact with Claude. This is a beta feature.";
 
 /* Audio Source Mode */
 "Mic" = "Mic";

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "Continuously feed transcript to Claude Code." = "Continuously feed transcript to Claude Code.";
 "Start Agent" = "Start";
 "Stop Agent" = "Stop";
+"Thinking…" = "Thinking…";
 
 /* Settings (Agent) */
 "Enable Agent (Beta)" = "Enable Agent (Beta)";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -34,9 +34,17 @@
 "Transcript" = "文字起こし";
 "Agent" = "エージェント";
 
+/* Agent */
+"Project Mode" = "プロジェクトモード";
+"Transcript Mode" = "文字起こしモード";
+"Run Claude Code in the project directory." = "プロジェクトディレクトリで Claude Code を実行します。";
+"Continuously feed transcript to Claude Code." = "文字起こしを継続的に Claude Code に入力します。";
+"Start Agent" = "開始";
+"Stop Agent" = "停止";
+
 /* Settings (Agent) */
 "Enable Agent (Beta)" = "エージェントを有効にする（ベータ）";
-"Enable the Agent tab to interact with Claude during transcription. This is a beta feature." = "文字起こし中に Claude と対話できるエージェントタブを有効にします。これはベータ機能です。";
+"Enable the Agent sidebar to interact with Claude. This is a beta feature." = "Claude と対話できるエージェントサイドバーを有効にします。これはベータ機能です。";
 
 /* Audio Source Mode */
 "Mic" = "マイク";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "Continuously feed transcript to Claude Code." = "文字起こしを継続的に Claude Code に入力します。";
 "Start Agent" = "開始";
 "Stop Agent" = "停止";
+"Thinking…" = "考え中…";
 
 /* Settings (Agent) */
 "Enable Agent (Beta)" = "エージェントを有効にする（ベータ）";

--- a/Sources/Dahlia/Services/AgentService.swift
+++ b/Sources/Dahlia/Services/AgentService.swift
@@ -2,6 +2,14 @@ import Combine
 import Foundation
 import os
 
+/// Agent の開始モード。
+enum AgentStartMode: String, CaseIterable {
+    /// プロジェクトディレクトリで Claude Code を実行（transcript 入力なし）。
+    case project
+    /// 文字起こしを継続的に Claude Code に入力として渡す。
+    case transcript
+}
+
 /// Claude Code CLI プロセスのメッセージロール。
 enum AgentMessageRole {
     case user
@@ -26,6 +34,9 @@ final class AgentService: ObservableObject {
     @Published var messages: [AgentMessage] = []
     @Published var isRunning = false
 
+    /// 起動時に選択されたモード。
+    private(set) var mode: AgentStartMode = .project
+
     // MARK: - Private State
 
     private var process: Process?
@@ -39,7 +50,8 @@ final class AgentService: ObservableObject {
 
     // MARK: - Lifecycle
 
-    func start(workingDirectory: URL, store: TranscriptStore) {
+    func start(workingDirectory: URL, mode: AgentStartMode, store: TranscriptStore?) {
+        self.mode = mode
         guard !isRunning else { return }
 
         let systemPrompt = """
@@ -90,7 +102,9 @@ final class AgentService: ObservableObject {
         self.isRunning = true
 
         startReadingStdout(stdout)
-        startObservingSegments(store: store)
+        if let store {
+            startObservingSegments(store: store)
+        }
     }
 
     /// ユーザーが手動で入力したメッセージを送信する。
@@ -117,6 +131,13 @@ final class AgentService: ObservableObject {
         process = nil
         stdinPipe = nil
         stdoutPipe = nil
+    }
+
+    /// transcript 切替時にセグメント追跡をリセットし、新しい store を再観測する。
+    func resetSegmentTracking(store: TranscriptStore) {
+        cancellable = nil
+        sentSegmentIds.removeAll()
+        startObservingSegments(store: store)
     }
 
     // MARK: - Stdin Writing

--- a/Sources/Dahlia/Services/AgentService.swift
+++ b/Sources/Dahlia/Services/AgentService.swift
@@ -127,9 +127,15 @@ final class AgentService: ObservableObject {
 
         let proc = process
         Task.detached {
+            // stdin を閉じた後、プロセスの自発的終了を待つ
             try? await Task.sleep(for: .milliseconds(500))
+            guard proc?.isRunning == true else { return }
+            // SIGTERM を送信
+            proc?.terminate()
+            try? await Task.sleep(for: .seconds(2))
             if proc?.isRunning == true {
-                proc?.terminate()
+                // 応答しない場合は SIGKILL で強制終了
+                kill(proc!.processIdentifier, SIGKILL)
             }
         }
 

--- a/Sources/Dahlia/Services/AgentService.swift
+++ b/Sources/Dahlia/Services/AgentService.swift
@@ -21,6 +21,21 @@ enum AgentMessageRole {
     case assistant
     case system
     case error
+    case toolUse
+}
+
+/// ツール実行結果の情報。
+struct ToolResultInfo {
+    let content: String
+    let isError: Bool
+}
+
+/// ツール呼び出しの詳細情報。
+struct ToolCallInfo {
+    let toolName: String
+    let toolUseId: String
+    let toolInput: [String: Any]
+    var toolResult: ToolResultInfo?
 }
 
 /// Claude Code CLI プロセスからの出力メッセージ。
@@ -28,6 +43,7 @@ struct AgentMessage: Identifiable {
     let id: UUID = .v7()
     let role: AgentMessageRole
     var content: String
+    var toolCallInfo: ToolCallInfo?
 }
 
 /// Claude Code CLI をサブプロセスとして管理し、確定済み文字起こしセグメントをストリーミングで送信するサービス。
@@ -53,6 +69,11 @@ final class AgentService: ObservableObject {
     private var readTask: Task<Void, Never>?
 
     private let logger = Logger(subsystem: "com.dahlia", category: "AgentService")
+
+    /// 結果を UI に表示しないツール。
+    static let toolsOmitResult: Set<String> = ["Glob", "Grep", "Read", "Write", "Edit", "TodoWrite"]
+    /// 入力サマリーを省略するツール。
+    static let toolsOmitInputSummary: Set<String> = ["TodoWrite"]
 
     // MARK: - Lifecycle
 
@@ -275,6 +296,17 @@ final class AgentService: ObservableObject {
                 if !text.isEmpty, !isDuplicateAssistantBubble(comparedTo: text) {
                     messages.append(AgentMessage(role: .assistant, content: text))
                 }
+                // tool_use ブロックを抽出
+                for block in content where block["type"] as? String == "tool_use" {
+                    guard let toolName = block["name"] as? String,
+                          let toolUseId = block["id"] as? String else { continue }
+                    // 重複チェック
+                    if messages.contains(where: { $0.toolCallInfo?.toolUseId == toolUseId }) { continue }
+                    let toolInput = block["input"] as? [String: Any] ?? [:]
+                    let summary = Self.toolInputSummary(toolName: toolName, input: toolInput)
+                    let info = ToolCallInfo(toolName: toolName, toolUseId: toolUseId, toolInput: toolInput)
+                    messages.append(AgentMessage(role: .toolUse, content: summary, toolCallInfo: info))
+                }
             }
         case "content_block_delta":
             if let delta = json["delta"] as? [String: Any],
@@ -284,6 +316,22 @@ final class AgentService: ObservableObject {
                     messages[lastIndex].content += text
                 } else {
                     messages.append(AgentMessage(role: .assistant, content: text))
+                }
+            }
+        case "user":
+            // tool_result ブロックをマッチする tool_use メッセージにマージ
+            if let message = json["message"] as? [String: Any],
+               let content = message["content"] as? [[String: Any]] {
+                for block in content where block["type"] as? String == "tool_result" {
+                    guard let toolUseId = block["tool_use_id"] as? String else { continue }
+                    let resultContent = (block["content"] as? String) ?? ""
+                    let isError = block["is_error"] as? Bool ?? false
+                    let resultInfo = ToolResultInfo(content: resultContent, isError: isError)
+                    if let idx = messages.lastIndex(where: {
+                        $0.role == .toolUse && $0.toolCallInfo?.toolUseId == toolUseId
+                    }) {
+                        messages[idx].toolCallInfo?.toolResult = resultInfo
+                    }
                 }
             }
         case "system":
@@ -299,6 +347,35 @@ final class AgentService: ObservableObject {
             messages.append(AgentMessage(role: .error, content: errorMsg))
         default:
             break
+        }
+    }
+
+    // MARK: - Tool Input Summary
+
+    /// ツール名と入力パラメータから人間可読なサマリー文字列を返す。
+    static func toolInputSummary(toolName: String, input: [String: Any]) -> String {
+        switch toolName {
+        case "Bash":
+            return (input["command"] as? String) ?? toolName
+        case "Read", "Write", "Edit":
+            return (input["file_path"] as? String) ?? toolName
+        case "Grep", "Glob":
+            return (input["pattern"] as? String) ?? toolName
+        case "WebSearch":
+            return (input["query"] as? String) ?? toolName
+        case "WebFetch":
+            return (input["url"] as? String) ?? toolName
+        case "Agent":
+            return (input["subagent_type"] as? String) ?? toolName
+        case "Skill":
+            return (input["skill"] as? String) ?? toolName
+        default:
+            if Self.toolsOmitInputSummary.contains(toolName) { return toolName }
+            if let data = try? JSONSerialization.data(withJSONObject: input, options: [.sortedKeys]),
+               let str = String(data: data, encoding: .utf8) {
+                return String(str.prefix(120))
+            }
+            return toolName
         }
     }
 }

--- a/Sources/Dahlia/Services/AgentService.swift
+++ b/Sources/Dahlia/Services/AgentService.swift
@@ -38,6 +38,7 @@ final class AgentService: ObservableObject {
 
     @Published var messages: [AgentMessage] = []
     @Published var isRunning = false
+    @Published var isProcessing = false
 
     /// 起動時に選択されたモード。
     private(set) var mode: AgentStartMode = .project
@@ -83,7 +84,8 @@ final class AgentService: ObservableObject {
             "--input-format", "stream-json",
             "--output-format", "stream-json",
             "--verbose",
-            "--permission-mode", "bypassPermissions",
+            "--permission-mode", "auto",
+            "--allowedTools", "Read(/*) Glob(/*) Grep(/*) TodoWrite",
             "--no-session-persistence",
             "--model", "sonnet",
             "--system-prompt", systemPrompt,
@@ -134,6 +136,7 @@ final class AgentService: ObservableObject {
 
     func stop() {
         isRunning = false
+        isProcessing = false
         cancellable = nil
         readTask?.cancel()
 
@@ -283,9 +286,12 @@ final class AgentService: ObservableObject {
                     messages.append(AgentMessage(role: .assistant, content: text))
                 }
             }
+        case "system":
+            if let subtype = json["subtype"] as? String, subtype == "init" {
+                isProcessing = true
+            }
         case "result":
-            // UI には `assistant` / `content_block_delta` のみ反映する（`result` はメタ用の重複になりがち）
-            break
+            isProcessing = false
         case "error":
             let errorMsg = (json["error"] as? [String: Any])?["message"] as? String
                 ?? json["error"] as? String

--- a/Sources/Dahlia/Services/AgentService.swift
+++ b/Sources/Dahlia/Services/AgentService.swift
@@ -71,9 +71,9 @@ final class AgentService: ObservableObject {
     private let logger = Logger(subsystem: "com.dahlia", category: "AgentService")
 
     /// 結果を UI に表示しないツール。
-    static let toolsOmitResult: Set<String> = ["Glob", "Grep", "Read", "Write", "Edit", "TodoWrite"]
+    static let toolsOmitResult: Set = ["Glob", "Grep", "Read", "Write", "Edit", "TodoWrite"]
     /// 入力サマリーを省略するツール。
-    static let toolsOmitInputSummary: Set<String> = ["TodoWrite"]
+    static let toolsOmitInputSummary: Set = ["TodoWrite"]
 
     // MARK: - Lifecycle
 
@@ -130,6 +130,7 @@ final class AgentService: ObservableObject {
             try proc.run()
         } catch {
             logger.error("Failed to launch claude process: \(error.localizedDescription)")
+            ErrorReportingService.capture(error, context: ["source": "agentProcessLaunch"])
             messages.append(AgentMessage(role: .error, content: "Claude Code の起動に失敗しました: \(error.localizedDescription)"))
             return
         }
@@ -370,7 +371,7 @@ final class AgentService: ObservableObject {
         case "Skill":
             return (input["skill"] as? String) ?? toolName
         default:
-            if Self.toolsOmitInputSummary.contains(toolName) { return toolName }
+            if toolsOmitInputSummary.contains(toolName) { return toolName }
             if let data = try? JSONSerialization.data(withJSONObject: input, options: [.sortedKeys]),
                let str = String(data: data, encoding: .utf8) {
                 return String(str.prefix(120))

--- a/Sources/Dahlia/Services/AgentService.swift
+++ b/Sources/Dahlia/Services/AgentService.swift
@@ -55,7 +55,7 @@ final class AgentService: ObservableObject {
 
     // MARK: - Lifecycle
 
-    func start(workingDirectory: URL, mode: AgentStartMode) {
+    func start(workingDirectory: URL, mode: AgentStartMode, initialMessage: String? = nil) {
         self.mode = mode
         guard !isRunning else { return }
 
@@ -119,6 +119,9 @@ final class AgentService: ObservableObject {
         startReadingStdout(stdout)
         if case let .transcript(store) = mode {
             startObservingSegments(store: store)
+        }
+        if let initialMessage, !initialMessage.isEmpty {
+            sendUserMessage(initialMessage)
         }
     }
 

--- a/Sources/Dahlia/Services/AgentService.swift
+++ b/Sources/Dahlia/Services/AgentService.swift
@@ -3,11 +3,16 @@ import Foundation
 import os
 
 /// Agent の開始モード。
-enum AgentStartMode: String, CaseIterable {
+enum AgentStartMode {
     /// プロジェクトディレクトリで Claude Code を実行（transcript 入力なし）。
     case project
     /// 文字起こしを継続的に Claude Code に入力として渡す。
-    case transcript
+    case transcript(store: TranscriptStore)
+
+    var isTranscript: Bool {
+        if case .transcript = self { return true }
+        return false
+    }
 }
 
 /// Claude Code CLI プロセスのメッセージロール。
@@ -50,7 +55,7 @@ final class AgentService: ObservableObject {
 
     // MARK: - Lifecycle
 
-    func start(workingDirectory: URL, mode: AgentStartMode, store: TranscriptStore?) {
+    func start(workingDirectory: URL, mode: AgentStartMode) {
         self.mode = mode
         guard !isRunning else { return }
 
@@ -102,7 +107,7 @@ final class AgentService: ObservableObject {
         self.isRunning = true
 
         startReadingStdout(stdout)
-        if let store {
+        if case let .transcript(store) = mode {
             startObservingSegments(store: store)
         }
     }

--- a/Sources/Dahlia/Services/AgentService.swift
+++ b/Sources/Dahlia/Services/AgentService.swift
@@ -59,11 +59,22 @@ final class AgentService: ObservableObject {
         self.mode = mode
         guard !isRunning else { return }
 
-        let systemPrompt = """
-            あなたはミーティングアシスタントです。\
-            リアルタイムの文字起こしを受け取り、要点の整理や質問への回答を行ってください。\
-            日本語で応答してください。
-            """
+        let systemPrompt: String
+        switch mode {
+        case .transcript:
+            systemPrompt = """
+                あなたはミーティングアシスタントです。\
+                ディレクトリ配下には過去の議事録が格納されています。\
+                リアルタイムの文字起こしを受け取り、要点の整理や質問への回答を行ってください。\
+                文字起こしは随時送られてくるため、新規の情報がない場合など、応答の必要がない場合は対応不要です。
+                """
+        case .project:
+            systemPrompt = """
+                あなたはミーティングアシスタントです。\
+                ディレクトリ配下には過去の議事録が格納されています。\
+                要点の整理や質問への回答など、ユーザーの質問に回答してください。
+                """
+        }
 
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
@@ -120,6 +131,7 @@ final class AgentService: ObservableObject {
     }
 
     func stop() {
+        isRunning = false
         cancellable = nil
         readTask?.cancel()
 
@@ -232,6 +244,13 @@ final class AgentService: ObservableObject {
         }
     }
 
+    /// `assistant` 確定イベントが、直前に `content_block_delta` で組み立てた本文と重複することがあるため、同一なら追加しない。
+    private func isDuplicateAssistantBubble(comparedTo text: String) -> Bool {
+        guard let last = messages.last, last.role == .assistant else { return false }
+        return last.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            == text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     private func handleOutputLine(_ line: String) {
         guard let data = line.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -248,7 +267,7 @@ final class AgentService: ObservableObject {
                     guard block["type"] as? String == "text" else { return nil }
                     return block["text"] as? String
                 }.joined()
-                if !text.isEmpty {
+                if !text.isEmpty, !isDuplicateAssistantBubble(comparedTo: text) {
                     messages.append(AgentMessage(role: .assistant, content: text))
                 }
             }
@@ -263,9 +282,8 @@ final class AgentService: ObservableObject {
                 }
             }
         case "result":
-            if let result = json["result"] as? String, !result.isEmpty {
-                messages.append(AgentMessage(role: .assistant, content: result))
-            }
+            // UI には `assistant` / `content_block_delta` のみ反映する（`result` はメタ用の重複になりがち）
+            break
         case "error":
             let errorMsg = (json["error"] as? [String: Any])?["message"] as? String
                 ?? json["error"] as? String

--- a/Sources/Dahlia/Services/AgentService.swift
+++ b/Sources/Dahlia/Services/AgentService.swift
@@ -59,21 +59,20 @@ final class AgentService: ObservableObject {
         self.mode = mode
         guard !isRunning else { return }
 
-        let systemPrompt: String
-        switch mode {
+        let systemPrompt = switch mode {
         case .transcript:
-            systemPrompt = """
-                あなたはミーティングアシスタントです。\
-                ディレクトリ配下には過去の議事録が格納されています。\
-                リアルタイムの文字起こしを受け取り、要点の整理や質問への回答を行ってください。\
-                文字起こしは随時送られてくるため、新規の情報がない場合など、応答の必要がない場合は対応不要です。
-                """
+            """
+            あなたはミーティングアシスタントです。\
+            ディレクトリ配下には過去の議事録が格納されています。\
+            リアルタイムの文字起こしを受け取り、要点の整理や質問への回答を行ってください。\
+            文字起こしは随時送られてくるため、新規の情報がない場合など、応答の必要がない場合は対応不要です。
+            """
         case .project:
-            systemPrompt = """
-                あなたはミーティングアシスタントです。\
-                ディレクトリ配下には過去の議事録が格納されています。\
-                要点の整理や質問への回答など、ユーザーの質問に回答してください。
-                """
+            """
+            あなたはミーティングアシスタントです。\
+            ディレクトリ配下には過去の議事録が格納されています。\
+            要点の整理や質問への回答など、ユーザーの質問に回答してください。
+            """
         }
 
         let proc = Process()
@@ -190,7 +189,7 @@ final class AgentService: ObservableObject {
     // MARK: - Segment Observation
 
     private func startObservingSegments(store: TranscriptStore) {
-        let existingConfirmed = store.segments.filter { $0.isConfirmed }
+        let existingConfirmed = store.segments.filter(\.isConfirmed)
         if !existingConfirmed.isEmpty {
             sendSegments(existingConfirmed)
         }

--- a/Sources/Dahlia/Services/ErrorReportingService.swift
+++ b/Sources/Dahlia/Services/ErrorReportingService.swift
@@ -1,0 +1,38 @@
+import Foundation
+@preconcurrency import Sentry
+
+/// Sentry を用いたエラー報告サービス。
+/// 環境変数 `SENTRY_DSN` が設定されている場合のみ有効化される。
+enum ErrorReportingService {
+    private nonisolated(unsafe) static var isEnabled = false
+
+    /// アプリ起動時に一度だけ呼ぶ。`SENTRY_DSN` 環境変数が未設定なら何もしない。
+    static func start() {
+        guard let dsn = ProcessInfo.processInfo.environment["SENTRY_DSN"],
+              !dsn.isEmpty
+        else { return }
+
+        isEnabled = true
+        SentrySDK.start { options in
+            options.dsn = dsn
+            options.enableCrashHandler = true
+            options.enableAutoPerformanceTracing = false
+            options.tracesSampleRate = 0
+            options.sendDefaultPii = false
+            #if DEBUG
+                options.environment = "debug"
+            #else
+                options.environment = "production"
+            #endif
+        }
+    }
+
+    static func capture(_ error: Error, context: [String: String] = [:]) {
+        guard isEnabled else { return }
+        SentrySDK.capture(error: error) { scope in
+            for (key, value) in context {
+                scope.setExtra(value: value, key: key)
+            }
+        }
+    }
+}

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -68,11 +68,26 @@ enum L10n {
     static var transcript: String { String(localized: "Transcript", bundle: bundle) }
     static var agent: String { String(localized: "Agent", bundle: bundle) }
 
+    // MARK: - Agent
+
+    static var agentProjectMode: String { String(localized: "Project Mode", bundle: bundle) }
+    static var agentTranscriptMode: String { String(localized: "Transcript Mode", bundle: bundle) }
+    static var agentProjectModeDescription: String { String(
+        localized: "Run Claude Code in the project directory.",
+        bundle: bundle
+    ) }
+    static var agentTranscriptModeDescription: String { String(
+        localized: "Continuously feed transcript to Claude Code.",
+        bundle: bundle
+    ) }
+    static var startAgent: String { String(localized: "Start Agent", bundle: bundle) }
+    static var stopAgent: String { String(localized: "Stop Agent", bundle: bundle) }
+
     // MARK: - Settings (Agent)
 
     static var agentEnabled: String { String(localized: "Enable Agent (Beta)", bundle: bundle) }
     static var agentEnabledDescription: String { String(
-        localized: "Enable the Agent tab to interact with Claude during transcription. This is a beta feature.",
+        localized: "Enable the Agent sidebar to interact with Claude. This is a beta feature.",
         bundle: bundle
     ) }
 

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -82,6 +82,7 @@ enum L10n {
     ) }
     static var startAgent: String { String(localized: "Start Agent", bundle: bundle) }
     static var stopAgent: String { String(localized: "Stop Agent", bundle: bundle) }
+    static var agentProcessing: String { String(localized: "Thinking…", bundle: bundle) }
 
     // MARK: - Settings (Agent)
 

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -268,7 +268,6 @@ final class CaptionViewModel: ObservableObject {
         resetNoteState()
         lastSummaryURL = nil
         summaryError = nil
-        stopAgent()
     }
 
     /// 現在の文字起こしコンテキスト（ID・プロジェクト情報）をセットする。
@@ -467,7 +466,6 @@ final class CaptionViewModel: ObservableObject {
         systemAudioManager?.stopCapture()
         systemAudioManager = nil
         isListening = false
-        stopAgent()
 
         let transcriptionId = currentTranscriptionId
         let projectName = selectedProjectName
@@ -519,17 +517,18 @@ final class CaptionViewModel: ObservableObject {
 
     // MARK: - Agent
 
-    /// Agent タブへの初回切り替え時に Claude Code プロセスを起動する。
-    func activateAgentIfNeeded() {
+    /// 指定モードで Agent を起動する。
+    func startAgent(mode: AgentStartMode) {
         guard agentService == nil,
-              isListening,
               let projectURL = currentProjectURL else { return }
         let service = AgentService()
         self.agentService = service
-        service.start(workingDirectory: projectURL, store: store)
+        let transcriptStore: TranscriptStore? = mode == .transcript ? store : nil
+        service.start(workingDirectory: projectURL, mode: mode, store: transcriptStore)
     }
 
-    private func stopAgent() {
+    /// Agent を明示的に停止する。
+    func stopAgent() {
         agentService?.stop()
         agentService = nil
     }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -231,6 +231,7 @@ final class CaptionViewModel: ObservableObject {
             } catch {
                 Logger(subsystem: "com.dahlia", category: "CaptionViewModel")
                     .error("Failed to load transcription \(transcriptionId): \(error)")
+                ErrorReportingService.capture(error, context: ["source": "loadTranscription"])
                 return
             }
 
@@ -437,6 +438,7 @@ final class CaptionViewModel: ObservableObject {
             } catch {
                 self.isPreparingAnalyzer = false
                 self.errorMessage = L10n.speechPreparationFailed(error.localizedDescription)
+                ErrorReportingService.capture(error, context: ["source": "prepareAnalyzer"])
             }
         }
     }
@@ -573,6 +575,7 @@ final class CaptionViewModel: ObservableObject {
             self.errorMessage = nil
         } catch {
             self.errorMessage = error.localizedDescription
+            ErrorReportingService.capture(error, context: ["source": "startListening"])
             audioManager?.stopCapture()
             audioManager = nil
             systemAudioManager?.stopCapture()
@@ -778,6 +781,7 @@ final class CaptionViewModel: ObservableObject {
                 summaryError = error.localizedDescription
             }
             summaryProgress.summaryGeneration = .failed(error.localizedDescription)
+            ErrorReportingService.capture(error, context: ["source": "summaryGeneration"])
         }
 
         if summaryGeneratingTranscriptionId == transcriptionId {

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -48,8 +48,6 @@ final class CaptionViewModel: ObservableObject {
     // MARK: - Agent State
 
     @Published var agentService: AgentService?
-    /// 右サイドバーのモード選択を保持（開閉でリセットされない）。
-    var selectedAgentMode: AgentStartMode = .project
 
     // MARK: - Note State
 
@@ -519,13 +517,13 @@ final class CaptionViewModel: ObservableObject {
 
     // MARK: - Agent
 
-    /// 指定モードで Agent を起動する。
-    func startAgent(mode: AgentStartMode) {
+    /// 指定モードで Agent を起動する。初期メッセージを渡すとプロジェクトモードで即座に送信する。
+    func startAgent(mode: AgentStartMode, initialMessage: String? = nil) {
         guard agentService == nil,
               let projectURL = currentProjectURL else { return }
         let service = AgentService()
         self.agentService = service
-        service.start(workingDirectory: projectURL, mode: mode)
+        service.start(workingDirectory: projectURL, mode: mode, initialMessage: initialMessage)
     }
 
     /// Agent を明示的に停止する。

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -48,7 +48,7 @@ final class CaptionViewModel: ObservableObject {
     // MARK: - Agent State
 
     @Published var agentService: AgentService?
-    /// Inspector のモード選択を保持（inspector 開閉でリセットされない）。
+    /// 右サイドバーのモード選択を保持（開閉でリセットされない）。
     var selectedAgentMode: AgentStartMode = .project
 
     // MARK: - Note State

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -10,6 +10,17 @@ private enum ScreenshotError: Error {
     case imageUnavailable
 }
 
+/// 録音中のナビゲーション時に保持する録音コンテキスト。
+private struct RecordingContext {
+    let transcriptionId: UUID?
+    let store: TranscriptStore
+    let projectURL: URL?
+    let projectId: UUID?
+    let projectName: String?
+    let vaultURL: URL?
+    let dbQueue: DatabaseQueue?
+}
+
 /// 音声キャプチャ → Speech フレームワーク文字起こし → UI 更新を統括するビューモデル。
 @MainActor
 final class CaptionViewModel: ObservableObject {
@@ -76,6 +87,19 @@ final class CaptionViewModel: ObservableObject {
     /// システム音声が有効か（audioSourceMode から導出）。
     var isSystemAudioEnabled: Bool { audioSourceMode == .systemAudio || audioSourceMode == .both }
 
+    // MARK: - Recording Context (録音中のナビゲーション時に保持)
+
+    /// 録音中に別トランスクリプトへナビゲーションした際の録音コンテキスト。
+    private var recordingContext: RecordingContext?
+
+    /// 録音対象の文字起こし ID。
+    var recordingTranscriptionId: UUID? { recordingContext?.transcriptionId }
+
+    /// 録音中かつ録音対象とは別のトランスクリプトを閲覧中。
+    var isViewingOtherWhileRecording: Bool {
+        isListening && recordingContext != nil
+    }
+
     // MARK: - Private
 
     private var currentDbQueue: DatabaseQueue?
@@ -88,11 +112,7 @@ final class CaptionViewModel: ObservableObject {
     private var transcriptionLoadTask: Task<Void, Never>?
 
     init() {
-        storeCancellable = store.objectWillChange
-            .throttle(for: .milliseconds(100), scheduler: RunLoop.main, latest: true)
-            .sink { [weak self] _ in
-                self?.objectWillChange.send()
-            }
+        resubscribeStoreCancellable()
 
         // AppSettings の表示言語設定変更を監視
         settingsCancellable = UserDefaults.standard
@@ -159,6 +179,7 @@ final class CaptionViewModel: ObservableObject {
     // MARK: - Transcription Loading
 
     /// DB から文字起こしのセグメントを読み込んで表示する。
+    /// 録音中でも呼び出し可能。録音パイプラインはバックグラウンドで継続する。
     func loadTranscription(
         _ transcriptionId: UUID,
         dbQueue: DatabaseQueue,
@@ -167,8 +188,23 @@ final class CaptionViewModel: ObservableObject {
         projectName: String? = nil,
         vaultURL: URL
     ) {
-        guard !isListening else { return }
-        resetTranscriptionState()
+        // 録音中に録音対象のトランスクリプトを選択した場合はライブ表示に復帰
+        if isListening, transcriptionId == recordingTranscriptionId {
+            returnToRecordingTranscription()
+            return
+        }
+
+        // 録音中の場合、録音コンテキストをバックアップして表示用ストアを差し替え
+        if isListening {
+            saveRecordingContextIfNeeded()
+            transcriptionLoadTask?.cancel()
+            saveNoteImmediately()
+            store = TranscriptStore()
+            resubscribeStoreCancellable()
+        } else {
+            resetTranscriptionState()
+        }
+
         setTranscriptionContext(
             id: transcriptionId,
             dbQueue: dbQueue,
@@ -202,13 +238,7 @@ final class CaptionViewModel: ObservableObject {
 
             self.store.recordingStartTime = loaded.startedAt
             self.store.loadSegments(loaded.segments)
-            self.screenshots = loaded.screenshots
-            self.lastSummaryURL = loaded.lastSummaryURL
-            self.noteText = loaded.note?.text ?? ""
-            self.currentNoteId = loaded.note?.id
-            self.currentNoteCreatedAt = loaded.note?.createdAt
-            self.lastSavedNoteText = self.noteText
-            self.setupNoteAutoSave()
+            self.applyLoadedDetail(loaded)
         }
     }
 
@@ -248,8 +278,19 @@ final class CaptionViewModel: ObservableObject {
     }
 
     /// 現在の文字起こし表示をクリアして初期状態に戻す。
+    /// 録音中はバックグラウンド録音を維持したまま表示のみクリアする。
     func clearCurrentTranscription() {
-        resetTranscriptionState()
+        if isListening {
+            saveRecordingContextIfNeeded()
+            store = TranscriptStore()
+            resubscribeStoreCancellable()
+            screenshots = []
+            resetNoteState()
+            lastSummaryURL = nil
+            summaryError = nil
+        } else {
+            resetTranscriptionState()
+        }
         currentTranscriptionId = nil
         currentProjectURL = nil
         currentProjectId = nil
@@ -257,7 +298,87 @@ final class CaptionViewModel: ObservableObject {
         currentVaultURL = nil
     }
 
+    /// 録音対象のトランスクリプトに表示を復帰する。
+    func returnToRecordingTranscription() {
+        guard let ctx = recordingContext else { return }
+        transcriptionLoadTask?.cancel()
+        saveNoteImmediately()
+
+        // コンテキストを先に復元（store 代入時の objectWillChange で SwiftUI が再評価する際に
+        // currentTranscriptionId 等が正しい値を返すようにする）
+        currentTranscriptionId = ctx.transcriptionId
+        currentProjectURL = ctx.projectURL
+        currentProjectId = ctx.projectId
+        currentProjectName = ctx.projectName
+        currentVaultURL = ctx.vaultURL
+        currentDbQueue = ctx.dbQueue
+
+        store = ctx.store
+        resubscribeStoreCancellable()
+        recordingContext = nil
+
+        reloadTranscriptionDetail()
+    }
+
+    /// 現在の transcriptionId のノート・スクリーンショット・サマリーを DB から読み込み直す。
+    private func reloadTranscriptionDetail() {
+        guard let transcriptionId = currentTranscriptionId,
+              let dbQueue = currentDbQueue,
+              let projectURL = currentProjectURL else { return }
+        transcriptionLoadTask = Task { [weak self, transcriptionId, dbQueue, projectURL] in
+            guard let self else { return }
+            let loaded: LoadedTranscriptionData
+            do {
+                loaded = try await Task.detached(priority: .userInitiated) {
+                    try Self.fetchLoadedTranscriptionData(
+                        transcriptionId: transcriptionId,
+                        dbQueue: dbQueue,
+                        projectURL: projectURL
+                    )
+                }.value
+            } catch {
+                return
+            }
+            guard !Task.isCancelled, self.currentTranscriptionId == transcriptionId else { return }
+            self.applyLoadedDetail(loaded)
+        }
+    }
+
+    /// 読み込み済みデータのノート・スクリーンショット・サマリーを UI 状態に反映する。
+    private func applyLoadedDetail(_ loaded: LoadedTranscriptionData) {
+        screenshots = loaded.screenshots
+        lastSummaryURL = loaded.lastSummaryURL
+        noteText = loaded.note?.text ?? ""
+        currentNoteId = loaded.note?.id
+        currentNoteCreatedAt = loaded.note?.createdAt
+        lastSavedNoteText = noteText
+        setupNoteAutoSave()
+    }
+
     // MARK: - Private Helpers
+
+    /// 録音コンテキストをバックアップする（初回ナビゲーション時のみ）。
+    private func saveRecordingContextIfNeeded() {
+        guard recordingContext == nil else { return }
+        recordingContext = RecordingContext(
+            transcriptionId: currentTranscriptionId,
+            store: store,
+            projectURL: currentProjectURL,
+            projectId: currentProjectId,
+            projectName: currentProjectName,
+            vaultURL: currentVaultURL,
+            dbQueue: currentDbQueue
+        )
+    }
+
+    /// storeCancellable を現在の store に再接続する。
+    private func resubscribeStoreCancellable() {
+        storeCancellable = store.objectWillChange
+            .throttle(for: .milliseconds(100), scheduler: RunLoop.main, latest: true)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+    }
 
     /// UI 状態をリセットし、次の文字起こし読み込みに備える。
     private func resetTranscriptionState() {
@@ -467,13 +588,19 @@ final class CaptionViewModel: ObservableObject {
         systemAudioManager = nil
         isListening = false
 
-        let transcriptionId = currentTranscriptionId
-        let projectName = selectedProjectName
-        let transcriptText = store.exportForSummary()
-        let projectURL = currentProjectURL
-        let recordingStart = store.recordingStartTime ?? Date()
-        let segments = store.segments
-        guard let vaultURL = currentVaultURL else { return }
+        // ナビゲーション済みの場合、録音コンテキストからデータを取得
+        let ctx = recordingContext
+        let activeStore = ctx?.store ?? store
+        let transcriptionId = ctx?.transcriptionId ?? currentTranscriptionId
+        let projectName = ctx?.projectName ?? selectedProjectName
+        let projectURL = ctx?.projectURL ?? currentProjectURL
+        let vaultURL = ctx?.vaultURL ?? currentVaultURL
+        let transcriptText = activeStore.exportForSummary()
+        let recordingStart = activeStore.recordingStartTime ?? Date()
+        let segments = activeStore.segments
+        recordingContext = nil
+
+        guard let vaultURL else { return }
 
         Task {
             for pipeline in pipelines {

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -518,9 +518,10 @@ final class CaptionViewModel: ObservableObject {
     // MARK: - Agent
 
     /// 指定モードで Agent を起動する。初期メッセージを渡すとプロジェクトモードで即座に送信する。
-    func startAgent(mode: AgentStartMode, initialMessage: String? = nil) {
+    /// `workingDirectory` を渡すと `currentProjectURL` より優先して使用する。
+    func startAgent(mode: AgentStartMode, initialMessage: String? = nil, workingDirectory: URL? = nil) {
         guard agentService == nil,
-              let projectURL = currentProjectURL else { return }
+              let projectURL = workingDirectory ?? currentProjectURL else { return }
         let service = AgentService()
         self.agentService = service
         service.start(workingDirectory: projectURL, mode: mode, initialMessage: initialMessage)

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -48,6 +48,8 @@ final class CaptionViewModel: ObservableObject {
     // MARK: - Agent State
 
     @Published var agentService: AgentService?
+    /// Inspector のモード選択を保持（inspector 開閉でリセットされない）。
+    var selectedAgentMode: AgentStartMode = .project
 
     // MARK: - Note State
 
@@ -523,14 +525,19 @@ final class CaptionViewModel: ObservableObject {
               let projectURL = currentProjectURL else { return }
         let service = AgentService()
         self.agentService = service
-        let transcriptStore: TranscriptStore? = mode == .transcript ? store : nil
-        service.start(workingDirectory: projectURL, mode: mode, store: transcriptStore)
+        service.start(workingDirectory: projectURL, mode: mode)
     }
 
     /// Agent を明示的に停止する。
     func stopAgent() {
         agentService?.stop()
         agentService = nil
+    }
+
+    /// transcript 切替時に Agent のセグメント追跡をリセットする（transcript モードのみ）。
+    func resetAgentSegmentTrackingIfNeeded() {
+        guard let service = agentService, service.mode.isTranscript else { return }
+        service.resetSegmentTracking(store: store)
     }
 
     // MARK: - Summary Generation

--- a/Sources/Dahlia/ViewModels/SidebarViewModel.swift
+++ b/Sources/Dahlia/ViewModels/SidebarViewModel.swift
@@ -406,6 +406,7 @@ final class SidebarViewModel {
             try transcriptionRepository?.deleteProjectsByPrefix(name: name, vaultId: vault.id)
         } catch {
             lastError = "データベースの更新に失敗しました: \(error.localizedDescription)"
+            ErrorReportingService.capture(error, context: ["source": "deleteProject"])
         }
     }
 

--- a/Sources/Dahlia/Views/AgentTabView.swift
+++ b/Sources/Dahlia/Views/AgentTabView.swift
@@ -266,11 +266,12 @@ private struct ChatBubbleView: View {
     private var isUser: Bool { message.role == .user }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 8) {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
             if isUser {
                 Spacer(minLength: 60)
             } else {
                 avatarView
+                    .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] }
             }
 
             bubbleContent

--- a/Sources/Dahlia/Views/AgentTabView.swift
+++ b/Sources/Dahlia/Views/AgentTabView.swift
@@ -1,29 +1,92 @@
 import SwiftUI
 
-/// Agent タブのコンテンツビュー。Claude Code CLI の出力をチャット風に表示する。
-struct AgentTabView: View {
+/// Agent 右サイドバーのコンテンツビュー。モード選択 UI またはチャット UI を表示する。
+struct AgentSidebarView: View {
     @ObservedObject var viewModel: CaptionViewModel
+    var sidebarViewModel: SidebarViewModel
+    @State private var selectedMode: AgentStartMode = .project
 
     var body: some View {
-        Group {
+        VStack(spacing: 0) {
             if let service = viewModel.agentService {
+                // ── Agent 起動中 ──
+                agentHeader(service: service)
+                Divider()
                 AgentChatView(service: service)
             } else {
-                ContentUnavailableView {
-                    Label(L10n.agent, systemImage: "sparkles")
-                } description: {
-                    if viewModel.isListening {
-                        Text("Agent タブに切り替えると Claude Code が起動します")
-                    } else {
-                        Text("文字起こしを開始してから Agent タブに切り替えてください")
-                    }
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                // ── Agent 未起動: モード選択 ──
+                agentModePicker
             }
         }
-        .onAppear {
-            viewModel.activateAgentIfNeeded()
+    }
+
+    // MARK: - Agent Header
+
+    @ViewBuilder
+    private func agentHeader(service: AgentService) -> some View {
+        HStack {
+            Image(systemName: "sparkles")
+                .foregroundStyle(.purple)
+            Text(service.mode == .project ? L10n.agentProjectMode : L10n.agentTranscriptMode)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Button {
+                viewModel.stopAgent()
+            } label: {
+                Label(L10n.stopAgent, systemImage: "stop.fill")
+                    .labelStyle(.iconOnly)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+            .buttonStyle(.plain)
+            .help(L10n.stopAgent)
         }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    // MARK: - Mode Picker
+
+    private var agentModePicker: some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            Image(systemName: "sparkles")
+                .font(.largeTitle)
+                .foregroundStyle(.purple)
+
+            Text(L10n.agent)
+                .font(.headline)
+
+            Picker(L10n.agent, selection: $selectedMode) {
+                Text(L10n.agentProjectMode).tag(AgentStartMode.project)
+                Text(L10n.agentTranscriptMode).tag(AgentStartMode.transcript)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .padding(.horizontal, 20)
+
+            Text(selectedMode == .project ? L10n.agentProjectModeDescription : L10n.agentTranscriptModeDescription)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 20)
+
+            Button {
+                viewModel.startAgent(mode: selectedMode)
+            } label: {
+                Label(L10n.startAgent, systemImage: "play.fill")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .padding(.horizontal, 20)
+            .disabled(sidebarViewModel.selectedProjectURL == nil)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 

--- a/Sources/Dahlia/Views/AgentTabView.swift
+++ b/Sources/Dahlia/Views/AgentTabView.swift
@@ -140,14 +140,14 @@ private struct AgentLauncherView: View {
                     projectURL: projectURL,
                     projectId: project.id,
                     projectName: project.name,
-                    vaultURL: vaultURL,
+                    vaultURL: vaultURL
                 )
             }
 
             viewModel.startAgent(
                 mode: .transcript(store: viewModel.store),
                 initialMessage: "文字起こしモードを開始します。リアルタイムの文字起こしが随時送信されます。準備ができたら教えてください。",
-                workingDirectory: sidebarViewModel.selectedProjectURL,
+                workingDirectory: sidebarViewModel.selectedProjectURL
             )
         }
     }

--- a/Sources/Dahlia/Views/AgentTabView.swift
+++ b/Sources/Dahlia/Views/AgentTabView.swift
@@ -1,22 +1,9 @@
 import SwiftUI
 
-/// Agent 右サイドバーのコンテンツビュー。モード選択 UI またはチャット UI を表示する。
+/// Agent 右サイドバーのコンテンツビュー。初期チャット入力画面またはチャット UI を表示する。
 struct AgentSidebarView: View {
     @ObservedObject var viewModel: CaptionViewModel
     var sidebarViewModel: SidebarViewModel
-
-    /// Picker 用の簡易モード（associated value なし）。
-    private enum PickerMode: String, CaseIterable {
-        case project
-        case transcript
-    }
-
-    private var pickerSelection: Binding<PickerMode> {
-        Binding(
-            get: { viewModel.selectedAgentMode.isTranscript ? .transcript : .project },
-            set: { viewModel.selectedAgentMode = $0 == .project ? .project : .transcript(store: viewModel.store) }
-        )
-    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -25,7 +12,7 @@ struct AgentSidebarView: View {
                 Divider()
                 AgentChatView(service: service)
             } else {
-                agentModePicker
+                AgentLauncherView(viewModel: viewModel, sidebarViewModel: sidebarViewModel)
             }
         }
     }
@@ -54,50 +41,94 @@ struct AgentSidebarView: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
     }
+}
 
-    // MARK: - Mode Picker
+/// Agent 起動前のランチャー画面。テキスト入力でプロジェクトモード、空入力で Transcript ボタンを表示。
+private struct AgentLauncherView: View {
+    @ObservedObject var viewModel: CaptionViewModel
+    var sidebarViewModel: SidebarViewModel
+    @State private var inputText = ""
+    @FocusState private var isTextFieldFocused: Bool
 
-    private var agentModePicker: some View {
-        VStack(spacing: 16) {
+    private var hasContent: Bool {
+        !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var isDisabled: Bool {
+        sidebarViewModel.selectedProjectURL == nil
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
             Spacer()
 
             Image(systemName: "sparkles")
-                .font(.largeTitle)
+                .font(.system(size: 36))
                 .foregroundStyle(.purple)
+                .padding(.bottom, 8)
 
             Text(L10n.agent)
                 .font(.headline)
+                .padding(.bottom, 4)
 
-            Picker(L10n.agent, selection: pickerSelection) {
-                Text(L10n.agentProjectMode).tag(PickerMode.project)
-                Text(L10n.agentTranscriptMode).tag(PickerMode.transcript)
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .padding(.horizontal, 20)
-
-            Text(viewModel.selectedAgentMode.isTranscript
-                ? L10n.agentTranscriptModeDescription
-                : L10n.agentProjectModeDescription)
+            Text(hasContent ? L10n.agentProjectModeDescription : L10n.agentTranscriptModeDescription)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 20)
 
-            Button {
-                viewModel.startAgent(mode: viewModel.selectedAgentMode)
-            } label: {
-                Label(L10n.startAgent, systemImage: "play.fill")
-                    .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-            .padding(.horizontal, 20)
-            .disabled(sidebarViewModel.selectedProjectURL == nil)
-
             Spacer()
+
+            Divider()
+            agentLauncherInputBar
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var agentLauncherInputBar: some View {
+        HStack(spacing: 8) {
+            TextField("メッセージを入力...", text: $inputText)
+                .textFieldStyle(.plain)
+                .font(.body)
+                .focused($isTextFieldFocused)
+                .onSubmit {
+                    guard hasContent else { return }
+                    launchProjectMode()
+                }
+
+            Button {
+                if hasContent {
+                    launchProjectMode()
+                } else {
+                    launchTranscriptMode()
+                }
+            } label: {
+                Image(systemName: hasContent ? "arrow.up.circle.fill" : "waveform.badge.microphone")
+                    .font(.system(size: 22))
+                    .foregroundStyle(hasContent ? Color.accentColor : .purple)
+            }
+            .buttonStyle(.plain)
+            .help(hasContent ? L10n.agentProjectMode : L10n.agentTranscriptMode)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .disabled(isDisabled)
+        .onAppear {
+            DispatchQueue.main.async {
+                isTextFieldFocused = true
+            }
+        }
+    }
+
+    private func launchProjectMode() {
+        let message = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !message.isEmpty else { return }
+        viewModel.startAgent(mode: .project, initialMessage: message)
+        inputText = ""
+    }
+
+    private func launchTranscriptMode() {
+        viewModel.startAgent(mode: .transcript(store: viewModel.store))
     }
 }
 

--- a/Sources/Dahlia/Views/AgentTabView.swift
+++ b/Sources/Dahlia/Views/AgentTabView.swift
@@ -32,7 +32,6 @@ struct AgentSidebarView: View {
 
     // MARK: - Agent Header
 
-    @ViewBuilder
     private func agentHeader(service: AgentService) -> some View {
         HStack {
             Image(systemName: "sparkles")
@@ -407,7 +406,6 @@ private struct MarkdownContentView: View {
         }
     }
 
-    @ViewBuilder
     private func tableView(headers: [String], rows: [[String]]) -> some View {
         Grid(alignment: .leading, horizontalSpacing: 0, verticalSpacing: 0) {
             // ヘッダー行
@@ -484,7 +482,7 @@ private struct MarkdownContentView: View {
             }
 
             // 水平線
-            if trimmed.allSatisfy({ $0 == "-" || $0 == " " }), trimmed.filter({ $0 == "-" }).count >= 3 {
+            if trimmed.allSatisfy({ $0 == "-" || $0 == " " }), trimmed.count(where: { $0 == "-" }) >= 3 {
                 blocks.append(.horizontalRule)
                 i += 1
                 continue

--- a/Sources/Dahlia/Views/AgentTabView.swift
+++ b/Sources/Dahlia/Views/AgentTabView.swift
@@ -152,15 +152,17 @@ private struct AgentChatView: View {
                 }
             }
 
-            // 入力欄
+            // 入力欄（インスペクター内では初回フォーカスが当たらないことがあるため明示的にフォーカスする）
             Divider()
-            ChatInputBar(text: $inputText) {
+            ChatInputBar(
+                text: $inputText,
+                isEnabled: service.isRunning
+            ) {
                 let message = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !message.isEmpty else { return }
                 service.sendUserMessage(message)
                 inputText = ""
             }
-            .disabled(!service.isRunning)
         }
     }
 }
@@ -168,7 +170,10 @@ private struct AgentChatView: View {
 /// チャット入力バー。
 private struct ChatInputBar: View {
     @Binding var text: String
+    var isEnabled: Bool
     let onSend: () -> Void
+
+    @FocusState private var isTextFieldFocused: Bool
 
     private var hasContent: Bool {
         !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -179,6 +184,7 @@ private struct ChatInputBar: View {
             TextField("メッセージを入力...", text: $text)
                 .textFieldStyle(.plain)
                 .font(.body)
+                .focused($isTextFieldFocused)
                 .onSubmit(onSend)
 
             Button(action: onSend) {
@@ -191,6 +197,19 @@ private struct ChatInputBar: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+        .disabled(!isEnabled)
+        .onAppear {
+            guard isEnabled else { return }
+            DispatchQueue.main.async {
+                isTextFieldFocused = true
+            }
+        }
+        .onChange(of: isEnabled) { _, enabled in
+            guard enabled else { return }
+            DispatchQueue.main.async {
+                isTextFieldFocused = true
+            }
+        }
     }
 }
 

--- a/Sources/Dahlia/Views/AgentTabView.swift
+++ b/Sources/Dahlia/Views/AgentTabView.swift
@@ -128,11 +128,28 @@ private struct AgentLauncherView: View {
     }
 
     private func launchTranscriptMode() {
-        viewModel.startAgent(
-            mode: .transcript(store: viewModel.store),
-            initialMessage: "文字起こしモードを開始します。リアルタイムの文字起こしが随時送信されます。準備ができたら教えてください。",
-            workingDirectory: sidebarViewModel.selectedProjectURL,
-        )
+        Task {
+            // 録音中でなければ文字起こしも同時に開始する
+            if !viewModel.isListening,
+               let dbQueue = sidebarViewModel.dbQueue,
+               let projectURL = sidebarViewModel.selectedProjectURL,
+               let project = sidebarViewModel.selectedProject,
+               let vaultURL = sidebarViewModel.currentVault?.url {
+                await viewModel.startListening(
+                    dbQueue: dbQueue,
+                    projectURL: projectURL,
+                    projectId: project.id,
+                    projectName: project.name,
+                    vaultURL: vaultURL,
+                )
+            }
+
+            viewModel.startAgent(
+                mode: .transcript(store: viewModel.store),
+                initialMessage: "文字起こしモードを開始します。リアルタイムの文字起こしが随時送信されます。準備ができたら教えてください。",
+                workingDirectory: sidebarViewModel.selectedProjectURL,
+            )
+        }
     }
 }
 
@@ -266,22 +283,30 @@ private struct ChatBubbleView: View {
     private var isUser: Bool { message.role == .user }
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
-            if isUser {
+        if message.role == .toolUse {
+            HStack(alignment: .top, spacing: 8) {
+                Color.clear.frame(width: 28, height: 28)
+                ToolUseCardView(message: message)
                 Spacer(minLength: 60)
-            } else {
-                avatarView
-                    .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] }
             }
+        } else {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                if isUser {
+                    Spacer(minLength: 60)
+                } else {
+                    avatarView
+                        .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] }
+                }
 
-            bubbleContent
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .background(bubbleBackground, in: RoundedRectangle(cornerRadius: 12))
-                .frame(maxWidth: .infinity, alignment: isUser ? .trailing : .leading)
+                bubbleContent
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(bubbleBackground, in: RoundedRectangle(cornerRadius: 12))
+                    .frame(maxWidth: .infinity, alignment: isUser ? .trailing : .leading)
 
-            if !isUser {
-                Spacer(minLength: 60)
+                if !isUser {
+                    Spacer(minLength: 60)
+                }
             }
         }
     }
@@ -307,7 +332,7 @@ private struct ChatBubbleView: View {
                 .foregroundStyle(.secondary)
                 .frame(width: 28, height: 28)
                 .background(.secondary.opacity(0.1), in: Circle())
-        case .user:
+        case .user, .toolUse:
             EmptyView()
         }
     }
@@ -332,6 +357,8 @@ private struct ChatBubbleView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .textSelection(.enabled)
+        case .toolUse:
+            EmptyView()
         }
     }
 
@@ -341,6 +368,202 @@ private struct ChatBubbleView: View {
         case .assistant: AnyShapeStyle(.background.secondary)
         case .error: AnyShapeStyle(Color.red.opacity(0.1))
         case .system: AnyShapeStyle(.background.tertiary)
+        case .toolUse: AnyShapeStyle(.clear)
+        }
+    }
+}
+
+// MARK: - Tool Use Card View
+
+/// ツール呼び出しをカード形式で表示するビュー。
+private struct ToolUseCardView: View {
+    let message: AgentMessage
+
+    private var info: ToolCallInfo? { message.toolCallInfo }
+    private var toolName: String { info?.toolName ?? "" }
+    private var hasResult: Bool { info?.toolResult != nil }
+    private var isError: Bool { info?.toolResult?.isError == true }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            toolHeader
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+
+            // TodoWrite: チェックリスト表示
+            if toolName == "TodoWrite" {
+                todoWriteSection
+            }
+
+            // Edit: diff 表示
+            if toolName == "Edit", let input = info?.toolInput {
+                editDiffSection(input: input)
+            }
+
+            // ツール結果（omit リストに含まれないもの）
+            if let result = info?.toolResult,
+               !AgentService.toolsOmitResult.contains(toolName) {
+                Divider()
+                toolResultSection(result)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+            }
+        }
+        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 8))
+        .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.separator, lineWidth: 0.5))
+    }
+
+    // MARK: - Header
+
+    private var toolHeader: some View {
+        HStack(spacing: 6) {
+            Image(systemName: toolIcon)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+
+            Text(toolName)
+                .font(.caption.bold())
+
+            if !AgentService.toolsOmitInputSummary.contains(toolName) {
+                Text(message.content)
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            Spacer(minLength: 0)
+
+            statusIndicator
+        }
+    }
+
+    private var toolIcon: String {
+        switch toolName {
+        case "Bash": "terminal.fill"
+        case "Read": "doc.text"
+        case "Write": "doc.badge.plus"
+        case "Edit": "pencil"
+        case "Grep": "magnifyingglass"
+        case "Glob": "folder.badge.magnifyingglass"
+        case "TodoWrite": "checklist"
+        case "Agent": "person.2"
+        case "Skill": "wand.and.stars"
+        default: "wrench"
+        }
+    }
+
+    @ViewBuilder
+    private var statusIndicator: some View {
+        if !hasResult {
+            ProgressView()
+                .controlSize(.mini)
+        } else if isError {
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 12))
+                .foregroundStyle(.red)
+        } else {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 12))
+                .foregroundStyle(.green)
+        }
+    }
+
+    // MARK: - TodoWrite
+
+    @ViewBuilder
+    private var todoWriteSection: some View {
+        if let todos = info?.toolInput["todos"] as? [[String: Any]], !todos.isEmpty {
+            Divider()
+            VStack(alignment: .leading, spacing: 3) {
+                ForEach(Array(todos.enumerated()), id: \.offset) { _, todo in
+                    let status = todo["status"] as? String ?? "pending"
+                    let content = todo["content"] as? String ?? ""
+                    HStack(spacing: 6) {
+                        Image(systemName: todoStatusIcon(status))
+                            .font(.system(size: 12))
+                            .foregroundStyle(todoStatusColor(status))
+                        Text(content)
+                            .font(.caption)
+                            .foregroundStyle(status == "completed" ? .secondary : .primary)
+                    }
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+        }
+    }
+
+    private func todoStatusIcon(_ status: String) -> String {
+        switch status {
+        case "completed": "checkmark.square.fill"
+        case "in_progress": "square.dotted"
+        default: "square"
+        }
+    }
+
+    private func todoStatusColor(_ status: String) -> Color {
+        switch status {
+        case "completed": .green
+        case "in_progress": .blue
+        default: .secondary
+        }
+    }
+
+    // MARK: - Edit Diff
+
+    @ViewBuilder
+    private func editDiffSection(input: [String: Any]) -> some View {
+        let oldString = input["old_string"] as? String
+        let newString = input["new_string"] as? String
+        if oldString != nil || newString != nil {
+            Divider()
+            VStack(alignment: .leading, spacing: 0) {
+                if let old = oldString {
+                    ForEach(Array(old.components(separatedBy: "\n").enumerated()), id: \.offset) { _, line in
+                        Text("- \(line)")
+                            .font(.system(.caption2, design: .monospaced))
+                            .foregroundStyle(.red)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 4)
+                            .background(Color.red.opacity(0.08))
+                    }
+                }
+                if let new = newString {
+                    ForEach(Array(new.components(separatedBy: "\n").enumerated()), id: \.offset) { _, line in
+                        Text("+ \(line)")
+                            .font(.system(.caption2, design: .monospaced))
+                            .foregroundStyle(.green)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 4)
+                            .background(Color.green.opacity(0.08))
+                    }
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    // MARK: - Tool Result
+
+    @ViewBuilder
+    private func toolResultSection(_ result: ToolResultInfo) -> some View {
+        if result.isError {
+            HStack(alignment: .top, spacing: 4) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.red)
+                Text(result.content)
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundStyle(.red)
+                    .textSelection(.enabled)
+            }
+        } else {
+            Text(result.content.prefix(500))
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+                .textSelection(.enabled)
         }
     }
 }

--- a/Sources/Dahlia/Views/AgentTabView.swift
+++ b/Sources/Dahlia/Views/AgentTabView.swift
@@ -123,12 +123,16 @@ private struct AgentLauncherView: View {
     private func launchProjectMode() {
         let message = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !message.isEmpty else { return }
-        viewModel.startAgent(mode: .project, initialMessage: message)
+        viewModel.startAgent(mode: .project, initialMessage: message, workingDirectory: sidebarViewModel.selectedProjectURL)
         inputText = ""
     }
 
     private func launchTranscriptMode() {
-        viewModel.startAgent(mode: .transcript(store: viewModel.store))
+        viewModel.startAgent(
+            mode: .transcript(store: viewModel.store),
+            initialMessage: "文字起こしモードを開始します。リアルタイムの文字起こしが随時送信されます。準備ができたら教えてください。",
+            workingDirectory: sidebarViewModel.selectedProjectURL,
+        )
     }
 }
 
@@ -162,6 +166,18 @@ private struct AgentChatView: View {
                         LazyVStack(spacing: 12) {
                             ForEach(service.messages) { message in
                                 ChatBubbleView(message: message)
+                            }
+
+                            if service.isProcessing {
+                                HStack(spacing: 8) {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                    Text(L10n.agentProcessing)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.leading, 36)
                             }
 
                             // スクロールアンカー

--- a/Sources/Dahlia/Views/AgentTabView.swift
+++ b/Sources/Dahlia/Views/AgentTabView.swift
@@ -4,17 +4,27 @@ import SwiftUI
 struct AgentSidebarView: View {
     @ObservedObject var viewModel: CaptionViewModel
     var sidebarViewModel: SidebarViewModel
-    @State private var selectedMode: AgentStartMode = .project
+
+    /// Picker 用の簡易モード（associated value なし）。
+    private enum PickerMode: String, CaseIterable {
+        case project
+        case transcript
+    }
+
+    private var pickerSelection: Binding<PickerMode> {
+        Binding(
+            get: { viewModel.selectedAgentMode.isTranscript ? .transcript : .project },
+            set: { viewModel.selectedAgentMode = $0 == .project ? .project : .transcript(store: viewModel.store) }
+        )
+    }
 
     var body: some View {
         VStack(spacing: 0) {
             if let service = viewModel.agentService {
-                // ── Agent 起動中 ──
                 agentHeader(service: service)
                 Divider()
                 AgentChatView(service: service)
             } else {
-                // ── Agent 未起動: モード選択 ──
                 agentModePicker
             }
         }
@@ -27,7 +37,7 @@ struct AgentSidebarView: View {
         HStack {
             Image(systemName: "sparkles")
                 .foregroundStyle(.purple)
-            Text(service.mode == .project ? L10n.agentProjectMode : L10n.agentTranscriptMode)
+            Text(service.mode.isTranscript ? L10n.agentTranscriptMode : L10n.agentProjectMode)
                 .font(.caption)
                 .foregroundStyle(.secondary)
             Spacer()
@@ -59,22 +69,24 @@ struct AgentSidebarView: View {
             Text(L10n.agent)
                 .font(.headline)
 
-            Picker(L10n.agent, selection: $selectedMode) {
-                Text(L10n.agentProjectMode).tag(AgentStartMode.project)
-                Text(L10n.agentTranscriptMode).tag(AgentStartMode.transcript)
+            Picker(L10n.agent, selection: pickerSelection) {
+                Text(L10n.agentProjectMode).tag(PickerMode.project)
+                Text(L10n.agentTranscriptMode).tag(PickerMode.transcript)
             }
             .pickerStyle(.segmented)
             .labelsHidden()
             .padding(.horizontal, 20)
 
-            Text(selectedMode == .project ? L10n.agentProjectModeDescription : L10n.agentTranscriptModeDescription)
+            Text(viewModel.selectedAgentMode.isTranscript
+                ? L10n.agentTranscriptModeDescription
+                : L10n.agentProjectModeDescription)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 20)
 
             Button {
-                viewModel.startAgent(mode: selectedMode)
+                viewModel.startAgent(mode: viewModel.selectedAgentMode)
             } label: {
                 Label(L10n.startAgent, systemImage: "play.fill")
                     .frame(maxWidth: .infinity)

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -28,10 +28,12 @@ struct ContentView: View {
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 if appSettings.agentEnabled {
+                    let isAgentRunning = viewModel.agentService?.isRunning == true
                     Button {
                         isInspectorPresented.toggle()
                     } label: {
                         Label(L10n.agent, systemImage: "sparkles")
+                            .foregroundStyle(isAgentRunning ? .purple : .secondary)
                     }
                     .help(L10n.agent)
                 }

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -6,6 +6,8 @@ struct ContentView: View {
     var sidebarViewModel: SidebarViewModel
     var onSelectVault: (VaultRecord) -> Void = { _ in }
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
+    @State private var isInspectorPresented = false
+    @AppStorage("agentEnabled") private var agentEnabled = false
 
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
@@ -18,6 +20,27 @@ struct ContentView: View {
             .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 360)
         } detail: {
             ControlPanelView(viewModel: viewModel, sidebarViewModel: sidebarViewModel)
+        }
+        .inspector(isPresented: $isInspectorPresented) {
+            AgentSidebarView(viewModel: viewModel, sidebarViewModel: sidebarViewModel)
+                .inspectorColumnWidth(min: 280, ideal: 340, max: 480)
+        }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                if agentEnabled {
+                    Button {
+                        isInspectorPresented.toggle()
+                    } label: {
+                        Label(L10n.agent, systemImage: "sparkles")
+                    }
+                    .help(L10n.agent)
+                }
+            }
+        }
+        .onChange(of: viewModel.currentTranscriptionId) { _, _ in
+            if let service = viewModel.agentService, service.mode == .transcript {
+                service.resetSegmentTracking(store: viewModel.store)
+            }
         }
     }
 }

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -6,10 +6,16 @@ struct ContentView: View {
     var sidebarViewModel: SidebarViewModel
     var onSelectVault: (VaultRecord) -> Void = { _ in }
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
-    @State private var isInspectorPresented = false
+    @State private var isAgentSidebarPresented = false
     @ObservedObject private var appSettings = AppSettings.shared
 
     var body: some View {
+        let controlPanel = ControlPanelView(
+            viewModel: viewModel,
+            sidebarViewModel: sidebarViewModel,
+            isAgentSidebarPresented: $isAgentSidebarPresented
+        )
+
         NavigationSplitView(columnVisibility: $columnVisibility) {
             SidebarView(
                 viewModel: viewModel,
@@ -19,39 +25,27 @@ struct ContentView: View {
             )
             .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 360)
         } detail: {
-            ControlPanelView(viewModel: viewModel, sidebarViewModel: sidebarViewModel)
-        }
-        .inspector(isPresented: $isInspectorPresented) {
-            AgentSidebarView(viewModel: viewModel, sidebarViewModel: sidebarViewModel)
-                .inspectorColumnWidth(min: 280, ideal: 340, max: 480)
-        }
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                if viewModel.currentTranscriptionId != nil {
-                    Button(L10n.export, systemImage: "square.and.arrow.up") {
-                        viewModel.exportTranscript()
-                    }
-                    .labelStyle(.iconOnly)
-                    .disabled(viewModel.store.segments.isEmpty)
-                    .help(L10n.export)
+            if appSettings.agentEnabled, isAgentSidebarPresented {
+                HSplitView {
+                    controlPanel
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                    AgentSidebarView(viewModel: viewModel, sidebarViewModel: sidebarViewModel)
+                        .frame(minWidth: 280, idealWidth: 340, maxWidth: 480, maxHeight: .infinity)
+                        .background(.background)
                 }
-            }
-            ToolbarItem(placement: .primaryAction) {
-                if appSettings.agentEnabled {
-                    let isAgentRunning = viewModel.agentService?.isRunning == true
-                    Button {
-                        isInspectorPresented.toggle()
-                    } label: {
-                        Label(L10n.agent, systemImage: "sparkles")
-                            .foregroundStyle(isAgentRunning ? .purple : .secondary)
-                    }
-                    .help(L10n.agent)
-                }
+            } else {
+                controlPanel
             }
         }
         .onChange(of: viewModel.currentTranscriptionId) { oldId, newId in
             guard oldId != newId else { return }
             viewModel.resetAgentSegmentTrackingIfNeeded()
+        }
+        .onChange(of: appSettings.agentEnabled) { _, isEnabled in
+            if !isEnabled {
+                isAgentSidebarPresented = false
+            }
         }
     }
 }

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -27,6 +27,16 @@ struct ContentView: View {
         }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
+                if viewModel.currentTranscriptionId != nil {
+                    Button(L10n.export, systemImage: "square.and.arrow.up") {
+                        viewModel.exportTranscript()
+                    }
+                    .labelStyle(.iconOnly)
+                    .disabled(viewModel.store.segments.isEmpty)
+                    .help(L10n.export)
+                }
+            }
+            ToolbarItem(placement: .primaryAction) {
                 if appSettings.agentEnabled {
                     let isAgentRunning = viewModel.agentService?.isRunning == true
                     Button {

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -7,7 +7,7 @@ struct ContentView: View {
     var onSelectVault: (VaultRecord) -> Void = { _ in }
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
     @State private var isInspectorPresented = false
-    @AppStorage("agentEnabled") private var agentEnabled = false
+    @ObservedObject private var appSettings = AppSettings.shared
 
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
@@ -27,7 +27,7 @@ struct ContentView: View {
         }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
-                if agentEnabled {
+                if appSettings.agentEnabled {
                     Button {
                         isInspectorPresented.toggle()
                     } label: {
@@ -37,10 +37,9 @@ struct ContentView: View {
                 }
             }
         }
-        .onChange(of: viewModel.currentTranscriptionId) { _, _ in
-            if let service = viewModel.agentService, service.mode == .transcript {
-                service.resetSegmentTracking(store: viewModel.store)
-            }
+        .onChange(of: viewModel.currentTranscriptionId) { oldId, newId in
+            guard oldId != newId else { return }
+            viewModel.resetAgentSegmentTrackingIfNeeded()
         }
     }
 }

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -18,7 +18,6 @@ enum DetailTab: String, CaseIterable, Identifiable {
     case notes
     case screenshots
     case transcript
-    case agent
 
     var id: String { rawValue }
 
@@ -28,7 +27,6 @@ enum DetailTab: String, CaseIterable, Identifiable {
         case .notes: L10n.notes
         case .screenshots: L10n.screenshots
         case .transcript: L10n.transcript
-        case .agent: L10n.agent
         }
     }
 
@@ -38,7 +36,6 @@ enum DetailTab: String, CaseIterable, Identifiable {
         case .notes: "pencil.line"
         case .screenshots: "photo.on.rectangle.angled"
         case .transcript: "waveform.badge.microphone"
-        case .agent: "sparkles"
         }
     }
 }
@@ -48,7 +45,6 @@ private struct DetailTabBar: View {
     @Binding var selection: DetailTab
     @ObservedObject var viewModel: CaptionViewModel
     var sidebarViewModel: SidebarViewModel
-    @AppStorage("agentEnabled") private var agentEnabled = false
     @Namespace private var tabNamespace
 
     /// フォルダ選択時（transcription 未選択）は全タブを無効化する。
@@ -56,15 +52,9 @@ private struct DetailTabBar: View {
         viewModel.currentTranscriptionId == nil
     }
 
-    private var visibleTabs: [DetailTab] {
-        DetailTab.allCases.filter { tab in
-            tab != .agent || agentEnabled
-        }
-    }
-
     var body: some View {
         HStack(spacing: 2) {
-            ForEach(visibleTabs) { tab in
+            ForEach(DetailTab.allCases) { tab in
                 DetailTabButton(
                     tab: tab,
                     isSelected: !isFolderOnly && selection == tab,
@@ -461,7 +451,6 @@ struct ControlPanelView: View {
     var sidebarViewModel: SidebarViewModel
     @State private var selectedTab: DetailTab = .transcript
     @State private var expandedScreenshot: ScreenshotRecord?
-    @AppStorage("agentEnabled") private var agentEnabled = false
 
     var body: some View {
         VStack(spacing: 12) {
@@ -488,8 +477,6 @@ struct ControlPanelView: View {
                         screenshotsTabContent
                     case .transcript:
                         transcriptTabContent
-                    case .agent:
-                        AgentTabView(viewModel: viewModel)
                     }
                 }
             }
@@ -526,11 +513,6 @@ struct ControlPanelView: View {
         }
         .padding()
         .frame(minWidth: 500, minHeight: 500)
-        .onChange(of: agentEnabled) {
-            if !agentEnabled, selectedTab == .agent {
-                selectedTab = .transcript
-            }
-        }
         .onChange(of: viewModel.requestShowSummaryTab) {
             if viewModel.requestShowSummaryTab {
                 selectedTab = .summary

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -1,17 +1,6 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
-/// ホバー時に背景がハイライトされるアイコンボタンスタイル。
-struct ToolbarIconButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .padding(6)
-            .glassEffect(.regular.interactive(), in: RoundedRectangle(cornerRadius: 5))
-            .opacity(configuration.isPressed ? 0.7 : 1.0)
-            .pointerStyle(.link)
-    }
-}
-
 /// メイン領域のタブ種別。
 enum DetailTab: String, CaseIterable, Identifiable {
     case summary
@@ -449,8 +438,10 @@ private struct DetailTabButton: View {
 struct ControlPanelView: View {
     @ObservedObject var viewModel: CaptionViewModel
     var sidebarViewModel: SidebarViewModel
+    @Binding var isAgentSidebarPresented: Bool
     @State private var selectedTab: DetailTab = .transcript
     @State private var expandedScreenshot: ScreenshotRecord?
+    @ObservedObject private var appSettings = AppSettings.shared
 
     var body: some View {
         VStack(spacing: 12) {
@@ -520,7 +511,24 @@ struct ControlPanelView: View {
             }
         }
         .navigationTitle(headerTitle)
-        .toolbar {}
+        .toolbar {
+            ToolbarItemGroup(placement: .primaryAction) {
+                if viewModel.currentTranscriptionId != nil {
+                    Button(L10n.export, systemImage: "square.and.arrow.up", action: exportTranscript)
+                        .labelStyle(.iconOnly)
+                        .disabled(viewModel.store.segments.isEmpty)
+                        .help(L10n.export)
+                }
+
+                if appSettings.agentEnabled {
+                    Button(action: toggleAgentSidebar) {
+                        Label(L10n.agent, systemImage: "sparkles")
+                            .foregroundStyle(isAgentRunning ? .purple : .secondary)
+                    }
+                    .help(L10n.agent)
+                }
+            }
+        }
         .overlay(alignment: .bottomTrailing) {
             if viewModel.summaryProgress.isVisible {
                 SummaryProgressToastView(state: viewModel.summaryProgress)
@@ -692,6 +700,10 @@ struct ControlPanelView: View {
 
     // MARK: - Computed
 
+    private var isAgentRunning: Bool {
+        viewModel.agentService?.isRunning == true
+    }
+
     /// ヘッダーに表示する「プロジェクト名 - トランスクリプション名」。
     private var headerTitle: String {
         guard let project = sidebarViewModel.selectedProject else { return "" }
@@ -711,5 +723,13 @@ struct ControlPanelView: View {
         f.dateFormat = "yyyy/MM/dd HH:mm"
         return f
     }()
+
+    private func exportTranscript() {
+        viewModel.exportTranscript()
+    }
+
+    private func toggleAgentSidebar() {
+        isAgentSidebarPresented.toggle()
+    }
 
 }

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -570,7 +570,6 @@ struct ControlPanelView: View {
         }
     }
 
-    @ViewBuilder
     private var notesTabContent: some View {
         TextEditor(text: $viewModel.noteText)
             .font(.body)

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -520,18 +520,7 @@ struct ControlPanelView: View {
             }
         }
         .navigationTitle(headerTitle)
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                if viewModel.currentTranscriptionId != nil {
-                    Button(L10n.export, systemImage: "square.and.arrow.up") {
-                        viewModel.exportTranscript()
-                    }
-                    .labelStyle(.iconOnly)
-                    .disabled(viewModel.store.segments.isEmpty)
-                    .help(L10n.export)
-                }
-            }
-        }
+        .toolbar {}
         .overlay(alignment: .bottomTrailing) {
             if viewModel.summaryProgress.isVisible {
                 SummaryProgressToastView(state: viewModel.summaryProgress)

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -37,8 +37,9 @@ private struct DetailTabBar: View {
     @Namespace private var tabNamespace
 
     /// フォルダ選択時（transcription 未選択）は全タブを無効化する。
+    /// 録音中は録音対象が存在するためタブを無効化しない。
     private var isFolderOnly: Bool {
-        viewModel.currentTranscriptionId == nil
+        viewModel.currentTranscriptionId == nil && !viewModel.isListening
     }
 
     var body: some View {
@@ -632,8 +633,8 @@ struct ControlPanelView: View {
                                 TranscriptRowView(segment: segment)
                             }
 
-                            // 録音中インジケータ
-                            if viewModel.isListening {
+                            // 録音中インジケータ（録音対象のトランスクリプト表示中のみ）
+                            if viewModel.isListening, !viewModel.isViewingOtherWhileRecording {
                                 HStack(spacing: 6) {
                                     ProgressView()
                                         .scaleEffect(0.5)

--- a/Sources/Dahlia/Views/SidebarView.swift
+++ b/Sources/Dahlia/Views/SidebarView.swift
@@ -164,8 +164,6 @@ struct SidebarView: View {
             viewModel.clearCurrentTranscription()
             return
         }
-        if viewModel.isListening, viewModel.currentTranscriptionId == transcriptionId { return }
-        guard !viewModel.isListening else { return }
 
         guard let dbQueue = sidebarViewModel.dbQueue,
               let projectURL = sidebarViewModel.selectedProjectURL,
@@ -321,8 +319,12 @@ private struct ProjectSectionView: View {
     }
 
     private func selectRow(_ row: FlatProjectRow) {
+        let hadSelection = sidebarViewModel.selectedTranscriptionId != nil
         sidebarViewModel.selectProject(id: row.id, name: row.name)
-        viewModel.clearCurrentTranscription()
+        // selectedTranscriptionId が nil → nil の場合 onChange が発火しないため直接呼ぶ
+        if !hadSelection {
+            viewModel.clearCurrentTranscription()
+        }
     }
 
     // MARK: - Transcription Row

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -47,7 +47,7 @@ if [ -d "$RESOURCE_BUNDLE" ]; then
 fi
 
 # コード署名（CODESIGN_IDENTITY 環境変数で署名 ID をオーバーライド可能）
-SIGN_IDENTITY="${CODESIGN_IDENTITY:--}"
+SIGN_IDENTITY="${CODESIGN_IDENTITY:-Developer ID Application: Kazuki Matsuda (XCHHYPN52N)}"
 codesign --force --sign "$SIGN_IDENTITY" --entitlements "${PROJECT_DIR}/Dahlia.entitlements" "${APP_BUNDLE}"
 
 echo "=== Build complete: ${APP_BUNDLE} ==="

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -7,6 +7,13 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
 cd "$PROJECT_DIR"
 
+# .env.local から環境変数を読み込む（SENTRY_DSN など）
+if [ -f .env.local ]; then
+    set -a
+    source .env.local
+    set +a
+fi
+
 echo "=== Building ${APP_NAME} (debug) ==="
 swift build
 

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -13,7 +13,8 @@ swift build
 BINARY=".build/debug/${APP_NAME}"
 
 # エンタイトルメント付きで署名（Data Protection Keychain + Touch ID が有効になる）
-codesign --force --sign - --entitlements "${PROJECT_DIR}/Dahlia.entitlements" "$BINARY"
+SIGN_IDENTITY="${CODESIGN_IDENTITY:-Developer ID Application: Kazuki Matsuda (XCHHYPN52N)}"
+codesign --force --sign "$SIGN_IDENTITY" --entitlements "${PROJECT_DIR}/Dahlia.entitlements" "$BINARY"
 
 echo "=== Running ${APP_NAME} ==="
 exec "$BINARY"


### PR DESCRIPTION
## 概要

- Agent を detail タブからナビゲーション右サイドバー（Inspector）に移動
- AgentService にツール呼び出し・結果の追跡機能を追加し、カード形式で UI 表示
- 録音中に他のフォルダ/トランスクリプトへナビゲーション可能に（録音パイプラインはバックグラウンドで継続）

## 主な変更

### Agent サイドバー
- `ContentView`: `NavigationSplitView` の detail 内で `HSplitView` を使い Agent サイドバーを表示
- `AgentTabView`: ツール呼び出しをカード形式（`ToolUseCardView`）で表示。Edit の diff、TodoWrite のチェックリストに対応
- `AgentService`: `tool_use` / `tool_result` メッセージのパース・マージ、ツール入力サマリー生成
- Agent の Transcript モードを起動する際に、未録音であれば自動的に録音を開始

### 録音中ナビゲーション修正
- `CaptionViewModel`: 録音コンテキスト（`RecordingContext` 構造体）と表示コンテキストを分離し、録音中でもサイドバーから別のトランスクリプトを閲覧可能に
- `SidebarView`: 録音中のナビゲーションガードを削除
- `ControlPanelView`: 録音中のタブ無効化・Recognizing インジケータ表示を適切に制御

## テスト計画

- [ ] Agent サイドバーの表示/非表示（ツールバーボタン）
- [ ] Project モード / Transcript モードの起動・チャット
- [ ] ツールカード（Bash, Edit, TodoWrite 等）の表示
- [ ] 録音開始 → 別フォルダをクリック → タブが有効のまま
- [ ] 録音開始 → 別トランスクリプトをクリック → 履歴表示、Recognizing 非表示
- [ ] 上記から録音中トランスクリプトに戻る → ライブ表示復帰
- [ ] 録音停止 → 要約が正常生成される
- [ ] 非録音時のナビゲーションが従来通り動作