### PR TITLE
Update Ask launcher layout and localization

### DIFF
--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -104,6 +104,11 @@
 "Stop Agent" = "Stop";
 "Live mode" = "Live mode";
 "Thinking…" = "Thinking…";
+"Ask anything about your meetings, notes, and transcripts." = "Ask anything about your meetings, notes, and transcripts.";
+"Ask anything about meetings, people, tasks, or transcripts…" = "Ask anything about meetings, people, tasks, or transcripts…";
+"Prep me for this week's project meeting" = "Prep me for this week's project meeting";
+"What did we discuss with this customer recently?" = "What did we discuss with this customer recently?";
+"Show my open action items" = "Show my open action items";
 "Enable Agent in Settings to use Ask." = "Enable Agent in Settings to use Ask.";
 
 /* Settings (Agent) */

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -104,6 +104,11 @@
 "Stop Agent" = "停止";
 "Live mode" = "Live mode";
 "Thinking…" = "考え中…";
+"Ask anything about your meetings, notes, and transcripts." = "ミーティング、ノート、文字起こしについて何でも聞けます。";
+"Ask anything about meetings, people, tasks, or transcripts…" = "ミーティング、人、タスク、文字起こしについて質問してください…";
+"Prep me for this week's project meeting" = "今週のプロジェクト会議に向けて準備して";
+"What did we discuss with this customer recently?" = "この顧客と最近何を話した？";
+"Show my open action items" = "自分の未完了アクションアイテムを見せて";
 "Enable Agent in Settings to use Ask." = "Ask を使うには設定で Agent を有効にしてください。";
 
 /* Settings (Agent) */

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -152,6 +152,26 @@ enum L10n {
     static var stopAgent: String { String(localized: "Stop Agent", bundle: bundle) }
     static var agentLiveMode: String { String(localized: "Live mode", bundle: bundle) }
     static var agentProcessing: String { String(localized: "Thinking…", bundle: bundle) }
+    static var askLauncherSubtitle: String { String(
+        localized: "Ask anything about your meetings, notes, and transcripts.",
+        bundle: bundle
+    ) }
+    static var askPromptPlaceholder: String { String(
+        localized: "Ask anything about meetings, people, tasks, or transcripts…",
+        bundle: bundle
+    ) }
+    static var askSuggestionMeetingPrep: String { String(
+        localized: "Prep me for this week's project meeting",
+        bundle: bundle
+    ) }
+    static var askSuggestionRecentDiscussion: String { String(
+        localized: "What did we discuss with this customer recently?",
+        bundle: bundle
+    ) }
+    static var askSuggestionActionItems: String { String(
+        localized: "Show my open action items",
+        bundle: bundle
+    ) }
     static var agentDisabledDescription: String { String(
         localized: "Enable Agent in Settings to use Ask.",
         bundle: bundle

--- a/Sources/Dahlia/Views/AgentTabView.swift
+++ b/Sources/Dahlia/Views/AgentTabView.swift
@@ -72,66 +72,127 @@ private struct AgentLauncherView: View {
         effectiveWorkingDirectory == nil
     }
 
-    var body: some View {
-        ZStack(alignment: .bottom) {
-            VStack(spacing: 0) {
-                Spacer()
-
-                Image(systemName: "sparkles")
-                    .font(.system(size: 36))
-                    .foregroundStyle(.purple)
-                    .padding(.bottom, 8)
-
-                Text(L10n.agent)
-                    .font(.headline)
-                    .padding(.bottom, 4)
-
-                Text(hasContent ? L10n.agentProjectModeDescription : L10n.agentTranscriptModeDescription)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 20)
-
-                Spacer()
-            }
-            .padding(.bottom, AgentFloatingInputMetrics.contentBottomInset)
-
-            agentLauncherInputBar
-                .padding(.bottom, AgentFloatingInputMetrics.bottomPadding)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    private var contextName: String? {
+        effectiveProjectName ?? sidebarViewModel.currentVault?.name
     }
 
-    private var agentLauncherInputBar: some View {
-        HStack(spacing: 8) {
-            TextField("メッセージを入力...", text: $inputText)
-                .textFieldStyle(.plain)
-                .font(.body)
-                .padding(.leading, 4)
-                .focused($isTextFieldFocused)
-                .onSubmit {
-                    guard hasContent else { return }
-                    launchProjectMode()
-                }
+    private var launcherSuggestions: [String] {
+        [
+            L10n.askSuggestionMeetingPrep,
+            L10n.askSuggestionRecentDiscussion,
+            L10n.askSuggestionActionItems,
+        ]
+    }
 
-            Button {
-                if hasContent {
-                    launchProjectMode()
-                } else {
-                    launchTranscriptMode()
+    var body: some View {
+        GeometryReader { proxy in
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: AskLauncherMetrics.sectionSpacing) {
+                    Spacer(minLength: AskLauncherMetrics.topSpacing)
+
+                    VStack(spacing: AskLauncherMetrics.headerSpacing) {
+                        if let contextName, !contextName.isEmpty {
+                            Label(contextName, systemImage: "folder")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 14)
+                                .padding(.vertical, 8)
+                                .background(.background.secondary, in: Capsule())
+                        }
+
+                        Text(L10n.ask)
+                            .font(.system(size: AskLauncherMetrics.titleSize, weight: .bold, design: .rounded))
+                            .foregroundStyle(.primary)
+
+                        Text(L10n.askLauncherSubtitle)
+                            .font(.title3)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+
+                    VStack(alignment: .leading, spacing: AskLauncherMetrics.cardSpacing) {
+                        TextField(L10n.askPromptPlaceholder, text: $inputText, axis: .vertical)
+                            .textFieldStyle(.plain)
+                            .font(.system(size: AskLauncherMetrics.promptSize, weight: .regular, design: .rounded))
+                            .lineLimit(1 ... 5)
+                            .focused($isTextFieldFocused)
+                            .disabled(isDisabled)
+                            .onSubmit {
+                                guard hasContent else { return }
+                                launchProjectMode()
+                            }
+
+                        HStack(alignment: .center, spacing: 12) {
+                            Button(action: launchTranscriptMode) {
+                                Label(L10n.agentTranscriptMode, systemImage: "waveform.badge.magnifyingglass")
+                                    .font(.body)
+                            }
+                            .buttonStyle(.plain)
+                            .foregroundStyle(isDisabled ? .tertiary : .secondary)
+                            .disabled(isDisabled)
+                            .help(L10n.agentTranscriptModeDescription)
+
+                            Spacer(minLength: 0)
+
+                            Button(action: launchProjectMode) {
+                                Image(systemName: "arrow.up")
+                                    .font(.system(size: 20, weight: .semibold))
+                                    .foregroundStyle(hasContent ? .primary : .tertiary)
+                                    .frame(width: 48, height: 48)
+                                    .background(
+                                        Circle()
+                                            .fill(hasContent ? Color.secondary.opacity(0.14) : Color.secondary.opacity(0.08))
+                                    )
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(!hasContent || isDisabled)
+                            .help(L10n.agentProjectMode)
+                        }
+                    }
+                    .padding(AskLauncherMetrics.cardPadding)
+                    .background(askLauncherCardBackground)
+
+                    VStack(alignment: .leading, spacing: AskLauncherMetrics.suggestionSpacing) {
+                        ForEach(launcherSuggestions, id: \.self) { suggestion in
+                            Button {
+                                guard !isDisabled else { return }
+                                inputText = suggestion
+                                launchProjectMode()
+                            } label: {
+                                HStack(spacing: 14) {
+                                    Image(systemName: "arrow.turn.down.right")
+                                        .font(.body)
+                                        .foregroundStyle(.tertiary)
+                                        .frame(width: 18)
+
+                                    Text(suggestion)
+                                        .font(.title3)
+                                        .foregroundStyle(isDisabled ? .tertiary : .secondary)
+                                        .multilineTextAlignment(.leading)
+
+                                    Spacer(minLength: 0)
+                                }
+                                .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(isDisabled)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Spacer(minLength: AskLauncherMetrics.bottomSpacing)
                 }
-            } label: {
-                Image(systemName: hasContent ? "arrow.up.circle.fill" : "waveform.badge.microphone")
-                    .font(.system(size: 22))
-                    .foregroundStyle(hasContent ? Color.accentColor : .purple)
+                .frame(
+                    maxWidth: AskLauncherMetrics.maxContentWidth,
+                    minHeight: max(proxy.size.height, AskLauncherMetrics.minHeight),
+                    alignment: .top
+                )
+                .padding(.horizontal, AskLauncherMetrics.outerPadding)
+                .frame(maxWidth: .infinity)
             }
-            .buttonStyle(.plain)
-            .help(hasContent ? L10n.agentProjectMode : L10n.agentTranscriptMode)
+            .background(askLauncherBackground)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .background(capsuleInputBarBackground)
-        .disabled(isDisabled)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear {
             DispatchQueue.main.async {
                 isTextFieldFocused = true
@@ -654,8 +715,60 @@ private var capsuleInputBarBackground: some View {
         .padding(.vertical, 8)
 }
 
+private var askLauncherBackground: some View {
+    ZStack {
+        Color.clear
+
+        LinearGradient(
+            colors: [
+                Color(nsColor: .windowBackgroundColor),
+                Color(nsColor: .windowBackgroundColor),
+                Color(nsColor: .underPageBackgroundColor),
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+
+        RadialGradient(
+            colors: [
+                .white.opacity(0.55),
+                .clear,
+            ],
+            center: .top,
+            startRadius: 80,
+            endRadius: 420
+        )
+        .blendMode(.plusLighter)
+    }
+}
+
+private var askLauncherCardBackground: some View {
+    RoundedRectangle(cornerRadius: 30)
+        .fill(.ultraThinMaterial)
+        .overlay {
+            RoundedRectangle(cornerRadius: 30)
+                .strokeBorder(.separator.opacity(0.28), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.08), radius: 28, y: 16)
+}
+
 private enum AgentFloatingInputMetrics {
     static let bottomPadding: CGFloat = 24
     static let contentBottomInset: CGFloat = 102
     static let scrollBottomInset: CGFloat = 110
+}
+
+private enum AskLauncherMetrics {
+    static let maxContentWidth: CGFloat = 1_140
+    static let minHeight: CGFloat = 760
+    static let outerPadding: CGFloat = 48
+    static let topSpacing: CGFloat = 72
+    static let bottomSpacing: CGFloat = 56
+    static let sectionSpacing: CGFloat = 40
+    static let headerSpacing: CGFloat = 16
+    static let titleSize: CGFloat = 60
+    static let promptSize: CGFloat = 28
+    static let cardSpacing: CGFloat = 28
+    static let cardPadding: CGFloat = 30
+    static let suggestionSpacing: CGFloat = 18
 }


### PR DESCRIPTION
## Summary
- Reworked the Ask launcher into a cleaner intro screen with a centered title, larger prompt card, and suggested prompts
- Kept the active chat UI unchanged and limited the redesign to the initial Ask state
- Added localized strings for the new subtitle, placeholder, and example prompts

## Testing
- `swift build`
- Not run (not requested)