### PR TITLE
要約エクスポートのリファクタリングとGoogle Drive UI改善

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+**/.env.local
+**/.claude/settings.local.json

--- a/Sources/Dahlia/Models/SummaryProgressState.swift
+++ b/Sources/Dahlia/Models/SummaryProgressState.swift
@@ -7,33 +7,31 @@ final class SummaryProgressState {
         case pending
         case running
         case completed
+        case skipped
         case failed(String)
 
         var isTerminal: Bool {
             switch self {
-            case .completed, .failed: true
+            case .completed, .skipped, .failed: true
             default: false
             }
         }
     }
 
     var isVisible = false
-    var screenshotExport: StepStatus?
-    var transcriptExport: StepStatus = .pending
+    var vaultExport: StepStatus = .pending
     var summaryGeneration: StepStatus = .pending
     var driveExport: StepStatus?
 
     /// 全ステップが完了またはスキップ済みか。
     var isAllDone: Bool {
-        (screenshotExport?.isTerminal ?? true)
-            && transcriptExport.isTerminal
+        vaultExport.isTerminal
             && summaryGeneration.isTerminal
             && (driveExport?.isTerminal ?? true)
     }
 
     func reset() {
-        screenshotExport = nil
-        transcriptExport = .pending
+        vaultExport = .pending
         summaryGeneration = .pending
         driveExport = nil
     }

--- a/Sources/Dahlia/Services/SummaryService.swift
+++ b/Sources/Dahlia/Services/SummaryService.swift
@@ -1,9 +1,8 @@
 import Foundation
 
-/// 文字起こしテキストを LLM で要約し、Obsidian 互換の Markdown ファイルとして保存するサービス。
+/// 文字起こしテキストを LLM で要約し、Obsidian 互換の Markdown を生成するサービス。
 enum SummaryService {
     struct GeneratedSummary {
-        let fileURL: URL
         let fileName: String
         let markdown: String
         let title: String
@@ -24,13 +23,10 @@ enum SummaryService {
         return f
     }()
 
-    /// 要約を生成して Markdown ファイルとして書き出す。
-    /// プロジェクトがある場合はそのフォルダ直下、ない場合は vault 直下へ保存する。
-    /// - Returns: 生成された `.md` ファイルの URL。
+    /// 要約を生成し、Markdown と関連メタデータを返す。
     @MainActor
     static func generateSummary(
         projectURL: URL?,
-        vaultURL: URL,
         meetingId: UUID,
         createdAt: Date,
         transcriptText: String,
@@ -131,23 +127,14 @@ enum SummaryService {
         let frontmatter = "---\n\(frontmatterFields)\n---"
 
         let markdown = frontmatter + "\n\n" + result.summary + "\n"
-
-        // 同じ meeting_id の要約ファイルが既に存在すればそのパスに上書きする
-        let fileURL: URL
-        if let existing = findSummaryFile(projectURL: projectURL, vaultURL: vaultURL, meetingId: meetingId) {
-            fileURL = existing
-        } else {
-            let datePrefix = dateFormatter.string(from: createdAt)
-            let fileName = summaryFileName(datePrefix: datePrefix, title: result.title, meetingId: meetingId)
-            let directoryURL = projectURL ?? vaultURL
-            try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
-            fileURL = directoryURL.appendingPathComponent("\(fileName).md")
-        }
-        try Data(markdown.utf8).write(to: fileURL, options: .atomic)
+        let fileName = summaryFileName(
+            datePrefix: dateFormatter.string(from: createdAt),
+            title: result.title,
+            meetingId: meetingId
+        ) + ".md"
 
         return GeneratedSummary(
-            fileURL: fileURL,
-            fileName: fileURL.lastPathComponent,
+            fileName: fileName,
             markdown: markdown,
             title: result.title,
             summary: result.summary,

--- a/Sources/Dahlia/Services/VaultSummaryExportService.swift
+++ b/Sources/Dahlia/Services/VaultSummaryExportService.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// 要約関連ファイルを Vault に書き出すサービス。
+enum VaultSummaryExportService {
+    typealias TranscriptExporter = @Sendable (URL, UUID, String, Date, [TranscriptSegment]) throws -> String
+    typealias ScreenshotExporter = @Sendable (URL, [MeetingScreenshotRecord]) throws -> [String]
+    typealias SummaryWriter = @Sendable (URL, String) throws -> URL
+
+    static func exportSummaryBundle(
+        projectURL: URL?,
+        vaultURL: URL,
+        meetingId: UUID,
+        createdAt: Date,
+        projectName: String,
+        segments: [TranscriptSegment],
+        screenshots: [MeetingScreenshotRecord],
+        summaryFileName: String,
+        summaryMarkdown: String
+    ) async throws -> URL {
+        try await exportSummaryBundle(
+            projectURL: projectURL,
+            vaultURL: vaultURL,
+            meetingId: meetingId,
+            createdAt: createdAt,
+            projectName: projectName,
+            segments: segments,
+            screenshots: screenshots,
+            summaryFileName: summaryFileName,
+            summaryMarkdown: summaryMarkdown,
+            exportTranscript: TranscriptExportService.exportTranscript,
+            exportScreenshots: ScreenshotExportService.exportScreenshots,
+            writeSummary: writeSummaryFile
+        )
+    }
+
+    static func exportSummaryBundle(
+        projectURL: URL?,
+        vaultURL: URL,
+        meetingId: UUID,
+        createdAt: Date,
+        projectName: String,
+        segments: [TranscriptSegment],
+        screenshots: [MeetingScreenshotRecord],
+        summaryFileName: String,
+        summaryMarkdown: String,
+        exportTranscript: @escaping TranscriptExporter,
+        exportScreenshots: @escaping ScreenshotExporter,
+        writeSummary: @escaping SummaryWriter
+    ) async throws -> URL {
+        let summaryFileURL = try resolveSummaryFileURL(
+            projectURL: projectURL,
+            vaultURL: vaultURL,
+            meetingId: meetingId,
+            summaryFileName: summaryFileName
+        )
+
+        return try await withThrowingTaskGroup(of: URL?.self) { group in
+            group.addTask {
+                try writeSummary(summaryFileURL, summaryMarkdown)
+            }
+            group.addTask {
+                _ = try exportTranscript(vaultURL, meetingId, projectName, createdAt, segments)
+                return nil
+            }
+            if !screenshots.isEmpty {
+                group.addTask {
+                    _ = try exportScreenshots(vaultURL, screenshots)
+                    return nil
+                }
+            }
+
+            var exportedSummaryURL: URL?
+            for try await url in group {
+                if let url {
+                    exportedSummaryURL = url
+                }
+            }
+
+            return exportedSummaryURL ?? summaryFileURL
+        }
+    }
+
+    static func resolveSummaryFileURL(
+        projectURL: URL?,
+        vaultURL: URL,
+        meetingId: UUID,
+        summaryFileName: String
+    ) throws -> URL {
+        if let existing = SummaryService.findSummaryFile(
+            projectURL: projectURL,
+            vaultURL: vaultURL,
+            meetingId: meetingId
+        ) {
+            return existing
+        }
+
+        let directoryURL = projectURL ?? vaultURL
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        return directoryURL.appendingPathComponent(summaryFileName)
+    }
+
+    static func writeSummaryFile(fileURL: URL, markdown: String) throws -> URL {
+        try Data(markdown.utf8).write(to: fileURL, options: .atomic)
+        return fileURL
+    }
+}

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -1023,31 +1023,33 @@ final class CaptionViewModel: ObservableObject {
         summaryError = nil
         summaryWarning = nil
         lastSummaryURL = nil
-        summaryProgress.show()
 
         do {
             let dbQueue = currentDbQueue
+            let projectId = currentProjectId
+            let repo = dbQueue.map { MeetingRepository(dbQueue: $0) }
             var screenshots: [MeetingScreenshotRecord] = []
-            if let queue = dbQueue {
-                let repo = MeetingRepository(dbQueue: queue)
+            var googleDriveFolderId: String?
+            if let repo {
                 screenshots = (try? repo.fetchScreenshots(forMeetingId: meetingId)) ?? []
+                if let projectId,
+                   let project = try repo.fetchProject(id: projectId),
+                   let folderId = project.googleDriveFolderId?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !folderId.isEmpty {
+                    googleDriveFolderId = folderId
+                }
             }
 
-            let screenshotsForExport = screenshots
-
-            // Screenshots の書き出し
-            summaryProgress.screenshotExport = screenshots.isEmpty ? nil : .running
-
-            // Transcript の書き出し
-            summaryProgress.transcriptExport = .running
+            summaryProgress.show()
+            if googleDriveFolderId != nil {
+                summaryProgress.driveExport = .pending
+            }
 
             // LLM 要約
             summaryProgress.summaryGeneration = .running
 
-            // LLM 要約とファイル書き出しを並行実行
-            async let summaryResult = SummaryService.generateSummary(
+            let generatedSummary = try await SummaryService.generateSummary(
                 projectURL: projectURL,
-                vaultURL: vaultURL,
                 meetingId: meetingId,
                 createdAt: createdAt,
                 transcriptText: transcriptText,
@@ -1055,48 +1057,7 @@ final class CaptionViewModel: ObservableObject {
                 screenshots: screenshots
             )
 
-            async let fileExport: Void = exportTranscriptAndScreenshotsWithProgress(
-                vaultURL: vaultURL,
-                meetingId: meetingId,
-                projectName: projectName,
-                createdAt: createdAt,
-                segments: segments,
-                screenshots: screenshotsForExport
-            )
-
-            let generatedSummary = try await summaryResult
-            summaryProgress.summaryGeneration = .completed
-
-            _ = await fileExport
-
-            if let dbQueue, let currentProjectId {
-                let repo = MeetingRepository(dbQueue: dbQueue)
-                if let project = try repo.fetchProject(id: currentProjectId),
-                   let folderId = project.googleDriveFolderId,
-                   !folderId.isEmpty {
-                    summaryProgress.driveExport = .running
-                    do {
-                        try await GoogleDriveSummaryExportService.exportSummary(
-                            folderId: folderId,
-                            meetingId: meetingId,
-                            projectId: currentProjectId,
-                            fileName: generatedSummary.fileName,
-                            markdown: generatedSummary.markdown
-                        )
-                        summaryProgress.driveExport = .completed
-                    } catch {
-                        let warning = GoogleAuthErrorFormatter.message(
-                            for: error,
-                            defaultMessage: L10n.googleDriveExportFailed
-                        )
-                        summaryWarning = warning
-                        summaryProgress.driveExport = .failed(warning)
-                    }
-                }
-            }
-
-            if let dbQueue {
-                let repo = MeetingRepository(dbQueue: dbQueue)
+            if let repo {
                 try repo.applyGeneratedSummary(
                     toMeetingId: meetingId,
                     title: generatedSummary.title,
@@ -1105,15 +1066,65 @@ final class CaptionViewModel: ObservableObject {
                     actionItems: generatedSummary.actionItems
                 )
             }
+            summaryProgress.summaryGeneration = .completed
             if currentMeetingId == meetingId {
                 currentMeetingSummary = generatedSummary.summary
-                lastSummaryURL = generatedSummary.fileURL
-                if let dbQueue {
-                    let repo = MeetingRepository(dbQueue: dbQueue)
-                    currentMeetingActionItems = (try? repo.fetchActionItems(forMeetingId: meetingId)) ?? []
-                } else {
-                    currentMeetingActionItems = []
+                currentMeetingActionItems = (try? repo?.fetchActionItems(forMeetingId: meetingId)) ?? []
+            }
+
+            summaryProgress.vaultExport = .running
+            if googleDriveFolderId != nil {
+                summaryProgress.driveExport = .running
+            }
+
+            async let vaultExport: URL = VaultSummaryExportService.exportSummaryBundle(
+                projectURL: projectURL,
+                vaultURL: vaultURL,
+                meetingId: meetingId,
+                createdAt: createdAt,
+                projectName: projectName,
+                segments: segments,
+                screenshots: screenshots,
+                summaryFileName: generatedSummary.fileName,
+                summaryMarkdown: generatedSummary.markdown
+            )
+            let driveExportTask = Task {
+                guard let googleDriveFolderId else { return }
+                try await GoogleDriveSummaryExportService.exportSummary(
+                    folderId: googleDriveFolderId,
+                    meetingId: meetingId,
+                    projectId: projectId,
+                    fileName: generatedSummary.fileName,
+                    markdown: generatedSummary.markdown
+                )
+            }
+
+            do {
+                let fileURL = try await vaultExport
+                summaryProgress.vaultExport = .completed
+                if currentMeetingId == meetingId {
+                    lastSummaryURL = fileURL
                 }
+            } catch {
+                summaryProgress.vaultExport = .failed(error.localizedDescription)
+                if currentMeetingId == meetingId {
+                    summaryError = error.localizedDescription
+                }
+                ErrorReportingService.capture(error, context: ["source": "vaultSummaryExport"])
+            }
+
+            do {
+                try await driveExportTask.value
+                if googleDriveFolderId != nil {
+                    summaryProgress.driveExport = .completed
+                }
+            } catch {
+                let warning = GoogleAuthErrorFormatter.message(
+                    for: error,
+                    defaultMessage: L10n.googleDriveExportFailed
+                )
+                summaryWarning = warning
+                summaryProgress.driveExport = .failed(warning)
             }
         } catch {
             if currentMeetingId == meetingId {
@@ -1121,6 +1132,10 @@ final class CaptionViewModel: ObservableObject {
                 requestShowSummaryTab = false
             }
             summaryProgress.summaryGeneration = .failed(error.localizedDescription)
+            summaryProgress.vaultExport = .skipped
+            if summaryProgress.driveExport != nil {
+                summaryProgress.driveExport = .skipped
+            }
             ErrorReportingService.capture(error, context: ["source": "summaryGeneration"])
         }
 
@@ -1189,42 +1204,6 @@ final class CaptionViewModel: ObservableObject {
 
         _ = await transcriptPath
         _ = await screenshotExport
-    }
-
-    /// transcript と screenshot をファイルに書き出し、進捗トーストを更新する。
-    private func exportTranscriptAndScreenshotsWithProgress(
-        vaultURL: URL,
-        meetingId: UUID,
-        projectName: String,
-        createdAt: Date,
-        segments: [TranscriptSegment],
-        screenshots: [MeetingScreenshotRecord]
-    ) async {
-        async let transcriptPath = Task.detached {
-            try? TranscriptExportService.exportTranscript(
-                vaultURL: vaultURL,
-                meetingId: meetingId,
-                projectName: projectName,
-                createdAt: createdAt,
-                segments: segments
-            )
-        }.value
-
-        async let screenshotExport: Void = Task.detached {
-            guard !screenshots.isEmpty else { return }
-            _ = try? ScreenshotExportService.exportScreenshots(
-                vaultURL: vaultURL,
-                screenshots: screenshots
-            )
-        }.value
-
-        _ = await transcriptPath
-        summaryProgress.transcriptExport = .completed
-
-        _ = await screenshotExport
-        if !screenshots.isEmpty {
-            summaryProgress.screenshotExport = .completed
-        }
     }
 
     func clearText() {

--- a/Sources/Dahlia/Views/ProjectDetailView.swift
+++ b/Sources/Dahlia/Views/ProjectDetailView.swift
@@ -178,6 +178,27 @@ private struct ProjectNameHeader: View {
     }
 }
 
+private struct ProjectSettingsActionButtonStyle: ButtonStyle {
+    let backgroundColor: Color
+
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.subheadline.bold())
+            .foregroundStyle(.white.opacity(isEnabled ? 1 : 0.7))
+            .padding(.horizontal, 14)
+            .frame(minHeight: 36)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(backgroundColor.opacity(isEnabled ? 1 : 0.45))
+            )
+            .opacity(configuration.isPressed ? 0.9 : 1)
+            .scaleEffect(configuration.isPressed ? 0.98 : 1)
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+    }
+}
+
 private struct ProjectDetailMeetingRow: View {
     let meeting: MeetingRecord
     let tags: [TagInfo]
@@ -447,7 +468,7 @@ struct ProjectDetailView: View {
                 }
 
                 ProjectSettingRow(title: L10n.location) {
-                    HStack(alignment: .center, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 10) {
                         Text(currentProjectURL?.path ?? "")
                             .font(.subheadline)
                             .textSelection(.enabled)
@@ -455,13 +476,16 @@ struct ProjectDetailView: View {
                             .truncationMode(.middle)
                             .frame(maxWidth: .infinity, alignment: .leading)
 
-                        Button(L10n.openInFinder) {
+                        Button {
                             guard let currentProjectURL else { return }
                             NSWorkspace.shared.open(currentProjectURL)
+                        } label: {
+                            Label(L10n.openInFinder, systemImage: "folder.fill")
                         }
-                        .buttonStyle(.link)
+                        .buttonStyle(ProjectSettingsActionButtonStyle(backgroundColor: .accentColor))
                         .disabled(isCurrentProjectMissingOnDisk || currentProjectURL == nil)
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
                 if googleDriveStore.isAuthorized {
@@ -497,22 +521,31 @@ struct ProjectDetailView: View {
 
                             HStack(spacing: 12) {
                                 if let googleDriveFolderURL {
-                                    Button(L10n.openInBrowser) {
+                                    Button {
                                         NSWorkspace.shared.open(googleDriveFolderURL)
+                                    } label: {
+                                        Label(L10n.openInBrowser, systemImage: "globe")
                                     }
-                                    .buttonStyle(.link)
+                                    .buttonStyle(ProjectSettingsActionButtonStyle(backgroundColor: .accentColor))
                                 }
 
-                                Button(currentProject?.googleDriveFolderId?.isEmpty == false ? L10n.changeFolder : L10n.chooseFolder) {
+                                Button {
                                     isShowingDriveFolderPicker = true
+                                } label: {
+                                    Label(
+                                        hasGoogleDriveFolder ? L10n.changeFolder : L10n.chooseFolder,
+                                        systemImage: hasGoogleDriveFolder ? "folder.badge.gearshape" : "folder.badge.plus"
+                                    )
                                 }
-                                .buttonStyle(.link)
+                                .buttonStyle(ProjectSettingsActionButtonStyle(backgroundColor: .gray))
 
-                                if currentProject?.googleDriveFolderId?.isEmpty == false {
-                                    Button(L10n.clear) {
+                                if hasGoogleDriveFolder {
+                                    Button {
                                         clearGoogleDriveFolderSelection()
+                                    } label: {
+                                        Label(L10n.clear, systemImage: "xmark")
                                     }
-                                    .buttonStyle(.link)
+                                    .buttonStyle(ProjectSettingsActionButtonStyle(backgroundColor: .red))
                                 }
                             }
                         }
@@ -534,6 +567,10 @@ struct ProjectDetailView: View {
 
     private var currentProjectURL: URL? {
         sidebarViewModel.selectedProjectURL
+    }
+
+    private var hasGoogleDriveFolder: Bool {
+        currentProject?.googleDriveFolderId?.isEmpty == false
     }
 
     private var googleDriveFolderURL: URL? {

--- a/Sources/Dahlia/Views/SummaryProgressToastView.swift
+++ b/Sources/Dahlia/Views/SummaryProgressToastView.swift
@@ -10,11 +10,8 @@ struct SummaryProgressToastView: View {
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(.primary)
 
-            if let screenshotStatus = state.screenshotExport {
-                StepRow(label: "Screenshots の書き出し", status: screenshotStatus)
-            }
-            StepRow(label: "Transcript の書き出し", status: state.transcriptExport)
             StepRow(label: "要約の生成", status: state.summaryGeneration)
+            StepRow(label: "Vault へ書き出し", status: state.vaultExport)
             if let driveStatus = state.driveExport {
                 StepRow(label: "Google Drive へ書き出し", status: driveStatus)
             }
@@ -56,6 +53,10 @@ private struct StepRow: View {
             Image(systemName: "checkmark.circle.fill")
                 .font(.system(size: 12))
                 .foregroundStyle(.green)
+        case .skipped:
+            Image(systemName: "minus.circle")
+                .font(.system(size: 12))
+                .foregroundStyle(.tertiary)
         case .failed:
             Image(systemName: "xmark.circle.fill")
                 .font(.system(size: 12))
@@ -67,7 +68,7 @@ private struct StepRow: View {
         switch status {
         case .pending: .secondary
         case .running: .primary
-        case .completed: .secondary
+        case .completed, .skipped: .secondary
         case .failed: .red
         }
     }

--- a/Tests/DahliaTests/VaultSummaryExportServiceTests.swift
+++ b/Tests/DahliaTests/VaultSummaryExportServiceTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+import Testing
+
+struct VaultSummaryExportServiceTests {
+    @Test
+    func exportSummaryBundleWritesSummaryTranscriptAndScreenshots() async throws {
+        let vaultURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let projectURL = vaultURL.appendingPathComponent("Project", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: vaultURL) }
+
+        try FileManager.default.createDirectory(at: projectURL, withIntermediateDirectories: true)
+
+        let meetingId = UUID()
+        let screenshot = MeetingScreenshotRecord(
+            id: UUID(),
+            meetingId: meetingId,
+            capturedAt: Date(timeIntervalSince1970: 0),
+            imageData: Data([0x89, 0x50, 0x4E, 0x47]),
+            mimeType: "image/png"
+        )
+        let summaryMarkdown = """
+        ---
+        meeting_id: "\(meetingId.uuidString)"
+        ---
+
+        Summary body
+        """
+
+        let summaryURL = try await VaultSummaryExportService.exportSummaryBundle(
+            projectURL: projectURL,
+            vaultURL: vaultURL,
+            meetingId: meetingId,
+            createdAt: Date(timeIntervalSince1970: 0),
+            projectName: "Test Project",
+            segments: [
+                TranscriptSegment(
+                    startTime: Date(timeIntervalSince1970: 0),
+                    text: "hello"
+                ),
+            ],
+            screenshots: [screenshot],
+            summaryFileName: "summary.md",
+            summaryMarkdown: summaryMarkdown
+        )
+
+        #expect(summaryURL == projectURL.appendingPathComponent("summary.md"))
+        #expect(try String(contentsOf: summaryURL, encoding: .utf8) == summaryMarkdown)
+        #expect(FileManager.default.fileExists(atPath: vaultURL.appendingPathComponent("_dahlia/transcripts/\(meetingId.uuidString).md").path))
+        #expect(
+            FileManager.default.fileExists(
+                atPath: vaultURL.appendingPathComponent("_dahlia/screenshots/\(screenshot.id.uuidString).png").path
+            )
+        )
+    }
+
+    @Test
+    func exportSummaryBundleReusesExistingSummaryFileForMeetingID() async throws {
+        let vaultURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let projectURL = vaultURL.appendingPathComponent("Project", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: vaultURL) }
+
+        try FileManager.default.createDirectory(at: projectURL, withIntermediateDirectories: true)
+
+        let meetingId = UUID()
+        let existingSummaryURL = projectURL.appendingPathComponent("existing-summary.md")
+        try Data(
+            """
+            ---
+            meeting_id: "\(meetingId.uuidString)"
+            ---
+
+            Old body
+            """.utf8
+        ).write(to: existingSummaryURL, options: .atomic)
+
+        let summaryMarkdown = """
+        ---
+        meeting_id: "\(meetingId.uuidString)"
+        ---
+
+        New body
+        """
+
+        let summaryURL = try await VaultSummaryExportService.exportSummaryBundle(
+            projectURL: projectURL,
+            vaultURL: vaultURL,
+            meetingId: meetingId,
+            createdAt: Date(timeIntervalSince1970: 0),
+            projectName: "Test Project",
+            segments: [],
+            screenshots: [],
+            summaryFileName: "new-summary.md",
+            summaryMarkdown: summaryMarkdown
+        )
+
+        #expect(summaryURL == existingSummaryURL)
+        #expect(try String(contentsOf: existingSummaryURL, encoding: .utf8) == summaryMarkdown)
+        #expect(!FileManager.default.fileExists(atPath: projectURL.appendingPathComponent("new-summary.md").path))
+    }
+
+    @Test
+    func exportSummaryBundleFailsWhenAnyArtifactExportFails() async throws {
+        enum ExpectedError: Error {
+            case transcriptFailed
+        }
+
+        let vaultURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let projectURL = vaultURL.appendingPathComponent("Project", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: vaultURL) }
+
+        try FileManager.default.createDirectory(at: projectURL, withIntermediateDirectories: true)
+
+        var didThrowExpectedError = false
+
+        do {
+            _ = try await VaultSummaryExportService.exportSummaryBundle(
+                projectURL: projectURL,
+                vaultURL: vaultURL,
+                meetingId: UUID(),
+                createdAt: Date(timeIntervalSince1970: 0),
+                projectName: "Test Project",
+                segments: [],
+                screenshots: [],
+                summaryFileName: "summary.md",
+                summaryMarkdown: "summary",
+                exportTranscript: { _, _, _, _, _ in
+                    throw ExpectedError.transcriptFailed
+                },
+                exportScreenshots: { _, _ in [] },
+                writeSummary: { fileURL, markdown in
+                    try Data(markdown.utf8).write(to: fileURL, options: .atomic)
+                    return fileURL
+                }
+            )
+        } catch is ExpectedError {
+            didThrowExpectedError = true
+        }
+
+        #expect(didThrowExpectedError)
+    }
+}
+#endif


### PR DESCRIPTION
## 概要

要約生成フローのリファクタリングとプロジェクト設定画面のUI改善。

### 要約エクスポートの責務分離
- `VaultSummaryExportService` を新規追加し、Vault へのファイル書き出し（要約・transcript・screenshot）を集約
- `SummaryService` からファイル書き出し責務を分離し、Markdown 生成のみに専念させた
- `CaptionViewModel` のフローを「LLM要約 → DB保存 → Vault書き出し + Drive書き出し（並行）」に再構成

### 進捗表示の簡素化
- `SummaryProgressState` の `screenshotExport` / `transcriptExport` を `vaultExport` に統合
- `skipped` ステータスを追加し、要約生成失敗時に後続ステップをスキップ表示

### プロジェクト設定画面の UI 改善
- `ProjectSettingsActionButtonStyle` を追加し、アクションボタンのスタイルを統一
- ロケーション行のレイアウトを HStack → VStack に変更
- Google Drive 関連ボタンにアイコン付き Label を採用

### テスト
- `VaultSummaryExportServiceTests` を追加（正常系・既存ファイル上書き・エラー伝播）

## テスト計画

- [ ] `swift build` が成功すること
- [ ] `VaultSummaryExportServiceTests` が全件パスすること
- [ ] 要約生成〜Vault書き出しフローが正常動作すること
- [ ] Google Drive 連携時の進捗トーストが正しく表示されること
- [ ] プロジェクト設定画面のボタンスタイルが統一されていること