### PR TITLE
マイク選択の改善・ScreenshotWindowOption 導入・プロジェクトパンくずナビゲーション追加

### DIFF
--- a/Sources/Dahlia/Audio/MicrophoneSelection.swift
+++ b/Sources/Dahlia/Audio/MicrophoneSelection.swift
@@ -1,0 +1,18 @@
+import CoreAudio
+
+enum MicrophoneSelection: Hashable, Sendable {
+    case none
+    case systemDefault
+    case device(AudioDeviceID)
+
+    func resolvedDeviceID(defaultDeviceID: AudioDeviceID?) -> AudioDeviceID? {
+        switch self {
+        case .none:
+            nil
+        case .systemDefault:
+            defaultDeviceID
+        case let .device(deviceID):
+            deviceID
+        }
+    }
+}

--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -102,6 +102,9 @@ enum MarkdownEditor: String, CaseIterable, Identifiable {
 @MainActor
 final class AppSettings: ObservableObject {
     static let shared = AppSettings()
+    nonisolated static let defaultAgentLaunchCommand = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".local/bin/claude")
+        .path
 
     // MARK: - 表示言語
 
@@ -176,7 +179,7 @@ final class AppSettings: ObservableObject {
 
     // MARK: - Agent 設定
 
-    @AppStorage("agentLaunchCommand") var agentLaunchCommand = "claude"
+    @AppStorage("agentLaunchCommand") var agentLaunchCommand = AppSettings.defaultAgentLaunchCommand
 
     // MARK: - LLM 設定
 

--- a/Sources/Dahlia/Models/ScreenshotWindowOption.swift
+++ b/Sources/Dahlia/Models/ScreenshotWindowOption.swift
@@ -1,0 +1,77 @@
+import CoreGraphics
+@preconcurrency import ScreenCaptureKit
+
+struct ScreenshotWindowOption: Identifiable, Equatable {
+    struct Snapshot: Equatable {
+        let windowID: CGWindowID
+        let appName: String?
+        let bundleIdentifier: String?
+        let title: String?
+        let frame: CGRect
+        let windowLayer: Int
+        let isOnScreen: Bool
+    }
+
+    let id: CGWindowID
+    let appName: String
+    let title: String
+    let isOnScreen: Bool
+
+    var displayName: String {
+        title.isEmpty ? appName : "\(appName) — \(title)"
+    }
+
+    static func build(from snapshots: [Snapshot], excludingBundleID bundleID: String?) -> [Self] {
+        snapshots
+            .compactMap { snapshot in
+                guard snapshot.frame.width > 0,
+                      snapshot.frame.height > 0,
+                      snapshot.windowLayer == 0 else {
+                    return nil
+                }
+
+                let title = snapshot.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                guard !title.isEmpty else { return nil }
+                guard snapshot.bundleIdentifier != bundleID else { return nil }
+
+                let trimmedAppName = snapshot.appName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                let appName = trimmedAppName.isEmpty ? "不明" : trimmedAppName
+
+                return Self(
+                    id: snapshot.windowID,
+                    appName: appName,
+                    title: title,
+                    isOnScreen: snapshot.isOnScreen
+                )
+            }
+            .sorted(by: sort)
+    }
+
+    private static func sort(lhs: Self, rhs: Self) -> Bool {
+        let appOrder = lhs.appName.localizedCaseInsensitiveCompare(rhs.appName)
+        if appOrder != .orderedSame {
+            return appOrder == .orderedAscending
+        }
+
+        let titleOrder = lhs.title.localizedCaseInsensitiveCompare(rhs.title)
+        if titleOrder != .orderedSame {
+            return titleOrder == .orderedAscending
+        }
+
+        return lhs.id < rhs.id
+    }
+}
+
+extension ScreenshotWindowOption.Snapshot {
+    init(window: SCWindow) {
+        self.init(
+            windowID: window.windowID,
+            appName: window.owningApplication?.applicationName,
+            bundleIdentifier: window.owningApplication?.bundleIdentifier,
+            title: window.title,
+            frame: window.frame,
+            windowLayer: window.windowLayer,
+            isOnScreen: window.isOnScreen
+        )
+    }
+}

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -132,6 +132,8 @@
 "System Audio" = "System Audio";
 "Both" = "Both";
 "None" = "None";
+"Same as System" = "Same as System";
+"Same as System (%@)" = "Same as System (%@)";
 "No computer audio" = "No computer audio";
 "Record computer audio" = "Record computer audio";
 

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -122,7 +122,7 @@
 
 /* Settings (Agent) */
 "Launch Command" = "Launch Command";
-"Command used to launch the agent from your PATH. Default: `claude`." = "Command used to launch the agent from your PATH. Default: `claude`.";
+"Command used to launch the agent from your PATH. Default: `claude`." = "Command used to launch the agent from your PATH. Default: `/Users/{user_name}/.local/bin/claude`.";
 
 /* Audio Source Mode */
 "Audio source" = "Audio source";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -132,6 +132,8 @@
 "System Audio" = "システムオーディオ";
 "Both" = "両方";
 "None" = "なし";
+"Same as System" = "システムと同じ";
+"Same as System (%@)" = "システムと同じ (%@)";
 "No computer audio" = "コンピュータ音声なし";
 "Record computer audio" = "コンピュータ音声を録音";
 

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -122,7 +122,7 @@
 
 /* Settings (Agent) */
 "Launch Command" = "起動コマンド";
-"Command used to launch the agent from your PATH. Default: `claude`." = "PATH からエージェントを起動するコマンドです。デフォルトは `claude` です。";
+"Command used to launch the agent from your PATH. Default: `claude`." = "PATH からエージェントを起動するコマンドです。デフォルトは `/Users/{user_name}/.local/bin/claude` です。";
 
 /* Audio Source Mode */
 "Audio source" = "音声ソース";

--- a/Sources/Dahlia/Services/AgentService.swift
+++ b/Sources/Dahlia/Services/AgentService.swift
@@ -82,7 +82,7 @@ final class AgentService: ObservableObject {
     static let toolsOmitResult: Set = ["Glob", "Grep", "Read", "Write", "Edit", "TodoWrite"]
     /// 入力サマリーを省略するツール。
     nonisolated static let toolsOmitInputSummary: Set = ["TodoWrite"]
-    nonisolated static let defaultLaunchCommand = "claude"
+    nonisolated static let defaultLaunchCommand = AppSettings.defaultAgentLaunchCommand
 
     // MARK: - Lifecycle
 

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -187,6 +187,8 @@ enum L10n {
     static var systemAudio: String { String(localized: "System Audio", bundle: bundle) }
     static var both: String { String(localized: "Both", bundle: bundle) }
     static var none: String { String(localized: "None", bundle: bundle) }
+    static var sameAsSystem: String { String(localized: "Same as System", bundle: bundle) }
+    static func sameAsSystem(_ deviceName: String) -> String { String(localized: "Same as System (\(deviceName))", bundle: bundle) }
     static var noComputerAudio: String { String(localized: "No computer audio", bundle: bundle) }
     static var recordComputerAudio: String { String(localized: "Record computer audio", bundle: bundle) }
 

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -34,7 +34,7 @@ final class CaptionViewModel: ObservableObject {
     @Published var isPreparingAnalyzer = false
     @Published var errorMessage: String?
     @Published var availableMicrophones: [MicrophoneDevice] = []
-    @Published var selectedMicrophoneID: AudioDeviceID? = AudioCaptureManager.defaultInputDeviceID()
+    @Published var microphoneSelection: MicrophoneSelection = .systemDefault
     @Published var isSystemAudioEnabled = true
     @Published var selectedLocale: String = AppSettings.shared.transcriptionLocale
     @Published var supportedLocales: [Locale] = []
@@ -131,6 +131,18 @@ final class CaptionViewModel: ObservableObject {
         !isListening && currentMeetingId != nil
     }
 
+    var selectedMicrophoneID: AudioDeviceID? {
+        microphoneSelection.resolvedDeviceID(defaultDeviceID: defaultInputDeviceIDProvider())
+    }
+
+    var systemDefaultMicrophoneTitle: String {
+        guard let defaultDeviceID = defaultInputDeviceIDProvider(),
+              let deviceName = availableMicrophones.first(where: { $0.id == defaultDeviceID })?.name else {
+            return L10n.sameAsSystem
+        }
+        return L10n.sameAsSystem(deviceName)
+    }
+
     /// マイクが有効か。
     var isMicEnabled: Bool { selectedMicrophoneID != nil }
 
@@ -175,12 +187,19 @@ final class CaptionViewModel: ObservableObject {
     private var storeCancellable: AnyCancellable?
     private var settingsCancellable: AnyCancellable?
     private var meetingLoadTask: Task<Void, Never>?
+    private let availableInputDevicesProvider: @Sendable () -> [MicrophoneDevice]
+    private let defaultInputDeviceIDProvider: @Sendable () -> AudioDeviceID?
 
     private var activeDbQueueForSessionControls: DatabaseQueue? {
         recordingContext?.dbQueue ?? currentDbQueue
     }
 
-    init() {
+    init(
+        availableInputDevicesProvider: @escaping @Sendable () -> [MicrophoneDevice] = AudioCaptureManager.availableInputDevices,
+        defaultInputDeviceIDProvider: @escaping @Sendable () -> AudioDeviceID? = AudioCaptureManager.defaultInputDeviceID
+    ) {
+        self.availableInputDevicesProvider = availableInputDevicesProvider
+        self.defaultInputDeviceIDProvider = defaultInputDeviceIDProvider
         resubscribeStoreCancellable()
         refreshAvailableMicrophones()
 
@@ -209,15 +228,15 @@ final class CaptionViewModel: ObservableObject {
     }
 
     func refreshAvailableMicrophones() {
-        let devices = AudioCaptureManager.availableInputDevices()
+        let devices = availableInputDevicesProvider()
 
         if devices != availableMicrophones {
             availableMicrophones = devices
         }
 
-        if let currentMicrophoneID = selectedMicrophoneID,
+        if case let .device(currentMicrophoneID) = microphoneSelection,
            !devices.contains(where: { $0.id == currentMicrophoneID }) {
-            self.selectedMicrophoneID = AudioCaptureManager.defaultInputDeviceID()
+            microphoneSelection = .systemDefault
         }
     }
 
@@ -651,9 +670,9 @@ final class CaptionViewModel: ObservableObject {
         applyLocaleChange(from: oldLocale, to: newLocale)
     }
 
-    func handleMicrophoneSelectionChange(from oldID: AudioDeviceID?, to newID: AudioDeviceID?) {
-        guard oldID != newID else { return }
-        applyAudioSourceSelectionChange { self.selectedMicrophoneID = oldID }
+    func handleMicrophoneSelectionChange(from oldSelection: MicrophoneSelection, to newSelection: MicrophoneSelection) {
+        guard oldSelection != newSelection else { return }
+        applyAudioSourceSelectionChange { self.microphoneSelection = oldSelection }
     }
 
     func handleSystemAudioSelectionChange(from oldValue: Bool, to newValue: Bool) {

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -79,7 +79,7 @@ final class CaptionViewModel: ObservableObject {
 
     @Published var screenshots: [MeetingScreenshotRecord] = []
     /// キャプチャ対象として選択可能なウィンドウ一覧。
-    @Published var availableWindows: [SCWindow] = []
+    @Published var availableWindows: [ScreenshotWindowOption] = []
     /// 選択中のウィンドウ ID。nil の場合はデスクトップ全体をキャプチャ。
     @Published var selectedWindowID: CGWindowID?
 
@@ -1242,21 +1242,18 @@ final class CaptionViewModel: ObservableObject {
     func refreshAvailableWindows() {
         Task {
             do {
-                let content = try await SCShareableContent.excludingDesktopWindows(true, onScreenWindowsOnly: true)
+                let content = try await SCShareableContent.excludingDesktopWindows(true, onScreenWindowsOnly: false)
                 let myBundleID = Bundle.main.bundleIdentifier
-                self.availableWindows = content.windows
-                    .filter { window in
-                        window.isOnScreen
-                            && window.frame.width > 0
-                            && window.frame.height > 0
-                            && window.windowLayer == 0
-                            && !(window.title ?? "").isEmpty
-                            && window.owningApplication?.bundleIdentifier != myBundleID
-                    }
-                    .sorted { ($0.owningApplication?.applicationName ?? "") < ($1.owningApplication?.applicationName ?? "") }
+                let newWindows = ScreenshotWindowOption.build(
+                    from: content.windows.map(ScreenshotWindowOption.Snapshot.init(window:)),
+                    excludingBundleID: myBundleID
+                )
+                if newWindows != self.availableWindows {
+                    self.availableWindows = newWindows
+                }
                 // 選択中のウィンドウが一覧から消えていたらリセット
                 if let id = selectedWindowID,
-                   !self.availableWindows.contains(where: { $0.windowID == id }) {
+                   !self.availableWindows.contains(where: { $0.id == id }) {
                     selectedWindowID = nil
                 }
             } catch {
@@ -1273,7 +1270,7 @@ final class CaptionViewModel: ObservableObject {
 
         Task {
             do {
-                let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+                let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
 
                 let filter: SCContentFilter
                 let config = SCScreenshotConfiguration()

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -227,22 +227,26 @@ private struct SessionSettingsMenu: View {
             // ── Transcribe ──
             Section("Transcribe") {
                 Menu {
-                    Picker(selection: $viewModel.selectedMicrophoneID) {
-                        Text(L10n.none).tag(AudioDeviceID?.none)
+                    Picker(selection: $viewModel.microphoneSelection) {
+                        Text(L10n.none).tag(MicrophoneSelection.none)
+
+                        Divider()
+
+                        Text(viewModel.systemDefaultMicrophoneTitle).tag(MicrophoneSelection.systemDefault)
 
                         if !viewModel.availableMicrophones.isEmpty {
                             Divider()
                         }
 
                         ForEach(viewModel.availableMicrophones) { microphone in
-                            Text(microphone.name).tag(AudioDeviceID?.some(microphone.id))
+                            Text(microphone.name).tag(MicrophoneSelection.device(microphone.id))
                         }
                     } label: {
                         EmptyView()
                     }
                     .pickerStyle(.inline)
                     .labelsHidden()
-                    .onChange(of: viewModel.selectedMicrophoneID) { oldValue, newValue in
+                    .onChange(of: viewModel.microphoneSelection) { oldValue, newValue in
                         viewModel.handleMicrophoneSelectionChange(from: oldValue, to: newValue)
                     }
                 } label: {

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -733,6 +733,73 @@ private struct MeetingNameHeader: View {
     }
 }
 
+private struct MeetingProjectBreadcrumbBar: View {
+    private struct BreadcrumbSegment: Identifiable {
+        let path: String
+        let label: String
+        let isNavigable: Bool
+        let isCurrent: Bool
+
+        var id: String { path }
+    }
+
+    let projectName: String
+    let availableProjectNames: Set<String>
+    let onOpenProjectsOverview: () -> Void
+    let onOpenProject: (String) -> Void
+
+    private var segments: [BreadcrumbSegment] {
+        let components = projectName
+            .split(separator: "/")
+            .map(String.init)
+
+        return components.indices.map { index in
+            let path = components[0 ... index].joined(separator: "/")
+            return BreadcrumbSegment(
+                path: path,
+                label: components[index],
+                isNavigable: availableProjectNames.contains(path),
+                isCurrent: index == components.indices.last
+            )
+        }
+    }
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                Button(L10n.projects, action: onOpenProjectsOverview)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .font(.system(size: 13))
+                    .actionCursor()
+
+                ForEach(segments) { segment in
+                    Image(systemName: "chevron.right")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .accessibilityHidden(true)
+
+                    Group {
+                        if segment.isNavigable {
+                            Button(segment.label) {
+                                onOpenProject(segment.path)
+                            }
+                            .buttonStyle(.plain)
+                            .actionCursor()
+                        } else {
+                            Text(segment.label)
+                        }
+                    }
+                    .foregroundStyle(segment.isCurrent ? .primary : .secondary)
+                    .font(.system(size: 13, weight: segment.isCurrent ? .semibold : .regular))
+                    .lineLimit(1)
+                }
+            }
+        }
+        .fixedSize(horizontal: true, vertical: false)
+    }
+}
+
 /// メインコントロールウィンドウ（議事録ビュー）。
 struct ControlPanelView: View {
     @ObservedObject var viewModel: CaptionViewModel
@@ -754,6 +821,26 @@ struct ControlPanelView: View {
                     .progressViewStyle(.linear)
             }
 
+            if shouldShowProjectHeaderRow {
+                HStack(alignment: .center, spacing: 12) {
+                    if let projectName = displayedProjectBreadcrumbName {
+                        MeetingProjectBreadcrumbBar(
+                            projectName: projectName,
+                            availableProjectNames: availableProjectNames,
+                            onOpenProjectsOverview: openProjectsOverview,
+                            onOpenProject: openProject(named:)
+                        )
+                    }
+
+                    MeetingProjectPicker(
+                        viewModel: viewModel,
+                        sidebarViewModel: sidebarViewModel,
+                        style: displayedProjectBreadcrumbName == nil ? .regular : .compact
+                    )
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
             if let meetingTitle = displayedMeetingTitle {
                 MeetingNameHeader(
                     title: meetingTitle,
@@ -765,7 +852,7 @@ struct ControlPanelView: View {
                     onCancel: cancelMeetingRename,
                     onEditorTap: markMeetingNameEditorTap
                 )
-                .padding(.top, -12)
+                .padding(.top, shouldShowProjectHeaderRow ? 0 : -12)
             }
 
             if currentMeetingItem != nil {
@@ -1056,6 +1143,20 @@ struct ControlPanelView: View {
         return nil
     }
 
+    private var displayedProjectBreadcrumbName: String? {
+        let projectName = currentMeetingItem?.projectName ?? viewModel.currentProjectName ?? ""
+        let trimmed = projectName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private var shouldShowProjectHeaderRow: Bool {
+        displayedProjectBreadcrumbName != nil || viewModel.hasDraftMeeting || viewModel.currentMeetingId != nil
+    }
+
+    private var availableProjectNames: Set<String> {
+        Set(sidebarViewModel.allProjectItems.map(\.projectName))
+    }
+
     private var persistedSummaryExists: Bool {
         currentMeetingItem?.hasSummary == true
     }
@@ -1086,6 +1187,27 @@ struct ControlPanelView: View {
         editingMeetingName = displayedMeetingTitle ?? ""
         isEditingMeetingName = true
         didTapInsideMeetingNameEditor = false
+    }
+
+    private func openProjectsOverview() {
+        sidebarViewModel.selectDestination(.projects)
+        DispatchQueue.main.async {
+            sidebarViewModel.clearProjectSelection()
+            sidebarViewModel.deselectProject()
+        }
+    }
+
+    private func openProject(named name: String) {
+        guard let project = sidebarViewModel.allProjectItems.first(where: { $0.projectName == name }) else {
+            openProjectsOverview()
+            return
+        }
+
+        sidebarViewModel.selectDestination(.projects)
+        DispatchQueue.main.async {
+            sidebarViewModel.clearMeetingSelection()
+            sidebarViewModel.singleSelectProjectFromOverview(project.projectId, name: project.projectName)
+        }
     }
 
     private func cancelMeetingRename() {

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -306,11 +306,8 @@ private struct SessionSettingsMenu: View {
 
                         Divider()
 
-                        ForEach(viewModel.availableWindows, id: \.windowID) { window in
-                            let appName = window.owningApplication?.applicationName ?? "不明"
-                            let title = window.title ?? ""
-                            let displayName = title.isEmpty ? appName : "\(appName) — \(title)"
-                            Text(displayName).tag(CGWindowID?.some(window.windowID))
+                        ForEach(viewModel.availableWindows) { window in
+                            Text(window.displayName).tag(CGWindowID?.some(window.id))
                         }
                     } label: {
                         EmptyView()

--- a/Sources/Dahlia/Views/MeetingMetadataBar.swift
+++ b/Sources/Dahlia/Views/MeetingMetadataBar.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// ミーティング詳細ヘッダーの下に配置するメタデータバー。
-/// タグチップ群 + プロジェクトピッカーを横並びで表示する。
+/// タグチップ群を横並びで表示する。
 struct MeetingMetadataBar: View {
     @ObservedObject var viewModel: CaptionViewModel
     var sidebarViewModel: SidebarViewModel
@@ -14,7 +14,6 @@ struct MeetingMetadataBar: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            MeetingProjectPicker(viewModel: viewModel, sidebarViewModel: sidebarViewModel)
             MeetingTagsView(viewModel: viewModel, tags: tags, sidebarViewModel: sidebarViewModel)
             Spacer(minLength: 0)
         }
@@ -218,9 +217,15 @@ private struct TagChip: View {
 
 // MARK: - Project Picker
 
-private struct MeetingProjectPicker: View {
+struct MeetingProjectPicker: View {
+    enum Style {
+        case regular
+        case compact
+    }
+
     @ObservedObject var viewModel: CaptionViewModel
     var sidebarViewModel: SidebarViewModel
+    var style: Style = .regular
 
     @State private var showProjectPopover = false
     @State private var projectInput = ""
@@ -256,7 +261,7 @@ private struct MeetingProjectPicker: View {
     }
 
     var body: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: style == .compact ? 3 : 4) {
             ZStack {
                 Image(systemName: "folder")
                     .font(.caption2)
@@ -280,8 +285,11 @@ private struct MeetingProjectPicker: View {
 
             Button(action: presentProjectPopover) {
                 HStack(spacing: 4) {
-                    Text(currentProjectName ?? L10n.noProject)
-                        .font(.caption.weight(.medium))
+                    if style == .regular {
+                        Text(currentProjectName ?? L10n.noProject)
+                            .font(.caption.weight(.medium))
+                            .lineLimit(1)
+                    }
                     Image(systemName: "chevron.down")
                         .font(.system(size: 8, weight: .medium))
                 }
@@ -289,18 +297,20 @@ private struct MeetingProjectPicker: View {
             .buttonStyle(.plain)
         }
         .foregroundStyle(.secondary)
-        .padding(.horizontal, 8)
+        .padding(.horizontal, style == .compact ? 6 : 8)
         .padding(.vertical, 3)
         .background(
             Capsule()
                 .fill(Color.primary.opacity(0.05))
         )
+        .fixedSize(horizontal: true, vertical: false)
         .onHover { hovering in
             isHovered = hovering
         }
         .popover(isPresented: $showProjectPopover, arrowEdge: .bottom) {
             projectPopoverContent
         }
+        .help(currentProjectName ?? L10n.noProject)
     }
 
     private func presentProjectPopover() {

--- a/Tests/DahliaTests/AgentServiceTests.swift
+++ b/Tests/DahliaTests/AgentServiceTests.swift
@@ -9,7 +9,7 @@ struct AgentServiceTests {
     func resolveLaunchArgumentsFallsBackToClaudeWhenBlank() {
         let arguments = AgentService.resolveLaunchArguments(from: "   ")
 
-        #expect(arguments == ["claude"])
+        #expect(arguments == [AgentService.defaultLaunchCommand])
     }
 
     @Test
@@ -126,7 +126,7 @@ import XCTest
 
 final class AgentServiceTests: XCTestCase {
     func testResolveLaunchArgumentsFallsBackToClaudeWhenBlank() {
-        XCTAssertEqual(AgentService.resolveLaunchArguments(from: "   "), ["claude"])
+        XCTAssertEqual(AgentService.resolveLaunchArguments(from: "   "), [AgentService.defaultLaunchCommand])
     }
 
     func testResolveLaunchArgumentsSplitsCommandAndArguments() {

--- a/Tests/DahliaTests/CaptionViewModelTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelTests.swift
@@ -10,6 +10,45 @@ struct CaptionViewModelTests {
     private let testVaultURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
 
     @Test
+    func systemDefaultMicrophoneSelectionResolvesCurrentDefaultDevice() {
+        var defaultDeviceID = AudioDeviceID(101)
+        let devices = [
+            MicrophoneDevice(id: 101, name: "Poly Sync 20"),
+            MicrophoneDevice(id: 202, name: "MacBook Pro Mic"),
+        ]
+        let viewModel = CaptionViewModel(
+            availableInputDevicesProvider: { devices },
+            defaultInputDeviceIDProvider: { defaultDeviceID }
+        )
+
+        #expect(viewModel.microphoneSelection == .systemDefault)
+        #expect(viewModel.selectedMicrophoneID == 101)
+
+        defaultDeviceID = 202
+
+        #expect(viewModel.selectedMicrophoneID == 202)
+    }
+
+    @Test
+    func missingSelectedMicrophoneFallsBackToSystemDefaultSelection() {
+        var availableDevices = [
+            MicrophoneDevice(id: 101, name: "Poly Sync 20"),
+            MicrophoneDevice(id: 202, name: "MacBook Pro Mic"),
+        ]
+        let viewModel = CaptionViewModel(
+            availableInputDevicesProvider: { availableDevices },
+            defaultInputDeviceIDProvider: { 202 }
+        )
+
+        viewModel.microphoneSelection = .device(101)
+        availableDevices = [MicrophoneDevice(id: 202, name: "MacBook Pro Mic")]
+        viewModel.refreshAvailableMicrophones()
+
+        #expect(viewModel.microphoneSelection == .systemDefault)
+        #expect(viewModel.selectedMicrophoneID == 202)
+    }
+
+    @Test
     func selectingActiveRecordingMeetingKeepsLiveTranscriptStore() throws {
         let viewModel = CaptionViewModel()
         let dbQueue = try DatabaseQueue(path: ":memory:")

--- a/Tests/DahliaTests/ScreenshotWindowOptionTests.swift
+++ b/Tests/DahliaTests/ScreenshotWindowOptionTests.swift
@@ -1,0 +1,79 @@
+import CoreGraphics
+@testable import Dahlia
+
+#if canImport(Testing)
+import Testing
+
+struct ScreenshotWindowOptionTests {
+    @Test
+    func buildIncludesWindowFromAnotherDesktop() {
+        let options = ScreenshotWindowOption.build(
+            from: [
+                .init(
+                    windowID: 101,
+                    appName: "Google Chrome",
+                    bundleIdentifier: "com.google.Chrome",
+                    title: "Databricks extension",
+                    frame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+                    windowLayer: 0,
+                    isOnScreen: false
+                ),
+            ],
+            excludingBundleID: "com.matsuda.Dahlia"
+        )
+
+        #expect(options.count == 1)
+        #expect(options[0].id == 101)
+        #expect(options[0].isOnScreen == false)
+        #expect(options[0].displayName == "Google Chrome — Databricks extension")
+    }
+
+    @Test
+    func buildExcludesOwnAppUntitledAndZeroSizedWindows() {
+        let options = ScreenshotWindowOption.build(
+            from: [
+                .init(
+                    windowID: 1,
+                    appName: "Dahlia",
+                    bundleIdentifier: "com.matsuda.Dahlia",
+                    title: "Control Panel",
+                    frame: CGRect(x: 0, y: 0, width: 1000, height: 700),
+                    windowLayer: 0,
+                    isOnScreen: true
+                ),
+                .init(
+                    windowID: 2,
+                    appName: "Slack",
+                    bundleIdentifier: "com.tinyspeck.slackmacgap",
+                    title: "   ",
+                    frame: CGRect(x: 0, y: 0, width: 1200, height: 800),
+                    windowLayer: 0,
+                    isOnScreen: true
+                ),
+                .init(
+                    windowID: 3,
+                    appName: "ChatGPT",
+                    bundleIdentifier: "com.openai.chat",
+                    title: "Summary",
+                    frame: CGRect(x: 0, y: 0, width: 0, height: 800),
+                    windowLayer: 0,
+                    isOnScreen: true
+                ),
+                .init(
+                    windowID: 4,
+                    appName: "Codex",
+                    bundleIdentifier: "com.openai.codex",
+                    title: "dahlia",
+                    frame: CGRect(x: 0, y: 0, width: 1200, height: 800),
+                    windowLayer: 0,
+                    isOnScreen: true
+                ),
+            ],
+            excludingBundleID: "com.matsuda.Dahlia"
+        )
+
+        #expect(options.map(\.id) == [4])
+        #expect(options[0].displayName == "Codex — dahlia")
+    }
+}
+#endif


### PR DESCRIPTION
## 概要

- **マイク選択の改善**: `selectedMicrophoneID` を `MicrophoneSelection` enum に置き換え、「システムと同じ」選択肢を追加。デバイスが切断された場合はシステムデフォルトへ自動フォールバック。DI 対応で `CaptionViewModel` のテスタビリティも向上。
- **ScreenshotWindowOption モデル導入**: ウィンドウ一覧のフィルタリング・ソートロジックを `SCWindow` 依存から独自モデルに分離。別デスクトップのウィンドウも表示可能に（`onScreenWindowsOnly: false`）。
- **プロジェクトパンくずナビゲーション**: `ControlPanelView` に `MeetingProjectBreadcrumbBar` を追加し、階層パスの各セグメントからプロジェクト一覧やプロジェクト詳細へ直接ナビゲート可能に。`MeetingProjectPicker` を compact スタイル対応にして `MeetingMetadataBar` から上部ヘッダーへ移動。
- **Agent 起動コマンドのデフォルト変更**: `"claude"` からフルパス `~/.local/bin/claude` に変更し、PATH に依存しない安定した起動を実現。

## 変更ファイル

### 新規
- `Sources/Dahlia/Audio/MicrophoneSelection.swift` — マイク選択 enum
- `Sources/Dahlia/Models/ScreenshotWindowOption.swift` — ウィンドウ選択モデル
- `Tests/DahliaTests/ScreenshotWindowOptionTests.swift` — ウィンドウモデルのテスト

### 変更
- `CaptionViewModel` — MicrophoneSelection 対応、DI プロバイダー追加、ウィンドウ一覧を ScreenshotWindowOption に変更
- `ControlPanelView` — パンくずナビゲーション追加、プロジェクトピッカー移動
- `MeetingMetadataBar` — プロジェクトピッカーを外部公開、compact スタイル対応
- `AppSettings` / `AgentService` — デフォルト起動コマンド変更
- `L10n` / Localizable.strings (ja/en) — 「システムと同じ」ローカライズ追加

## テスト

- [x] `CaptionViewModelTests` — systemDefault 解決・デバイス切断時のフォールバックテスト追加
- [x] `ScreenshotWindowOptionTests` — フィルタリング・除外条件のテスト追加
- [x] `AgentServiceTests` — デフォルトコマンド変更に追従