### PR TITLE
文字起こし言語の選択ロジックを ViewModel に集約

### DIFF
--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -307,6 +307,10 @@ final class AppSettings: ObservableObject {
 
 extension UserDefaults {
     /// NOTE: KVO を正しく動作させるため、プロパティ名を UserDefaults キー名と一致させる
+    @objc dynamic var transcriptionLocale: String? {
+        string(forKey: "transcriptionLocale")
+    }
+
     @objc dynamic var enabledLocaleIdentifiers: String? {
         string(forKey: "enabledLocaleIdentifiers")
     }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -36,7 +36,13 @@ final class CaptionViewModel: ObservableObject {
     @Published var availableMicrophones: [MicrophoneDevice] = []
     @Published var microphoneSelection: MicrophoneSelection = .systemDefault
     @Published var isSystemAudioEnabled = true
-    @Published var selectedLocale: String = AppSettings.shared.transcriptionLocale
+    @Published var selectedLocale: String = AppSettings.shared.transcriptionLocale {
+        didSet {
+            guard selectedLocale != oldValue else { return }
+            updateFilteredLocales()
+            applyLocaleChange(from: oldValue, to: selectedLocale)
+        }
+    }
     @Published var supportedLocales: [Locale] = []
     @Published var filteredLocales: [Locale] = []
 
@@ -192,6 +198,7 @@ final class CaptionViewModel: ObservableObject {
     private var persistenceService: MeetingPersistenceService?
     private var storeCancellable: AnyCancellable?
     private var settingsCancellable: AnyCancellable?
+    private var transcriptionLocaleCancellable: AnyCancellable?
     private var meetingLoadTask: Task<Void, Never>?
     private let availableInputDevicesProvider: @Sendable () -> [MicrophoneDevice]
     private let defaultInputDeviceIDProvider: @Sendable () -> AudioDeviceID?
@@ -216,6 +223,16 @@ final class CaptionViewModel: ObservableObject {
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 self?.updateFilteredLocales()
+            }
+
+        transcriptionLocaleCancellable = UserDefaults.standard
+            .publisher(for: \.transcriptionLocale)
+            .compactMap { $0 }
+            .removeDuplicates()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] localeIdentifier in
+                guard let self, self.selectedLocale != localeIdentifier else { return }
+                self.selectedLocale = localeIdentifier
             }
     }
 
@@ -673,11 +690,6 @@ final class CaptionViewModel: ObservableObject {
                 ErrorReportingService.capture(error, context: ["source": "prepareAnalyzer"])
             }
         }
-    }
-
-    /// SwiftUI の selection binding 更新後に副作用だけを適用する。
-    func handleLocaleSelectionChange(from oldLocale: String, to newLocale: String) {
-        applyLocaleChange(from: oldLocale, to: newLocale)
     }
 
     func handleMicrophoneSelectionChange(from oldSelection: MicrophoneSelection, to newSelection: MicrophoneSelection) {

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -290,9 +290,6 @@ private struct SessionSettingsMenu: View {
                     }
                     .pickerStyle(.inline)
                     .labelsHidden()
-                    .onChange(of: viewModel.selectedLocale) { oldValue, newValue in
-                        viewModel.handleLocaleSelectionChange(from: oldValue, to: newValue)
-                    }
                 } label: {
                     Label("Language", systemImage: "globe")
                 }


### PR DESCRIPTION
## Summary
- 文字起こし言語（locale）の変更ハンドリングを View の `.onChange` から ViewModel の `didSet` に移動し、ロジックを集約
- UserDefaults の KVO publisher を追加し、設定画面など外部からの locale 変更を `CaptionViewModel` に自動反映
- 不要になった `handleLocaleSelectionChange` メソッドを削除

## Changes
- **AppSettings.swift**: `UserDefaults` に `transcriptionLocale` の KVO プロパティを追加
- **CaptionViewModel.swift**: `selectedLocale` に `didSet` を追加して副作用を集約、KVO subscription で外部変更を監視
- **ControlPanelView.swift**: `.onChange` ハンドラを削除（ViewModel 側で処理するため不要に）

## Test plan
- [x] 言語ピッカーから言語を切り替え、文字起こしが正しく切り替わることを確認
- [x] 録音中に言語を切り替え、パイプラインが再構築されることを確認
- [x] 設定画面から言語を変更した場合、コントロールパネルの表示が同期されることを確認