### PR TITLE
ロケール解決の強化と Google Drive フォルダピッカーの改善

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>5</string>
+    <string>6</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.0.5</string>
+    <string>0.0.6</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/Models/GoogleDriveFolderItem.swift
+++ b/Sources/Dahlia/Models/GoogleDriveFolderItem.swift
@@ -10,16 +10,22 @@ struct GoogleDriveFolderItem: Equatable, Identifiable {
     let name: String
     let detail: String
     let kind: GoogleDriveFolderItemKind
+    let driveId: String?
+    let driveName: String?
 
     init(
         id: String,
         name: String,
         detail: String,
-        kind: GoogleDriveFolderItemKind = .folder
+        kind: GoogleDriveFolderItemKind = .folder,
+        driveId: String? = nil,
+        driveName: String? = nil
     ) {
         self.id = id
         self.name = name
         self.detail = detail
         self.kind = kind
+        self.driveId = driveId
+        self.driveName = driveName
     }
 }

--- a/Sources/Dahlia/Services/GoogleDriveAPIClient.swift
+++ b/Sources/Dahlia/Services/GoogleDriveAPIClient.swift
@@ -100,7 +100,9 @@ final class GoogleDriveAPIClient: GoogleDriveAPIClientProviding, @unchecked Send
                 id: $0.id,
                 name: $0.name,
                 detail: L10n.googleDriveSharedDriveLabel,
-                kind: .sharedDrive
+                kind: .sharedDrive,
+                driveId: $0.id,
+                driveName: $0.name
             )
         }
         .sorted {
@@ -173,20 +175,42 @@ final class GoogleDriveAPIClient: GoogleDriveAPIClientProviding, @unchecked Send
     }
 
     private func enrichFolders(_ files: [DriveFilePayload], accessToken: String) async throws -> [GoogleDriveFolderItem] {
-        let parentNames = try await fetchParentNames(
-            accessToken: accessToken,
-            parentIds: Set(files.compactMap { $0.parents?.first })
-        )
+        async let parentNames = batchFetchNames(
+            ids: Set(files.compactMap { $0.parents?.first }),
+            accessToken: accessToken
+        ) { id in
+            (try? await self.getFile(accessToken: accessToken, id: id, fields: "id,name"))?.name
+        }
+        async let driveNames = batchFetchNames(
+            ids: Set(files.compactMap(\.driveId)),
+            accessToken: accessToken
+        ) { id in
+            (try? await self.getDrive(accessToken: accessToken, id: id, fields: "id,name"))?.name
+        }
+        let (resolvedParentNames, resolvedDriveNames) = try await (parentNames, driveNames)
 
         return files.map { file in
-            let detail: String = if let driveId = file.driveId, !driveId.isEmpty {
-                "Shared Drive (\(driveId))"
-            } else if let parentId = file.parents?.first, let parentName = parentNames[parentId] {
+            let parentId = file.parents?.first
+            let parentName = parentId.flatMap { resolvedParentNames[$0] }
+            let driveName = file.driveId.flatMap { resolvedDriveNames[$0] }
+            let detail: String = if let driveName {
+                if let parentName, !parentName.isEmpty {
+                    "\(driveName) / \(parentName)"
+                } else {
+                    driveName
+                }
+            } else if let parentName {
                 parentName
             } else {
                 file.id
             }
-            return GoogleDriveFolderItem(id: file.id, name: file.name, detail: detail)
+            return GoogleDriveFolderItem(
+                id: file.id,
+                name: file.name,
+                detail: detail,
+                driveId: file.driveId,
+                driveName: driveName
+            )
         }
         .sorted {
             let nameOrder = $0.name.localizedStandardCompare($1.name)
@@ -197,19 +221,22 @@ final class GoogleDriveAPIClient: GoogleDriveAPIClientProviding, @unchecked Send
         }
     }
 
-    private func fetchParentNames(accessToken: String, parentIds: Set<String>) async throws -> [String: String] {
-        guard !parentIds.isEmpty else { return [:] }
+    private func batchFetchNames(
+        ids: Set<String>,
+        accessToken: String,
+        fetchName: @Sendable @escaping (String) async -> String?
+    ) async throws -> [String: String] {
+        guard !ids.isEmpty else { return [:] }
         return try await withThrowingTaskGroup(of: (String, String?).self) { group in
-            for parentId in parentIds {
+            for id in ids {
                 group.addTask {
-                    let file = try? await self.getFile(accessToken: accessToken, id: parentId, fields: "id,name")
-                    return (parentId, file?.name)
+                    (id, await fetchName(id))
                 }
             }
             var result: [String: String] = [:]
-            for try await (parentId, parentName) in group {
-                if let parentName {
-                    result[parentId] = parentName
+            for try await (id, name) in group {
+                if let name {
+                    result[id] = name
                 }
             }
             return result
@@ -296,6 +323,15 @@ final class GoogleDriveAPIClient: GoogleDriveAPIClientProviding, @unchecked Send
         ]
         let data = try await request(accessToken: accessToken, url: components.url!)
         return try JSONDecoder().decode(DriveFilePayload.self, from: data)
+    }
+
+    private func getDrive(accessToken: String, id: String, fields: String) async throws -> DrivePayload {
+        var components = URLComponents(string: "https://www.googleapis.com/drive/v3/drives/\(id)")!
+        components.queryItems = [
+            .init(name: "fields", value: fields),
+        ]
+        let data = try await request(accessToken: accessToken, url: components.url!)
+        return try JSONDecoder().decode(DrivePayload.self, from: data)
     }
 
     private func request(accessToken: String, url: URL) async throws -> Data {

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -44,6 +44,7 @@ final class CaptionViewModel: ObservableObject {
         didSet {
             guard selectedLocale != oldValue else { return }
             updateFilteredLocales()
+            guard !isSynchronizingSelectedLocale else { return }
             applyLocaleChange(from: oldValue, to: selectedLocale)
         }
     }
@@ -205,9 +206,15 @@ final class CaptionViewModel: ObservableObject {
     private var storeSegmentsCancellable: AnyCancellable?
     private var transcriptionLocaleCancellable: AnyCancellable?
     private var meetingLoadTask: Task<Void, Never>?
+    private var isSynchronizingSelectedLocale = false
     private let availableInputDevicesProvider: @Sendable () -> [MicrophoneDevice]
     private let defaultInputDeviceIDProvider: @Sendable () -> AudioDeviceID?
     private let transcriptTranslationService = TranscriptTranslationService()
+
+    nonisolated private static let preferredTranscriptionLocaleFallbacksByLanguage = [
+        "en": "en_US",
+        "ja": "ja_JP",
+    ]
 
     private var activeDbQueueForSessionControls: DatabaseQueue? {
         recordingContext?.dbQueue ?? currentDbQueue
@@ -264,6 +271,78 @@ final class CaptionViewModel: ObservableObject {
                     || locale.identifier == selectedLocale
             }
         }
+    }
+
+    nonisolated static func resolvedSupportedLocaleIdentifier(
+        preferredIdentifier: String,
+        supportedLocales: [Locale]
+    ) -> String {
+        let trimmedIdentifier = preferredIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedIdentifier = normalizedLocaleIdentifier(from: trimmedIdentifier)
+        let supportedLocaleIdentifiers = Set(supportedLocales.map(\.identifier))
+
+        if supportedLocaleIdentifiers.contains(normalizedIdentifier) {
+            return normalizedIdentifier
+        }
+
+        let preferredLanguageIdentifier = TranscriptTranslationLanguage.normalizedLanguageIdentifier(from: trimmedIdentifier)
+        if let preferredFallback = preferredTranscriptionLocaleFallbacksByLanguage[preferredLanguageIdentifier],
+           supportedLocaleIdentifiers.contains(preferredFallback) {
+            return preferredFallback
+        }
+
+        let sortedLocales = supportedLocales.sorted(by: { $0.identifier < $1.identifier })
+
+        if let sameLanguageLocale = sortedLocales
+            .first(where: {
+                TranscriptTranslationLanguage.normalizedLanguageIdentifier(from: $0.identifier) == preferredLanguageIdentifier
+            }) {
+            return sameLanguageLocale.identifier
+        }
+
+        for fallback in preferredTranscriptionLocaleFallbacksByLanguage.values.sorted() {
+            if supportedLocaleIdentifiers.contains(fallback) {
+                return fallback
+            }
+        }
+
+        return sortedLocales.first?.identifier ?? normalizedIdentifier
+    }
+
+    private nonisolated static func normalizedLocaleIdentifier(from identifier: String) -> String {
+        guard !identifier.isEmpty else { return identifier }
+
+        let locale = Locale(identifier: identifier)
+        guard let languageCode = locale.language.languageCode?.identifier.nilIfBlank else {
+            return identifier
+                .replacingOccurrences(of: "-", with: "_")
+                .split(separator: "@", maxSplits: 1)
+                .first
+                .map(String.init) ?? identifier
+        }
+
+        guard let regionCode = locale.region?.identifier.nilIfBlank else {
+            return languageCode
+        }
+
+        return "\(languageCode)_\(regionCode)"
+    }
+
+    private func resolvedSelectedLocale() -> Locale {
+        let resolvedIdentifier = Self.resolvedSupportedLocaleIdentifier(
+            preferredIdentifier: selectedLocale,
+            supportedLocales: supportedLocales
+        )
+        synchronizeSelectedLocaleIfNeeded(resolvedIdentifier)
+        return Locale(identifier: resolvedIdentifier)
+    }
+
+    private func synchronizeSelectedLocaleIfNeeded(_ localeIdentifier: String) {
+        guard selectedLocale != localeIdentifier else { return }
+        isSynchronizingSelectedLocale = true
+        selectedLocale = localeIdentifier
+        isSynchronizingSelectedLocale = false
+        AppSettings.shared.transcriptionLocale = localeIdentifier
     }
 
     func refreshAvailableMicrophones() {
@@ -668,9 +747,6 @@ final class CaptionViewModel: ObservableObject {
         isPreparingAnalyzer = true
         errorMessage = nil
 
-        let localeIdentifier = selectedLocale
-        let locale = Locale(identifier: localeIdentifier)
-
         Task {
             do {
                 guard SpeechTranscriber.isAvailable else {
@@ -685,6 +761,7 @@ final class CaptionViewModel: ObservableObject {
                 self.updateFilteredLocales()
 
                 // モデルのダウンロードと準備確認
+                let locale = self.resolvedSelectedLocale()
                 try await SpeechTranscriberService.ensureModelInstalled(locale: locale)
                 self.analyzerReady = true
                 self.isPreparingAnalyzer = false
@@ -740,7 +817,7 @@ final class CaptionViewModel: ObservableObject {
         await stopActivePipelines()
         stopActiveCaptures()
 
-        let primaryLocale = Locale(identifier: selectedLocale)
+        let primaryLocale = resolvedSelectedLocale()
         do {
             try await SpeechTranscriberService.ensureModelInstalled(locale: primaryLocale)
         } catch {
@@ -883,7 +960,7 @@ final class CaptionViewModel: ObservableObject {
         persistenceService = nil
 
         do {
-            let primaryLocale = Locale(identifier: selectedLocale)
+            let primaryLocale = resolvedSelectedLocale()
             try await SpeechTranscriberService.ensureModelInstalled(locale: primaryLocale)
 
             if isMicEnabled {

--- a/Sources/Dahlia/Views/GoogleDriveFolderPickerView.swift
+++ b/Sources/Dahlia/Views/GoogleDriveFolderPickerView.swift
@@ -187,40 +187,28 @@ struct GoogleDriveFolderPickerView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             List(driveStore.folders) { folder in
-                HStack(spacing: 12) {
-                    Button {
-                        open(folder)
-                    } label: {
-                        HStack(spacing: 12) {
-                            Image(systemName: "folder")
-                                .foregroundStyle(Color.accentColor)
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(folder.name)
-                                    .font(.headline)
-                                    .foregroundStyle(.primary)
-                                Text(folder.detail)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer(minLength: 0)
-                            if !isSearching {
-                                Image(systemName: "chevron.right")
-                                    .font(.caption)
-                                    .foregroundStyle(.tertiary)
-                            }
+                Button {
+                    open(folder)
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: "folder")
+                            .foregroundStyle(Color.accentColor)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(folder.name)
+                                .font(.headline)
+                                .foregroundStyle(.primary)
+                            Text(folder.detail)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         }
-                        .contentShape(Rectangle())
+                        Spacer(minLength: 0)
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
                     }
-                    .buttonStyle(.plain)
-
-                    if isSearching {
-                        Button(L10n.selectFolder) {
-                            onSelect(folder)
-                            dismiss()
-                        }
-                        .buttonStyle(.link)
-                    }
+                    .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
                 .padding(.vertical, 4)
             }
             .listStyle(.inset)
@@ -254,8 +242,7 @@ struct GoogleDriveFolderPickerView: View {
 
     private func open(_ folder: GoogleDriveFolderItem) {
         if isSearching {
-            onSelect(folder)
-            dismiss()
+            openSearchResult(folder)
             return
         }
 
@@ -271,6 +258,35 @@ struct GoogleDriveFolderPickerView: View {
         }
         Task {
             await reloadCurrentView()
+        }
+    }
+
+    private func openSearchResult(_ folder: GoogleDriveFolderItem) {
+        let targetTab: PickerTab
+
+        if let driveId = folder.driveId, !driveId.isEmpty {
+            targetTab = .sharedDrives
+            let driveName = folder.driveName ?? L10n.googleDriveSharedDrives
+            sharedDrivePath = [.init(id: driveId, name: driveName)]
+            if folder.kind != .sharedDrive || folder.id != driveId {
+                sharedDrivePath.append(.init(id: folder.id, name: folder.name))
+            }
+        } else {
+            targetTab = .myDrive
+            myDrivePath = [
+                .init(id: "root", name: L10n.googleDriveMyDrive),
+                .init(id: folder.id, name: folder.name),
+            ]
+        }
+
+        clearSearch()
+
+        if selectedTab == targetTab {
+            Task {
+                await reloadCurrentView()
+            }
+        } else {
+            selectedTab = targetTab
         }
     }
 
@@ -361,8 +377,8 @@ struct GoogleDriveFolderPickerView: View {
     }
 
     private func clearSearch() {
-        searchText = ""
         searchQuery = ""
+        searchText = ""
         dismissSearchFocus()
     }
 

--- a/Tests/DahliaTests/CaptionViewModelTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelTests.swift
@@ -49,6 +49,37 @@ struct CaptionViewModelTests {
     }
 
     @Test
+    func unsupportedLocaleFallsBackToPreferredSupportedLanguageVariant() {
+        let supportedLocales = [
+            Locale(identifier: "en_AU"),
+            Locale(identifier: "en_US"),
+            Locale(identifier: "ja_JP"),
+        ]
+
+        let resolved = CaptionViewModel.resolvedSupportedLocaleIdentifier(
+            preferredIdentifier: "en_JP",
+            supportedLocales: supportedLocales
+        )
+
+        #expect(resolved == "en_US")
+    }
+
+    @Test
+    func localeIdentifierExtensionsAreStrippedBeforeSupportLookup() {
+        let supportedLocales = [
+            Locale(identifier: "en_US"),
+            Locale(identifier: "ja_JP"),
+        ]
+
+        let resolved = CaptionViewModel.resolvedSupportedLocaleIdentifier(
+            preferredIdentifier: "ja_JP@calendar=iso8601",
+            supportedLocales: supportedLocales
+        )
+
+        #expect(resolved == "ja_JP")
+    }
+
+    @Test
     func selectingActiveRecordingMeetingKeepsLiveTranscriptStore() throws {
         let viewModel = CaptionViewModel()
         let dbQueue = try DatabaseQueue(path: ":memory:")


### PR DESCRIPTION
## 概要

### ロケール解決の強化
- `CaptionViewModel` に `resolvedSupportedLocaleIdentifier` を追加し、未サポートロケールが指定された場合に同一言語の優先バリアント（例: `en_JP` → `en_US`）へフォールバックする仕組みを導入
- ロケール識別子の正規化処理（ハイフン→アンダースコア変換、`@calendar=...` 等の拡張子除去）を追加
- `selectedLocale` の `didSet` でロケール同期中の不要な `applyLocaleChange` 呼び出しを抑止
- フォールバックロジックのユニットテストを追加

### Google Drive フォルダピッカーの改善
- `GoogleDriveFolderItem` に `driveId` / `driveName` を追加し、検索結果から共有ドライブのフォルダへ直接ナビゲートできるように改善
- 検索結果クリック時にピッカーを閉じず、該当タブ・パスへ遷移する `openSearchResult` を実装
- フォルダ詳細表示を「共有ドライブ名 / 親フォルダ名」形式に改善
- `fetchParentNames` と `fetchDriveNames` の重複コードを汎用 `batchFetchNames` に統合し、`async let` で並行実行するようリファクタ
- リスト行の不要な `HStack` ネストを除去し、View 構造を簡素化

## テスト計画
- [x] `CaptionViewModelTests` にロケールフォールバックのテストを追加済み
- [ ] Google Drive 検索から共有ドライブ内フォルダへのナビゲーションを手動確認
- [ ] マイドライブ内フォルダへの検索ナビゲーションを手動確認
- [ ] 通常のフォルダブラウズが既存通り動作することを確認