### PR TITLE
TranscriptTabView のセグメントウィンドウイングによるアプリハング修正

### DIFF
--- a/Sources/Dahlia/Models/TranscriptStore.swift
+++ b/Sources/Dahlia/Models/TranscriptStore.swift
@@ -67,10 +67,21 @@ final class TranscriptStore: ObservableObject {
     }
 
     private func applyUnconfirmedMutation(_ mutation: UnconfirmedMutation, forSource sourceLabel: String? = nil) {
-        segments.removeAll { !$0.isConfirmed && $0.speakerLabel == sourceLabel }
-        if case let .upsert(segment) = mutation {
-            segments.append(segment)
+        let existingIndex = segments.lastIndex(where: { !$0.isConfirmed && $0.speakerLabel == sourceLabel })
+
+        switch mutation {
+        case .clear:
+            if let index = existingIndex {
+                segments.remove(at: index)
+            }
+        case let .upsert(segment):
+            if let index = existingIndex {
+                segments[index] = segment
+            } else {
+                segments.append(segment)
+            }
         }
+
         let key = sourceLabel ?? ""
         lastUnconfirmedUpdate[key] = .now
         pendingUnconfirmed[key] = nil

--- a/Sources/Dahlia/Views/AgentTabView.swift
+++ b/Sources/Dahlia/Views/AgentTabView.swift
@@ -93,29 +93,27 @@ private struct AgentLauncherView: View {
     }
 
     private var sidebarLauncherContent: some View {
-        ZStack(alignment: .bottom) {
-            VStack(spacing: 0) {
-                Spacer()
+        VStack(spacing: 0) {
+            Spacer()
 
-                Image(systemName: "sparkles")
-                    .font(.system(size: 36))
-                    .foregroundStyle(.purple)
-                    .padding(.bottom, 8)
+            Image(systemName: "sparkles")
+                .font(.system(size: 36))
+                .foregroundStyle(.purple)
+                .padding(.bottom, 8)
 
-                Text(L10n.agent)
-                    .font(.headline)
-                    .padding(.bottom, 4)
+            Text(L10n.agent)
+                .font(.headline)
+                .padding(.bottom, 4)
 
-                Text(hasContent ? L10n.agentProjectModeDescription : L10n.agentTranscriptModeDescription)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 20)
+            Text(hasContent ? L10n.agentProjectModeDescription : L10n.agentTranscriptModeDescription)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 20)
 
-                Spacer()
-            }
-            .padding(.bottom, AgentFloatingInputMetrics.contentBottomInset)
-
+            Spacer()
+        }
+        .safeAreaInset(edge: .bottom) {
             compactLauncherInputBar
                 .padding(.bottom, AgentFloatingInputMetrics.bottomPadding)
         }
@@ -251,85 +249,86 @@ private struct AgentChatView: View {
     @State private var inputText = ""
 
     var body: some View {
-        ZStack(alignment: .bottom) {
-            // メッセージ一覧
-            if service.messages.isEmpty {
-                VStack(spacing: 12) {
-                    if service.isRunning {
-                        ProgressView()
-                        Text(L10n.agentLaunching)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    } else {
-                        ContentUnavailableView {
-                            Label(L10n.agent, systemImage: "sparkles")
-                        } description: {
-                            Text("Agent の出力はまだありません")
-                        }
+        chatContentView
+            .safeAreaInset(edge: .bottom) {
+                VStack(spacing: 0) {
+                    AgentSessionBar(
+                        projectName: projectName,
+                        isLiveMode: service.mode.isTranscript,
+                        showsLiveModeBadge: showsLiveModeBadge
+                    )
+
+                    ChatInputBar(
+                        text: $inputText,
+                        isEnabled: service.isRunning
+                    ) {
+                        let message = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !message.isEmpty else { return }
+                        service.sendUserMessage(message)
+                        inputText = ""
                     }
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .padding(.bottom, AgentFloatingInputMetrics.contentBottomInset)
-            } else {
-                ScrollViewReader { proxy in
-                    ScrollView {
-                        LazyVStack(spacing: 12) {
-                            ForEach(service.messages) { message in
-                                ChatBubbleView(message: message)
-                            }
+                .padding(.bottom, AgentFloatingInputMetrics.bottomPadding)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
 
-                            if service.isProcessing {
-                                HStack(spacing: 8) {
-                                    ProgressView()
-                                        .controlSize(.small)
-                                    Text(L10n.agentProcessing)
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                }
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.leading, 36)
-                            }
-
-                            // スクロールアンカー
-                            Color.clear
-                                .frame(height: 1)
-                                .id("agent-bottom")
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.top, 12)
-                        .padding(.bottom, AgentFloatingInputMetrics.scrollBottomInset)
+    @ViewBuilder
+    private var chatContentView: some View {
+        if service.messages.isEmpty {
+            VStack(spacing: 12) {
+                if service.isRunning {
+                    ProgressView()
+                    Text(L10n.agentLaunching)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ContentUnavailableView {
+                        Label(L10n.agent, systemImage: "sparkles")
+                    } description: {
+                        Text("Agent の出力はまだありません")
                     }
-                    .onAppear {
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: 12) {
+                        ForEach(service.messages) { message in
+                            ChatBubbleView(message: message)
+                        }
+
+                        if service.isProcessing {
+                            HStack(spacing: 8) {
+                                ProgressView()
+                                    .controlSize(.small)
+                                Text(L10n.agentProcessing)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.leading, 36)
+                        }
+
+                        // スクロールアンカー
+                        Color.clear
+                            .frame(height: 1)
+                            .id("agent-bottom")
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.top, 12)
+                }
+                .onAppear {
+                    proxy.scrollTo("agent-bottom", anchor: .bottom)
+                }
+                .onChange(of: service.messages.count) {
+                    withAnimation(.easeOut(duration: 0.2)) {
                         proxy.scrollTo("agent-bottom", anchor: .bottom)
                     }
-                    .onChange(of: service.messages.count) {
-                        withAnimation(.easeOut(duration: 0.2)) {
-                            proxy.scrollTo("agent-bottom", anchor: .bottom)
-                        }
-                    }
                 }
             }
-
-            VStack(spacing: 0) {
-                AgentSessionBar(
-                    projectName: projectName,
-                    isLiveMode: service.mode.isTranscript,
-                    showsLiveModeBadge: showsLiveModeBadge
-                )
-
-                ChatInputBar(
-                    text: $inputText,
-                    isEnabled: service.isRunning
-                ) {
-                    let message = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !message.isEmpty else { return }
-                    service.sendUserMessage(message)
-                    inputText = ""
-                }
-            }
-            .padding(.bottom, AgentFloatingInputMetrics.bottomPadding)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 
@@ -728,6 +727,4 @@ private var askPageInputBackground: some View {
 
 private enum AgentFloatingInputMetrics {
     static let bottomPadding: CGFloat = 24
-    static let contentBottomInset: CGFloat = 102
-    static let scrollBottomInset: CGFloat = 110
 }

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -684,7 +684,7 @@ private struct LiveSubtitleOverlaySyncView: View {
             .onDisappear {
                 liveSubtitleOverlayService.hide()
             }
-            .onChange(of: store.segments) { _, _ in
+            .onReceive(store.objectWillChange.debounce(for: .milliseconds(200), scheduler: RunLoop.main)) { _ in
                 syncOverlay()
             }
             .onChange(of: isListening) { _, _ in

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -403,24 +403,18 @@ struct ContentView: View {
 
     @ViewBuilder
     private func workspaceContent<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        if shouldShowWorkspaceAgentSidebar {
-            HSplitView {
-                content()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .overlay(alignment: .bottom) {
-                        bottomOverlayBar
-                    }
-
-                AgentSidebarView(viewModel: viewModel, sidebarViewModel: sidebarViewModel)
-                    .frame(minWidth: 280, idealWidth: 340, maxWidth: 480, maxHeight: .infinity)
-                    .background(.background)
-            }
-        } else {
+        HSplitView {
             content()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .overlay(alignment: .bottom) {
                     bottomOverlayBar
                 }
+
+            if shouldShowWorkspaceAgentSidebar {
+                AgentSidebarView(viewModel: viewModel, sidebarViewModel: sidebarViewModel)
+                    .frame(minWidth: 280, idealWidth: 340, maxWidth: 480, maxHeight: .infinity)
+                    .background(.background)
+            }
         }
     }
 

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -1001,8 +1001,8 @@ struct ControlPanelView: View {
         .onChange(of: hasSummaryTab) {
             updateSummaryTabSelection()
         }
-        .onChange(of: displayedMeetingIdentity) { _, _ in
-            if displayedMeetingIdentity != nil {
+        .onChange(of: displayedMeetingIdentity) { _, newIdentity in
+            if newIdentity != nil {
                 selectedTab = initialTabSelection
             }
             viewModel.requestShowSummaryTab = false

--- a/Sources/Dahlia/Views/TranscriptTabView.swift
+++ b/Sources/Dahlia/Views/TranscriptTabView.swift
@@ -7,6 +7,11 @@ struct TranscriptTabView: View {
         static let followThreshold: CGFloat = 32
     }
 
+    private enum WindowMetrics {
+        static let initialWindowSize = 150
+        static let loadMoreCount = 100
+    }
+
     private struct BottomOffsetPreferenceKey: PreferenceKey {
         static let defaultValue: CGFloat = 0
 
@@ -35,6 +40,23 @@ struct TranscriptTabView: View {
 
     @State private var bottomOffset: CGFloat = 0
     @State private var shouldFollowLatest = true
+    @State private var windowSize = WindowMetrics.initialWindowSize
+
+    /// ForEach の ID 照合対象を制限するため、末尾 windowSize 件のみ返す。
+    private var windowedSegments: [TranscriptSegment] {
+        let segments = store.segments
+        guard segments.count > windowSize else { return segments }
+        return Array(segments.suffix(windowSize))
+    }
+
+    /// 配列確保なしでウィンドウ内のセグメント数を返す。
+    private var windowedSegmentCount: Int {
+        min(store.segments.count, windowSize)
+    }
+
+    private var hasMoreAbove: Bool {
+        store.segments.count > windowSize
+    }
 
     var body: some View {
         Group {
@@ -56,7 +78,16 @@ struct TranscriptTabView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 2) {
-                        ForEach(store.segments) { segment in
+                        if hasMoreAbove {
+                            ProgressView()
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 8)
+                                .onAppear {
+                                    loadMoreSegments()
+                                }
+                        }
+
+                        ForEach(windowedSegments) { segment in
                             TranscriptRowView(
                                 segment: segment,
                                 showsTranslatedText: showsTranslatedText
@@ -93,12 +124,21 @@ struct TranscriptTabView: View {
                     bottomOffset = newOffset
                     refreshFollowState(viewportHeight: geometry.size.height, bottomOffset: newOffset)
                 }
-                .onChange(of: store.segments.count) { oldCount, newCount in
+                .onChange(of: windowedSegmentCount) { oldCount, newCount in
                     guard newCount > oldCount, shouldFollowLatest else { return }
                     scrollToBottom(using: proxy)
                 }
+                .onChange(of: shouldFollowLatest) { _, isFollowing in
+                    if isFollowing {
+                        windowSize = WindowMetrics.initialWindowSize
+                    }
+                }
             }
         }
+    }
+
+    private func loadMoreSegments() {
+        windowSize = min(windowSize + WindowMetrics.loadMoreCount, store.segments.count)
     }
 
     private func refreshFollowState(viewportHeight: CGFloat, bottomOffset: CGFloat) {


### PR DESCRIPTION
## 概要

Sentry で報告されたアプリハング (2000ms+, DAHLIA-APP-P) を修正。

録音中にスクロールアップした際、`LazyVStack` 内の `ForEach` が全セグメントの ID 照合パスを実行し、数百件蓄積された状態でメインスレッドが長時間ブロックされていた。

## 変更内容

- **TranscriptTabView**: ForEach に渡すセグメントを末尾 150 件に制限するウィンドウイングを導入。スクロールアップ時に段階的に拡大し、自動追従モードに戻るとリセット
- **TranscriptStore**: `applyUnconfirmedMutation` を `removeAll` + `append` からインプレース置換に変更し、配列バッファの再確保を回避
- **ContentView**: `LiveSubtitleOverlaySyncView` の `.onChange(of: store.segments)` を `.onReceive(objectWillChange.debounce)` に変更し、O(n) の Equatable 比較を除去

## テスト計画

- [x] 録音を10分以上実行し、セグメントが数百件蓄積された状態でスクロールアップしてもハングしないこと
- [x] 録音中の自動スクロールが正常に動作すること
- [x] スクロールアップで過去のセグメントが段階的に読み込まれること
- [x] 過去のトランスクリプトを開いた際にハングしないこと
- [x] ライブ字幕オーバーレイが正常に更新されること

Fixes DAHLIA-APP-P