### PR TITLE
SwiftUI レイアウトハング修正 (Fixes DAHLIA-APP-1)

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>7</string>
+    <string>8</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.0.7</string>
+    <string>0.0.8</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/Audio/MicrophoneSelection.swift
+++ b/Sources/Dahlia/Audio/MicrophoneSelection.swift
@@ -1,6 +1,6 @@
 import CoreAudio
 
-enum MicrophoneSelection: Hashable, Sendable {
+enum MicrophoneSelection: Hashable {
     case none
     case systemDefault
     case device(AudioDeviceID)

--- a/Sources/Dahlia/DahliaApp.swift
+++ b/Sources/Dahlia/DahliaApp.swift
@@ -206,6 +206,7 @@ struct DahliaApp: App {
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_: Notification) {
+        signal(SIGPIPE, SIG_IGN)
         ErrorReportingService.start()
         NSApplication.shared.setActivationPolicy(.regular)
     }

--- a/Sources/Dahlia/DahliaApp.swift
+++ b/Sources/Dahlia/DahliaApp.swift
@@ -206,6 +206,7 @@ struct DahliaApp: App {
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_: Notification) {
+        // Agent サブプロセスの stdin パイプが閉じた際の SIGPIPE クラッシュを防止
         signal(SIGPIPE, SIG_IGN)
         ErrorReportingService.start()
         NSApplication.shared.setActivationPolicy(.regular)

--- a/Sources/Dahlia/Models/LiveSubtitleOverlayPayload.swift
+++ b/Sources/Dahlia/Models/LiveSubtitleOverlayPayload.swift
@@ -40,7 +40,7 @@ struct LiveSubtitleOverlayPayload: Equatable {
             var selectedIndices = [latestUnconfirmedIndex]
             var candidateIndex = latestUnconfirmedIndex - 1
 
-            while candidateIndex >= 0 && selectedIndices.count < clampedMaxEntries {
+            while candidateIndex >= 0, selectedIndices.count < clampedMaxEntries {
                 selectedIndices.append(candidateIndex)
                 candidateIndex -= 1
             }

--- a/Sources/Dahlia/Models/LiveSubtitleSourceMode.swift
+++ b/Sources/Dahlia/Models/LiveSubtitleSourceMode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum LiveSubtitleSourceMode: String, CaseIterable, Identifiable, Sendable {
+enum LiveSubtitleSourceMode: String, CaseIterable, Identifiable {
     case systemAudioOnly
     case includeMicrophone
 

--- a/Sources/Dahlia/Services/AgentService.swift
+++ b/Sources/Dahlia/Services/AgentService.swift
@@ -64,6 +64,20 @@ enum AgentLaunchError: LocalizedError {
     }
 }
 
+enum AgentCrashError: LocalizedError {
+    case unexpectedSignal(Int32)
+    case abnormalExit(Int32)
+
+    var errorDescription: String? {
+        switch self {
+        case let .unexpectedSignal(signal):
+            "Agent が予期せず終了しました (signal \(signal))"
+        case let .abnormalExit(code):
+            "Agent が異常終了しました (exit code \(code))"
+        }
+    }
+}
+
 /// Agent CLI をサブプロセスとして管理し、確定済み文字起こしセグメントをストリーミングで送信するサービス。
 @MainActor
 final class AgentService: ObservableObject {
@@ -151,14 +165,36 @@ final class AgentService: ObservableObject {
 
         let stdin = Pipe()
         let stdout = Pipe()
-        let stderr = Pipe()
         proc.standardInput = stdin
         proc.standardOutput = stdout
-        proc.standardError = stderr
+        proc.standardError = FileHandle.nullDevice
 
-        proc.terminationHandler = { [weak self] _ in
+        proc.terminationHandler = { [weak self] terminatedProcess in
+            let reason = terminatedProcess.terminationReason
+            let status = terminatedProcess.terminationStatus
             Task { @MainActor [weak self] in
-                self?.isRunning = false
+                guard let self else { return }
+                self.cancellable = nil
+                try? self.stdinPipe?.fileHandleForWriting.close()
+                self.stdinPipe = nil
+                self.readTask?.cancel()
+                self.isRunning = false
+                self.isProcessing = false
+                self.flushPendingDelta()
+
+                if reason == .uncaughtSignal {
+                    let error = AgentCrashError.unexpectedSignal(status)
+                    self.messages.append(AgentMessage(role: .error, content: error.localizedDescription))
+                    self.logger.error("\(error.localizedDescription)")
+                    ErrorReportingService.capture(
+                        error,
+                        context: ["source": "agentProcessCrash", "signal": "\(status)"]
+                    )
+                } else if status != 0 {
+                    let error = AgentCrashError.abnormalExit(status)
+                    self.messages.append(AgentMessage(role: .error, content: error.localizedDescription))
+                    self.logger.warning("\(error.localizedDescription)")
+                }
             }
         }
 
@@ -210,9 +246,9 @@ final class AgentService: ObservableObject {
             // SIGTERM を送信
             proc?.terminate()
             try? await Task.sleep(for: .seconds(2))
-            if proc?.isRunning == true {
+            if let proc, proc.isRunning {
                 // 応答しない場合は SIGKILL で強制終了
-                kill(proc!.processIdentifier, SIGKILL)
+                kill(proc.processIdentifier, SIGKILL)
             }
         }
 
@@ -232,7 +268,7 @@ final class AgentService: ObservableObject {
     // MARK: - Stdin Writing
 
     private func writeToStdin(content: String) {
-        guard let pipe = stdinPipe else { return }
+        guard isRunning, let pipe = stdinPipe else { return }
 
         let payload: [String: Any] = [
             "type": "user",

--- a/Sources/Dahlia/Services/AgentService.swift
+++ b/Sources/Dahlia/Services/AgentService.swift
@@ -31,7 +31,8 @@ struct ToolResultInfo {
 }
 
 /// ツール呼び出しの詳細情報。
-struct ToolCallInfo {
+/// `@unchecked Sendable`: toolInput の `[String: Any]` は JSONSerialization 由来の不変値型のみ含む。
+struct ToolCallInfo: @unchecked Sendable {
     let toolName: String
     let toolUseId: String
     let toolInput: [String: Any]
@@ -39,7 +40,7 @@ struct ToolCallInfo {
 }
 
 /// Agent CLI プロセスからの出力メッセージ。
-struct AgentMessage: Identifiable {
+struct AgentMessage: Identifiable, @unchecked Sendable {
     let id: UUID = .v7()
     let role: AgentMessageRole
     var content: String
@@ -465,7 +466,7 @@ final class AgentService: ObservableObject {
             pendingDeltaText += text
             if deltaFlushTask == nil {
                 deltaFlushTask = Task { @MainActor [weak self] in
-                    try? await Task.sleep(for: .milliseconds(50))
+                    try? await Task.sleep(for: .milliseconds(100))
                     self?.flushPendingDelta()
                 }
             }

--- a/Sources/Dahlia/Services/GoogleDriveAPIClient.swift
+++ b/Sources/Dahlia/Services/GoogleDriveAPIClient.swift
@@ -179,13 +179,13 @@ final class GoogleDriveAPIClient: GoogleDriveAPIClientProviding, @unchecked Send
             ids: Set(files.compactMap { $0.parents?.first }),
             accessToken: accessToken
         ) { id in
-            (try? await self.getFile(accessToken: accessToken, id: id, fields: "id,name"))?.name
+            await (try? self.getFile(accessToken: accessToken, id: id, fields: "id,name"))?.name
         }
         async let driveNames = batchFetchNames(
             ids: Set(files.compactMap(\.driveId)),
             accessToken: accessToken
         ) { id in
-            (try? await self.getDrive(accessToken: accessToken, id: id, fields: "id,name"))?.name
+            await (try? self.getDrive(accessToken: accessToken, id: id, fields: "id,name"))?.name
         }
         let (resolvedParentNames, resolvedDriveNames) = try await (parentNames, driveNames)
 
@@ -223,14 +223,14 @@ final class GoogleDriveAPIClient: GoogleDriveAPIClientProviding, @unchecked Send
 
     private func batchFetchNames(
         ids: Set<String>,
-        accessToken: String,
+        accessToken _: String,
         fetchName: @Sendable @escaping (String) async -> String?
     ) async throws -> [String: String] {
         guard !ids.isEmpty else { return [:] }
         return try await withThrowingTaskGroup(of: (String, String?).self) { group in
             for id in ids {
                 group.addTask {
-                    (id, await fetchName(id))
+                    await (id, fetchName(id))
                 }
             }
             var result: [String: String] = [:]

--- a/Sources/Dahlia/Services/LiveSubtitleOverlayService.swift
+++ b/Sources/Dahlia/Services/LiveSubtitleOverlayService.swift
@@ -112,7 +112,7 @@ final class LiveSubtitleOverlayService: ObservableObject {
             )
         }
 
-        if let persistedTopLeft = persistedTopLeft {
+        if let persistedTopLeft {
             return frame(
                 anchoredAtTopLeft: persistedTopLeft,
                 size: resolvedSize,

--- a/Sources/Dahlia/Services/TranscriptTranslationService.swift
+++ b/Sources/Dahlia/Services/TranscriptTranslationService.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Translation
 import os
+import Translation
 
 actor TranscriptTranslationService {
     private struct LanguagePair: Hashable {

--- a/Sources/Dahlia/Speech/SpeechTranscriberService.swift
+++ b/Sources/Dahlia/Speech/SpeechTranscriberService.swift
@@ -8,7 +8,7 @@ import Speech
 actor SpeechTranscriberService {
     typealias SegmentTranslationHandler = @Sendable (TranscriptSegment) async -> String?
 
-    private nonisolated static let ignoredConfirmedTexts: Set<String> = [".", "あ"]
+    private nonisolated static let ignoredConfirmedTexts: Set = [".", "あ"]
 
     private var analyzer: SpeechAnalyzer?
     private var transcriber: SpeechTranscriber?

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -112,7 +112,10 @@ enum L10n {
     static var useForSummary: String { String(localized: "Use for Summary", bundle: bundle) }
     static var useAutoInstructions: String { String(localized: "Use Auto", bundle: bundle) }
     static var summaryInstructionSelected: String { String(localized: "This instruction is currently used for summary generation.", bundle: bundle) }
-    static var summaryInstructionNotSelected: String { String(localized: "This instruction is not currently used for summary generation.", bundle: bundle) }
+    static var summaryInstructionNotSelected: String { String(
+        localized: "This instruction is not currently used for summary generation.",
+        bundle: bundle
+    ) }
     static var instructionsEmptyContent: String { String(localized: "No content yet", bundle: bundle) }
     static var noResultsFound: String { String(localized: "No results found", bundle: bundle) }
     static var noProject: String { String(localized: "No project", bundle: bundle) }
@@ -136,13 +139,22 @@ enum L10n {
     static var showLiveSubtitles: String { String(localized: "Show Live Subtitles", bundle: bundle) }
     static var hideLiveSubtitles: String { String(localized: "Hide Live Subtitles", bundle: bundle) }
     static var liveSubtitleOverlay: String { String(localized: "Live Subtitle Overlay", bundle: bundle) }
-    static var liveSubtitleOverlayDescription: String { String(localized: "Configure how the desktop live subtitle overlay is shown while recording.", bundle: bundle) }
+    static var liveSubtitleOverlayDescription: String { String(
+        localized: "Configure how the desktop live subtitle overlay is shown while recording.",
+        bundle: bundle
+    ) }
     static var subtitles: String { String(localized: "Subtitles", bundle: bundle) }
     static var systemAudioOnly: String { String(localized: "System Audio Only", bundle: bundle) }
     static var includeMicrophone: String { String(localized: "Include Microphone", bundle: bundle) }
-    static var liveSubtitleSourceDescription: String { String(localized: "Choose whether live subtitles only show system audio or also include microphone input.", bundle: bundle) }
+    static var liveSubtitleSourceDescription: String { String(
+        localized: "Choose whether live subtitles only show system audio or also include microphone input.",
+        bundle: bundle
+    ) }
     static var liveSubtitleOverlaySegmentCount: String { String(localized: "Overlay Segment Count", bundle: bundle) }
-    static var liveSubtitleOverlaySegmentCountDescription: String { String(localized: "Choose how many recent transcript segments the live subtitle overlay shows.", bundle: bundle) }
+    static var liveSubtitleOverlaySegmentCountDescription: String { String(
+        localized: "Choose how many recent transcript segments the live subtitle overlay shows.",
+        bundle: bundle
+    ) }
 
     // MARK: - Detail Tabs
 

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -33,6 +33,7 @@ final class CaptionViewModel: ObservableObject {
             bindStoreSegments()
         }
     }
+
     @Published var isListening = false
     @Published var analyzerReady = false
     @Published var isPreparingAnalyzer = false
@@ -48,6 +49,7 @@ final class CaptionViewModel: ObservableObject {
             applyLocaleChange(from: oldValue, to: selectedLocale)
         }
     }
+
     @Published var supportedLocales: [Locale] = []
     @Published var filteredLocales: [Locale] = []
 
@@ -211,7 +213,7 @@ final class CaptionViewModel: ObservableObject {
     private let defaultInputDeviceIDProvider: @Sendable () -> AudioDeviceID?
     private let transcriptTranslationService = TranscriptTranslationService()
 
-    nonisolated private static let preferredTranscriptionLocaleFallbacksByLanguage = [
+    private nonisolated static let preferredTranscriptionLocaleFallbacksByLanguage = [
         "en": "en_US",
         "ja": "ja_JP",
     ]
@@ -240,7 +242,7 @@ final class CaptionViewModel: ObservableObject {
 
         transcriptionLocaleCancellable = UserDefaults.standard
             .publisher(for: \.transcriptionLocale)
-            .compactMap { $0 }
+            .compactMap(\.self)
             .removeDuplicates()
             .receive(on: RunLoop.main)
             .sink { [weak self] localeIdentifier in

--- a/Sources/Dahlia/Views/AgentTabView.swift
+++ b/Sources/Dahlia/Views/AgentTabView.swift
@@ -357,6 +357,9 @@ private struct AgentChatView: View {
                     withTransaction(transaction) {
                         proxy.scrollTo("agent-bottom", anchor: .bottom)
                     }
+                    if messageWindowSize > WindowMetrics.initialWindowSize {
+                        messageWindowSize = WindowMetrics.initialWindowSize
+                    }
                 }
             }
         }

--- a/Sources/Dahlia/Views/AgentTabView.swift
+++ b/Sources/Dahlia/Views/AgentTabView.swift
@@ -243,10 +243,26 @@ private struct AgentLauncherView: View {
 
 /// AgentService を直接 @ObservedObject で監視するチャットビュー。
 private struct AgentChatView: View {
+    private enum WindowMetrics {
+        static let initialWindowSize = 50
+        static let loadMoreCount = 30
+    }
+
     @ObservedObject var service: AgentService
     let projectName: String
     let showsLiveModeBadge: Bool
     @State private var inputText = ""
+    @State private var messageWindowSize = WindowMetrics.initialWindowSize
+
+    private var windowedMessages: ArraySlice<AgentMessage> {
+        let messages = service.messages
+        guard messages.count > messageWindowSize else { return messages[...] }
+        return messages.suffix(messageWindowSize)
+    }
+
+    private var hasMoreAbove: Bool {
+        service.messages.count > messageWindowSize
+    }
 
     var body: some View {
         chatContentView
@@ -295,8 +311,21 @@ private struct AgentChatView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(spacing: 12) {
-                        ForEach(service.messages) { message in
+                        if hasMoreAbove {
+                            ProgressView()
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 8)
+                                .onAppear {
+                                    messageWindowSize = min(
+                                        messageWindowSize + WindowMetrics.loadMoreCount,
+                                        service.messages.count
+                                    )
+                                }
+                        }
+
+                        ForEach(windowedMessages) { message in
                             ChatBubbleView(message: message)
+                                .equatable()
                         }
 
                         if service.isProcessing {
@@ -323,7 +352,9 @@ private struct AgentChatView: View {
                     proxy.scrollTo("agent-bottom", anchor: .bottom)
                 }
                 .onChange(of: service.messages.count) {
-                    withAnimation(.easeOut(duration: 0.2)) {
+                    var transaction = Transaction(animation: nil)
+                    transaction.disablesAnimations = true
+                    withTransaction(transaction) {
                         proxy.scrollTo("agent-bottom", anchor: .bottom)
                     }
                 }
@@ -410,7 +441,16 @@ private struct ChatInputBar: View {
 }
 
 /// チャット風の吹き出しビュー。
-private struct ChatBubbleView: View {
+private struct ChatBubbleView: View, Equatable {
+    nonisolated static func == (lhs: ChatBubbleView, rhs: ChatBubbleView) -> Bool {
+        lhs.message.id == rhs.message.id
+            && lhs.message.content == rhs.message.content
+            && lhs.message.role == rhs.message.role
+            && lhs.message.toolCallInfo?.toolName == rhs.message.toolCallInfo?.toolName
+            && lhs.message.toolCallInfo?.toolResult?.content == rhs.message.toolCallInfo?.toolResult?.content
+            && lhs.message.toolCallInfo?.toolResult?.isError == rhs.message.toolCallInfo?.toolResult?.isError
+    }
+
     let message: AgentMessage
 
     private var isUser: Bool { message.role == .user }

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -386,7 +386,6 @@ struct ContentView: View {
         ActionItemsOverviewView(sidebarViewModel: sidebarViewModel)
     }
 
-    @ViewBuilder
     private var askWorkspaceContent: some View {
         AgentSidebarView(viewModel: viewModel, sidebarViewModel: sidebarViewModel)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -401,8 +400,7 @@ struct ContentView: View {
         }
     }
 
-    @ViewBuilder
-    private func workspaceContent<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+    private func workspaceContent(@ViewBuilder content: () -> some View) -> some View {
         HSplitView {
             content()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/Dahlia/Views/MarkdownContentView.swift
+++ b/Sources/Dahlia/Views/MarkdownContentView.swift
@@ -51,7 +51,7 @@ struct MarkdownContentView: View {
                 .font(.body)
         case let .unorderedList(items):
             VStack(alignment: .leading, spacing: 2) {
-                ForEach(items, id: \.self) { item in
+                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
                     HStack(alignment: .firstTextBaseline, spacing: 6) {
                         Text("•")
                         inlineMarkdownText(item)
@@ -118,7 +118,7 @@ struct MarkdownContentView: View {
     private func tableView(headers: [String], rows: [[String]]) -> some View {
         Grid(alignment: .leading, horizontalSpacing: 0, verticalSpacing: 0) {
             GridRow {
-                ForEach(headers, id: \.self) { header in
+                ForEach(Array(headers.enumerated()), id: \.offset) { _, header in
                     Text(header)
                         .font(.caption.bold())
                         .padding(.horizontal, 8)

--- a/Sources/Dahlia/Views/MarkdownContentView.swift
+++ b/Sources/Dahlia/Views/MarkdownContentView.swift
@@ -9,7 +9,7 @@ struct MarkdownContentView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
+            ForEach(blocks, id: \.self) { block in
                 blockView(block)
             }
         }
@@ -23,14 +23,14 @@ struct MarkdownContentView: View {
         .onChange(of: markdown) { _, newValue in
             parseTask?.cancel()
             parseTask = Task { @MainActor in
-                try? await Task.sleep(for: .milliseconds(100))
+                try? await Task.sleep(for: .milliseconds(200))
                 guard !Task.isCancelled else { return }
                 blocks = Self.parseBlocks(newValue)
             }
         }
     }
 
-    private enum Block {
+    private enum Block: Hashable {
         case heading(level: Int, text: String)
         case paragraph(text: String)
         case unorderedList(items: [String])
@@ -51,7 +51,7 @@ struct MarkdownContentView: View {
                 .font(.body)
         case let .unorderedList(items):
             VStack(alignment: .leading, spacing: 2) {
-                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                ForEach(items, id: \.self) { item in
                     HStack(alignment: .firstTextBaseline, spacing: 6) {
                         Text("•")
                         inlineMarkdownText(item)
@@ -118,7 +118,7 @@ struct MarkdownContentView: View {
     private func tableView(headers: [String], rows: [[String]]) -> some View {
         Grid(alignment: .leading, horizontalSpacing: 0, verticalSpacing: 0) {
             GridRow {
-                ForEach(Array(headers.enumerated()), id: \.offset) { _, header in
+                ForEach(headers, id: \.self) { header in
                     Text(header)
                         .font(.caption.bold())
                         .padding(.horizontal, 8)

--- a/Sources/Dahlia/Views/MeetingMetadataBar.swift
+++ b/Sources/Dahlia/Views/MeetingMetadataBar.swift
@@ -465,4 +465,3 @@ struct MeetingProjectPicker: View {
         showProjectPopover = false
     }
 }
-

--- a/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
@@ -35,7 +35,7 @@ struct TranscriptionSettingsView: View {
                             .frame(width: 220, alignment: .trailing)
                         }
 
-                        if !settings.isTranscriptTranslationEffectivelyEnabled && settings.transcriptTranslationEnabled {
+                        if !settings.isTranscriptTranslationEffectivelyEnabled, settings.transcriptTranslationEnabled {
                             Divider()
 
                             SettingsStatusMessage(

--- a/Sources/Dahlia/Views/TranscriptTabView.swift
+++ b/Sources/Dahlia/Views/TranscriptTabView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct TranscriptTabView: View {
     private enum ScrollMetrics {
         static let bottomAnchorID = "transcript-bottom"
-        static let coordinateSpaceName = "TranscriptTabScrollView"
         static let followThreshold: CGFloat = 32
     }
 
@@ -12,41 +11,19 @@ struct TranscriptTabView: View {
         static let loadMoreCount = 100
     }
 
-    private struct BottomOffsetPreferenceKey: PreferenceKey {
-        static let defaultValue: CGFloat = 0
-
-        static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-            value = nextValue()
-        }
-    }
-
-    private struct BottomOffsetReader: View {
-        var body: some View {
-            GeometryReader { proxy in
-                Color.clear
-                    .preference(
-                        key: BottomOffsetPreferenceKey.self,
-                        value: proxy.frame(in: .named(ScrollMetrics.coordinateSpaceName)).maxY
-                    )
-            }
-            .frame(height: 1)
-        }
-    }
-
     @ObservedObject var store: TranscriptStore
     let isListening: Bool
     let showsRecordingIndicator: Bool
     let showsTranslatedText: Bool
 
-    @State private var bottomOffset: CGFloat = 0
     @State private var shouldFollowLatest = true
     @State private var windowSize = WindowMetrics.initialWindowSize
 
     /// ForEach の ID 照合対象を制限するため、末尾 windowSize 件のみ返す。
-    private var windowedSegments: [TranscriptSegment] {
+    private var windowedSegments: ArraySlice<TranscriptSegment> {
         let segments = store.segments
-        guard segments.count > windowSize else { return segments }
-        return Array(segments.suffix(windowSize))
+        guard segments.count > windowSize else { return segments[...] }
+        return segments.suffix(windowSize)
     }
 
     /// 配列確保なしでウィンドウ内のセグメント数を返す。
@@ -74,64 +51,60 @@ struct TranscriptTabView: View {
     }
 
     private var transcriptScrollView: some View {
-        GeometryReader { geometry in
-            ScrollViewReader { proxy in
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 2) {
-                        if hasMoreAbove {
-                            ProgressView()
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 8)
-                                .onAppear {
-                                    loadMoreSegments()
-                                }
-                        }
-
-                        ForEach(windowedSegments) { segment in
-                            TranscriptRowView(
-                                segment: segment,
-                                showsTranslatedText: showsTranslatedText
-                            )
-                            .equatable()
-                        }
-
-                        if showsRecordingIndicator {
-                            HStack(spacing: 6) {
-                                ProgressView()
-                                    .scaleEffect(0.5)
-                                    .frame(width: 12, height: 12)
-                                Text(L10n.recognizing)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 2) {
+                    if hasMoreAbove {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 8)
+                            .onAppear {
+                                loadMoreSegments()
                             }
-                            .padding(.vertical, 4)
-                            .padding(.leading, 68)
-                        }
+                    }
 
-                        BottomOffsetReader()
-                            .id(ScrollMetrics.bottomAnchorID)
+                    ForEach(windowedSegments) { segment in
+                        TranscriptRowView(
+                            segment: segment,
+                            showsTranslatedText: showsTranslatedText
+                        )
+                        .equatable()
                     }
-                    .padding(8)
-                }
-                .coordinateSpace(name: ScrollMetrics.coordinateSpaceName)
-                .onAppear {
-                    refreshFollowState(viewportHeight: geometry.size.height, bottomOffset: bottomOffset)
-                }
-                .onChange(of: geometry.size.height) { _, newHeight in
-                    refreshFollowState(viewportHeight: newHeight, bottomOffset: bottomOffset)
-                }
-                .onPreferenceChange(BottomOffsetPreferenceKey.self) { newOffset in
-                    bottomOffset = newOffset
-                    refreshFollowState(viewportHeight: geometry.size.height, bottomOffset: newOffset)
-                }
-                .onChange(of: windowedSegmentCount) { oldCount, newCount in
-                    guard newCount > oldCount, shouldFollowLatest else { return }
-                    scrollToBottom(using: proxy)
-                }
-                .onChange(of: shouldFollowLatest) { _, isFollowing in
-                    if isFollowing {
-                        windowSize = WindowMetrics.initialWindowSize
+
+                    if showsRecordingIndicator {
+                        HStack(spacing: 6) {
+                            ProgressView()
+                                .scaleEffect(0.5)
+                                .frame(width: 12, height: 12)
+                            Text(L10n.recognizing)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.vertical, 4)
+                        .padding(.leading, 68)
                     }
+
+                    Color.clear
+                        .frame(height: 1)
+                        .id(ScrollMetrics.bottomAnchorID)
+                }
+                .padding(8)
+            }
+            .onScrollGeometryChange(for: Bool.self) { geometry in
+                let distanceFromBottom = geometry.contentSize.height
+                    - geometry.contentOffset.y
+                    - geometry.containerSize.height
+                return distanceFromBottom <= ScrollMetrics.followThreshold
+            } action: { _, isNearBottom in
+                shouldFollowLatest = isNearBottom
+            }
+            .onChange(of: windowedSegmentCount) { oldCount, newCount in
+                guard newCount > oldCount, shouldFollowLatest else { return }
+                scrollToBottom(using: proxy)
+            }
+            .onChange(of: shouldFollowLatest) { _, isFollowing in
+                if isFollowing {
+                    windowSize = WindowMetrics.initialWindowSize
                 }
             }
         }
@@ -139,18 +112,6 @@ struct TranscriptTabView: View {
 
     private func loadMoreSegments() {
         windowSize = min(windowSize + WindowMetrics.loadMoreCount, store.segments.count)
-    }
-
-    private func refreshFollowState(viewportHeight: CGFloat, bottomOffset: CGFloat) {
-        guard viewportHeight > 0 else {
-            shouldFollowLatest = true
-            return
-        }
-
-        let isNearBottom = bottomOffset - viewportHeight <= ScrollMetrics.followThreshold
-        if shouldFollowLatest != isNearBottom {
-            shouldFollowLatest = isNearBottom
-        }
     }
 
     private func scrollToBottom(using proxy: ScrollViewProxy) {


### PR DESCRIPTION
## 概要

Sentry issue [DAHLIA-APP-1](https://dahlia-app.sentry.io/issues/7410206357/) で報告されている「App Hanging for at least 2000 ms」を修正。SwiftUI のレイアウト計算（GeometryReader → ScrollView → LazyVStack → ForEach）でメインスレッドがブロックされていた。

## 変更内容

### TranscriptTabView — GeometryReader レイアウトフィードバックループの除去
- 外側の `GeometryReader` と内部の `BottomOffsetReader`（PreferenceKey ベースのスクロール追跡）を完全に除去
- macOS 26+ の `.onScrollGeometryChange(for:)` API に置き換え
- `windowedSegments` を `ArraySlice` に変更し、毎回の `Array` 新規作成を回避

### AgentChatView — パフォーマンス改善
- メッセージウィンドウイング追加（末尾50件、上スクロールで+30件読み込み）
- `ChatBubbleView` に `Equatable` 準拠を追加し `.equatable()` で未変更バブルの再描画をスキップ
- アニメーション付きスクロールをアニメーション無し `Transaction` に変更

### MarkdownContentView — レンダリング効率化
- `Block` enum に `Hashable` 準拠を追加し、`ForEach(blocks, id: \.self)` でコンテンツベースの安定IDに変更
- `onChange` debounce を 100ms → 200ms に増加

### AgentService — 更新頻度の削減
- delta flush 間隔を 50ms → 100ms に変更
- `ToolCallInfo`, `AgentMessage` に `Sendable` 準拠を追加

## テスト計画

- [x] 200+ セグメントの文字起こしセッションで TranscriptTabView の自動スクロール・load more 動作確認
- [x] Agent ストリーミングセッションでハングが発生しないことを確認
- [x] Agent チャットでツール結果の表示が正常に更新されることを確認

Fixes DAHLIA-APP-1