### PR TITLE
Transcript/Agent タブのスクロールウィンドウ早期拡張を修正 (v0.0.9)

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>8</string>
+    <string>9</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.0.8</string>
+    <string>0.0.9</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/Views/AgentTabView.swift
+++ b/Sources/Dahlia/Views/AgentTabView.swift
@@ -247,6 +247,7 @@ private struct AgentChatView: View {
         static let initialWindowSize = 50
         static let loadMoreCount = 30
         static let loadMoreThreshold: CGFloat = 24
+        static let bottomAnchorID = "agent-bottom"
     }
 
     @ObservedObject var service: AgentService
@@ -319,7 +320,7 @@ private struct AgentChatView: View {
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, 8)
                                 .onAppear {
-                                    loadMoreMessagesIfNeeded(totalCount: service.messages.count)
+                                    loadMoreMessagesIfNeeded()
                                 }
                         }
 
@@ -343,7 +344,7 @@ private struct AgentChatView: View {
                         // スクロールアンカー
                         Color.clear
                             .frame(height: 1)
-                            .id("agent-bottom")
+                            .id(WindowMetrics.bottomAnchorID)
                     }
                     .padding(.horizontal, 12)
                     .padding(.top, 12)
@@ -362,7 +363,7 @@ private struct AgentChatView: View {
                     var transaction = Transaction(animation: nil)
                     transaction.disablesAnimations = true
                     withTransaction(transaction) {
-                        proxy.scrollTo("agent-bottom", anchor: .bottom)
+                        proxy.scrollTo(WindowMetrics.bottomAnchorID, anchor: .bottom)
                     }
                     if messageWindowSize > WindowMetrics.initialWindowSize {
                         messageWindowSize = WindowMetrics.initialWindowSize
@@ -372,12 +373,12 @@ private struct AgentChatView: View {
         }
     }
 
-    private func loadMoreMessagesIfNeeded(totalCount: Int) {
+    private func loadMoreMessagesIfNeeded() {
         guard didCompleteInitialBottomScroll, canLoadMoreFromTop else { return }
         canLoadMoreFromTop = false
         messageWindowSize = min(
             messageWindowSize + WindowMetrics.loadMoreCount,
-            totalCount
+            service.messages.count
         )
     }
 
@@ -386,9 +387,10 @@ private struct AgentChatView: View {
         canLoadMoreFromTop = true
         messageWindowSize = WindowMetrics.initialWindowSize
 
+        // LazyVStack の初期レイアウト確定後にスクロールするため、1 ターン譲る。
         Task { @MainActor in
             await Task.yield()
-            proxy.scrollTo("agent-bottom", anchor: .bottom)
+            proxy.scrollTo(WindowMetrics.bottomAnchorID, anchor: .bottom)
             didCompleteInitialBottomScroll = true
         }
     }

--- a/Sources/Dahlia/Views/AgentTabView.swift
+++ b/Sources/Dahlia/Views/AgentTabView.swift
@@ -242,12 +242,21 @@ private struct AgentLauncherView: View {
 }
 
 /// AgentService を直接 @ObservedObject で監視するチャットビュー。
+///
+/// 親 (`AgentSidebarView`) が agentService 切替時に if/else で本ビューを再生成するため、
+/// セッション切替時の状態リセットは @State の初期化に依存する（明示的な onChange は不要）。
 private struct AgentChatView: View {
     private enum WindowMetrics {
         static let initialWindowSize = 50
         static let loadMoreCount = 30
+        static let followThreshold: CGFloat = 32
         static let loadMoreThreshold: CGFloat = 24
         static let bottomAnchorID = "agent-bottom"
+    }
+
+    private struct EdgeProximity: Equatable {
+        let isNearBottom: Bool
+        let isNearTop: Bool
     }
 
     @ObservedObject var service: AgentService
@@ -256,7 +265,12 @@ private struct AgentChatView: View {
     @State private var inputText = ""
     @State private var messageWindowSize = WindowMetrics.initialWindowSize
     @State private var didCompleteInitialBottomScroll = false
+    @State private var shouldFollowLatest = true
+    /// 上端到達時の onAppear が連射しないようにする単発フラグ。
+    /// 一度 false に倒したら、ユーザーが上端から離れた瞬間 (`!isNearTop`) にのみ再アームする。
     @State private var canLoadMoreFromTop = true
+    /// resetMessageWindowAndScrollToBottom 中の deferred scroll を保持し、リセット連発時に古い Task を cancel する。
+    @State private var pendingScrollTask: Task<Void, Never>?
 
     private var windowedMessages: ArraySlice<AgentMessage> {
         let messages = service.messages
@@ -352,20 +366,26 @@ private struct AgentChatView: View {
                 .onAppear {
                     resetMessageWindowAndScrollToBottom(using: proxy)
                 }
-                .onScrollGeometryChange(for: Bool.self) { geometry in
-                    geometry.contentOffset.y <= WindowMetrics.loadMoreThreshold
-                } action: { _, isNearTop in
-                    if !isNearTop {
+                .onScrollGeometryChange(for: EdgeProximity.self) { geometry in
+                    let distanceFromBottom = geometry.contentSize.height
+                        - geometry.contentOffset.y
+                        - geometry.containerSize.height
+                    return EdgeProximity(
+                        isNearBottom: distanceFromBottom <= WindowMetrics.followThreshold,
+                        isNearTop: geometry.contentOffset.y <= WindowMetrics.loadMoreThreshold
+                    )
+                } action: { _, proximity in
+                    shouldFollowLatest = proximity.isNearBottom
+                    if !proximity.isNearTop {
                         canLoadMoreFromTop = true
                     }
                 }
-                .onChange(of: service.messages.count) {
-                    var transaction = Transaction(animation: nil)
-                    transaction.disablesAnimations = true
-                    withTransaction(transaction) {
-                        proxy.scrollTo(WindowMetrics.bottomAnchorID, anchor: .bottom)
-                    }
-                    if messageWindowSize > WindowMetrics.initialWindowSize {
+                .onChange(of: service.messages.count) { oldCount, newCount in
+                    guard newCount > oldCount, shouldFollowLatest else { return }
+                    scrollToBottom(using: proxy)
+                }
+                .onChange(of: shouldFollowLatest) { _, isFollowing in
+                    if isFollowing {
                         messageWindowSize = WindowMetrics.initialWindowSize
                     }
                 }
@@ -374,7 +394,7 @@ private struct AgentChatView: View {
     }
 
     private func loadMoreMessagesIfNeeded() {
-        guard didCompleteInitialBottomScroll, canLoadMoreFromTop else { return }
+        guard didCompleteInitialBottomScroll, !shouldFollowLatest, canLoadMoreFromTop else { return }
         canLoadMoreFromTop = false
         messageWindowSize = min(
             messageWindowSize + WindowMetrics.loadMoreCount,
@@ -385,13 +405,25 @@ private struct AgentChatView: View {
     private func resetMessageWindowAndScrollToBottom(using proxy: ScrollViewProxy) {
         didCompleteInitialBottomScroll = false
         canLoadMoreFromTop = true
+        shouldFollowLatest = true
         messageWindowSize = WindowMetrics.initialWindowSize
 
-        // LazyVStack の初期レイアウト確定後にスクロールするため、1 ターン譲る。
-        Task { @MainActor in
+        // 連続リセット時に古い Task が新しい状態を上書きしないよう、pending Task を cancel する。
+        pendingScrollTask?.cancel()
+        pendingScrollTask = Task { @MainActor in
+            // LazyVStack の初期レイアウト確定後にスクロールするため、1 ターン譲る。
             await Task.yield()
-            proxy.scrollTo(WindowMetrics.bottomAnchorID, anchor: .bottom)
+            guard !Task.isCancelled else { return }
+            scrollToBottom(using: proxy)
             didCompleteInitialBottomScroll = true
+        }
+    }
+
+    private func scrollToBottom(using proxy: ScrollViewProxy) {
+        var transaction = Transaction(animation: nil)
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            proxy.scrollTo(WindowMetrics.bottomAnchorID, anchor: .bottom)
         }
     }
 }

--- a/Sources/Dahlia/Views/AgentTabView.swift
+++ b/Sources/Dahlia/Views/AgentTabView.swift
@@ -246,6 +246,7 @@ private struct AgentChatView: View {
     private enum WindowMetrics {
         static let initialWindowSize = 50
         static let loadMoreCount = 30
+        static let loadMoreThreshold: CGFloat = 24
     }
 
     @ObservedObject var service: AgentService
@@ -253,6 +254,8 @@ private struct AgentChatView: View {
     let showsLiveModeBadge: Bool
     @State private var inputText = ""
     @State private var messageWindowSize = WindowMetrics.initialWindowSize
+    @State private var didCompleteInitialBottomScroll = false
+    @State private var canLoadMoreFromTop = true
 
     private var windowedMessages: ArraySlice<AgentMessage> {
         let messages = service.messages
@@ -316,10 +319,7 @@ private struct AgentChatView: View {
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, 8)
                                 .onAppear {
-                                    messageWindowSize = min(
-                                        messageWindowSize + WindowMetrics.loadMoreCount,
-                                        service.messages.count
-                                    )
+                                    loadMoreMessagesIfNeeded(totalCount: service.messages.count)
                                 }
                         }
 
@@ -349,7 +349,14 @@ private struct AgentChatView: View {
                     .padding(.top, 12)
                 }
                 .onAppear {
-                    proxy.scrollTo("agent-bottom", anchor: .bottom)
+                    resetMessageWindowAndScrollToBottom(using: proxy)
+                }
+                .onScrollGeometryChange(for: Bool.self) { geometry in
+                    geometry.contentOffset.y <= WindowMetrics.loadMoreThreshold
+                } action: { _, isNearTop in
+                    if !isNearTop {
+                        canLoadMoreFromTop = true
+                    }
                 }
                 .onChange(of: service.messages.count) {
                     var transaction = Transaction(animation: nil)
@@ -362,6 +369,27 @@ private struct AgentChatView: View {
                     }
                 }
             }
+        }
+    }
+
+    private func loadMoreMessagesIfNeeded(totalCount: Int) {
+        guard didCompleteInitialBottomScroll, canLoadMoreFromTop else { return }
+        canLoadMoreFromTop = false
+        messageWindowSize = min(
+            messageWindowSize + WindowMetrics.loadMoreCount,
+            totalCount
+        )
+    }
+
+    private func resetMessageWindowAndScrollToBottom(using proxy: ScrollViewProxy) {
+        didCompleteInitialBottomScroll = false
+        canLoadMoreFromTop = true
+        messageWindowSize = WindowMetrics.initialWindowSize
+
+        Task { @MainActor in
+            await Task.yield()
+            proxy.scrollTo("agent-bottom", anchor: .bottom)
+            didCompleteInitialBottomScroll = true
         }
     }
 }

--- a/Sources/Dahlia/Views/TranscriptTabView.swift
+++ b/Sources/Dahlia/Views/TranscriptTabView.swift
@@ -7,6 +7,11 @@ struct TranscriptTabView: View {
         static let loadMoreThreshold: CGFloat = 24
     }
 
+    private struct EdgeProximity: Equatable {
+        let isNearBottom: Bool
+        let isNearTop: Bool
+    }
+
     private enum WindowMetrics {
         static let initialWindowSize = 150
         static let loadMoreCount = 100
@@ -99,18 +104,17 @@ struct TranscriptTabView: View {
             .onChange(of: store.segments.first?.id) { _, _ in
                 resetWindowAndScrollToBottom(using: proxy)
             }
-            .onScrollGeometryChange(for: Bool.self) { geometry in
+            .onScrollGeometryChange(for: EdgeProximity.self) { geometry in
                 let distanceFromBottom = geometry.contentSize.height
                     - geometry.contentOffset.y
                     - geometry.containerSize.height
-                return distanceFromBottom <= ScrollMetrics.followThreshold
-            } action: { _, isNearBottom in
-                shouldFollowLatest = isNearBottom
-            }
-            .onScrollGeometryChange(for: Bool.self) { geometry in
-                geometry.contentOffset.y <= ScrollMetrics.loadMoreThreshold
-            } action: { _, isNearTop in
-                if !isNearTop {
+                return EdgeProximity(
+                    isNearBottom: distanceFromBottom <= ScrollMetrics.followThreshold,
+                    isNearTop: geometry.contentOffset.y <= ScrollMetrics.loadMoreThreshold
+                )
+            } action: { _, proximity in
+                shouldFollowLatest = proximity.isNearBottom
+                if !proximity.isNearTop {
                     canLoadMoreFromTop = true
                 }
             }
@@ -138,6 +142,7 @@ struct TranscriptTabView: View {
         shouldFollowLatest = true
         windowSize = WindowMetrics.initialWindowSize
 
+        // LazyVStack の初期レイアウト確定後にスクロールするため、1 ターン譲る。
         Task { @MainActor in
             await Task.yield()
             scrollToBottom(using: proxy)

--- a/Sources/Dahlia/Views/TranscriptTabView.swift
+++ b/Sources/Dahlia/Views/TranscriptTabView.swift
@@ -4,6 +4,7 @@ struct TranscriptTabView: View {
     private enum ScrollMetrics {
         static let bottomAnchorID = "transcript-bottom"
         static let followThreshold: CGFloat = 32
+        static let loadMoreThreshold: CGFloat = 24
     }
 
     private enum WindowMetrics {
@@ -18,6 +19,8 @@ struct TranscriptTabView: View {
 
     @State private var shouldFollowLatest = true
     @State private var windowSize = WindowMetrics.initialWindowSize
+    @State private var didCompleteInitialBottomScroll = false
+    @State private var canLoadMoreFromTop = true
 
     /// ForEach の ID 照合対象を制限するため、末尾 windowSize 件のみ返す。
     private var windowedSegments: ArraySlice<TranscriptSegment> {
@@ -59,7 +62,7 @@ struct TranscriptTabView: View {
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 8)
                             .onAppear {
-                                loadMoreSegments()
+                                loadMoreSegmentsIfNeeded()
                             }
                     }
 
@@ -90,6 +93,12 @@ struct TranscriptTabView: View {
                 }
                 .padding(8)
             }
+            .onAppear {
+                resetWindowAndScrollToBottom(using: proxy)
+            }
+            .onChange(of: store.segments.first?.id) { _, _ in
+                resetWindowAndScrollToBottom(using: proxy)
+            }
             .onScrollGeometryChange(for: Bool.self) { geometry in
                 let distanceFromBottom = geometry.contentSize.height
                     - geometry.contentOffset.y
@@ -97,6 +106,13 @@ struct TranscriptTabView: View {
                 return distanceFromBottom <= ScrollMetrics.followThreshold
             } action: { _, isNearBottom in
                 shouldFollowLatest = isNearBottom
+            }
+            .onScrollGeometryChange(for: Bool.self) { geometry in
+                geometry.contentOffset.y <= ScrollMetrics.loadMoreThreshold
+            } action: { _, isNearTop in
+                if !isNearTop {
+                    canLoadMoreFromTop = true
+                }
             }
             .onChange(of: windowedSegmentCount) { oldCount, newCount in
                 guard newCount > oldCount, shouldFollowLatest else { return }
@@ -110,8 +126,23 @@ struct TranscriptTabView: View {
         }
     }
 
-    private func loadMoreSegments() {
+    private func loadMoreSegmentsIfNeeded() {
+        guard didCompleteInitialBottomScroll, !shouldFollowLatest, canLoadMoreFromTop else { return }
+        canLoadMoreFromTop = false
         windowSize = min(windowSize + WindowMetrics.loadMoreCount, store.segments.count)
+    }
+
+    private func resetWindowAndScrollToBottom(using proxy: ScrollViewProxy) {
+        didCompleteInitialBottomScroll = false
+        canLoadMoreFromTop = true
+        shouldFollowLatest = true
+        windowSize = WindowMetrics.initialWindowSize
+
+        Task { @MainActor in
+            await Task.yield()
+            scrollToBottom(using: proxy)
+            didCompleteInitialBottomScroll = true
+        }
     }
 
     private func scrollToBottom(using proxy: ScrollViewProxy) {

--- a/Sources/Dahlia/Views/TranscriptTabView.swift
+++ b/Sources/Dahlia/Views/TranscriptTabView.swift
@@ -25,7 +25,12 @@ struct TranscriptTabView: View {
     @State private var shouldFollowLatest = true
     @State private var windowSize = WindowMetrics.initialWindowSize
     @State private var didCompleteInitialBottomScroll = false
+    /// 上端到達時の onAppear が連射しないようにする単発フラグ。
+    /// 一度 false に倒したら、ユーザーが上端から離れた瞬間 (`!isNearTop`) にのみ再アームする。
+    /// Spinner が表示領域に留まり続けるケースで誤って再ロードが走るのを防ぐ。
     @State private var canLoadMoreFromTop = true
+    /// resetWindowAndScrollToBottom 中の deferred scroll を保持し、リセット連発時に古い Task を cancel する。
+    @State private var pendingScrollTask: Task<Void, Never>?
 
     /// ForEach の ID 照合対象を制限するため、末尾 windowSize 件のみ返す。
     private var windowedSegments: ArraySlice<TranscriptSegment> {
@@ -142,9 +147,12 @@ struct TranscriptTabView: View {
         shouldFollowLatest = true
         windowSize = WindowMetrics.initialWindowSize
 
-        // LazyVStack の初期レイアウト確定後にスクロールするため、1 ターン譲る。
-        Task { @MainActor in
+        // 連続リセット時に古い Task が新しい状態を上書きしないよう、pending Task を cancel する。
+        pendingScrollTask?.cancel()
+        pendingScrollTask = Task { @MainActor in
+            // LazyVStack の初期レイアウト確定後にスクロールするため、1 ターン譲る。
             await Task.yield()
+            guard !Task.isCancelled else { return }
             scrollToBottom(using: proxy)
             didCompleteInitialBottomScroll = true
         }

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -23,6 +23,7 @@ mkdir -p "$CLANG_MODULE_CACHE_PATH"
 
 echo "=== Building ${APP_NAME} ==="
 swift build -c release
+dsymutil ".build/release/${APP_NAME}" -o ".build/release/${APP_NAME}.dSYM"
 
 # .app バンドル作成
 BUILD_DIR=".build/release"

--- a/scripts/upload-dsyms.sh
+++ b/scripts/upload-dsyms.sh
@@ -12,7 +12,7 @@ fi
 BUILD_DIR="$1"
 APP_NAME="${2:-Dahlia}"
 DSYM_PATH="${BUILD_DIR}/${APP_NAME}.dSYM"
-SENTRY_ORG="${SENTRY_ORG:-dahlia-ez}"
+SENTRY_ORG="${SENTRY_ORG:-dahlia-app}"
 SENTRY_PROJECT="${SENTRY_PROJECT:-dahlia-app}"
 
 cd "$PROJECT_DIR"


### PR DESCRIPTION
## 概要

`TranscriptTabView` と `AgentChatView` で、初期表示時のスクロール位置確定前や末尾追従中に上端の `LoadMoreSentinel` が `onAppear` を発火させ、ウィンドウサイズが意図せず拡張されていた問題を修正する。あわせてセッション/トランスクリプト切替時のリセット競合も解消する。

## 変更点

### スクロール挙動の修正
- `TranscriptTabView`
  - `didCompleteInitialBottomScroll` / `canLoadMoreFromTop` フラグを追加し、初期スクロール完了前および末尾追従中は `loadMoreSegmentsIfNeeded` を抑止。
  - `onScrollGeometryChange` を `EdgeProximity`(isNearBottom/isNearTop) に拡張し、上端から離れた瞬間にのみ `canLoadMoreFromTop` を再アームすることで Spinner 連射を防止。
  - `store.segments.first?.id` 変化時にウィンドウとフラグをリセットして末尾へスクロール。
  - `pendingScrollTask` を保持し、リセット連発時に古い deferred scroll Task を `cancel()` して状態を上書きさせない。
- `AgentChatView`
  - 同様の早期発火防止ロジックを導入。親 (`AgentSidebarView`) が `agentService` 切替時に if/else でビューを再生成するため `@State` 初期化に依存することをコメントで明示。
  - `WindowMetrics` に `followThreshold` / `loadMoreThreshold` / `bottomAnchorID` を集約し、`pendingScrollTask` で初期 scroll の競合をキャンセル可能に。
  - `shouldFollowLatest` が立ったタイミングでウィンドウを `initialWindowSize` に縮小し、メモリ/レイアウト負荷を抑制。

### ビルド/Sentry
- `scripts/build-app.sh` に `dsymutil` 実行を追加し、Release ビルドで `Dahlia.dSYM` を生成。
- `scripts/upload-dsyms.sh` の Sentry org デフォルトを `dahlia-ez` → `dahlia-app` に修正。

### バージョン
- `Resources/Info.plist` を `CFBundleVersion=9` / `CFBundleShortVersionString=0.0.9` に更新。

## 動作確認

- [ ] Transcript タブで初期表示時にウィンドウが勝手に拡張されないこと
- [ ] Transcript タブで末尾追従中（最下部固定中）に上方向の `LoadMore` が発火しないこと
- [ ] スクロールを上端付近まで戻したときに過去ログがロードされ、上端から離れるまで再ロードされないこと
- [ ] トランスクリプトを切り替えても末尾スクロールが正しく行われること
- [ ] Agent タブで初期表示時にウィンドウが勝手に拡張されないこと
- [ ] Agent セッションを切り替えてもウィンドウ/スクロール状態がリセットされること
- [ ] Agent タブで上方向スクロール時に過去メッセージがロードされること
- [ ] \`./scripts/build-app.sh\` 実行で \`Dahlia.dSYM\` が生成されること