### PR TITLE
Obsidian 画像埋め込みを拡張子付きファイル名に対応させる

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,21 +9,34 @@ on:
 jobs:
   review:
     if: |
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.comment.body == '@claude review')
+      (
+        github.event_name == 'pull_request' &&
+        (
+          github.event.pull_request.head.repo.full_name == github.repository ||
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+        )
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '@claude review') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      )
+
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: true
 
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-      issues: write
-      id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review
@@ -31,5 +44,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: '/code-review xhigh --comment'
-          claude_args: '--model opus --allowedTools mcp__github_inline_comment__create_inline_comment,Bash(gh:*),Bash(git:*),Read,Grep,Glob'
+          claude_args: >-
+            --model opus
+            --allowedTools mcp__github_inline_comment__create_inline_comment,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(git rev-parse:*),Bash(git merge-base:*),Read,Grep,Glob
           # See https://code.claude.com/docs/en/code-review

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,35 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.comment.body == '@claude review')
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: '/code-review xhigh --comment'
+          claude_args: '--model opus --allowedTools mcp__github_inline_comment__create_inline_comment,Bash(gh:*),Bash(git:*),Read,Grep,Glob'
+          # See https://code.claude.com/docs/en/code-review

--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -198,7 +198,9 @@ final class AppSettings: ObservableObject {
     - Use the most relevant timestamp for the referenced point.
     </transcript_links>
     <screenshot_embeds>
-    - When referencing a screenshot, embed it using the format `![[<image_id>]]`.
+    - When referencing a screenshot, embed it using the format `![[<image_filename>]]`.
+    - Use the exact provided image filename, including its file extension.
+    - Example: `![[019E61FD-B5D6-7A04-AC25-4B820FE951E6.jpeg]]`.
     - Use the screenshot whose timestamp is closest to the referenced point.
     </screenshot_embeds>
     </rendering_rules>

--- a/Sources/Dahlia/Services/ScreenshotExportService.swift
+++ b/Sources/Dahlia/Services/ScreenshotExportService.swift
@@ -8,6 +8,10 @@ enum ScreenshotExportService {
             .appendingPathComponent("screenshots", isDirectory: true)
     }
 
+    static func filename(for screenshot: MeetingScreenshotRecord) -> String {
+        "\(screenshot.id.uuidString).\(fileExtension(for: screenshot))"
+    }
+
     /// スクリーンショットを `<vault>/_dahlia/screenshots/<screenshotId>.<ext>` に書き出す。
     /// DB の `imageData` をそのまま書き出す。
     /// - Returns: vault 相対パスの配列
@@ -23,10 +27,7 @@ enum ScreenshotExportService {
         var relativePaths: [String] = []
 
         for screenshot in screenshots {
-            let ext = ImageEncoder.fileExtension(for: screenshot.mimeType)
-                ?? ImageEncoder.fileExtension(for: ImageEncoder.mimeType(for: screenshot.imageData) ?? "")
-                ?? ImageEncoder.preferredFileExtension
-            let filename = "\(screenshot.id.uuidString).\(ext)"
+            let filename = filename(for: screenshot)
             let relativePath = "_dahlia/screenshots/\(filename)"
             let fileURL = vaultURL.appendingPathComponent(relativePath)
             try screenshot.imageData.write(to: fileURL, options: .atomic)
@@ -34,5 +35,11 @@ enum ScreenshotExportService {
         }
 
         return relativePaths
+    }
+
+    private static func fileExtension(for screenshot: MeetingScreenshotRecord) -> String {
+        ImageEncoder.fileExtension(for: screenshot.mimeType)
+            ?? ImageEncoder.fileExtension(for: ImageEncoder.mimeType(for: screenshot.imageData) ?? "")
+            ?? ImageEncoder.preferredFileExtension
     }
 }

--- a/Sources/Dahlia/Services/SummaryService.swift
+++ b/Sources/Dahlia/Services/SummaryService.swift
@@ -72,19 +72,20 @@ enum SummaryService {
             messages.append(.init(role: "user", content: transcriptContent))
         } else {
             // マルチモーダル: テキスト + スクリーンショット画像（MainActor 外でリサイズ・エンコード）
-            let preparedImages = await Task.detached(priority: .userInitiated) {
+            let preparedImageDataURIs = await Task.detached(priority: .userInitiated) {
                 screenshots.map { screenshot in
                     let imageData = ImageEncoder.resized(screenshot.imageData, maxLongEdge: 1024)
                     let mimeType = ImageEncoder.mimeType(for: imageData) ?? screenshot.mimeType
-                    let ext = ImageEncoder.fileExtension(for: mimeType) ?? ImageEncoder.preferredFileExtension
-                    return (mimeType: mimeType, ext: ext, dataURI: "data:\(mimeType);base64,\(imageData.base64EncodedString())")
+                    return "data:\(mimeType);base64,\(imageData.base64EncodedString())"
                 }
             }.value
             var parts: [LLMService.ContentPart] = [.text(transcriptContent)]
-            for (screenshot, preparedImage) in zip(screenshots, preparedImages) {
+            for (screenshot, preparedImageDataURI) in zip(screenshots, preparedImageDataURIs) {
                 let time = timeFormatter.string(from: screenshot.capturedAt)
-                parts.append(.text("<time>\(time)</time> <image_id>\(screenshot.id.uuidString).\(preparedImage.ext)</image_id>"))
-                parts.append(.imageURL(preparedImage.dataURI))
+                let imageFilename = ScreenshotExportService.filename(for: screenshot)
+                let imageMetadata = "<time>\(time)</time> <image_id>\(imageFilename)</image_id> <image_filename>\(imageFilename)</image_filename>"
+                parts.append(.text(imageMetadata))
+                parts.append(.imageURL(preparedImageDataURI))
             }
             messages.append(.init(role: "user", parts: parts))
         }
@@ -127,7 +128,8 @@ enum SummaryService {
 
         let frontmatter = "---\n\(frontmatterFields)\n---"
 
-        let markdown = frontmatter + "\n\n" + result.summary + "\n"
+        let summary = normalizeScreenshotEmbeds(result.summary, screenshots: screenshots)
+        let markdown = frontmatter + "\n\n" + summary + "\n"
         let fileName = summaryFileName(
             datePrefix: dateFormatter.string(from: createdAt),
             title: result.title,
@@ -138,7 +140,7 @@ enum SummaryService {
             fileName: fileName,
             markdown: markdown,
             title: result.title,
-            summary: result.summary,
+            summary: summary,
             tags: tags,
             actionItems: result.actionItems
         )
@@ -181,9 +183,44 @@ enum SummaryService {
         return tags
     }
 
+    private static let obsidianImageEmbedRegex = try! NSRegularExpression(
+        pattern: #"\!\[\[([^\]|]+)(?:\|([^\]]+))?\]\]"#
+    )
+
     private static let obsidianLinkRegex = try! NSRegularExpression(
         pattern: #"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]"#
     )
+
+    static func normalizeScreenshotEmbeds(_ summary: String, screenshots: [MeetingScreenshotRecord]) -> String {
+        guard !screenshots.isEmpty else { return summary }
+
+        let matches = obsidianImageEmbedRegex.matches(in: summary, range: NSRange(summary.startIndex..., in: summary))
+        guard !matches.isEmpty else { return summary }
+
+        let filenamesById = Dictionary(
+            screenshots.map { screenshot in
+                (screenshot.id.uuidString.lowercased(), ScreenshotExportService.filename(for: screenshot))
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        var normalized = summary
+        for match in matches.reversed() {
+            guard let fullRange = Range(match.range(at: 0), in: normalized),
+                  let targetRange = Range(match.range(at: 1), in: normalized) else { continue }
+            let target = String(normalized[targetRange])
+            guard let filename = normalizedScreenshotFilename(for: target, filenamesById: filenamesById) else { continue }
+
+            let replacement = if let aliasRange = Range(match.range(at: 2), in: normalized) {
+                "![[\(filename)|\(normalized[aliasRange])]]"
+            } else {
+                "![[\(filename)]]"
+            }
+            normalized.replaceSubrange(fullRange, with: replacement)
+        }
+
+        return normalized
+    }
 
     static func sanitizeDisplaySummary(_ summary: String) -> String {
         var sanitized = summary.replacingOccurrences(
@@ -214,6 +251,23 @@ enum SummaryService {
     }
 
     // MARK: - Private Helpers
+
+    private static func normalizedScreenshotFilename(for obsidianTarget: String, filenamesById: [String: String]) -> String? {
+        let target = obsidianTarget.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !target.isEmpty else { return nil }
+
+        let targetPath = target as NSString
+        let directory = targetPath.deletingLastPathComponent
+        let lastPathComponent = targetPath.lastPathComponent as NSString
+        let id = lastPathComponent.deletingPathExtension.lowercased()
+        guard let filename = filenamesById[id] else { return nil }
+
+        return if directory.isEmpty || directory == "." {
+            filename
+        } else {
+            "\(directory)/\(filename)"
+        }
+    }
 
     private static func summaryFileName(datePrefix: String, title: String, meetingId: UUID) -> String {
         guard !title.isEmpty else {

--- a/Sources/Dahlia/Services/SummaryService.swift
+++ b/Sources/Dahlia/Services/SummaryService.swift
@@ -129,6 +129,7 @@ enum SummaryService {
         let frontmatter = "---\n\(frontmatterFields)\n---"
 
         let summary = normalizeScreenshotEmbeds(result.summary, screenshots: screenshots)
+        let actionItems = normalizeActionItems(result.actionItems, screenshots: screenshots)
         let markdown = frontmatter + "\n\n" + summary + "\n"
         let fileName = summaryFileName(
             datePrefix: dateFormatter.string(from: createdAt),
@@ -142,7 +143,7 @@ enum SummaryService {
             title: result.title,
             summary: summary,
             tags: tags,
-            actionItems: result.actionItems
+            actionItems: actionItems
         )
     }
 
@@ -220,6 +221,16 @@ enum SummaryService {
         }
 
         return normalized
+    }
+
+    static func normalizeActionItems(_ actionItems: [SummaryActionItem], screenshots: [MeetingScreenshotRecord]) -> [SummaryActionItem] {
+        guard !actionItems.isEmpty else { return actionItems }
+
+        return actionItems.map { item in
+            let title = normalizeScreenshotEmbeds(item.title, screenshots: screenshots)
+            guard title != item.title else { return item }
+            return SummaryActionItem(title: title, assignee: item.assignee)
+        }
     }
 
     static func sanitizeDisplaySummary(_ summary: String) -> String {

--- a/Tests/DahliaTests/SummaryServiceTests.swift
+++ b/Tests/DahliaTests/SummaryServiceTests.swift
@@ -70,6 +70,36 @@ struct SummaryServiceTests {
     }
 
     @Test
+    func normalizeScreenshotEmbedsUsesExportedFilenameWithExtension() throws {
+        let screenshotId = try #require(UUID(uuidString: "019E61FD-B5D6-7A04-AC25-4B820FE951E6"))
+        let screenshot = MeetingScreenshotRecord(
+            id: screenshotId,
+            meetingId: UUID(),
+            capturedAt: Date(timeIntervalSince1970: 0),
+            imageData: Data(),
+            mimeType: "image/jpeg"
+        )
+        let input = """
+        - Main image ![[\(screenshotId.uuidString)]]
+        - Path image ![[_dahlia/screenshots/\(screenshotId.uuidString).webp|Screen]]
+        - Other image ![[not-a-screenshot]]
+        """
+
+        let normalized = SummaryService.normalizeScreenshotEmbeds(input, screenshots: [screenshot])
+
+        #expect(normalized.contains("![[\(screenshotId.uuidString).jpeg]]"))
+        #expect(normalized.contains("![[_dahlia/screenshots/\(screenshotId.uuidString).jpeg|Screen]]"))
+        #expect(normalized.contains("![[not-a-screenshot]]"))
+        #expect(!normalized.contains("\(screenshotId.uuidString).webp"))
+    }
+
+    @Test
+    func defaultSummaryPromptRequiresScreenshotFilenameExtension() {
+        #expect(AppSettings.defaultSummaryPrompt.contains("![[<image_filename>]]"))
+        #expect(AppSettings.defaultSummaryPrompt.contains("including its file extension"))
+    }
+
+    @Test
     func resolvedTagsDoesNotInjectAISummary() {
         let context = """
         ---

--- a/Tests/DahliaTests/SummaryServiceTests.swift
+++ b/Tests/DahliaTests/SummaryServiceTests.swift
@@ -94,6 +94,25 @@ struct SummaryServiceTests {
     }
 
     @Test
+    func normalizeActionItemsUsesExportedFilenameWithExtension() throws {
+        let screenshotId = try #require(UUID(uuidString: "019E61FD-B5D6-7A04-AC25-4B820FE951E6"))
+        let screenshot = MeetingScreenshotRecord(
+            id: screenshotId,
+            meetingId: UUID(),
+            capturedAt: Date(timeIntervalSince1970: 0),
+            imageData: Data(),
+            mimeType: "image/jpeg"
+        )
+        let actionItems = [
+            SummaryActionItem(title: "Review ![[\(screenshotId.uuidString)]]", assignee: "me"),
+        ]
+
+        let normalized = SummaryService.normalizeActionItems(actionItems, screenshots: [screenshot])
+
+        #expect(normalized == [SummaryActionItem(title: "Review ![[\(screenshotId.uuidString).jpeg]]", assignee: "me")])
+    }
+
+    @Test
     func defaultSummaryPromptRequiresScreenshotFilenameExtension() {
         #expect(AppSettings.defaultSummaryPrompt.contains("![[<image_filename>]]"))
         #expect(AppSettings.defaultSummaryPrompt.contains("including its file extension"))


### PR DESCRIPTION
**Summary**
- Vault への要約書き出し時に、スクリーンショット参照を `![[UUID.ext]]` 形式へ正規化するように変更
- LLM への指示文を新しい画像ファイル名形式に合わせて更新
- スクリーンショット保存ファイル名の生成を共通化し、書き出し先と参照元で同じ名前を使うように整理
- 画像リンクの正規化とプロンプト要件をカバーするテストを追加

**Testing**
- `swift build`
- `swift test --filter SummaryServiceTests`
- 既存のフォーマット確認で差分に問題がないことを確認