### PR TITLE
ライブ字幕オーバーレイの更新負荷を下げて App Hang を抑制する

### DIFF
--- a/Sources/Dahlia/Models/LiveSubtitleOverlayPayload.swift
+++ b/Sources/Dahlia/Models/LiveSubtitleOverlayPayload.swift
@@ -27,6 +27,12 @@ struct LiveSubtitleOverlayPayload: Equatable {
         var foundUnconfirmed = false
 
         for segment in segments.reversed() {
+            if !foundUnconfirmed,
+               segment.isConfirmed,
+               latestConfirmedEntriesReversed.count >= clampedMaxEntries {
+                continue
+            }
+
             guard let entry = entry(
                 for: segment,
                 sourceMode: sourceMode,

--- a/Sources/Dahlia/Models/LiveSubtitleOverlayPayload.swift
+++ b/Sources/Dahlia/Models/LiveSubtitleOverlayPayload.swift
@@ -22,38 +22,49 @@ struct LiveSubtitleOverlayPayload: Equatable {
             targetLanguageIdentifier: targetLanguageIdentifier
         )
 
-        let validSegments = segments.compactMap { segment -> (segment: TranscriptSegment, entry: Entry)? in
-            guard sourceMode.includesSpeakerLabel(segment.speakerLabel) else { return nil }
-            guard let primaryText = segment.displayText.nilIfBlank else { return nil }
-            return (
-                segment,
-                Entry(
-                    primaryText: primaryText,
-                    secondaryText: showsTranslation ? segment.displayTranslatedText : nil
-                )
-            )
-        }
+        var latestConfirmedEntriesReversed: [Entry] = []
+        var entriesAroundUnconfirmedReversed: [Entry] = []
+        var foundUnconfirmed = false
 
-        guard !validSegments.isEmpty else { return nil }
+        for segment in segments.reversed() {
+            guard let entry = entry(
+                for: segment,
+                sourceMode: sourceMode,
+                showsTranslation: showsTranslation
+            ) else { continue }
 
-        if let latestUnconfirmedIndex = validSegments.lastIndex(where: { !$0.segment.isConfirmed }) {
-            var selectedIndices = [latestUnconfirmedIndex]
-            var candidateIndex = latestUnconfirmedIndex - 1
-
-            while candidateIndex >= 0, selectedIndices.count < clampedMaxEntries {
-                selectedIndices.append(candidateIndex)
-                candidateIndex -= 1
+            if foundUnconfirmed {
+                entriesAroundUnconfirmedReversed.append(entry)
+            } else if segment.isConfirmed {
+                if latestConfirmedEntriesReversed.count < clampedMaxEntries {
+                    latestConfirmedEntriesReversed.append(entry)
+                }
+            } else {
+                foundUnconfirmed = true
+                entriesAroundUnconfirmedReversed.append(entry)
             }
 
-            let entries = selectedIndices
-                .sorted()
-                .map { validSegments[$0].entry }
-            return Self(entries: entries)
+            if foundUnconfirmed, entriesAroundUnconfirmedReversed.count >= clampedMaxEntries {
+                break
+            }
         }
 
-        let entries = validSegments
-            .suffix(clampedMaxEntries)
-            .map(\.entry)
-        return Self(entries: Array(entries))
+        let reversedEntries = foundUnconfirmed ? entriesAroundUnconfirmedReversed : latestConfirmedEntriesReversed
+        guard !reversedEntries.isEmpty else { return nil }
+        return Self(entries: Array(reversedEntries.reversed()))
+    }
+
+    private static func entry(
+        for segment: TranscriptSegment,
+        sourceMode: LiveSubtitleSourceMode,
+        showsTranslation: Bool
+    ) -> Entry? {
+        guard sourceMode.includesSpeakerLabel(segment.speakerLabel),
+              let primaryText = segment.displayText.nilIfBlank else { return nil }
+
+        return Entry(
+            primaryText: primaryText,
+            secondaryText: showsTranslation ? segment.displayTranslatedText : nil
+        )
     }
 }

--- a/Sources/Dahlia/Services/LiveSubtitleOverlayService.swift
+++ b/Sources/Dahlia/Services/LiveSubtitleOverlayService.swift
@@ -9,6 +9,7 @@ final class LiveSubtitleOverlayService: ObservableObject {
     private var contentModel: ContentModel?
     private var panelMoveObserver: NSObjectProtocol?
     private var lastResolvedPanelSize: NSSize?
+    private var pendingLayoutTask: Task<Void, Never>?
 
     init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
@@ -23,6 +24,7 @@ final class LiveSubtitleOverlayService: ObservableObject {
         if let contentModel {
             guard contentModel.payload != payload else { return }
             contentModel.payload = payload
+            lastResolvedPanelSize = nil
         } else {
             let contentModel = ContentModel(payload: payload)
             let overlayView = LiveSubtitleOverlayView(model: contentModel)
@@ -39,10 +41,12 @@ final class LiveSubtitleOverlayService: ObservableObject {
             }
         }
 
-        updatePanelLayout(animated: false)
+        schedulePanelLayoutUpdate()
     }
 
     func hide() {
+        pendingLayoutTask?.cancel()
+        pendingLayoutTask = nil
         contentModel = nil
         hostingView = nil
         lastResolvedPanelSize = nil
@@ -83,8 +87,17 @@ final class LiveSubtitleOverlayService: ObservableObject {
         panel.ignoresMouseEvents = false
         panel.contentView = hostingView
         observePanelMoves(panel)
-        lastResolvedPanelSize = resolvedPanelSize(for: hostingView.fittingSize)
         return panel
+    }
+
+    private func schedulePanelLayoutUpdate() {
+        pendingLayoutTask?.cancel()
+        pendingLayoutTask = Task { @MainActor [weak self] in
+            await Task.yield()
+            guard !Task.isCancelled else { return }
+            self?.updatePanelLayout(animated: false)
+            self?.pendingLayoutTask = nil
+        }
     }
 
     private func updatePanelLayout(animated: Bool) {
@@ -93,19 +106,22 @@ final class LiveSubtitleOverlayService: ObservableObject {
         hostingView.layoutSubtreeIfNeeded()
         let resolvedSize = resolvedPanelSize(for: hostingView.fittingSize)
         let nextFrame = panelFrame(for: resolvedSize, currentFrame: panel.frame)
-        let sizeChanged = resolvedSize != lastResolvedPanelSize
-        let frameChanged = !panel.frame.equalTo(nextFrame)
-        guard sizeChanged || frameChanged else { return }
+        let cachedSize = lastResolvedPanelSize
+        let sizeChanged = cachedSize.map { !sizesMatch($0, resolvedSize) } ?? false
+        let frameChanged = !framesMatch(panel.frame, nextFrame)
+        guard sizeChanged || frameChanged || cachedSize == nil else { return }
 
-        if sizeChanged {
-            hostingView.setFrameSize(resolvedSize)
-            lastResolvedPanelSize = resolvedSize
-        }
+        lastResolvedPanelSize = resolvedSize
+        guard sizeChanged || frameChanged else { return }
+        let shouldDisplayImmediately = sizeChanged && (
+            nextFrame.width > panel.frame.width
+                || nextFrame.height > panel.frame.height
+        )
 
         if animated {
             panel.animator().setFrame(nextFrame, display: true)
         } else {
-            panel.setFrame(nextFrame, display: false)
+            panel.setFrame(nextFrame, display: shouldDisplayImmediately)
         }
     }
 
@@ -187,10 +203,10 @@ final class LiveSubtitleOverlayService: ObservableObject {
             fallbackScreen: fallbackScreen
         )
         let origin = CGPoint(
-            x: clampedTopLeft.x,
-            y: clampedTopLeft.y - size.height
+            x: clampedTopLeft.x.rounded(),
+            y: (clampedTopLeft.y - size.height).rounded()
         )
-        return NSRect(origin: origin, size: size)
+        return NSRect(origin: origin, size: roundedSize(size))
     }
 
     private func topLeft(of frame: NSRect) -> CGPoint {
@@ -200,7 +216,28 @@ final class LiveSubtitleOverlayService: ObservableObject {
     private func resolvedPanelSize(for size: NSSize) -> NSSize {
         NSSize(
             width: LiveSubtitleOverlayLayout.fixedWidth,
-            height: max(size.height, LiveSubtitleOverlayLayout.minimumHeight)
+            height: max(size.height, LiveSubtitleOverlayLayout.minimumHeight).rounded()
+        )
+    }
+
+    private func roundedSize(_ size: NSSize) -> NSSize {
+        NSSize(width: size.width.rounded(), height: size.height.rounded())
+    }
+
+    private func sizesMatch(_ lhs: NSSize, _ rhs: NSSize) -> Bool {
+        roundedSize(lhs) == roundedSize(rhs)
+    }
+
+    private func framesMatch(_ lhs: NSRect, _ rhs: NSRect) -> Bool {
+        roundedFrame(lhs).equalTo(roundedFrame(rhs))
+    }
+
+    private func roundedFrame(_ frame: NSRect) -> NSRect {
+        NSRect(
+            x: frame.minX.rounded(),
+            y: frame.minY.rounded(),
+            width: frame.width.rounded(),
+            height: frame.height.rounded()
         )
     }
 

--- a/Sources/Dahlia/Services/LiveSubtitleOverlayService.swift
+++ b/Sources/Dahlia/Services/LiveSubtitleOverlayService.swift
@@ -109,14 +109,16 @@ final class LiveSubtitleOverlayService: ObservableObject {
         let cachedSize = lastResolvedPanelSize
         let sizeChanged = cachedSize.map { !sizesMatch($0, resolvedSize) } ?? false
         let frameChanged = !framesMatch(panel.frame, nextFrame)
-        guard sizeChanged || frameChanged || cachedSize == nil else { return }
 
-        lastResolvedPanelSize = resolvedSize
-        guard sizeChanged || frameChanged else { return }
-        let shouldDisplayImmediately = sizeChanged && (
-            nextFrame.width > panel.frame.width
-                || nextFrame.height > panel.frame.height
-        )
+        if cachedSize == nil {
+            lastResolvedPanelSize = resolvedSize
+            guard frameChanged else { return }
+        } else {
+            guard sizeChanged || frameChanged else { return }
+            lastResolvedPanelSize = resolvedSize
+        }
+
+        let shouldDisplayImmediately = sizeChanged && nextFrame.isLargerThan(panel.frame)
 
         if animated {
             panel.animator().setFrame(nextFrame, display: true)
@@ -261,6 +263,12 @@ private enum LiveSubtitleOverlayLayout {
     static let fixedWidth: CGFloat = 960
     static let minimumHeight: CGFloat = 72
     static let anchorDefaultsKey = "liveSubtitleOverlayTopLeftAnchor"
+}
+
+private extension NSRect {
+    func isLargerThan(_ other: NSRect) -> Bool {
+        width > other.width || height > other.height
+    }
 }
 
 private final class ContentModel: ObservableObject {

--- a/Sources/Dahlia/Services/LiveSubtitleOverlayService.swift
+++ b/Sources/Dahlia/Services/LiveSubtitleOverlayService.swift
@@ -8,6 +8,7 @@ final class LiveSubtitleOverlayService: ObservableObject {
     private var hostingView: NSHostingView<LiveSubtitleOverlayView>?
     private var contentModel: ContentModel?
     private var panelMoveObserver: NSObjectProtocol?
+    private var lastResolvedPanelSize: NSSize?
 
     init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
@@ -26,7 +27,7 @@ final class LiveSubtitleOverlayService: ObservableObject {
             let contentModel = ContentModel(payload: payload)
             let overlayView = LiveSubtitleOverlayView(model: contentModel)
             let hostingView = NSHostingView(rootView: overlayView)
-            hostingView.setFrameSize(hostingView.fittingSize)
+            hostingView.setFrameSize(resolvedPanelSize(for: hostingView.fittingSize))
             self.contentModel = contentModel
             self.hostingView = hostingView
             panel = makePanel(with: hostingView)
@@ -44,6 +45,7 @@ final class LiveSubtitleOverlayService: ObservableObject {
     func hide() {
         contentModel = nil
         hostingView = nil
+        lastResolvedPanelSize = nil
 
         guard let panel else { return }
         self.panel = nil
@@ -81,6 +83,7 @@ final class LiveSubtitleOverlayService: ObservableObject {
         panel.ignoresMouseEvents = false
         panel.contentView = hostingView
         observePanelMoves(panel)
+        lastResolvedPanelSize = resolvedPanelSize(for: hostingView.fittingSize)
         return panel
     }
 
@@ -88,21 +91,26 @@ final class LiveSubtitleOverlayService: ObservableObject {
         guard let panel, let hostingView else { return }
 
         hostingView.layoutSubtreeIfNeeded()
-        hostingView.setFrameSize(hostingView.fittingSize)
-        let nextFrame = panelFrame(for: hostingView.fittingSize, currentFrame: panel.frame)
+        let resolvedSize = resolvedPanelSize(for: hostingView.fittingSize)
+        let nextFrame = panelFrame(for: resolvedSize, currentFrame: panel.frame)
+        let sizeChanged = resolvedSize != lastResolvedPanelSize
+        let frameChanged = !panel.frame.equalTo(nextFrame)
+        guard sizeChanged || frameChanged else { return }
+
+        if sizeChanged {
+            hostingView.setFrameSize(resolvedSize)
+            lastResolvedPanelSize = resolvedSize
+        }
 
         if animated {
             panel.animator().setFrame(nextFrame, display: true)
         } else {
-            panel.setFrame(nextFrame, display: true)
+            panel.setFrame(nextFrame, display: false)
         }
     }
 
     private func panelFrame(for size: NSSize, currentFrame: NSRect? = nil) -> NSRect {
-        let resolvedSize = NSSize(
-            width: LiveSubtitleOverlayLayout.fixedWidth,
-            height: max(size.height, LiveSubtitleOverlayLayout.minimumHeight)
-        )
+        let resolvedSize = resolvedPanelSize(for: size)
 
         if let currentFrame {
             return frame(
@@ -187,6 +195,13 @@ final class LiveSubtitleOverlayService: ObservableObject {
 
     private func topLeft(of frame: NSRect) -> CGPoint {
         CGPoint(x: frame.minX, y: frame.maxY)
+    }
+
+    private func resolvedPanelSize(for size: NSSize) -> NSSize {
+        NSSize(
+            width: LiveSubtitleOverlayLayout.fixedWidth,
+            height: max(size.height, LiveSubtitleOverlayLayout.minimumHeight)
+        )
     }
 
     private func clampedTopLeft(preferredTopLeft: CGPoint, size: NSSize, fallbackScreen: NSScreen?) -> CGPoint {


### PR DESCRIPTION
## Summary
- ライブ字幕 payload の生成を末尾走査に変え、必要なセグメントだけを拾うようにして無駄な全件変換を避けました。
- オーバーレイの `NSPanel` 更新をサイズ/フレーム変化時のみに限定し、不要な再レイアウトと描画を減らしました。
- 同サイズでも画面移動やクランプが必要なケースは維持しつつ、main thread の停滞を起こしにくい形に整理しました。

## Testing
- `swift test --filter LiveSubtitleOverlayPayloadTests`
- `swift test`
- `swift build`
- `git diff --check`