### PR TITLE
Bump app version to 0.1.0

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>9</string>
+    <string>10</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.0.9</string>
+    <string>0.1.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>


### PR DESCRIPTION
## Summary

- Bump the app marketing version from `0.0.9` to `0.1.0`.
- Increment the bundle build number from `9` to `10`.

## Validation

- `plutil -lint Resources/Info.plist`
- `git show :Resources/Info.plist | plutil -lint -`

## Notes

The working tree contains other pre-existing uncommitted changes. This PR intentionally includes only the version bump commit.