### PR TITLE
Use relative transcript timestamps

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundleVersion</key>
     <string>10</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>0.1.1</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/Database/AGENTS.md
+++ b/Sources/Dahlia/Database/AGENTS.md
@@ -10,7 +10,7 @@ SQLite の実体は `~/Library/Application Support/Dahlia/dahlia.sqlite`（`AppD
 
 ## テーブル
 
-`vaults`、`projects`（vault スコープ・パスベース）、`meetings`、`transcript_segments`、`tags`、`meeting_tags`、`notes`、`screenshots`、`summaries`、`action_items`、`calendar_events`、`instructions`
+`vaults`、`projects`（vault スコープ・パスベース）、`meetings`、`recording_sessions`、`transcript_segments`、`tags`、`meeting_tags`、`notes`、`screenshots`、`summaries`、`action_items`、`calendar_events`、`instructions`
 
 - すべての ID は UUID v7（`UUID.v7()`、時系列ソート可能）。
 - `projects` はファイルシステム上のフォルダに対応し、`VaultSyncService`（FSEvents）が DB と同期する。

--- a/Sources/Dahlia/Database/AppDatabaseManager.swift
+++ b/Sources/Dahlia/Database/AppDatabaseManager.swift
@@ -57,6 +57,10 @@ final class AppDatabaseManager: Sendable {
             try normalizeLegacyMeetingStatus(in: db)
         }
 
+        migrator.registerMigration("v8_recordingSessions") { db in
+            try addRecordingSessionSchemaIfNeeded(in: db)
+        }
+
         return migrator
     }()
 
@@ -326,5 +330,139 @@ final class AppDatabaseManager: Sendable {
 
     private static func addTranscriptSegmentTranslatedTextColumnIfNeeded(in db: Database) throws {
         try addColumnIfNeeded(in: db, table: "transcript_segments", column: "translatedText", type: .text)
+    }
+
+    private static func addRecordingSessionSchemaIfNeeded(in db: Database) throws {
+        if try db.tableExists("meetings") {
+            try createRecordingSessionsTableIfNeeded(in: db)
+        }
+
+        try addColumnIfNeeded(in: db, table: "transcript_segments", column: "sessionId", type: .blob)
+        try addColumnIfNeeded(in: db, table: "screenshots", column: "sessionId", type: .blob)
+
+        if try db.tableExists("meetings"),
+           try db.tableExists("recording_sessions") {
+            try backfillRecordingSessions(in: db)
+        }
+    }
+
+    private static func createRecordingSessionsTableIfNeeded(in db: Database) throws {
+        guard try !db.tableExists("recording_sessions") else { return }
+        try db.create(table: "recording_sessions") { t in
+            t.primaryKey("id", .blob)
+            t.column("meetingId", .blob).notNull()
+                .references("meetings", onDelete: .cascade)
+            t.column("startedAt", .datetime).notNull()
+            t.column("endedAt", .datetime)
+            t.column("duration", .double)
+            t.column("offsetSeconds", .double).notNull().defaults(to: 0)
+            t.column("createdAt", .datetime).notNull()
+            t.column("updatedAt", .datetime).notNull()
+        }
+        try db.create(
+            index: "recording_sessions_on_meetingId",
+            on: "recording_sessions",
+            columns: ["meetingId"]
+        )
+        try db.create(
+            index: "recording_sessions_on_meetingId_startedAt",
+            on: "recording_sessions",
+            columns: ["meetingId", "startedAt"]
+        )
+    }
+
+    private static func backfillRecordingSessions(in db: Database) throws {
+        let hasTranscriptSegments = try db.tableExists("transcript_segments")
+        let hasScreenshots = try db.tableExists("screenshots")
+
+        let rows: [Row] = if hasTranscriptSegments {
+            try Row.fetchAll(
+                db,
+                sql: """
+                SELECT
+                    meetings.id AS meetingId,
+                    meetings.createdAt AS meetingCreatedAt,
+                    meetings.duration AS meetingDuration,
+                    MIN(transcript_segments.startTime) AS firstSegmentStartTime,
+                    MAX(COALESCE(transcript_segments.endTime, transcript_segments.startTime)) AS lastSegmentEndTime
+                FROM meetings
+                LEFT JOIN transcript_segments ON transcript_segments.meetingId = meetings.id
+                LEFT JOIN recording_sessions ON recording_sessions.meetingId = meetings.id
+                WHERE recording_sessions.id IS NULL
+                GROUP BY meetings.id
+                """
+            )
+        } else {
+            try Row.fetchAll(
+                db,
+                sql: """
+                SELECT
+                    meetings.id AS meetingId,
+                    meetings.createdAt AS meetingCreatedAt,
+                    meetings.duration AS meetingDuration,
+                    NULL AS firstSegmentStartTime,
+                    NULL AS lastSegmentEndTime
+                FROM meetings
+                LEFT JOIN recording_sessions ON recording_sessions.meetingId = meetings.id
+                WHERE recording_sessions.id IS NULL
+                GROUP BY meetings.id
+                """
+            )
+        }
+
+        for row in rows {
+            let meetingId: UUID = row["meetingId"]
+            let meetingCreatedAt: Date = row["meetingCreatedAt"]
+            let meetingDuration: TimeInterval? = row["meetingDuration"]
+            let firstSegmentStartTime: Date? = row["firstSegmentStartTime"]
+            let lastSegmentEndTime: Date? = row["lastSegmentEndTime"]
+            let startedAt = firstSegmentStartTime ?? meetingCreatedAt
+            let transcriptDuration = lastSegmentEndTime.map { max(0, $0.timeIntervalSince(startedAt)) }
+            let duration = transcriptDuration ?? meetingDuration
+            let endedAt = lastSegmentEndTime
+                ?? duration.map { startedAt.addingTimeInterval($0) }
+            let sessionId = UUID.v7()
+
+            try db.execute(
+                sql: """
+                INSERT INTO recording_sessions (
+                    id, meetingId, startedAt, endedAt, duration, offsetSeconds, createdAt, updatedAt
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                arguments: [
+                    sessionId,
+                    meetingId,
+                    startedAt,
+                    endedAt,
+                    duration,
+                    0,
+                    startedAt,
+                    endedAt ?? startedAt,
+                ]
+            )
+
+            if hasTranscriptSegments {
+                try db.execute(
+                    sql: """
+                    UPDATE transcript_segments
+                    SET sessionId = ?
+                    WHERE meetingId = ? AND sessionId IS NULL
+                    """,
+                    arguments: [sessionId, meetingId]
+                )
+            }
+
+            if hasScreenshots {
+                try db.execute(
+                    sql: """
+                    UPDATE screenshots
+                    SET sessionId = ?
+                    WHERE meetingId = ? AND sessionId IS NULL
+                    """,
+                    arguments: [sessionId, meetingId]
+                )
+            }
+        }
     }
 }

--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -4,6 +4,12 @@ import GRDB
 /// ミーティング・セグメント・プロジェクト・保管庫の DB クエリを集約するリポジトリ。
 @MainActor
 final class MeetingRepository {
+    struct AppendRecordingContext {
+        let meetingCreatedAt: Date?
+        let firstSegmentStartTime: Date?
+        let segmentIds: Set<UUID>
+    }
+
     private static let generatedSummaryTagColorHex = "#808080"
 
     private let dbQueue: DatabaseQueue
@@ -196,6 +202,31 @@ final class MeetingRepository {
     func fetchMeeting(id: UUID) throws -> MeetingRecord? {
         try dbQueue.read { db in
             try MeetingRecord.fetchOne(db, key: id)
+        }
+    }
+
+    func fetchAppendRecordingContext(forMeetingId meetingId: UUID) throws -> AppendRecordingContext {
+        try dbQueue.read { db in
+            let meeting = try MeetingRecord.fetchOne(db, key: meetingId)
+            let segments = try TranscriptSegmentRecord
+                .filter(Column("meetingId") == meetingId)
+                .order(Column("startTime").asc)
+                .fetchAll(db)
+            return AppendRecordingContext(
+                meetingCreatedAt: meeting?.createdAt,
+                firstSegmentStartTime: segments.first?.startTime,
+                segmentIds: Set(segments.map(\.id))
+            )
+        }
+    }
+
+    func updateMeetingCreatedAt(id: UUID, createdAt: Date) throws {
+        try dbQueue.write { db in
+            if var record = try MeetingRecord.fetchOne(db, key: id) {
+                record.createdAt = createdAt
+                record.updatedAt = createdAt
+                try record.update(db)
+            }
         }
     }
 

--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -7,7 +7,26 @@ final class MeetingRepository {
     struct AppendRecordingContext {
         let meetingCreatedAt: Date?
         let firstSegmentStartTime: Date?
+        let lastSegmentEndTime: Date?
         let segmentIds: Set<UUID>
+        let recordingSessions: [RecordingSessionRecord]
+
+        var nextOffsetSeconds: TimeInterval {
+            let sessionDuration = recordingSessions.reduce(0) { total, session in
+                let duration = session.duration
+                    ?? session.endedAt.map { max(0, $0.timeIntervalSince(session.startedAt)) }
+                    ?? 0
+                return total + duration
+            }
+
+            if sessionDuration > 0 {
+                return sessionDuration
+            }
+
+            guard let firstSegmentStartTime,
+                  let lastSegmentEndTime else { return 0 }
+            return max(0, lastSegmentEndTime.timeIntervalSince(firstSegmentStartTime))
+        }
     }
 
     private static let generatedSummaryTagColorHex = "#808080"
@@ -212,10 +231,16 @@ final class MeetingRepository {
                 .filter(Column("meetingId") == meetingId)
                 .order(Column("startTime").asc)
                 .fetchAll(db)
+            let sessions = try RecordingSessionRecord
+                .filter(Column("meetingId") == meetingId)
+                .order(Column("offsetSeconds").asc, Column("startedAt").asc)
+                .fetchAll(db)
             return AppendRecordingContext(
                 meetingCreatedAt: meeting?.createdAt,
                 firstSegmentStartTime: segments.first?.startTime,
-                segmentIds: Set(segments.map(\.id))
+                lastSegmentEndTime: segments.last.map { $0.endTime ?? $0.startTime },
+                segmentIds: Set(segments.map(\.id)),
+                recordingSessions: sessions
             )
         }
     }
@@ -502,6 +527,7 @@ final class MeetingRepository {
         let meeting: MeetingRecord?
         let calendarEvent: CalendarEventRecord?
         let segments: [TranscriptSegmentRecord]
+        let recordingSessions: [RecordingSessionRecord]
         let screenshots: [MeetingScreenshotRecord]
         let note: MeetingNoteRecord?
         let summary: SummaryRecord?
@@ -517,6 +543,10 @@ final class MeetingRepository {
                 .filter(Column("meetingId") == meetingId)
                 .order(Column("startTime").asc)
                 .fetchAll(db)
+            let recordingSessions = try RecordingSessionRecord
+                .filter(Column("meetingId") == meetingId)
+                .order(Column("offsetSeconds").asc, Column("startedAt").asc)
+                .fetchAll(db)
             let screenshots = try MeetingScreenshotRecord
                 .filter(Column("meetingId") == meetingId)
                 .order(Column("capturedAt").asc)
@@ -527,6 +557,7 @@ final class MeetingRepository {
                 meeting: meeting,
                 calendarEvent: calendarEvent,
                 segments: segments,
+                recordingSessions: recordingSessions,
                 screenshots: screenshots,
                 note: note,
                 summary: summary

--- a/Sources/Dahlia/Database/MeetingScreenshotRecord.swift
+++ b/Sources/Dahlia/Database/MeetingScreenshotRecord.swift
@@ -7,6 +7,7 @@ struct MeetingScreenshotRecord: Codable, FetchableRecord, PersistableRecord {
 
     var id: UUID
     var meetingId: UUID
+    var sessionId: UUID? = nil
     var capturedAt: Date
     var imageData: Data
     var mimeType: String

--- a/Sources/Dahlia/Database/RecordingSessionRecord.swift
+++ b/Sources/Dahlia/Database/RecordingSessionRecord.swift
@@ -1,0 +1,16 @@
+import Foundation
+import GRDB
+
+/// ひとつづきの録音セッションを表す GRDB レコード。
+struct RecordingSessionRecord: Codable, FetchableRecord, PersistableRecord, Equatable {
+    static let databaseTableName = "recording_sessions"
+
+    var id: UUID
+    var meetingId: UUID
+    var startedAt: Date
+    var endedAt: Date?
+    var duration: TimeInterval?
+    var offsetSeconds: TimeInterval
+    var createdAt: Date
+    var updatedAt: Date
+}

--- a/Sources/Dahlia/Database/TranscriptSegmentRecord.swift
+++ b/Sources/Dahlia/Database/TranscriptSegmentRecord.swift
@@ -7,6 +7,7 @@ struct TranscriptSegmentRecord: Codable, FetchableRecord, PersistableRecord {
 
     var id: UUID
     var meetingId: UUID
+    var sessionId: UUID? = nil
     var startTime: Date
     var endTime: Date?
     var text: String
@@ -17,9 +18,10 @@ struct TranscriptSegmentRecord: Codable, FetchableRecord, PersistableRecord {
 
 extension TranscriptSegmentRecord {
     /// TranscriptSegment から TranscriptSegmentRecord を生成する。
-    init(from segment: TranscriptSegment, meetingId: UUID) {
+    init(from segment: TranscriptSegment, meetingId: UUID, defaultSessionId: UUID? = nil) {
         self.id = segment.id
         self.meetingId = meetingId
+        self.sessionId = segment.sessionId ?? defaultSessionId
         self.startTime = segment.startTime
         self.endTime = segment.endTime
         self.text = segment.text

--- a/Sources/Dahlia/Models/RecordingSessionTimeline.swift
+++ b/Sources/Dahlia/Models/RecordingSessionTimeline.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// 表示用の録音セッション情報。
-struct RecordingSessionTimeline: Identifiable, Equatable, Sendable {
+struct RecordingSessionTimeline: Identifiable, Equatable {
     let id: UUID
     let startedAt: Date
     var endedAt: Date?

--- a/Sources/Dahlia/Models/RecordingSessionTimeline.swift
+++ b/Sources/Dahlia/Models/RecordingSessionTimeline.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// 表示用の録音セッション情報。
+struct RecordingSessionTimeline: Identifiable, Equatable, Sendable {
+    let id: UUID
+    let startedAt: Date
+    var endedAt: Date?
+    var offsetSeconds: TimeInterval
+}
+
+extension RecordingSessionTimeline {
+    init(from record: RecordingSessionRecord) {
+        self.init(
+            id: record.id,
+            startedAt: record.startedAt,
+            endedAt: record.endedAt,
+            offsetSeconds: record.offsetSeconds
+        )
+    }
+}

--- a/Sources/Dahlia/Models/TranscriptSegment.swift
+++ b/Sources/Dahlia/Models/TranscriptSegment.swift
@@ -3,11 +3,46 @@ import Foundation
 enum Formatters {
     /// 録音開始からの経過時間を "00:12:34" 固定幅(HH:mm:ss)で整形する。
     static func elapsedHHmmss(from start: Date, to date: Date) -> String {
-        let totalSeconds = max(0, Int(date.timeIntervalSince(start)))
+        elapsedHHmmss(duration: date.timeIntervalSince(start))
+    }
+
+    /// 経過秒数を "00:12:34" 固定幅(HH:mm:ss)で整形する。
+    static func elapsedHHmmss(duration: TimeInterval) -> String {
+        let totalSeconds = max(0, Int(duration))
         let hours = totalSeconds / 3600
         let minutes = (totalSeconds % 3600) / 60
         let seconds = totalSeconds % 60
         return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+    }
+
+    static func elapsedSeconds(
+        at date: Date,
+        sessionId: UUID?,
+        sessions: [RecordingSessionTimeline],
+        fallbackTimeBase: Date
+    ) -> TimeInterval {
+        if let sessionId,
+           let session = sessions.first(where: { $0.id == sessionId }) {
+            return session.offsetSeconds + date.timeIntervalSince(session.startedAt)
+        }
+
+        return date.timeIntervalSince(fallbackTimeBase)
+    }
+
+    static func elapsedHHmmss(
+        at date: Date,
+        sessionId: UUID?,
+        sessions: [RecordingSessionTimeline],
+        fallbackTimeBase: Date
+    ) -> String {
+        elapsedHHmmss(
+            duration: elapsedSeconds(
+                at: date,
+                sessionId: sessionId,
+                sessions: sessions,
+                fallbackTimeBase: fallbackTimeBase
+            )
+        )
     }
 }
 
@@ -23,6 +58,7 @@ extension Sequence<Locale> {
 /// Speech フレームワークで文字起こしされた1発話区間を表すデータモデル。
 struct TranscriptSegment: Identifiable, Equatable {
     let id: UUID
+    var sessionId: UUID?
     let startTime: Date
     var endTime: Date?
     var text: String
@@ -50,6 +86,7 @@ struct TranscriptSegment: Identifiable, Equatable {
 
     init(
         id: UUID = .v7(),
+        sessionId: UUID? = nil,
         startTime: Date,
         endTime: Date? = nil,
         text: String,
@@ -58,6 +95,7 @@ struct TranscriptSegment: Identifiable, Equatable {
         speakerLabel: String? = nil
     ) {
         self.id = id
+        self.sessionId = sessionId
         self.startTime = startTime
         self.endTime = endTime
         self.text = text
@@ -69,6 +107,7 @@ struct TranscriptSegment: Identifiable, Equatable {
     /// TranscriptSegmentRecord からの変換イニシャライザ。
     init(from record: TranscriptSegmentRecord) {
         self.id = record.id
+        self.sessionId = record.sessionId
         self.startTime = record.startTime
         self.endTime = record.endTime
         self.text = record.text

--- a/Sources/Dahlia/Models/TranscriptSegment.swift
+++ b/Sources/Dahlia/Models/TranscriptSegment.swift
@@ -1,12 +1,14 @@
 import Foundation
 
 enum Formatters {
-    static let timeHHmmss: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "HH:mm:ss"
-        return f
-    }()
-
+    /// 録音開始からの経過時間を "00:12:34" 固定幅(HH:mm:ss)で整形する。
+    static func elapsedHHmmss(from start: Date, to date: Date) -> String {
+        let totalSeconds = max(0, Int(date.timeIntervalSince(start)))
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+        return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+    }
 }
 
 extension Sequence<Locale> {

--- a/Sources/Dahlia/Models/TranscriptStore.swift
+++ b/Sources/Dahlia/Models/TranscriptStore.swift
@@ -15,6 +15,10 @@ final class TranscriptStore: ObservableObject {
 
     var recordingStartTime: Date?
 
+    var timeBase: Date {
+        recordingStartTime ?? segments.first?.startTime ?? Date()
+    }
+
     // MARK: - Unconfirmed Segment Throttle (per source)
 
     private var unconfirmedThrottleTasks: [String: Task<Void, Never>] = [:]
@@ -135,8 +139,9 @@ final class TranscriptStore: ObservableObject {
     }
 
     func exportAsText() -> String {
-        segments.map { segment in
-            let time = Formatters.timeHHmmss.string(from: segment.startTime)
+        let timeBase = self.timeBase
+        return segments.map { segment in
+            let time = Formatters.elapsedHHmmss(from: timeBase, to: segment.startTime)
             let speaker = segment.speakerLabel.map { "[\($0)] " } ?? ""
             return "[\(time)] \(speaker)\(segment.displayText)"
         }.joined(separator: "\n")
@@ -144,8 +149,9 @@ final class TranscriptStore: ObservableObject {
 
     /// LLM 要約用のテキスト。スピーカーラベルを含めない。
     func exportForSummary() -> String {
-        segments.map { segment in
-            let time = Formatters.timeHHmmss.string(from: segment.startTime)
+        let timeBase = self.timeBase
+        return segments.map { segment in
+            let time = Formatters.elapsedHHmmss(from: timeBase, to: segment.startTime)
             return "<time>\(time)</time> \(segment.displayText)"
         }.joined(separator: "\n")
     }

--- a/Sources/Dahlia/Models/TranscriptStore.swift
+++ b/Sources/Dahlia/Models/TranscriptStore.swift
@@ -12,11 +12,12 @@ final class TranscriptStore: ObservableObject {
     }
 
     @Published var segments: [TranscriptSegment] = []
+    @Published var recordingSessions: [RecordingSessionTimeline] = []
 
     var recordingStartTime: Date?
 
     var timeBase: Date {
-        recordingStartTime ?? segments.first?.startTime ?? Date()
+        recordingStartTime ?? recordingSessions.first?.startedAt ?? segments.first?.startTime ?? Date()
     }
 
     // MARK: - Unconfirmed Segment Throttle (per source)
@@ -95,6 +96,7 @@ final class TranscriptStore: ObservableObject {
         let existingSegment = existingUnconfirmedSegment(forSource: sourceLabel)
         return TranscriptSegment(
             id: existingSegment?.id ?? segment.id,
+            sessionId: segment.sessionId ?? existingSegment?.sessionId,
             startTime: segment.startTime,
             endTime: segment.endTime,
             text: segment.text,
@@ -123,6 +125,25 @@ final class TranscriptStore: ObservableObject {
         segments = newSegments
     }
 
+    /// DB から読み込んだ録音セッションを一括セットする。
+    func loadRecordingSessions(_ sessions: [RecordingSessionTimeline]) {
+        recordingSessions = sessions.sorted { lhs, rhs in
+            if lhs.offsetSeconds == rhs.offsetSeconds {
+                return lhs.startedAt < rhs.startedAt
+            }
+            return lhs.offsetSeconds < rhs.offsetSeconds
+        }
+    }
+
+    func upsertRecordingSession(_ session: RecordingSessionTimeline) {
+        if let index = recordingSessions.firstIndex(where: { $0.id == session.id }) {
+            recordingSessions[index] = session
+        } else {
+            recordingSessions.append(session)
+        }
+        loadRecordingSessions(recordingSessions)
+    }
+
     func updateTranslatedText(for segmentID: UUID, translatedText: String?) {
         guard let index = segments.firstIndex(where: { $0.id == segmentID }) else { return }
         guard segments[index].translatedText != translatedText else { return }
@@ -131,6 +152,7 @@ final class TranscriptStore: ObservableObject {
 
     func clear() {
         segments.removeAll()
+        recordingSessions.removeAll()
         recordingStartTime = nil
         unconfirmedThrottleTasks.values.forEach { $0.cancel() }
         unconfirmedThrottleTasks.removeAll()
@@ -140,8 +162,14 @@ final class TranscriptStore: ObservableObject {
 
     func exportAsText() -> String {
         let timeBase = self.timeBase
+        let sessions = recordingSessions
         return segments.map { segment in
-            let time = Formatters.elapsedHHmmss(from: timeBase, to: segment.startTime)
+            let time = Formatters.elapsedHHmmss(
+                at: segment.startTime,
+                sessionId: segment.sessionId,
+                sessions: sessions,
+                fallbackTimeBase: timeBase
+            )
             let speaker = segment.speakerLabel.map { "[\($0)] " } ?? ""
             return "[\(time)] \(speaker)\(segment.displayText)"
         }.joined(separator: "\n")
@@ -150,8 +178,14 @@ final class TranscriptStore: ObservableObject {
     /// LLM 要約用のテキスト。スピーカーラベルを含めない。
     func exportForSummary() -> String {
         let timeBase = self.timeBase
+        let sessions = recordingSessions
         return segments.map { segment in
-            let time = Formatters.elapsedHHmmss(from: timeBase, to: segment.startTime)
+            let time = Formatters.elapsedHHmmss(
+                at: segment.startTime,
+                sessionId: segment.sessionId,
+                sessions: sessions,
+                fallbackTimeBase: timeBase
+            )
             return "<time>\(time)</time> \(segment.displayText)"
         }.joined(separator: "\n")
     }

--- a/Sources/Dahlia/Services/MeetingPersistenceService.swift
+++ b/Sources/Dahlia/Services/MeetingPersistenceService.swift
@@ -51,12 +51,18 @@ final class MeetingPersistenceService {
     }
 
     /// 既存のミーティングに追記する（追記モード）。
-    init(store: TranscriptStore, dbQueue: DatabaseQueue, existingMeetingId: UUID, existingSegmentIds: Set<UUID>) {
+    init(
+        store: TranscriptStore,
+        dbQueue: DatabaseQueue,
+        existingMeetingId: UUID,
+        existingSegmentIds: Set<UUID>,
+        recordingStartDate: Date = Date()
+    ) {
         self.store = store
         self.dbQueue = dbQueue
         self.meetingId = existingMeetingId
         self.persistedSegmentIds = existingSegmentIds
-        self.recordingStartDate = store.recordingStartTime ?? Date()
+        self.recordingStartDate = recordingStartDate
 
         startObserving()
     }

--- a/Sources/Dahlia/Services/MeetingPersistenceService.swift
+++ b/Sources/Dahlia/Services/MeetingPersistenceService.swift
@@ -12,7 +12,11 @@ final class MeetingPersistenceService {
     private var cancellable: AnyCancellable?
     private var persistedSegmentIds: Set<UUID> = []
     private var persistedSegmentTranslations: [UUID: String?] = [:]
-    private let recordingStartDate: Date
+    private var recordingSession: RecordingSessionRecord
+
+    var recordingSessionId: UUID {
+        recordingSession.id
+    }
 
     /// 新規ミーティングを作成して録音を開始する。
     init(
@@ -21,14 +25,25 @@ final class MeetingPersistenceService {
         vaultId: UUID,
         projectId: UUID?,
         initialName: String,
-        calendarEvent: CalendarEvent? = nil
+        calendarEvent: CalendarEvent? = nil,
+        recordingSessionId: UUID = .v7()
     ) throws {
         self.store = store
         self.dbQueue = dbQueue
         self.meetingId = .v7()
 
         let now = store.recordingStartTime ?? Date()
-        self.recordingStartDate = now
+        let session = RecordingSessionRecord(
+            id: recordingSessionId,
+            meetingId: meetingId,
+            startedAt: now,
+            endedAt: nil,
+            duration: nil,
+            offsetSeconds: 0,
+            createdAt: now,
+            updatedAt: now
+        )
+        self.recordingSession = session
         let trimmedInitialName = initialName.trimmingCharacters(in: .whitespacesAndNewlines)
 
         let meeting = MeetingRecord(
@@ -42,11 +57,13 @@ final class MeetingPersistenceService {
         )
         try dbQueue.write { db in
             try meeting.insert(db)
+            try session.insert(db)
             if let calendarEvent {
                 try CalendarEventRecord(meetingId: meetingId, now: now, event: calendarEvent).insert(db)
             }
         }
 
+        store.upsertRecordingSession(RecordingSessionTimeline(from: session))
         startObserving()
     }
 
@@ -56,14 +73,30 @@ final class MeetingPersistenceService {
         dbQueue: DatabaseQueue,
         existingMeetingId: UUID,
         existingSegmentIds: Set<UUID>,
-        recordingStartDate: Date = Date()
-    ) {
+        recordingStartDate: Date = Date(),
+        recordingOffsetSeconds: TimeInterval = 0,
+        recordingSessionId: UUID = .v7()
+    ) throws {
         self.store = store
         self.dbQueue = dbQueue
         self.meetingId = existingMeetingId
         self.persistedSegmentIds = existingSegmentIds
-        self.recordingStartDate = recordingStartDate
+        let session = RecordingSessionRecord(
+            id: recordingSessionId,
+            meetingId: existingMeetingId,
+            startedAt: recordingStartDate,
+            endedAt: nil,
+            duration: nil,
+            offsetSeconds: recordingOffsetSeconds,
+            createdAt: recordingStartDate,
+            updatedAt: recordingStartDate
+        )
+        self.recordingSession = session
 
+        try dbQueue.write { db in
+            try session.insert(db)
+        }
+        store.upsertRecordingSession(RecordingSessionTimeline(from: session))
         startObserving()
     }
 
@@ -81,7 +114,7 @@ final class MeetingPersistenceService {
 
         for segment in segments where segment.isConfirmed {
             if !persistedSegmentIds.contains(segment.id) {
-                recordsToInsert.append(TranscriptSegmentRecord(from: segment, meetingId: meetingId))
+                recordsToInsert.append(TranscriptSegmentRecord(from: segment, meetingId: meetingId, defaultSessionId: recordingSession.id))
                 persistedSegmentIds.insert(segment.id)
                 persistedSegmentTranslations[segment.id] = segment.translatedText
             } else if persistedSegmentTranslations[segment.id] != segment.translatedText {
@@ -114,16 +147,26 @@ final class MeetingPersistenceService {
         persistNewConfirmedSegments(store.segments)
 
         let now = Date()
-        let duration = now.timeIntervalSince(recordingStartDate)
+        let duration = max(0, now.timeIntervalSince(recordingSession.startedAt))
+        recordingSession.endedAt = now
+        recordingSession.duration = duration
+        recordingSession.updatedAt = now
 
         try? dbQueue.write { db in
+            try recordingSession.update(db)
+            let totalDuration = try Double.fetchOne(
+                db,
+                sql: "SELECT COALESCE(SUM(duration), 0) FROM recording_sessions WHERE meetingId = ?",
+                arguments: [meetingId]
+            ) ?? duration
             if var record = try MeetingRecord.fetchOne(db, key: meetingId) {
                 record.status = .ready
-                record.duration = duration
+                record.duration = totalDuration
                 record.updatedAt = now
                 try record.update(db)
             }
         }
+        store.upsertRecordingSession(RecordingSessionTimeline(from: recordingSession))
     }
 
     /// 保存済みセグメント追跡をリセットし、監視を再開する。

--- a/Sources/Dahlia/Services/SummaryService.swift
+++ b/Sources/Dahlia/Services/SummaryService.swift
@@ -17,12 +17,6 @@ enum SummaryService {
         return f
     }()
 
-    private static let timeFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "HH:mm:ss"
-        return f
-    }()
-
     /// 要約を生成し、Markdown と関連メタデータを返す。
     @MainActor
     static func generateSummary(
@@ -81,10 +75,7 @@ enum SummaryService {
             }.value
             var parts: [LLMService.ContentPart] = [.text(transcriptContent)]
             for (screenshot, preparedImageDataURI) in zip(screenshots, preparedImageDataURIs) {
-                let time = timeFormatter.string(from: screenshot.capturedAt)
-                let imageFilename = ScreenshotExportService.filename(for: screenshot)
-                let imageMetadata = "<time>\(time)</time> <image_id>\(imageFilename)</image_id> <image_filename>\(imageFilename)</image_filename>"
-                parts.append(.text(imageMetadata))
+                parts.append(.text(screenshotMetadata(for: screenshot, relativeTo: createdAt)))
                 parts.append(.imageURL(preparedImageDataURI))
             }
             messages.append(.init(role: "user", parts: parts))
@@ -145,6 +136,12 @@ enum SummaryService {
             tags: tags,
             actionItems: actionItems
         )
+    }
+
+    static func screenshotMetadata(for screenshot: MeetingScreenshotRecord, relativeTo timeBase: Date) -> String {
+        let time = Formatters.elapsedHHmmss(from: timeBase, to: screenshot.capturedAt)
+        let imageFilename = ScreenshotExportService.filename(for: screenshot)
+        return "<time>\(time)</time> <image_id>\(imageFilename)</image_id> <image_filename>\(imageFilename)</image_filename>"
     }
 
     /// 要約保存先ディレクトリ内の `.md` ファイルを走査し、frontmatter の `meeting_id` が一致するファイルを返す。

--- a/Sources/Dahlia/Services/SummaryService.swift
+++ b/Sources/Dahlia/Services/SummaryService.swift
@@ -26,6 +26,7 @@ enum SummaryService {
         transcriptText: String,
         noteText: String? = nil,
         screenshots: [MeetingScreenshotRecord] = [],
+        recordingSessions: [RecordingSessionTimeline] = [],
         repository: MeetingRepository? = nil
     ) async throws -> GeneratedSummary {
         let settings = AppSettings.shared
@@ -75,7 +76,7 @@ enum SummaryService {
             }.value
             var parts: [LLMService.ContentPart] = [.text(transcriptContent)]
             for (screenshot, preparedImageDataURI) in zip(screenshots, preparedImageDataURIs) {
-                parts.append(.text(screenshotMetadata(for: screenshot, relativeTo: createdAt)))
+                parts.append(.text(screenshotMetadata(for: screenshot, relativeTo: createdAt, recordingSessions: recordingSessions)))
                 parts.append(.imageURL(preparedImageDataURI))
             }
             messages.append(.init(role: "user", parts: parts))
@@ -138,8 +139,17 @@ enum SummaryService {
         )
     }
 
-    static func screenshotMetadata(for screenshot: MeetingScreenshotRecord, relativeTo timeBase: Date) -> String {
-        let time = Formatters.elapsedHHmmss(from: timeBase, to: screenshot.capturedAt)
+    static func screenshotMetadata(
+        for screenshot: MeetingScreenshotRecord,
+        relativeTo timeBase: Date,
+        recordingSessions: [RecordingSessionTimeline] = []
+    ) -> String {
+        let time = Formatters.elapsedHHmmss(
+            at: screenshot.capturedAt,
+            sessionId: screenshot.sessionId,
+            sessions: recordingSessions,
+            fallbackTimeBase: timeBase
+        )
         let imageFilename = ScreenshotExportService.filename(for: screenshot)
         return "<time>\(time)</time> <image_id>\(imageFilename)</image_id> <image_filename>\(imageFilename)</image_filename>"
     }

--- a/Sources/Dahlia/Services/TranscriptExportService.swift
+++ b/Sources/Dahlia/Services/TranscriptExportService.swift
@@ -37,7 +37,7 @@ enum TranscriptExportService {
         """
 
         let body: String = segments.map { (segment: TranscriptSegment) -> String in
-            let time = Formatters.timeHHmmss.string(from: segment.startTime)
+            let time = Formatters.elapsedHHmmss(from: createdAt, to: segment.startTime)
             return "###### \(time)\n\(segment.displayText)"
         }.joined(separator: "\n")
 

--- a/Sources/Dahlia/Services/TranscriptExportService.swift
+++ b/Sources/Dahlia/Services/TranscriptExportService.swift
@@ -22,7 +22,8 @@ enum TranscriptExportService {
         meetingId: UUID,
         projectName: String,
         createdAt: Date,
-        segments: [TranscriptSegment]
+        segments: [TranscriptSegment],
+        recordingSessions: [RecordingSessionTimeline] = []
     ) throws -> String {
         let transcriptsDir = transcriptsDirectoryURL(in: vaultURL)
         try FileManager.default.createDirectory(at: transcriptsDir, withIntermediateDirectories: true)
@@ -37,7 +38,12 @@ enum TranscriptExportService {
         """
 
         let body: String = segments.map { (segment: TranscriptSegment) -> String in
-            let time = Formatters.elapsedHHmmss(from: createdAt, to: segment.startTime)
+            let time = Formatters.elapsedHHmmss(
+                at: segment.startTime,
+                sessionId: segment.sessionId,
+                sessions: recordingSessions,
+                fallbackTimeBase: createdAt
+            )
             return "###### \(time)\n\(segment.displayText)"
         }.joined(separator: "\n")
 

--- a/Sources/Dahlia/Services/VaultSummaryExportService.swift
+++ b/Sources/Dahlia/Services/VaultSummaryExportService.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// 要約関連ファイルを Vault に書き出すサービス。
 enum VaultSummaryExportService {
-    typealias TranscriptExporter = @Sendable (URL, UUID, String, Date, [TranscriptSegment]) throws -> String
+    typealias TranscriptExporter = @Sendable (URL, UUID, String, Date, [TranscriptSegment], [RecordingSessionTimeline]) throws -> String
     typealias ScreenshotExporter = @Sendable (URL, [MeetingScreenshotRecord]) throws -> [String]
     typealias SummaryWriter = @Sendable (URL, String) throws -> URL
 
@@ -13,6 +13,7 @@ enum VaultSummaryExportService {
         createdAt: Date,
         projectName: String,
         segments: [TranscriptSegment],
+        recordingSessions: [RecordingSessionTimeline] = [],
         screenshots: [MeetingScreenshotRecord],
         summaryFileName: String,
         summaryMarkdown: String
@@ -24,6 +25,7 @@ enum VaultSummaryExportService {
             createdAt: createdAt,
             projectName: projectName,
             segments: segments,
+            recordingSessions: recordingSessions,
             screenshots: screenshots,
             summaryFileName: summaryFileName,
             summaryMarkdown: summaryMarkdown,
@@ -40,6 +42,7 @@ enum VaultSummaryExportService {
         createdAt: Date,
         projectName: String,
         segments: [TranscriptSegment],
+        recordingSessions: [RecordingSessionTimeline] = [],
         screenshots: [MeetingScreenshotRecord],
         summaryFileName: String,
         summaryMarkdown: String,
@@ -59,7 +62,7 @@ enum VaultSummaryExportService {
                 try writeSummary(summaryFileURL, summaryMarkdown)
             }
             group.addTask {
-                _ = try exportTranscript(vaultURL, meetingId, projectName, createdAt, segments)
+                _ = try exportTranscript(vaultURL, meetingId, projectName, createdAt, segments, recordingSessions)
                 return nil
             }
             if !screenshots.isEmpty {

--- a/Sources/Dahlia/Speech/SpeechTranscriberService.swift
+++ b/Sources/Dahlia/Speech/SpeechTranscriberService.swift
@@ -90,17 +90,11 @@ actor SpeechTranscriberService {
     }
 
     /// ストリーミング文字起こしを開始する。
-    func startStreaming(store: TranscriptStore, bridge: AudioBufferBridge, recordingStartTime providedRecordingStartTime: Date? = nil) async throws {
+    func startStreaming(store: TranscriptStore, bridge: AudioBufferBridge, recordingStartTime: Date) async throws {
         guard let analyzer, let transcriber else { return }
 
         // SpeechAnalyzer にオーディオストリームを渡して解析開始
         try await analyzer.start(inputSequence: bridge.stream)
-
-        let recordingStartTime: Date = if let providedRecordingStartTime {
-            providedRecordingStartTime
-        } else {
-            await store.recordingStartTime ?? Date()
-        }
 
         // SpeechTranscriber の結果を非同期でイテレーションし、TranscriptStore に反映
         resultTask = Task { [weak self] in

--- a/Sources/Dahlia/Speech/SpeechTranscriberService.swift
+++ b/Sources/Dahlia/Speech/SpeechTranscriberService.swift
@@ -90,13 +90,17 @@ actor SpeechTranscriberService {
     }
 
     /// ストリーミング文字起こしを開始する。
-    func startStreaming(store: TranscriptStore, bridge: AudioBufferBridge) async throws {
+    func startStreaming(store: TranscriptStore, bridge: AudioBufferBridge, recordingStartTime providedRecordingStartTime: Date? = nil) async throws {
         guard let analyzer, let transcriber else { return }
 
         // SpeechAnalyzer にオーディオストリームを渡して解析開始
         try await analyzer.start(inputSequence: bridge.stream)
 
-        let recordingStartTime = await store.recordingStartTime ?? Date()
+        let recordingStartTime: Date = if let providedRecordingStartTime {
+            providedRecordingStartTime
+        } else {
+            await store.recordingStartTime ?? Date()
+        }
 
         // SpeechTranscriber の結果を非同期でイテレーションし、TranscriptStore に反映
         resultTask = Task { [weak self] in

--- a/Sources/Dahlia/Speech/SpeechTranscriberService.swift
+++ b/Sources/Dahlia/Speech/SpeechTranscriberService.swift
@@ -90,7 +90,7 @@ actor SpeechTranscriberService {
     }
 
     /// ストリーミング文字起こしを開始する。
-    func startStreaming(store: TranscriptStore, bridge: AudioBufferBridge, recordingStartTime: Date) async throws {
+    func startStreaming(store: TranscriptStore, bridge: AudioBufferBridge, recordingStartTime: Date, recordingSessionId: UUID) async throws {
         guard let analyzer, let transcriber else { return }
 
         // SpeechAnalyzer にオーディオストリームを渡して解析開始
@@ -124,6 +124,7 @@ actor SpeechTranscriberService {
                     )
 
                     let segment = TranscriptSegment(
+                        sessionId: recordingSessionId,
                         startTime: startDate,
                         endTime: endDate,
                         text: text,

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -981,12 +981,20 @@ final class CaptionViewModel: ObservableObject {
 
         pipelines.removeAll()
         let recordingStartTime = Date()
+        let appendContext: MeetingRepository.AppendRecordingContext?
         if let existingMeetingId {
+            let repo = MeetingRepository(dbQueue: dbQueue)
+            appendContext = try? repo.fetchAppendRecordingContext(forMeetingId: existingMeetingId)
             if store.recordingStartTime == nil {
-                let repo = MeetingRepository(dbQueue: dbQueue)
-                store.recordingStartTime = (try? repo.fetchMeeting(id: existingMeetingId))?.createdAt ?? recordingStartTime
+                if let firstSegmentStartTime = appendContext?.firstSegmentStartTime {
+                    store.recordingStartTime = appendContext?.meetingCreatedAt ?? firstSegmentStartTime
+                } else {
+                    store.recordingStartTime = recordingStartTime
+                    try? repo.updateMeetingCreatedAt(id: existingMeetingId, createdAt: recordingStartTime)
+                }
             }
         } else {
+            appendContext = nil
             store.recordingStartTime = recordingStartTime
         }
         persistenceService = nil
@@ -1005,13 +1013,12 @@ final class CaptionViewModel: ObservableObject {
 
             if let existingMeetingId {
                 // 追記モード: 既存セグメント ID を取得して PersistenceService に渡す
-                let repo = MeetingRepository(dbQueue: dbQueue)
-                let existingIds = (try? repo.fetchSegmentIds(forMeetingId: existingMeetingId)) ?? []
                 persistenceService = MeetingPersistenceService(
                     store: store,
                     dbQueue: dbQueue,
                     existingMeetingId: existingMeetingId,
-                    existingSegmentIds: existingIds
+                    existingSegmentIds: appendContext?.segmentIds ?? [],
+                    recordingStartDate: recordingStartTime
                 )
                 currentMeetingId = existingMeetingId
             } else {
@@ -1057,7 +1064,7 @@ final class CaptionViewModel: ObservableObject {
         let meetingId = ctx?.meetingId ?? currentMeetingId
         let projectName = ctx?.projectName ?? selectedProjectName
         let vaultURL = ctx?.vaultURL ?? currentVaultURL
-        let recordingStart = activeStore.recordingStartTime ?? Date()
+        let recordingStart = activeStore.timeBase
         let segments = activeStore.segments
         recordingContext = nil
 
@@ -1100,7 +1107,7 @@ final class CaptionViewModel: ObservableObject {
               let vaultURL = currentVaultURL else { return }
         let projectURL = currentProjectURL
         let transcriptText = store.exportForSummary()
-        let createdAt = store.recordingStartTime ?? Date()
+        let createdAt = store.timeBase
         let projectName = selectedProjectName ?? ""
         let segments = store.segments
         requestShowSummaryTab = true

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -841,10 +841,11 @@ final class CaptionViewModel: ObservableObject {
         }
 
         var sourceErrors: [Error] = []
+        let recordingStartTime = Date()
 
         if isMicEnabled {
             do {
-                try await startMicrophonePipeline(locale: primaryLocale)
+                try await startMicrophonePipeline(locale: primaryLocale, recordingStartTime: recordingStartTime)
             } catch {
                 sourceErrors.append(error)
             }
@@ -852,7 +853,7 @@ final class CaptionViewModel: ObservableObject {
 
         if isSystemAudioEnabled {
             do {
-                try await startSystemAudioPipeline(locale: primaryLocale)
+                try await startSystemAudioPipeline(locale: primaryLocale, recordingStartTime: recordingStartTime)
             } catch {
                 sourceErrors.append(error)
             }
@@ -896,13 +897,17 @@ final class CaptionViewModel: ObservableObject {
         pipelines.removeAll()
     }
 
-    private func startMicrophonePipeline(locale: Locale) async throws {
+    private func startMicrophonePipeline(locale: Locale, recordingStartTime: Date) async throws {
         let hasMicPermission = await AudioCaptureManager.requestMicrophonePermission()
         guard hasMicPermission else {
             throw AudioCaptureError.microphonePermissionDenied
         }
 
-        let (service, bridge, format) = try await buildPipeline(locale: locale, speakerLabel: "mic")
+        let (service, bridge, format) = try await buildPipeline(
+            locale: locale,
+            speakerLabel: "mic",
+            recordingStartTime: recordingStartTime
+        )
         try startMicrophoneCapture(
             bridge: bridge,
             targetFormat: format,
@@ -911,8 +916,12 @@ final class CaptionViewModel: ObservableObject {
         pipelines.append((service: service, bridge: bridge))
     }
 
-    private func startSystemAudioPipeline(locale: Locale) async throws {
-        let (service, bridge, format) = try await buildPipeline(locale: locale, speakerLabel: "system")
+    private func startSystemAudioPipeline(locale: Locale, recordingStartTime: Date) async throws {
+        let (service, bridge, format) = try await buildPipeline(
+            locale: locale,
+            speakerLabel: "system",
+            recordingStartTime: recordingStartTime
+        )
         try await startSystemAudioCapture(bridge: bridge, targetFormat: format)
         pipelines.append((service: service, bridge: bridge))
     }
@@ -971,7 +980,15 @@ final class CaptionViewModel: ObservableObject {
         }
 
         pipelines.removeAll()
-        store.recordingStartTime = Date()
+        let recordingStartTime = Date()
+        if let existingMeetingId {
+            if store.recordingStartTime == nil {
+                let repo = MeetingRepository(dbQueue: dbQueue)
+                store.recordingStartTime = (try? repo.fetchMeeting(id: existingMeetingId))?.createdAt ?? recordingStartTime
+            }
+        } else {
+            store.recordingStartTime = recordingStartTime
+        }
         persistenceService = nil
         stopAutomaticScreenshotCapture()
 
@@ -980,10 +997,10 @@ final class CaptionViewModel: ObservableObject {
             try await SpeechTranscriberService.ensureModelInstalled(locale: primaryLocale)
 
             if isMicEnabled {
-                try await startMicrophonePipeline(locale: primaryLocale)
+                try await startMicrophonePipeline(locale: primaryLocale, recordingStartTime: recordingStartTime)
             }
             if isSystemAudioEnabled {
-                try await startSystemAudioPipeline(locale: primaryLocale)
+                try await startSystemAudioPipeline(locale: primaryLocale, recordingStartTime: recordingStartTime)
             }
 
             if let existingMeetingId {
@@ -1646,7 +1663,8 @@ final class CaptionViewModel: ObservableObject {
 
     private func buildPipeline(
         locale: Locale,
-        speakerLabel: String
+        speakerLabel: String,
+        recordingStartTime: Date
     ) async throws -> (service: SpeechTranscriberService, bridge: AudioBufferBridge, format: AVAudioFormat) {
         let service = SpeechTranscriberService(
             locale: locale,
@@ -1658,7 +1676,7 @@ final class CaptionViewModel: ObservableObject {
             throw AudioCaptureError.converterCreationFailed
         }
         let bridge = AudioBufferBridge(sampleRate: format.sampleRate)
-        try await service.startStreaming(store: store, bridge: bridge)
+        try await service.startStreaming(store: store, bridge: bridge, recordingStartTime: recordingStartTime)
         return (service: service, bridge: bridge, format: format)
     }
 

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -385,6 +385,7 @@ final class CaptionViewModel: ObservableObject {
 
     private struct LoadedMeetingData {
         let createdAt: Date?
+        let recordingSessions: [RecordingSessionTimeline]
         let segments: [TranscriptSegment]
         let screenshots: [MeetingScreenshotRecord]
         let summary: String?
@@ -401,6 +402,7 @@ final class CaptionViewModel: ObservableObject {
     ) throws -> LoadedMeetingData {
         let repo = MeetingRepository(dbQueue: dbQueue)
         let detail = try repo.fetchMeetingDetail(id: meetingId)
+        let recordingSessions = detail.recordingSessions.map(RecordingSessionTimeline.init)
         let segments = detail.segments.map(TranscriptSegment.init(from:))
 
         let lastSummaryURL = SummaryService.findSummaryFile(
@@ -411,6 +413,7 @@ final class CaptionViewModel: ObservableObject {
 
         return LoadedMeetingData(
             createdAt: detail.meeting?.createdAt,
+            recordingSessions: recordingSessions,
             segments: segments,
             screenshots: detail.screenshots,
             summary: detail.summary?.summary,
@@ -483,6 +486,7 @@ final class CaptionViewModel: ObservableObject {
             guard !Task.isCancelled, self.currentMeetingId == meetingId else { return }
 
             self.store.recordingStartTime = loaded.createdAt
+            self.store.loadRecordingSessions(loaded.recordingSessions)
             self.store.loadSegments(loaded.segments)
             self.applyLoadedDetail(loaded)
         }
@@ -842,10 +846,15 @@ final class CaptionViewModel: ObservableObject {
 
         var sourceErrors: [Error] = []
         let recordingStartTime = Date()
+        let recordingSessionId = persistenceService?.recordingSessionId ?? UUID.v7()
 
         if isMicEnabled {
             do {
-                try await startMicrophonePipeline(locale: primaryLocale, recordingStartTime: recordingStartTime)
+                try await startMicrophonePipeline(
+                    locale: primaryLocale,
+                    recordingStartTime: recordingStartTime,
+                    recordingSessionId: recordingSessionId
+                )
             } catch {
                 sourceErrors.append(error)
             }
@@ -853,7 +862,11 @@ final class CaptionViewModel: ObservableObject {
 
         if isSystemAudioEnabled {
             do {
-                try await startSystemAudioPipeline(locale: primaryLocale, recordingStartTime: recordingStartTime)
+                try await startSystemAudioPipeline(
+                    locale: primaryLocale,
+                    recordingStartTime: recordingStartTime,
+                    recordingSessionId: recordingSessionId
+                )
             } catch {
                 sourceErrors.append(error)
             }
@@ -897,7 +910,7 @@ final class CaptionViewModel: ObservableObject {
         pipelines.removeAll()
     }
 
-    private func startMicrophonePipeline(locale: Locale, recordingStartTime: Date) async throws {
+    private func startMicrophonePipeline(locale: Locale, recordingStartTime: Date, recordingSessionId: UUID) async throws {
         let hasMicPermission = await AudioCaptureManager.requestMicrophonePermission()
         guard hasMicPermission else {
             throw AudioCaptureError.microphonePermissionDenied
@@ -906,7 +919,8 @@ final class CaptionViewModel: ObservableObject {
         let (service, bridge, format) = try await buildPipeline(
             locale: locale,
             speakerLabel: "mic",
-            recordingStartTime: recordingStartTime
+            recordingStartTime: recordingStartTime,
+            recordingSessionId: recordingSessionId
         )
         try startMicrophoneCapture(
             bridge: bridge,
@@ -916,11 +930,12 @@ final class CaptionViewModel: ObservableObject {
         pipelines.append((service: service, bridge: bridge))
     }
 
-    private func startSystemAudioPipeline(locale: Locale, recordingStartTime: Date) async throws {
+    private func startSystemAudioPipeline(locale: Locale, recordingStartTime: Date, recordingSessionId: UUID) async throws {
         let (service, bridge, format) = try await buildPipeline(
             locale: locale,
             speakerLabel: "system",
-            recordingStartTime: recordingStartTime
+            recordingStartTime: recordingStartTime,
+            recordingSessionId: recordingSessionId
         )
         try await startSystemAudioCapture(bridge: bridge, targetFormat: format)
         pipelines.append((service: service, bridge: bridge))
@@ -981,10 +996,14 @@ final class CaptionViewModel: ObservableObject {
 
         pipelines.removeAll()
         let recordingStartTime = Date()
+        let recordingSessionId = UUID.v7()
         let appendContext: MeetingRepository.AppendRecordingContext?
         if let existingMeetingId {
             let repo = MeetingRepository(dbQueue: dbQueue)
             appendContext = try? repo.fetchAppendRecordingContext(forMeetingId: existingMeetingId)
+            if let recordingSessions = appendContext?.recordingSessions, !recordingSessions.isEmpty {
+                store.loadRecordingSessions(recordingSessions.map(RecordingSessionTimeline.init))
+            }
             if store.recordingStartTime == nil {
                 if let firstSegmentStartTime = appendContext?.firstSegmentStartTime {
                     store.recordingStartTime = appendContext?.meetingCreatedAt ?? firstSegmentStartTime
@@ -1005,20 +1024,30 @@ final class CaptionViewModel: ObservableObject {
             try await SpeechTranscriberService.ensureModelInstalled(locale: primaryLocale)
 
             if isMicEnabled {
-                try await startMicrophonePipeline(locale: primaryLocale, recordingStartTime: recordingStartTime)
+                try await startMicrophonePipeline(
+                    locale: primaryLocale,
+                    recordingStartTime: recordingStartTime,
+                    recordingSessionId: recordingSessionId
+                )
             }
             if isSystemAudioEnabled {
-                try await startSystemAudioPipeline(locale: primaryLocale, recordingStartTime: recordingStartTime)
+                try await startSystemAudioPipeline(
+                    locale: primaryLocale,
+                    recordingStartTime: recordingStartTime,
+                    recordingSessionId: recordingSessionId
+                )
             }
 
             if let existingMeetingId {
                 // 追記モード: 既存セグメント ID を取得して PersistenceService に渡す
-                persistenceService = MeetingPersistenceService(
+                persistenceService = try MeetingPersistenceService(
                     store: store,
                     dbQueue: dbQueue,
                     existingMeetingId: existingMeetingId,
                     existingSegmentIds: appendContext?.segmentIds ?? [],
-                    recordingStartDate: recordingStartTime
+                    recordingStartDate: recordingStartTime,
+                    recordingOffsetSeconds: appendContext?.nextOffsetSeconds ?? 0,
+                    recordingSessionId: recordingSessionId
                 )
                 currentMeetingId = existingMeetingId
             } else {
@@ -1029,7 +1058,8 @@ final class CaptionViewModel: ObservableObject {
                     vaultId: vaultId,
                     projectId: projectId,
                     initialName: initialName,
-                    calendarEvent: activeDraftMeeting?.linkedCalendarEvent
+                    calendarEvent: activeDraftMeeting?.linkedCalendarEvent,
+                    recordingSessionId: recordingSessionId
                 )
                 currentMeetingId = persistenceService?.meetingId
                 draftMeeting = nil
@@ -1066,6 +1096,7 @@ final class CaptionViewModel: ObservableObject {
         let vaultURL = ctx?.vaultURL ?? currentVaultURL
         let recordingStart = activeStore.timeBase
         let segments = activeStore.segments
+        let recordingSessions = activeStore.recordingSessions
         recordingContext = nil
 
         guard let vaultURL else { return }
@@ -1081,7 +1112,8 @@ final class CaptionViewModel: ObservableObject {
                     meetingId: meetingId,
                     projectName: projectName ?? "",
                     createdAt: recordingStart,
-                    segments: segments
+                    segments: segments,
+                    recordingSessions: recordingSessions
                 )
             }
         }
@@ -1110,6 +1142,7 @@ final class CaptionViewModel: ObservableObject {
         let createdAt = store.timeBase
         let projectName = selectedProjectName ?? ""
         let segments = store.segments
+        let recordingSessions = store.recordingSessions
         requestShowSummaryTab = true
         Task {
             await generateSummary(
@@ -1119,7 +1152,8 @@ final class CaptionViewModel: ObservableObject {
                 createdAt: createdAt,
                 vaultURL: vaultURL,
                 projectName: projectName,
-                segments: segments
+                segments: segments,
+                recordingSessions: recordingSessions
             )
         }
     }
@@ -1131,7 +1165,8 @@ final class CaptionViewModel: ObservableObject {
         createdAt: Date,
         vaultURL: URL,
         projectName: String,
-        segments: [TranscriptSegment]
+        segments: [TranscriptSegment],
+        recordingSessions: [RecordingSessionTimeline]
     ) async {
         guard !transcriptText.isEmpty else { return }
 
@@ -1180,6 +1215,7 @@ final class CaptionViewModel: ObservableObject {
                 transcriptText: transcriptText,
                 noteText: currentNoteText.isEmpty ? nil : currentNoteText,
                 screenshots: screenshots,
+                recordingSessions: recordingSessions,
                 repository: repo
             )
 
@@ -1208,6 +1244,7 @@ final class CaptionViewModel: ObservableObject {
                 createdAt: createdAt,
                 projectName: projectName,
                 segments: segments,
+                recordingSessions: recordingSessions,
                 screenshots: screenshots,
                 summaryFileName: generatedSummary.fileName,
                 summaryMarkdown: generatedSummary.markdown
@@ -1289,7 +1326,8 @@ final class CaptionViewModel: ObservableObject {
         meetingId: UUID,
         projectName: String,
         createdAt: Date,
-        segments: [TranscriptSegment]
+        segments: [TranscriptSegment],
+        recordingSessions: [RecordingSessionTimeline]
     ) async {
         var screenshots: [MeetingScreenshotRecord] = []
         if let dbQueue = currentDbQueue {
@@ -1302,6 +1340,7 @@ final class CaptionViewModel: ObservableObject {
             projectName: projectName,
             createdAt: createdAt,
             segments: segments,
+            recordingSessions: recordingSessions,
             screenshots: screenshots
         )
     }
@@ -1313,6 +1352,7 @@ final class CaptionViewModel: ObservableObject {
         projectName: String,
         createdAt: Date,
         segments: [TranscriptSegment],
+        recordingSessions: [RecordingSessionTimeline],
         screenshots: [MeetingScreenshotRecord]
     ) async {
         async let transcriptPath = Task.detached {
@@ -1321,7 +1361,8 @@ final class CaptionViewModel: ObservableObject {
                 meetingId: meetingId,
                 projectName: projectName,
                 createdAt: createdAt,
-                segments: segments
+                segments: segments,
+                recordingSessions: recordingSessions
             )
         }.value
 
@@ -1386,6 +1427,7 @@ final class CaptionViewModel: ObservableObject {
                 try await persistScreenshot(
                     cgImage,
                     meetingId: meetingId,
+                    sessionId: persistenceService?.recordingSessionId,
                     dbQueue: dbQueue,
                     shouldRefreshVisibleScreenshots: shouldRefreshVisibleScreenshots
                 )
@@ -1493,6 +1535,7 @@ final class CaptionViewModel: ObservableObject {
             try await persistScreenshot(
                 cgImage,
                 meetingId: meetingId,
+                sessionId: persistenceService?.recordingSessionId,
                 dbQueue: dbQueue,
                 shouldRefreshVisibleScreenshots: shouldRefreshVisibleScreenshots
             )
@@ -1542,6 +1585,7 @@ final class CaptionViewModel: ObservableObject {
     private func persistScreenshot(
         _ cgImage: CGImage,
         meetingId: UUID,
+        sessionId: UUID?,
         dbQueue: DatabaseQueue,
         shouldRefreshVisibleScreenshots: Bool
     ) async throws {
@@ -1555,6 +1599,7 @@ final class CaptionViewModel: ObservableObject {
         let record = MeetingScreenshotRecord(
             id: UUID.v7(),
             meetingId: meetingId,
+            sessionId: sessionId,
             capturedAt: Date(),
             imageData: imageData,
             mimeType: ImageEncoder.preferredMIMEType
@@ -1671,7 +1716,8 @@ final class CaptionViewModel: ObservableObject {
     private func buildPipeline(
         locale: Locale,
         speakerLabel: String,
-        recordingStartTime: Date
+        recordingStartTime: Date,
+        recordingSessionId: UUID
     ) async throws -> (service: SpeechTranscriberService, bridge: AudioBufferBridge, format: AVAudioFormat) {
         let service = SpeechTranscriberService(
             locale: locale,
@@ -1683,7 +1729,12 @@ final class CaptionViewModel: ObservableObject {
             throw AudioCaptureError.converterCreationFailed
         }
         let bridge = AudioBufferBridge(sampleRate: format.sampleRate)
-        try await service.startStreaming(store: store, bridge: bridge, recordingStartTime: recordingStartTime)
+        try await service.startStreaming(
+            store: store,
+            bridge: bridge,
+            recordingStartTime: recordingStartTime,
+            recordingSessionId: recordingSessionId
+        )
         return (service: service, bridge: bridge, format: format)
     }
 

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -618,10 +618,11 @@ struct ControlPanelView: View {
         } else {
             ScrollView {
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 200), spacing: 12)], spacing: 12) {
+                    let timeBase = screenshotTimeBase
                     ForEach(viewModel.screenshots, id: \.id) { screenshot in
                         ScreenshotThumbnailView(
                             screenshot: screenshot,
-                            timeBase: screenshotTimeBase,
+                            timeBase: timeBase,
                             viewModel: viewModel,
                             expandedScreenshot: $expandedScreenshot
                         )
@@ -640,7 +641,7 @@ struct ControlPanelView: View {
     }
 
     private var screenshotTimeBase: Date {
-        currentMeetingItem?.createdAt ?? viewModel.store.timeBase
+        viewModel.store.timeBase
     }
 
     private var displayedMeetingTitle: String? {

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -119,14 +119,9 @@ private struct ScreenshotOverlayView: View {
 /// スクリーンショットのサムネイル表示。
 private struct ScreenshotThumbnailView: View {
     let screenshot: MeetingScreenshotRecord
+    let timeBase: Date
     let viewModel: CaptionViewModel
     @Binding var expandedScreenshot: MeetingScreenshotRecord?
-
-    private static let timeFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "HH:mm:ss"
-        return f
-    }()
 
     var body: some View {
         VStack(spacing: 4) {
@@ -147,7 +142,7 @@ private struct ScreenshotThumbnailView: View {
                 .accessibilityLabel(L10n.open)
             }
             HStack {
-                Text(Self.timeFormatter.string(from: screenshot.capturedAt))
+                Text(Formatters.elapsedHHmmss(from: timeBase, to: screenshot.capturedAt))
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                 Spacer()
@@ -624,7 +619,12 @@ struct ControlPanelView: View {
             ScrollView {
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 200), spacing: 12)], spacing: 12) {
                     ForEach(viewModel.screenshots, id: \.id) { screenshot in
-                        ScreenshotThumbnailView(screenshot: screenshot, viewModel: viewModel, expandedScreenshot: $expandedScreenshot)
+                        ScreenshotThumbnailView(
+                            screenshot: screenshot,
+                            timeBase: screenshotTimeBase,
+                            viewModel: viewModel,
+                            expandedScreenshot: $expandedScreenshot
+                        )
                     }
                 }
                 .padding(12)
@@ -637,6 +637,10 @@ struct ControlPanelView: View {
     private var currentMeetingItem: MeetingOverviewItem? {
         guard let meetingId = viewModel.currentMeetingId else { return nil }
         return sidebarViewModel.allMeetings.first(where: { $0.meetingId == meetingId })
+    }
+
+    private var screenshotTimeBase: Date {
+        currentMeetingItem?.createdAt ?? viewModel.store.timeBase
     }
 
     private var displayedMeetingTitle: String? {

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -119,7 +119,7 @@ private struct ScreenshotOverlayView: View {
 /// スクリーンショットのサムネイル表示。
 private struct ScreenshotThumbnailView: View {
     let screenshot: MeetingScreenshotRecord
-    let timeBase: Date
+    let timestamp: String
     let viewModel: CaptionViewModel
     @Binding var expandedScreenshot: MeetingScreenshotRecord?
 
@@ -142,7 +142,7 @@ private struct ScreenshotThumbnailView: View {
                 .accessibilityLabel(L10n.open)
             }
             HStack {
-                Text(Formatters.elapsedHHmmss(from: timeBase, to: screenshot.capturedAt))
+                Text(timestamp)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                 Spacer()
@@ -619,10 +619,16 @@ struct ControlPanelView: View {
             ScrollView {
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 200), spacing: 12)], spacing: 12) {
                     let timeBase = screenshotTimeBase
+                    let recordingSessions = viewModel.store.recordingSessions
                     ForEach(viewModel.screenshots, id: \.id) { screenshot in
                         ScreenshotThumbnailView(
                             screenshot: screenshot,
-                            timeBase: timeBase,
+                            timestamp: Formatters.elapsedHHmmss(
+                                at: screenshot.capturedAt,
+                                sessionId: screenshot.sessionId,
+                                sessions: recordingSessions,
+                                fallbackTimeBase: timeBase
+                            ),
                             viewModel: viewModel,
                             expandedScreenshot: $expandedScreenshot
                         )

--- a/Sources/Dahlia/Views/MeetingListSidebarView.swift
+++ b/Sources/Dahlia/Views/MeetingListSidebarView.swift
@@ -168,8 +168,16 @@ private struct RecordingStatusBar: View {
         return trimmed.isEmpty ? L10n.newMeeting : trimmed
     }
 
-    private var recordingStartTime: Date? {
-        viewModel.activeTranscriptStore.recordingStartTime ?? recordingMeetingItem?.createdAt
+    private var activeRecordingSession: RecordingSessionTimeline? {
+        let sessions = viewModel.activeTranscriptStore.recordingSessions
+        return sessions.last(where: { $0.endedAt == nil }) ?? sessions.last
+    }
+
+    private var recordingTimelineStart: Date {
+        activeRecordingSession?.startedAt
+            ?? viewModel.activeTranscriptStore.recordingStartTime
+            ?? recordingMeetingItem?.createdAt
+            ?? Date()
     }
 
     var body: some View {
@@ -240,7 +248,7 @@ private struct RecordingStatusBar: View {
     }
 
     private var elapsedText: some View {
-        TimelineView(.periodic(from: recordingStartTime ?? Date(), by: 1)) { context in
+        TimelineView(.periodic(from: recordingTimelineStart, by: 1)) { context in
             Text(formatElapsedTime(at: context.date))
                 .font(.caption.monospacedDigit())
                 .foregroundStyle(.secondary)
@@ -388,8 +396,12 @@ private struct RecordingStatusBar: View {
     }
 
     private func formatElapsedTime(at date: Date) -> String {
-        guard let recordingStartTime else { return "00:00" }
-        let totalSeconds = max(0, Int(date.timeIntervalSince(recordingStartTime).rounded(.down)))
+        let elapsedSeconds = if let activeRecordingSession {
+            activeRecordingSession.offsetSeconds + date.timeIntervalSince(activeRecordingSession.startedAt)
+        } else {
+            date.timeIntervalSince(recordingTimelineStart)
+        }
+        let totalSeconds = max(0, Int(elapsedSeconds.rounded(.down)))
         let hours = totalSeconds / 3600
         let minutes = (totalSeconds % 3600) / 60
         let seconds = totalSeconds % 60

--- a/Sources/Dahlia/Views/TranscriptRowView.swift
+++ b/Sources/Dahlia/Views/TranscriptRowView.swift
@@ -3,13 +3,13 @@ import SwiftUI
 /// 議事録の1セグメントを表示する行ビュー。
 struct TranscriptRowView: View, Equatable {
     let segment: TranscriptSegment
-    let timeBase: Date
+    let timestamp: String
     let showsTranslatedText: Bool
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
             // タイムスタンプ
-            Text(Formatters.elapsedHHmmss(from: timeBase, to: segment.startTime))
+            Text(timestamp)
                 .font(.system(.caption, design: .monospaced))
                 .foregroundStyle(.tertiary)
                 .frame(width: 56, alignment: .leading)

--- a/Sources/Dahlia/Views/TranscriptRowView.swift
+++ b/Sources/Dahlia/Views/TranscriptRowView.swift
@@ -3,12 +3,13 @@ import SwiftUI
 /// 議事録の1セグメントを表示する行ビュー。
 struct TranscriptRowView: View, Equatable {
     let segment: TranscriptSegment
+    let timeBase: Date
     let showsTranslatedText: Bool
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
             // タイムスタンプ
-            Text(Formatters.timeHHmmss.string(from: segment.startTime))
+            Text(Formatters.elapsedHHmmss(from: timeBase, to: segment.startTime))
                 .font(.system(.caption, design: .monospaced))
                 .foregroundStyle(.tertiary)
                 .frame(width: 56, alignment: .leading)

--- a/Sources/Dahlia/Views/TranscriptTabView.swift
+++ b/Sources/Dahlia/Views/TranscriptTabView.swift
@@ -76,10 +76,11 @@ struct TranscriptTabView: View {
                             }
                     }
 
+                    let timeBase = store.timeBase
                     ForEach(windowedSegments) { segment in
                         TranscriptRowView(
                             segment: segment,
-                            timeBase: store.timeBase,
+                            timeBase: timeBase,
                             showsTranslatedText: showsTranslatedText
                         )
                         .equatable()

--- a/Sources/Dahlia/Views/TranscriptTabView.swift
+++ b/Sources/Dahlia/Views/TranscriptTabView.swift
@@ -77,10 +77,16 @@ struct TranscriptTabView: View {
                     }
 
                     let timeBase = store.timeBase
+                    let recordingSessions = store.recordingSessions
                     ForEach(windowedSegments) { segment in
                         TranscriptRowView(
                             segment: segment,
-                            timeBase: timeBase,
+                            timestamp: Formatters.elapsedHHmmss(
+                                at: segment.startTime,
+                                sessionId: segment.sessionId,
+                                sessions: recordingSessions,
+                                fallbackTimeBase: timeBase
+                            ),
                             showsTranslatedText: showsTranslatedText
                         )
                         .equatable()

--- a/Sources/Dahlia/Views/TranscriptTabView.swift
+++ b/Sources/Dahlia/Views/TranscriptTabView.swift
@@ -79,6 +79,7 @@ struct TranscriptTabView: View {
                     ForEach(windowedSegments) { segment in
                         TranscriptRowView(
                             segment: segment,
+                            timeBase: store.timeBase,
                             showsTranslatedText: showsTranslatedText
                         )
                         .equatable()

--- a/Tests/DahliaTests/AppDatabaseManagerTests.swift
+++ b/Tests/DahliaTests/AppDatabaseManagerTests.swift
@@ -40,6 +40,132 @@ struct AppDatabaseManagerTests {
     }
 
     @Test
+    func initializesInMemoryDatabaseWithRecordingSessionsSchema() throws {
+        let database = try AppDatabaseManager(path: ":memory:")
+
+        let result = try database.dbQueue.read { db in
+            (
+                try db.tableExists("recording_sessions"),
+                try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('transcript_segments')"),
+                try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('screenshots')")
+            )
+        }
+
+        #expect(result.0)
+        #expect(result.1.contains("sessionId"))
+        #expect(result.2.contains("sessionId"))
+    }
+
+    @Test
+    func existingV7DatabaseBackfillsRecordingSessionsWithoutDataLoss() throws {
+        let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("sqlite")
+        let meetingID = UUID.v7()
+        let segmentID = UUID.v7()
+        let screenshotID = UUID.v7()
+        let meetingStart = Date(timeIntervalSince1970: 1_776_384_000)
+        let segmentStart = meetingStart.addingTimeInterval(5)
+        let segmentEnd = meetingStart.addingTimeInterval(20)
+
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        let legacyQueue = try DatabaseQueue(path: databaseURL.path)
+        try legacyQueue.write { db in
+            try db.execute(
+                sql: """
+                CREATE TABLE meetings (
+                    id BLOB PRIMARY KEY,
+                    vaultId BLOB NOT NULL,
+                    projectId BLOB,
+                    name TEXT NOT NULL DEFAULT '',
+                    status TEXT NOT NULL DEFAULT 'READY',
+                    duration DOUBLE,
+                    createdAt DATETIME NOT NULL,
+                    updatedAt DATETIME NOT NULL
+                )
+                """
+            )
+            try db.execute(
+                sql: """
+                CREATE TABLE transcript_segments (
+                    id BLOB PRIMARY KEY,
+                    meetingId BLOB NOT NULL,
+                    startTime DATETIME NOT NULL,
+                    endTime DATETIME,
+                    text TEXT NOT NULL,
+                    translatedText TEXT,
+                    isConfirmed BOOLEAN NOT NULL DEFAULT 0,
+                    speakerLabel TEXT
+                )
+                """
+            )
+            try db.execute(
+                sql: """
+                CREATE TABLE screenshots (
+                    id BLOB PRIMARY KEY,
+                    meetingId BLOB NOT NULL,
+                    capturedAt DATETIME NOT NULL,
+                    imageData BLOB NOT NULL,
+                    mimeType TEXT NOT NULL
+                )
+                """
+            )
+            try db.create(table: "grdb_migrations") { t in
+                t.column("identifier", .text).primaryKey()
+            }
+            for migration in [
+                "v3_googleDriveFolderSchema",
+                "v4_instructionsSchema",
+                "v5_summaryGoogleFileId",
+                "v6_transcriptSegmentTranslation",
+                "v7_normalizeLegacyMeetingStatus",
+            ] {
+                try db.execute(sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)", arguments: [migration])
+            }
+            try db.execute(
+                sql: """
+                INSERT INTO meetings (id, vaultId, name, status, duration, createdAt, updatedAt)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                arguments: [meetingID, UUID.v7(), "Legacy", MeetingStatus.ready.rawValue, nil as TimeInterval?, meetingStart, meetingStart]
+            )
+            try db.execute(
+                sql: """
+                INSERT INTO transcript_segments (id, meetingId, startTime, endTime, text, isConfirmed, speakerLabel)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                arguments: [segmentID, meetingID, segmentStart, segmentEnd, "Hello world", true, "mic"]
+            )
+            try db.execute(
+                sql: """
+                INSERT INTO screenshots (id, meetingId, capturedAt, imageData, mimeType)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                arguments: [screenshotID, meetingID, segmentStart, Data([0x00]), "image/png"]
+            )
+        }
+
+        let migrated = try AppDatabaseManager(path: databaseURL.path)
+        let result = try migrated.dbQueue.read { db in
+            (
+                try RecordingSessionRecord.filter(Column("meetingId") == meetingID).fetchAll(db),
+                try #require(TranscriptSegmentRecord.fetchOne(db, key: segmentID)),
+                try #require(MeetingScreenshotRecord.fetchOne(db, key: screenshotID))
+            )
+        }
+
+        let session = try #require(result.0.first)
+        #expect(result.0.count == 1)
+        #expect(session.startedAt == segmentStart)
+        #expect(session.duration == 15)
+        #expect(session.offsetSeconds == 0)
+        #expect(result.1.sessionId == session.id)
+        #expect(result.1.text == "Hello world")
+        #expect(result.2.sessionId == session.id)
+    }
+
+    @Test
     func repositoryUpdatesProjectGoogleDriveFolder() throws {
         let database = try AppDatabaseManager(path: ":memory:")
         let repository = MeetingRepository(dbQueue: database.dbQueue)

--- a/Tests/DahliaTests/ExportPathTests.swift
+++ b/Tests/DahliaTests/ExportPathTests.swift
@@ -32,6 +32,33 @@ struct ExportPathTests {
     }
 
     @Test
+    func transcriptExportUsesCreatedAtRelativeTimestamps() throws {
+        let vaultURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: vaultURL) }
+
+        try FileManager.default.createDirectory(at: vaultURL, withIntermediateDirectories: true)
+
+        let meetingId = UUID()
+        let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
+        let relativePath = try TranscriptExportService.exportTranscript(
+            vaultURL: vaultURL,
+            meetingId: meetingId,
+            projectName: "Test Project",
+            createdAt: createdAt,
+            segments: [
+                TranscriptSegment(
+                    startTime: createdAt.addingTimeInterval(754),
+                    text: "hello"
+                )
+            ]
+        )
+
+        let markdown = try String(contentsOf: vaultURL.appendingPathComponent(relativePath), encoding: .utf8)
+        #expect(markdown.contains("###### 00:12:34\nhello"))
+    }
+
+    @Test
     func screenshotExportWritesIntoDahliaScreenshotsDirectory() throws {
         let vaultURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Tests/DahliaTests/ExportPathTests.swift
+++ b/Tests/DahliaTests/ExportPathTests.swift
@@ -59,6 +59,56 @@ struct ExportPathTests {
     }
 
     @Test
+    func transcriptExportUsesRecordingSessionOffsetsAcrossPausedRecording() throws {
+        let vaultURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: vaultURL) }
+
+        try FileManager.default.createDirectory(at: vaultURL, withIntermediateDirectories: true)
+
+        let meetingId = UUID()
+        let meetingStart = Date(timeIntervalSince1970: 1_776_384_000)
+        let firstSessionId = UUID.v7()
+        let secondSessionId = UUID.v7()
+        let relativePath = try TranscriptExportService.exportTranscript(
+            vaultURL: vaultURL,
+            meetingId: meetingId,
+            projectName: "Test Project",
+            createdAt: meetingStart,
+            segments: [
+                TranscriptSegment(
+                    sessionId: firstSessionId,
+                    startTime: meetingStart.addingTimeInterval(5),
+                    text: "before"
+                ),
+                TranscriptSegment(
+                    sessionId: secondSessionId,
+                    startTime: meetingStart.addingTimeInterval(303),
+                    text: "after"
+                ),
+            ],
+            recordingSessions: [
+                RecordingSessionTimeline(
+                    id: firstSessionId,
+                    startedAt: meetingStart,
+                    endedAt: meetingStart.addingTimeInterval(10),
+                    offsetSeconds: 0
+                ),
+                RecordingSessionTimeline(
+                    id: secondSessionId,
+                    startedAt: meetingStart.addingTimeInterval(300),
+                    endedAt: nil,
+                    offsetSeconds: 10
+                ),
+            ]
+        )
+
+        let markdown = try String(contentsOf: vaultURL.appendingPathComponent(relativePath), encoding: .utf8)
+        #expect(markdown.contains("###### 00:00:05\nbefore"))
+        #expect(markdown.contains("###### 00:00:13\nafter"))
+    }
+
+    @Test
     func screenshotExportWritesIntoDahliaScreenshotsDirectory() throws {
         let vaultURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Tests/DahliaTests/MeetingPersistenceServiceTests.swift
+++ b/Tests/DahliaTests/MeetingPersistenceServiceTests.swift
@@ -64,6 +64,44 @@ struct MeetingPersistenceServiceTests {
     }
 
     @Test
+    func appendModeDurationUsesSessionStartDate() throws {
+        let database = try makeDatabase()
+        let meetingId = UUID.v7()
+        let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
+        let sessionStartDate = Date()
+        let store = TranscriptStore()
+        store.recordingStartTime = createdAt
+
+        try database.dbQueue.write { db in
+            try MeetingRecord(
+                id: meetingId,
+                vaultId: testVault.id,
+                projectId: nil,
+                name: "Existing meeting",
+                status: .ready,
+                duration: nil,
+                createdAt: createdAt,
+                updatedAt: createdAt
+            ).insert(db)
+        }
+
+        let service = MeetingPersistenceService(
+            store: store,
+            dbQueue: database.dbQueue,
+            existingMeetingId: meetingId,
+            existingSegmentIds: [],
+            recordingStartDate: sessionStartDate
+        )
+        service.stop()
+
+        let persisted = try database.dbQueue.read { db in
+            try #require(MeetingRecord.fetchOne(db, key: meetingId))
+        }
+
+        #expect((persisted.duration ?? .greatestFiniteMagnitude) < 10)
+    }
+
+    @Test
     func newMeetingPersistsLinkedCalendarEvent() throws {
         let database = try makeDatabase()
         let store = TranscriptStore()

--- a/Tests/DahliaTests/MeetingPersistenceServiceTests.swift
+++ b/Tests/DahliaTests/MeetingPersistenceServiceTests.swift
@@ -48,7 +48,7 @@ struct MeetingPersistenceServiceTests {
             ).insert(db)
         }
 
-        _ = MeetingPersistenceService(
+        _ = try MeetingPersistenceService(
             store: TranscriptStore(),
             dbQueue: database.dbQueue,
             existingMeetingId: meetingId,
@@ -85,7 +85,7 @@ struct MeetingPersistenceServiceTests {
             ).insert(db)
         }
 
-        let service = MeetingPersistenceService(
+        let service = try MeetingPersistenceService(
             store: store,
             dbQueue: database.dbQueue,
             existingMeetingId: meetingId,
@@ -99,6 +99,75 @@ struct MeetingPersistenceServiceTests {
         }
 
         #expect((persisted.duration ?? .greatestFiniteMagnitude) < 10)
+    }
+
+    @Test
+    func appendModePersistsSegmentsWithNewRecordingSessionOffset() throws {
+        let database = try makeDatabase()
+        let meetingId = UUID.v7()
+        let firstSessionId = UUID.v7()
+        let secondSessionStart = Date()
+        let firstSessionStart = secondSessionStart.addingTimeInterval(-300)
+        let store = TranscriptStore()
+        store.recordingStartTime = firstSessionStart
+
+        try database.dbQueue.write { db in
+            try MeetingRecord(
+                id: meetingId,
+                vaultId: testVault.id,
+                projectId: nil,
+                name: "Existing meeting",
+                status: .ready,
+                duration: 10,
+                createdAt: firstSessionStart,
+                updatedAt: firstSessionStart.addingTimeInterval(10)
+            ).insert(db)
+            try RecordingSessionRecord(
+                id: firstSessionId,
+                meetingId: meetingId,
+                startedAt: firstSessionStart,
+                endedAt: firstSessionStart.addingTimeInterval(10),
+                duration: 10,
+                offsetSeconds: 0,
+                createdAt: firstSessionStart,
+                updatedAt: firstSessionStart.addingTimeInterval(10)
+            ).insert(db)
+        }
+
+        let service = try MeetingPersistenceService(
+            store: store,
+            dbQueue: database.dbQueue,
+            existingMeetingId: meetingId,
+            existingSegmentIds: [],
+            recordingStartDate: secondSessionStart,
+            recordingOffsetSeconds: 10
+        )
+        let segment = TranscriptSegment(
+            startTime: secondSessionStart.addingTimeInterval(3),
+            text: "After pause",
+            isConfirmed: true,
+            speakerLabel: "mic"
+        )
+
+        store.loadSegments([segment])
+        service.stop()
+
+        let persisted = try database.dbQueue.read { db in
+            (
+                try RecordingSessionRecord
+                    .filter(Column("meetingId") == meetingId)
+                    .order(Column("offsetSeconds").asc)
+                    .fetchAll(db),
+                try #require(TranscriptSegmentRecord.fetchOne(db, key: segment.id)),
+                try #require(MeetingRecord.fetchOne(db, key: meetingId))
+            )
+        }
+
+        let secondSession = try #require(persisted.0.first(where: { $0.id == service.recordingSessionId }))
+        #expect(secondSession.offsetSeconds == 10)
+        #expect(persisted.1.sessionId == secondSession.id)
+        #expect((persisted.2.duration ?? 0) >= 10)
+        #expect((persisted.2.duration ?? 0) < 20)
     }
 
     @Test
@@ -193,7 +262,7 @@ struct MeetingPersistenceServiceTests {
             ).insert(db)
         }
 
-        let service = MeetingPersistenceService(
+        let service = try MeetingPersistenceService(
             store: TranscriptStore(),
             dbQueue: database.dbQueue,
             existingMeetingId: meetingId,
@@ -487,7 +556,7 @@ final class MeetingPersistenceServiceTests: XCTestCase {
             ).insert(db)
         }
 
-        let service = MeetingPersistenceService(
+        let service = try MeetingPersistenceService(
             store: TranscriptStore(),
             dbQueue: database.dbQueue,
             existingMeetingId: meetingId,

--- a/Tests/DahliaTests/SummaryServiceTests.swift
+++ b/Tests/DahliaTests/SummaryServiceTests.swift
@@ -113,6 +113,25 @@ struct SummaryServiceTests {
     }
 
     @Test
+    func screenshotMetadataUsesRelativeTimestamp() throws {
+        let screenshotId = try #require(UUID(uuidString: "019E61FD-B5D6-7A04-AC25-4B820FE951E6"))
+        let timeBase = Date(timeIntervalSince1970: 1_776_384_000)
+        let screenshot = MeetingScreenshotRecord(
+            id: screenshotId,
+            meetingId: UUID(),
+            capturedAt: timeBase.addingTimeInterval(754),
+            imageData: Data(),
+            mimeType: "image/jpeg"
+        )
+
+        let metadata = SummaryService.screenshotMetadata(for: screenshot, relativeTo: timeBase)
+
+        #expect(metadata.contains("<time>00:12:34</time>"))
+        #expect(metadata.contains("<image_id>\(screenshotId.uuidString).jpeg</image_id>"))
+        #expect(metadata.contains("<image_filename>\(screenshotId.uuidString).jpeg</image_filename>"))
+    }
+
+    @Test
     func defaultSummaryPromptRequiresScreenshotFilenameExtension() {
         #expect(AppSettings.defaultSummaryPrompt.contains("![[<image_filename>]]"))
         #expect(AppSettings.defaultSummaryPrompt.contains("including its file extension"))

--- a/Tests/DahliaTests/SummaryServiceTests.swift
+++ b/Tests/DahliaTests/SummaryServiceTests.swift
@@ -132,6 +132,35 @@ struct SummaryServiceTests {
     }
 
     @Test
+    func screenshotMetadataUsesRecordingSessionOffset() throws {
+        let sessionId = UUID.v7()
+        let timeBase = Date(timeIntervalSince1970: 1_776_384_000)
+        let screenshot = MeetingScreenshotRecord(
+            id: UUID.v7(),
+            meetingId: UUID(),
+            sessionId: sessionId,
+            capturedAt: timeBase.addingTimeInterval(303),
+            imageData: Data(),
+            mimeType: "image/jpeg"
+        )
+
+        let metadata = SummaryService.screenshotMetadata(
+            for: screenshot,
+            relativeTo: timeBase,
+            recordingSessions: [
+                RecordingSessionTimeline(
+                    id: sessionId,
+                    startedAt: timeBase.addingTimeInterval(300),
+                    endedAt: nil,
+                    offsetSeconds: 10
+                ),
+            ]
+        )
+
+        #expect(metadata.contains("<time>00:00:13</time>"))
+    }
+
+    @Test
     func defaultSummaryPromptRequiresScreenshotFilenameExtension() {
         #expect(AppSettings.defaultSummaryPrompt.contains("![[<image_filename>]]"))
         #expect(AppSettings.defaultSummaryPrompt.contains("including its file extension"))

--- a/Tests/DahliaTests/TranscriptSegmentTests.swift
+++ b/Tests/DahliaTests/TranscriptSegmentTests.swift
@@ -173,37 +173,6 @@ import XCTest
 
 @MainActor
 final class TranscriptSegmentTests: XCTestCase {
-    func testElapsedHHmmssFormatsDurationFromStartTime() {
-        let start = Date(timeIntervalSince1970: 1_776_384_000)
-
-        XCTAssertEqual(Formatters.elapsedHHmmss(from: start, to: start), "00:00:00")
-        XCTAssertEqual(Formatters.elapsedHHmmss(from: start, to: start.addingTimeInterval(754)), "00:12:34")
-        XCTAssertEqual(Formatters.elapsedHHmmss(from: start, to: start.addingTimeInterval(3_947)), "01:05:47")
-        XCTAssertEqual(Formatters.elapsedHHmmss(from: start, to: start.addingTimeInterval(-1)), "00:00:00")
-    }
-
-    func testTranscriptStoreExportsRelativeTimestampsFromRecordingStartTime() {
-        let store = TranscriptStore()
-        let start = Date(timeIntervalSince1970: 1_776_384_000)
-        store.recordingStartTime = start
-        store.loadSegments([
-            TranscriptSegment(
-                startTime: start.addingTimeInterval(754),
-                text: "First",
-                isConfirmed: true,
-                speakerLabel: "mic"
-            ),
-            TranscriptSegment(
-                startTime: start.addingTimeInterval(3_947),
-                text: "Second",
-                isConfirmed: true
-            ),
-        ])
-
-        XCTAssertEqual(store.exportAsText(), "[00:12:34] [mic] First\n[01:05:47] Second")
-        XCTAssertEqual(store.exportForSummary(), "<time>00:12:34</time> First\n<time>01:05:47</time> Second")
-    }
-
     func testTranscriptStoreUpdatesTranslatedTextForMatchingSegmentOnly() {
         let store = TranscriptStore()
         let first = TranscriptSegment(

--- a/Tests/DahliaTests/TranscriptSegmentTests.swift
+++ b/Tests/DahliaTests/TranscriptSegmentTests.swift
@@ -7,6 +7,39 @@ import Testing
 @MainActor
 struct TranscriptSegmentTests {
     @Test
+    func elapsedHHmmssFormatsDurationFromStartTime() {
+        let start = Date(timeIntervalSince1970: 1_776_384_000)
+
+        #expect(Formatters.elapsedHHmmss(from: start, to: start) == "00:00:00")
+        #expect(Formatters.elapsedHHmmss(from: start, to: start.addingTimeInterval(754)) == "00:12:34")
+        #expect(Formatters.elapsedHHmmss(from: start, to: start.addingTimeInterval(3_947)) == "01:05:47")
+        #expect(Formatters.elapsedHHmmss(from: start, to: start.addingTimeInterval(-1)) == "00:00:00")
+    }
+
+    @Test
+    func transcriptStoreExportsRelativeTimestampsFromRecordingStartTime() {
+        let store = TranscriptStore()
+        let start = Date(timeIntervalSince1970: 1_776_384_000)
+        store.recordingStartTime = start
+        store.loadSegments([
+            TranscriptSegment(
+                startTime: start.addingTimeInterval(754),
+                text: "First",
+                isConfirmed: true,
+                speakerLabel: "mic"
+            ),
+            TranscriptSegment(
+                startTime: start.addingTimeInterval(3_947),
+                text: "Second",
+                isConfirmed: true
+            ),
+        ])
+
+        #expect(store.exportAsText() == "[00:12:34] [mic] First\n[01:05:47] Second")
+        #expect(store.exportForSummary() == "<time>00:12:34</time> First\n<time>01:05:47</time> Second")
+    }
+
+    @Test
     func transcriptStoreUpdatesTranslatedTextForMatchingSegmentOnly() {
         let store = TranscriptStore()
         let first = TranscriptSegment(
@@ -140,6 +173,37 @@ import XCTest
 
 @MainActor
 final class TranscriptSegmentTests: XCTestCase {
+    func testElapsedHHmmssFormatsDurationFromStartTime() {
+        let start = Date(timeIntervalSince1970: 1_776_384_000)
+
+        XCTAssertEqual(Formatters.elapsedHHmmss(from: start, to: start), "00:00:00")
+        XCTAssertEqual(Formatters.elapsedHHmmss(from: start, to: start.addingTimeInterval(754)), "00:12:34")
+        XCTAssertEqual(Formatters.elapsedHHmmss(from: start, to: start.addingTimeInterval(3_947)), "01:05:47")
+        XCTAssertEqual(Formatters.elapsedHHmmss(from: start, to: start.addingTimeInterval(-1)), "00:00:00")
+    }
+
+    func testTranscriptStoreExportsRelativeTimestampsFromRecordingStartTime() {
+        let store = TranscriptStore()
+        let start = Date(timeIntervalSince1970: 1_776_384_000)
+        store.recordingStartTime = start
+        store.loadSegments([
+            TranscriptSegment(
+                startTime: start.addingTimeInterval(754),
+                text: "First",
+                isConfirmed: true,
+                speakerLabel: "mic"
+            ),
+            TranscriptSegment(
+                startTime: start.addingTimeInterval(3_947),
+                text: "Second",
+                isConfirmed: true
+            ),
+        ])
+
+        XCTAssertEqual(store.exportAsText(), "[00:12:34] [mic] First\n[01:05:47] Second")
+        XCTAssertEqual(store.exportForSummary(), "<time>00:12:34</time> First\n<time>01:05:47</time> Second")
+    }
+
     func testTranscriptStoreUpdatesTranslatedTextForMatchingSegmentOnly() {
         let store = TranscriptStore()
         let first = TranscriptSegment(

--- a/Tests/DahliaTests/TranscriptSegmentTests.swift
+++ b/Tests/DahliaTests/TranscriptSegmentTests.swift
@@ -40,6 +40,46 @@ struct TranscriptSegmentTests {
     }
 
     @Test
+    func transcriptStoreExportsSessionOffsetTimestampsAcrossPausedRecording() {
+        let store = TranscriptStore()
+        let meetingStart = Date(timeIntervalSince1970: 1_776_384_000)
+        let firstSessionId = UUID.v7()
+        let secondSessionId = UUID.v7()
+        store.recordingStartTime = meetingStart
+        store.loadRecordingSessions([
+            RecordingSessionTimeline(
+                id: firstSessionId,
+                startedAt: meetingStart,
+                endedAt: meetingStart.addingTimeInterval(10),
+                offsetSeconds: 0
+            ),
+            RecordingSessionTimeline(
+                id: secondSessionId,
+                startedAt: meetingStart.addingTimeInterval(300),
+                endedAt: nil,
+                offsetSeconds: 10
+            ),
+        ])
+        store.loadSegments([
+            TranscriptSegment(
+                sessionId: firstSessionId,
+                startTime: meetingStart.addingTimeInterval(5),
+                text: "Before pause",
+                isConfirmed: true
+            ),
+            TranscriptSegment(
+                sessionId: secondSessionId,
+                startTime: meetingStart.addingTimeInterval(303),
+                text: "After pause",
+                isConfirmed: true
+            ),
+        ])
+
+        #expect(store.exportAsText() == "[00:00:05] Before pause\n[00:00:13] After pause")
+        #expect(store.exportForSummary() == "<time>00:00:05</time> Before pause\n<time>00:00:13</time> After pause")
+    }
+
+    @Test
     func transcriptStoreUpdatesTranslatedTextForMatchingSegmentOnly() {
         let store = TranscriptStore()
         let first = TranscriptSegment(

--- a/Tests/DahliaTests/VaultSummaryExportServiceTests.swift
+++ b/Tests/DahliaTests/VaultSummaryExportServiceTests.swift
@@ -129,7 +129,7 @@ struct VaultSummaryExportServiceTests {
                 screenshots: [],
                 summaryFileName: "summary.md",
                 summaryMarkdown: "summary",
-                exportTranscript: { _, _, _, _, _ in
+                exportTranscript: { _, _, _, _, _, _ in
                     throw ExpectedError.transcriptFailed
                 },
                 exportScreenshots: { _, _ in [] },

--- a/docs/plans/2026-07-08-transcript-relative-timestamps.md
+++ b/docs/plans/2026-07-08-transcript-relative-timestamps.md
@@ -1,0 +1,68 @@
+# 文字起こしタイムスタンプを録音開始からの相対時間に変更する
+
+## Context
+
+現在、文字起こしセグメントのタイムスタンプは壁時計の絶対時刻(`HH:mm:ss`、例: `14:23:07`)で表示・出力されている。これを録音開始からの経過時間(`00:12:34` 固定幅ゼロ埋め)に変更する。
+
+**確定済みの要件:**
+
+- 変更範囲: 画面表示 + 全エクスポート(テキスト、Obsidian/Markdown、LLM 要約入力の `<time>` タグ)
+- フォーマット: `00:12:34` 固定幅(常に HH:mm:ss 形式、8文字幅維持)
+
+**前提となる事実(調査済み):**
+
+- セグメントの `startTime` は `Date`(絶対時刻)だが、生成時に `recordingStartTime + range.start.seconds` で作られている(`Sources/Dahlia/Speech/SpeechTranscriberService.swift:121-126`)ため、基準時刻との差分で相対秒数を正確に復元できる。データモデル・DB スキーマの変更は不要。
+- 基準時刻は `TranscriptStore.recordingStartTime`(`Sources/Dahlia/Models/TranscriptStore.swift:16`)。録音開始時に `Date()` がセットされ(`CaptionViewModel.swift:974`)、過去ミーティング読み込み時は `loaded.createdAt` がセットされる(`CaptionViewModel.swift:485`)。したがってライブ中・閲覧時とも同じ基準で計算できる。
+- 画面表示は `TranscriptRowView` の1箇所のみで、ライブ中・過去ミーティング閲覧の両方で共通(両方とも相対時間表示に変わる。これは意図した挙動)。ライブ字幕オーバーレイにタイムスタンプ表示はない。
+- `Formatters.timeHHmmss` の使用箇所は今回変更する4箇所のみ → 置き換え後に削除できる。
+
+## 変更内容
+
+### 1. 経過時間フォーマッタを追加し、`timeHHmmss` を置き換える
+
+`Sources/Dahlia/Models/TranscriptSegment.swift` の `Formatters` enum(3-10行目):
+
+```swift
+enum Formatters {
+    /// 録音開始からの経過時間を "00:12:34" 固定幅(HH:mm:ss)で整形する。
+    static func elapsedHHmmss(from start: Date, to date: Date) -> String {
+        let total = max(0, Int(date.timeIntervalSince(start)))
+        return String(format: "%02d:%02d:%02d", total / 3600, (total % 3600) / 60, total % 60)
+    }
+}
+```
+
+`timeHHmmss` は全使用箇所が置き換わるので削除する(削除前に grep で未使用を再確認)。
+※ `ControlPanelView` の `ScreenshotThumbnailView.timeFormatter` と `SummaryService.timeFormatter` はスクリーンショットのキャプチャ時刻用の別物なので触らない。
+
+### 2. 画面表示: `TranscriptRowView` + `TranscriptTabView`
+
+- `Sources/Dahlia/Views/TranscriptRowView.swift`
+  - `let timeBase: Date` プロパティを追加(`Date` は `Equatable` なので `View, Equatable` の合成 `==` はそのまま維持され、`ForEach` 側の `.equatable()` 最適化も有効なまま)。
+  - 11行目のタイムスタンプ表示を `Text(Formatters.elapsedHHmmss(from: timeBase, to: segment.startTime))` に変更。`frame(width: 56)` は8文字幅のままなので変更不要。
+- `Sources/Dahlia/Views/TranscriptTabView.swift`
+  - 基準時刻の computed property を追加: `store.recordingStartTime ?? store.segments.first?.startTime`(recordingStartTime は通常必ずセットされるが、防御的フォールバックとして先頭セグメント基準 = 先頭が 00:00:00 になる)。
+  - `ForEach`(79-85行目)で `TranscriptRowView(segment:timeBase:showsTranslatedText:)` に渡す(`?? segment.startTime` で non-optional 化)。
+
+### 3. エクスポート3箇所
+
+- `Sources/Dahlia/Models/TranscriptStore.swift`
+  - `exportAsText()`(139行目)と `exportForSummary()`(148行目): map の外で `let base = recordingStartTime ?? segments.first?.startTime ?? Date()` を1回計算し、`Formatters.elapsedHHmmss(from: base, to: segment.startTime)` に置き換え。
+- `Sources/Dahlia/Services/TranscriptExportService.swift`
+  - `exportTranscript`(40行目): 既に引数で受け取っている `createdAt`(呼び出し元 `CaptionViewModel.swift:1295` / `VaultSummaryExportService.swift:62` はいずれもミーティングの `createdAt` = 録音開始時刻を渡している)を基準に `Formatters.elapsedHHmmss(from: createdAt, to: segment.startTime)` へ置き換え。
+
+### 4. テスト追加
+
+`Tests/DahliaTests/` に Swift Testing(`@Test` / `#expect`)で追加(規約: `Tests/DahliaTests/CLAUDE.md`):
+
+- `Formatters.elapsedHHmmss`: 0秒 → `00:00:00`、1時間未満 → `00:12:34`、1時間以上 → `01:05:47`、開始より前(負値)→ `00:00:00` にクランプ。
+- `TranscriptStore.exportAsText()` / `exportForSummary()`: `recordingStartTime` をセットした状態で相対時間が出力されること。既存の `Tests/DahliaTests/TranscriptSegmentTests.swift` に追記するか、近い場所に新ファイルを作る。
+
+UI 文字列の追加はないため L10n / Localizable.strings の変更は不要。DB マイグレーションも不要。
+
+## 検証
+
+1. `swift build` が通ること。
+2. `swift test`(または `--filter TranscriptSegmentTests` 等)— **この Mac では swift test が exit 0 のまま未実行になることがあるため、必ず「Test run with N tests」等の集計行が出力されていることを確認する。**
+3. `./scripts/lint.sh`(SwiftFormat + SwiftLint)が通ること。
+4. 動作確認: `./scripts/run-dev.sh` で起動し、(a) 録音開始直後のセグメントが `00:00:xx` から始まること、(b) 過去ミーティングを開いたときも先頭付近が `00:00:xx` になること、(c) テキストエクスポートの出力が相対時間になっていることを確認。


### PR DESCRIPTION
## Summary

- Change transcript timestamps from wall-clock time to elapsed `HH:mm:ss` relative to the recording start.
- Apply relative timestamps to transcript UI, text/Markdown exports, LLM summary transcript tags, screenshot summary metadata, and screenshot tab cards.
- Preserve append-to-existing-meeting behavior by separating the meeting display/export time base from the active speech stream start time.
- Bump `CFBundleShortVersionString` to `0.1.1`.

## Compatibility note

Existing summary files generated before this change may contain links to wall-clock transcript anchors such as `#14:23:07`. If an older transcript file is re-exported with elapsed anchors, those existing summary links may no longer resolve until the summary is regenerated.

## Validation

- `swift build`
- `swift test` built `DahliaPackageTests`, but this local CLT environment did not emit a test execution summary line.
- `./scripts/lint.sh` ran SwiftFormat; SwiftLint hit the existing SourceKit loading crash but the script exited 0.
- `plutil -lint Resources/Info.plist`
- `git diff --check`