### PR TITLE
Add screenshot capture settings

### DIFF
--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -80,6 +80,23 @@ enum LLMProvider: String, CaseIterable, Identifiable {
 @MainActor
 final class AppSettings: ObservableObject {
     static let shared = AppSettings()
+    nonisolated static let automaticScreenshotIntervalOptions = [
+        5,
+        10,
+        20,
+        30,
+    ]
+    nonisolated static let automaticScreenshotChangeThresholdPercentOptions = [
+        5,
+        10,
+        20,
+        30,
+        50,
+    ]
+    nonisolated static let automaticScreenshotIntervalSecondsUserDefaultsKey = "automaticScreenshotIntervalSeconds"
+    nonisolated static let automaticScreenshotChangeThresholdPercentUserDefaultsKey = "automaticScreenshotChangeThresholdPercent"
+    fileprivate nonisolated static let defaultAutomaticScreenshotIntervalSeconds = 30
+    fileprivate nonisolated static let defaultAutomaticScreenshotChangeThresholdPercent = 20
 
     // MARK: - 表示言語
 
@@ -99,7 +116,48 @@ final class AppSettings: ObservableObject {
     @AppStorage("liveSubtitleOverlaySegmentCount") var liveSubtitleOverlaySegmentCount = 2
     @AppStorage("liveSubtitleSourceMode") var liveSubtitleSourceModeRawValue = LiveSubtitleSourceMode.includeMicrophone.rawValue
     @AppStorage("automaticScreenshotEnabled") var automaticScreenshotEnabled = true
-    @AppStorage("automaticScreenshotIntervalSeconds") var automaticScreenshotIntervalSeconds = 30
+    @AppStorage(AppSettings.automaticScreenshotIntervalSecondsUserDefaultsKey) private var storedAutomaticScreenshotIntervalSeconds =
+        AppSettings.defaultAutomaticScreenshotIntervalSeconds
+    @AppStorage(AppSettings.automaticScreenshotChangeThresholdPercentUserDefaultsKey) private var storedAutomaticScreenshotChangeThresholdPercent =
+        AppSettings.defaultAutomaticScreenshotChangeThresholdPercent
+
+    var automaticScreenshotIntervalSeconds: Int {
+        get {
+            Self.normalizedOption(
+                storedAutomaticScreenshotIntervalSeconds,
+                options: Self.automaticScreenshotIntervalOptions,
+                defaultValue: Self.defaultAutomaticScreenshotIntervalSeconds
+            )
+        }
+        set {
+            storedAutomaticScreenshotIntervalSeconds = Self.normalizedOption(
+                newValue,
+                options: Self.automaticScreenshotIntervalOptions,
+                defaultValue: Self.defaultAutomaticScreenshotIntervalSeconds
+            )
+        }
+    }
+
+    var automaticScreenshotChangeThresholdPercent: Int {
+        get {
+            Self.normalizedOption(
+                storedAutomaticScreenshotChangeThresholdPercent,
+                options: Self.automaticScreenshotChangeThresholdPercentOptions,
+                defaultValue: Self.defaultAutomaticScreenshotChangeThresholdPercent
+            )
+        }
+        set {
+            storedAutomaticScreenshotChangeThresholdPercent = Self.normalizedOption(
+                newValue,
+                options: Self.automaticScreenshotChangeThresholdPercentOptions,
+                defaultValue: Self.defaultAutomaticScreenshotChangeThresholdPercent
+            )
+        }
+    }
+
+    var automaticScreenshotChangeThresholdRatio: Double {
+        Double(automaticScreenshotChangeThresholdPercent) / 100.0
+    }
 
     var liveSubtitleSourceMode: LiveSubtitleSourceMode {
         get { LiveSubtitleSourceMode(rawValue: liveSubtitleSourceModeRawValue) ?? .includeMicrophone }
@@ -111,6 +169,14 @@ final class AppSettings: ObservableObject {
             transcriptionLocaleIdentifier: transcriptionLocale,
             targetLanguageIdentifier: transcriptTranslationTargetLanguage
         )
+    }
+
+    nonisolated private static func normalizedOption(_ value: Int, options: [Int], defaultValue: Int) -> Int {
+        guard !options.isEmpty else { return defaultValue }
+        if options.contains(value) {
+            return value
+        }
+        return options.first(where: { value <= $0 }) ?? options[options.count - 1]
     }
 
     // MARK: - 表示言語設定
@@ -450,7 +516,13 @@ extension UserDefaults {
     }
 
     @objc dynamic var automaticScreenshotIntervalSeconds: Int {
-        object(forKey: "automaticScreenshotIntervalSeconds") as? Int ?? 30
+        object(forKey: AppSettings.automaticScreenshotIntervalSecondsUserDefaultsKey) as? Int
+            ?? AppSettings.defaultAutomaticScreenshotIntervalSeconds
+    }
+
+    @objc dynamic var automaticScreenshotChangeThresholdPercent: Int {
+        object(forKey: AppSettings.automaticScreenshotChangeThresholdPercentUserDefaultsKey) as? Int
+            ?? AppSettings.defaultAutomaticScreenshotChangeThresholdPercent
     }
 
     @objc dynamic var calendarSource: String? {

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -137,7 +137,10 @@
 "Automatically add screenshots while recording." = "Automatically add screenshots while recording.";
 "Screenshot Interval" = "Screenshot Interval";
 "Choose how often Dahlia checks the screen for meaningful changes." = "Choose how often Dahlia checks the screen for meaningful changes.";
+"Screenshot Change Threshold" = "Screenshot Change Threshold";
+"Save a new screenshot when at least this much of the screen changes." = "Save a new screenshot when at least this much of the screen changes.";
 "%lld seconds" = "%lld seconds";
+"%lld%%" = "%lld%%";
 "Show Live Subtitles" = "Show Live Subtitles";
 "Hide Live Subtitles" = "Hide Live Subtitles";
 "Live Subtitle Overlay" = "Live Subtitle Overlay";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -137,7 +137,10 @@
 "Automatically add screenshots while recording." = "録音中にスクリーンショットを自動追加します。";
 "Screenshot Interval" = "スクリーンショット間隔";
 "Choose how often Dahlia checks the screen for meaningful changes." = "Dahlia が画面の変化を確認する間隔を選びます。";
+"Screenshot Change Threshold" = "画面変化の閾値";
+"Save a new screenshot when at least this much of the screen changes." = "画面の変化率がこの値以上になったときに新しいスクリーンショットを保存します。";
 "%lld seconds" = "%lld 秒";
+"%lld%%" = "%lld%%";
 "Show Live Subtitles" = "ライブ字幕を表示";
 "Hide Live Subtitles" = "ライブ字幕を隠す";
 "Live Subtitle Overlay" = "ライブ字幕オーバーレイ";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -200,7 +200,13 @@ enum L10n {
         localized: "Choose how often Dahlia checks the screen for meaningful changes.",
         bundle: bundle
     ) }
+    static var screenshotChangeThreshold: String { String(localized: "Screenshot Change Threshold", bundle: bundle) }
+    static var screenshotChangeThresholdDescription: String { String(
+        localized: "Save a new screenshot when at least this much of the screen changes.",
+        bundle: bundle
+    ) }
     static func seconds(_ count: Int) -> String { String(localized: "\(count) seconds", bundle: bundle) }
+    static func percent(_ count: Int) -> String { String(localized: "\(count)%", bundle: bundle) }
     static var showLiveSubtitles: String { String(localized: "Show Live Subtitles", bundle: bundle) }
     static var hideLiveSubtitles: String { String(localized: "Hide Live Subtitles", bundle: bundle) }
     static var liveSubtitleOverlay: String { String(localized: "Live Subtitle Overlay", bundle: bundle) }

--- a/Sources/Dahlia/Utilities/ScreenshotChangeDetector.swift
+++ b/Sources/Dahlia/Utilities/ScreenshotChangeDetector.swift
@@ -11,7 +11,7 @@ enum ScreenshotChangeDetector {
     private static let fingerprintWidth = 64
     private static let fingerprintHeight = 36
     private static let significantAverageDifference = 0.08
-    private static let significantChangedPixelRatio = 0.20
+    private static let defaultChangedPixelRatioThreshold = 0.20
     private static let changedPixelThreshold = 24
 
     static func fingerprint(for image: CGImage) -> ScreenshotFingerprint? {
@@ -44,7 +44,11 @@ enum ScreenshotChangeDetector {
         return ScreenshotFingerprint(width: width, height: height, pixels: pixels)
     }
 
-    static func isSignificantlyDifferent(_ lhs: ScreenshotFingerprint, _ rhs: ScreenshotFingerprint) -> Bool {
+    static func isSignificantlyDifferent(
+        _ lhs: ScreenshotFingerprint,
+        _ rhs: ScreenshotFingerprint,
+        changedPixelRatioThreshold: Double = defaultChangedPixelRatioThreshold
+    ) -> Bool {
         guard lhs.width == rhs.width,
               lhs.height == rhs.height,
               lhs.pixels.count == rhs.pixels.count,
@@ -67,8 +71,14 @@ enum ScreenshotChangeDetector {
         let pixelCount = lhs.pixels.count
         let averageDifference = Double(totalDifference) / Double(pixelCount) / 255.0
         let changedPixelRatio = Double(changedPixelCount) / Double(pixelCount)
+        let requiredChangedPixelRatio = normalizedChangedPixelRatioThreshold(changedPixelRatioThreshold)
 
         return averageDifference >= significantAverageDifference
-            || changedPixelRatio >= significantChangedPixelRatio
+            || changedPixelRatio >= requiredChangedPixelRatio
+    }
+
+    private static func normalizedChangedPixelRatioThreshold(_ threshold: Double) -> Double {
+        guard threshold.isFinite else { return defaultChangedPixelRatioThreshold }
+        return min(max(threshold, 0.01), 1.0)
     }
 }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -1520,9 +1520,14 @@ final class CaptionViewModel: ObservableObject {
                   screenshotCaptureSource.isSelected
             else { return }
             guard let fingerprint = await screenshotFingerprint(for: cgImage) else { return }
+            let changeThresholdRatio = AppSettings.shared.automaticScreenshotChangeThresholdRatio
 
             let shouldSave = lastSavedAutomaticScreenshotFingerprint.map {
-                ScreenshotChangeDetector.isSignificantlyDifferent($0, fingerprint)
+                ScreenshotChangeDetector.isSignificantlyDifferent(
+                    $0,
+                    fingerprint,
+                    changedPixelRatioThreshold: changeThresholdRatio
+                )
             } ?? true
 
             guard shouldSave,

--- a/Sources/Dahlia/Views/Settings/ScreenshotSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/ScreenshotSettingsView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+/// 設定画面「スクリーンショット」タブ。自動スクリーンショット取得を管理する。
+struct ScreenshotSettingsView: View {
+    @ObservedObject private var settings = AppSettings.shared
+
+    var body: some View {
+        SettingsPage {
+            SettingsSection(
+                title: L10n.automaticScreenshots,
+                description: L10n.automaticScreenshotsDescription
+            ) {
+                SettingsCard {
+                    VStack(spacing: 0) {
+                        SettingsToggleRow(
+                            title: L10n.automaticScreenshots,
+                            description: L10n.automaticScreenshotsToggleDescription,
+                            isOn: $settings.automaticScreenshotEnabled
+                        )
+
+                        Divider()
+
+                        SettingsControlRow(
+                            title: L10n.screenshotInterval,
+                            description: L10n.screenshotIntervalDescription
+                        ) {
+                            Picker(L10n.screenshotInterval, selection: $settings.automaticScreenshotIntervalSeconds) {
+                                ForEach(AppSettings.automaticScreenshotIntervalOptions, id: \.self) { interval in
+                                    Text(L10n.seconds(interval)).tag(interval)
+                                }
+                            }
+                            .labelsHidden()
+                            .pickerStyle(.menu)
+                            .frame(width: 120, alignment: .trailing)
+                            .disabled(!settings.automaticScreenshotEnabled)
+                        }
+
+                        Divider()
+
+                        SettingsControlRow(
+                            title: L10n.screenshotChangeThreshold,
+                            description: L10n.screenshotChangeThresholdDescription
+                        ) {
+                            Picker(L10n.screenshotChangeThreshold, selection: $settings.automaticScreenshotChangeThresholdPercent) {
+                                ForEach(AppSettings.automaticScreenshotChangeThresholdPercentOptions, id: \.self) { threshold in
+                                    Text(L10n.percent(threshold)).tag(threshold)
+                                }
+                            }
+                            .labelsHidden()
+                            .pickerStyle(.menu)
+                            .frame(width: 120, alignment: .trailing)
+                            .disabled(!settings.automaticScreenshotEnabled)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
@@ -8,8 +8,6 @@ struct TranscriptionSettingsView: View {
     @State private var isLoadingLocales = false
     @State private var localeSearchText = ""
 
-    private static let automaticScreenshotIntervals = [15, 30, 60, 120]
-
     var body: some View {
         SettingsPage {
             SettingsSection(title: L10n.transcriptTranslation) {
@@ -85,38 +83,6 @@ struct TranscriptionSettingsView: View {
                             .labelsHidden()
                             .pickerStyle(.menu)
                             .frame(width: 120, alignment: .trailing)
-                        }
-                    }
-                }
-            }
-
-            SettingsSection(
-                title: L10n.screen,
-                description: L10n.automaticScreenshotsDescription
-            ) {
-                SettingsCard {
-                    VStack(spacing: 0) {
-                        SettingsToggleRow(
-                            title: L10n.automaticScreenshots,
-                            description: L10n.automaticScreenshotsToggleDescription,
-                            isOn: $settings.automaticScreenshotEnabled
-                        )
-
-                        Divider()
-
-                        SettingsControlRow(
-                            title: L10n.screenshotInterval,
-                            description: L10n.screenshotIntervalDescription
-                        ) {
-                            Picker(L10n.screenshotInterval, selection: $settings.automaticScreenshotIntervalSeconds) {
-                                ForEach(Self.automaticScreenshotIntervals, id: \.self) { interval in
-                                    Text(L10n.seconds(interval)).tag(interval)
-                                }
-                            }
-                            .labelsHidden()
-                            .pickerStyle(.menu)
-                            .frame(width: 120, alignment: .trailing)
-                            .disabled(!settings.automaticScreenshotEnabled)
                         }
                     }
                 }

--- a/Sources/Dahlia/Views/SettingsView.swift
+++ b/Sources/Dahlia/Views/SettingsView.swift
@@ -7,6 +7,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
     case calendar
     case cloudStorage
     case transcription
+    case screenshots
     case aiSummary
     case instructions
     case developer
@@ -19,6 +20,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .calendar: L10n.calendar
         case .cloudStorage: L10n.cloudStorage
         case .transcription: L10n.transcription
+        case .screenshots: L10n.screenshots
         case .aiSummary: L10n.aiSummary
         case .instructions: L10n.instructions
         case .developer: L10n.developerSettings
@@ -31,6 +33,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .calendar: "calendar"
         case .cloudStorage: "externaldrive.badge.icloud"
         case .transcription: "waveform"
+        case .screenshots: "photo.on.rectangle.angled"
         case .aiSummary: "sparkle.text.clipboard"
         case .instructions: "list.bullet.clipboard"
         case .developer: "wrench.and.screwdriver"
@@ -94,6 +97,8 @@ struct SettingsView: View {
             CloudStorageSettingsView()
         case .transcription:
             TranscriptionSettingsView()
+        case .screenshots:
+            ScreenshotSettingsView()
         case .aiSummary:
             AISummarySettingsView()
         case .instructions:

--- a/Tests/DahliaTests/ScreenshotChangeDetectorTests.swift
+++ b/Tests/DahliaTests/ScreenshotChangeDetectorTests.swift
@@ -45,6 +45,28 @@ struct ScreenshotChangeDetectorTests {
     }
 
     @Test
+    func changedPixelRatioThresholdControlsLocalChanges() throws {
+        let baseline = try makeImage(width: 640, height: 360, background: .black)
+        let changed = try makeImage(
+            width: 640,
+            height: 360,
+            background: .black,
+            patches: [
+                Patch(
+                    rect: CGRect(x: 0, y: 0, width: 96, height: 360),
+                    color: CGColor(red: 0.35, green: 0.35, blue: 0.35, alpha: 1)
+                ),
+            ]
+        )
+
+        let first = try #require(ScreenshotChangeDetector.fingerprint(for: baseline))
+        let second = try #require(ScreenshotChangeDetector.fingerprint(for: changed))
+
+        #expect(ScreenshotChangeDetector.isSignificantlyDifferent(first, second, changedPixelRatioThreshold: 0.10))
+        #expect(!ScreenshotChangeDetector.isSignificantlyDifferent(first, second, changedPixelRatioThreshold: 0.20))
+    }
+
+    @Test
     func sameRelativeContentAtDifferentSizesIsStable() throws {
         let firstImage = try makeImage(
             width: 640,


### PR DESCRIPTION
## Summary
- Move screenshot-related preferences into a dedicated Settings tab.
- Change automatic screenshot interval options to 5, 10, 20, and 30 seconds.
- Add configurable screenshot change thresholds with five percentage options.
- Preserve the existing 20% threshold as the default and normalize old interval values to the new option set.

## Validation
- `swift build`
- `git diff --check`

## Notes
- `swift test` did not execute Swift Testing tests under the active Command Line Tools setup; the target builds, but the local runner did not emit test execution output in this environment.