### PR TITLE
Sanitize generated summary tags

### DIFF
--- a/Sources/Dahlia/Services/SummaryService.swift
+++ b/Sources/Dahlia/Services/SummaryService.swift
@@ -45,7 +45,11 @@ enum SummaryService {
         Your response MUST be a JSON object with exactly four keys:
         - "title": a concise title for this meeting/transcript (one line, no quotes)
         - "summary": the full summary in Markdown format
-        - "tags": an array of relevant short tags for categorization (empty array if none)
+        - "tags": an array of relevant short Obsidian-compatible tags for categorization (empty array if none)
+          - Tags MUST contain no spaces.
+          - Tags MUST use only letters, numbers, "_" and "-".
+          - Use "_" or "-" to join words instead of spaces or punctuation.
+          - Do not include "#", slashes, emojis, quotes, brackets, commas, or other symbols.
         - "action_items": an array of objects with exactly two keys:
           - "title": the concrete action item
           - "assignee": who owns it, or an empty string if unclear
@@ -198,6 +202,9 @@ enum SummaryService {
     private static let obsidianLinkRegex = try! NSRegularExpression(
         pattern: #"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]"#
     )
+
+    private static let tagAllowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_-"))
+    private static let tagTrimCharacters = CharacterSet(charactersIn: "_-")
 
     static func normalizeScreenshotEmbeds(_ summary: String, screenshots: [MeetingScreenshotRecord]) -> String {
         guard !screenshots.isEmpty else { return summary }
@@ -371,9 +378,27 @@ enum SummaryService {
 
     private static func appendUniqueTags(_ candidates: [String], to tags: inout [String]) {
         for candidate in candidates {
-            let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty, !tags.contains(trimmed) else { continue }
-            tags.append(trimmed)
+            guard let tag = normalizedTag(candidate), !tags.contains(tag) else { continue }
+            tags.append(tag)
         }
+    }
+
+    private static func normalizedTag(_ candidate: String) -> String? {
+        var normalized = ""
+        var lastWasSeparator = false
+
+        for scalar in candidate.trimmingCharacters(in: .whitespacesAndNewlines).unicodeScalars {
+            if tagAllowedCharacters.contains(scalar) {
+                normalized.unicodeScalars.append(scalar)
+                lastWasSeparator = false
+            } else if !lastWasSeparator {
+                normalized.append("_")
+                lastWasSeparator = true
+            }
+        }
+
+        let tag = normalized.trimmingCharacters(in: tagTrimCharacters)
+        guard tag.contains(where: { $0.isLetter || $0.isNumber }) else { return nil }
+        return tag
     }
 }

--- a/Sources/Dahlia/Services/SummaryService.swift
+++ b/Sources/Dahlia/Services/SummaryService.swift
@@ -47,6 +47,7 @@ enum SummaryService {
         - "summary": the full summary in Markdown format
         - "tags": an array of relevant short Obsidian-compatible tags for categorization (empty array if none)
           - Tags MUST contain no spaces.
+          - Tags MUST not be numeric-only.
           - Tags MUST use only letters, numbers, "_" and "-".
           - Use "_" or "-" to join words instead of spaces or punctuation.
           - Do not include "#", slashes, emojis, quotes, brackets, commas, or other symbols.
@@ -398,7 +399,7 @@ enum SummaryService {
         }
 
         let tag = normalized.trimmingCharacters(in: tagTrimCharacters)
-        guard tag.contains(where: { $0.isLetter || $0.isNumber }) else { return nil }
+        guard tag.contains(where: { !$0.isNumber }) else { return nil }
         return tag
     }
 }

--- a/Tests/DahliaTests/SummaryServiceTests.swift
+++ b/Tests/DahliaTests/SummaryServiceTests.swift
@@ -238,6 +238,40 @@ struct SummaryServiceTests {
     }
 
     @Test
+    func resolvedTagsNormalizesObsidianIncompatibleTags() {
+        let context = """
+        ---
+        tags:
+          - context tag
+          - "Q&A"
+          - customer-meeting
+        ---
+        """
+
+        let tags = SummaryService.resolvedTags(
+            resultTags: [
+                "customer meeting",
+                "customer_meeting",
+                "sales/enterprise",
+                "risk:high",
+                "team-check_in",
+                "!!!",
+            ],
+            contextContent: context,
+        )
+
+        #expect(tags == [
+            "customer_meeting",
+            "sales_enterprise",
+            "risk_high",
+            "team-check_in",
+            "context_tag",
+            "Q_A",
+            "customer-meeting",
+        ])
+    }
+
+    @Test
     func resolvedSummaryPromptUsesDefaultWhenAutoSelected() {
         let previousInstructionID = AppSettings.shared.selectedInstructionID
         let previousVault = AppSettings.shared.currentVault

--- a/Tests/DahliaTests/SummaryServiceTests.swift
+++ b/Tests/DahliaTests/SummaryServiceTests.swift
@@ -245,6 +245,7 @@ struct SummaryServiceTests {
           - context tag
           - "Q&A"
           - customer-meeting
+          - 2026
         ---
         """
 
@@ -255,6 +256,9 @@ struct SummaryServiceTests {
                 "sales/enterprise",
                 "risk:high",
                 "team-check_in",
+                "2026",
+                "#123",
+                "2026-q1",
                 "!!!",
             ],
             contextContent: context,
@@ -265,6 +269,7 @@ struct SummaryServiceTests {
             "sales_enterprise",
             "risk_high",
             "team-check_in",
+            "2026-q1",
             "context_tag",
             "Q_A",
             "customer-meeting",


### PR DESCRIPTION
## Summary
- Tighten the summary generation instructions so LLM-produced tags are Obsidian-compatible.
- Normalize generated and context-derived tags before writing frontmatter.
- Add a regression test for spaces and unsupported punctuation in tags.

## Why
Obsidian does not accept space-delimited tag names, and LLM-generated summary tags could include spaces or punctuation.

## Validation
- `swift test --filter SummaryServiceTests`