### PR TITLE
Honor screenshot change threshold

### DIFF
--- a/Sources/Dahlia/Utilities/ScreenshotChangeDetector.swift
+++ b/Sources/Dahlia/Utilities/ScreenshotChangeDetector.swift
@@ -10,7 +10,6 @@ struct ScreenshotFingerprint: Equatable {
 enum ScreenshotChangeDetector {
     private static let fingerprintWidth = 64
     private static let fingerprintHeight = 36
-    private static let significantAverageDifference = 0.08
     private static let defaultChangedPixelRatioThreshold = 0.20
     private static let changedPixelThreshold = 24
 
@@ -57,24 +56,20 @@ enum ScreenshotChangeDetector {
             return true
         }
 
-        var totalDifference = 0
         var changedPixelCount = 0
 
         for index in lhs.pixels.indices {
             let difference = abs(Int(lhs.pixels[index]) - Int(rhs.pixels[index]))
-            totalDifference += difference
             if difference >= changedPixelThreshold {
                 changedPixelCount += 1
             }
         }
 
         let pixelCount = lhs.pixels.count
-        let averageDifference = Double(totalDifference) / Double(pixelCount) / 255.0
         let changedPixelRatio = Double(changedPixelCount) / Double(pixelCount)
         let requiredChangedPixelRatio = normalizedChangedPixelRatioThreshold(changedPixelRatioThreshold)
 
-        return averageDifference >= significantAverageDifference
-            || changedPixelRatio >= requiredChangedPixelRatio
+        return changedPixelRatio >= requiredChangedPixelRatio
     }
 
     private static func normalizedChangedPixelRatioThreshold(_ threshold: Double) -> Double {

--- a/Sources/Dahlia/Utilities/ScreenshotChangeDetector.swift
+++ b/Sources/Dahlia/Utilities/ScreenshotChangeDetector.swift
@@ -11,7 +11,7 @@ enum ScreenshotChangeDetector {
     private static let fingerprintWidth = 64
     private static let fingerprintHeight = 36
     private static let defaultChangedPixelRatioThreshold = 0.20
-    private static let changedPixelThreshold = 24
+    private static let minimumChangedPixelDifference = 8
 
     static func fingerprint(for image: CGImage) -> ScreenshotFingerprint? {
         let width = fingerprintWidth
@@ -60,7 +60,7 @@ enum ScreenshotChangeDetector {
 
         for index in lhs.pixels.indices {
             let difference = abs(Int(lhs.pixels[index]) - Int(rhs.pixels[index]))
-            if difference >= changedPixelThreshold {
+            if difference >= minimumChangedPixelDifference {
                 changedPixelCount += 1
             }
         }

--- a/Tests/DahliaTests/ScreenshotChangeDetectorTests.swift
+++ b/Tests/DahliaTests/ScreenshotChangeDetectorTests.swift
@@ -86,6 +86,21 @@ struct ScreenshotChangeDetectorTests {
     }
 
     @Test
+    func screenWideLowContrastChangeIsSignificant() throws {
+        let baseline = try makeImage(width: 640, height: 360, background: .black)
+        let changed = try makeImage(
+            width: 640,
+            height: 360,
+            background: CGColor(red: 0.08, green: 0.08, blue: 0.08, alpha: 1)
+        )
+
+        let first = try #require(ScreenshotChangeDetector.fingerprint(for: baseline))
+        let second = try #require(ScreenshotChangeDetector.fingerprint(for: changed))
+
+        #expect(ScreenshotChangeDetector.isSignificantlyDifferent(first, second, changedPixelRatioThreshold: 0.50))
+    }
+
+    @Test
     func sameRelativeContentAtDifferentSizesIsStable() throws {
         let firstImage = try makeImage(
             width: 640,

--- a/Tests/DahliaTests/ScreenshotChangeDetectorTests.swift
+++ b/Tests/DahliaTests/ScreenshotChangeDetectorTests.swift
@@ -67,6 +67,25 @@ struct ScreenshotChangeDetectorTests {
     }
 
     @Test
+    func highContrastLocalChangeRespectsConfiguredThreshold() throws {
+        let baseline = try makeImage(width: 640, height: 360, background: .black)
+        let changed = try makeImage(
+            width: 640,
+            height: 360,
+            background: .black,
+            patches: [
+                Patch(rect: CGRect(x: 0, y: 0, width: 80, height: 360), color: .white),
+            ]
+        )
+
+        let first = try #require(ScreenshotChangeDetector.fingerprint(for: baseline))
+        let second = try #require(ScreenshotChangeDetector.fingerprint(for: changed))
+
+        #expect(ScreenshotChangeDetector.isSignificantlyDifferent(first, second, changedPixelRatioThreshold: 0.10))
+        #expect(!ScreenshotChangeDetector.isSignificantlyDifferent(first, second, changedPixelRatioThreshold: 0.20))
+    }
+
+    @Test
     func sameRelativeContentAtDifferentSizesIsStable() throws {
         let firstImage = try makeImage(
             width: 640,


### PR DESCRIPTION
## Summary
- Remove the fixed average-difference shortcut from screenshot change detection.
- Keep automatic screenshot saves governed by the configured changed-pixel ratio threshold.
- Add a regression test for high-contrast local changes that should be ignored when the threshold is higher.

## Why
PR #38 added a user-facing screenshot change threshold, but the detector still saved screenshots when a fixed average-difference cutoff was met. That allowed common high-contrast local UI changes to bypass settings like 20%, 30%, or 50%.

## Validation
- `swift test --filter ScreenshotChangeDetectorTests`
- `swift test`