### PR TITLE
Fix screenshot hang

### DIFF
--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -473,7 +473,7 @@ final class MeetingRepository {
 
     // MARK: - Screenshots
 
-    func fetchScreenshots(forMeetingId meetingId: UUID) throws -> [MeetingScreenshotRecord] {
+    nonisolated func fetchScreenshots(forMeetingId meetingId: UUID) throws -> [MeetingScreenshotRecord] {
         try dbQueue.read { db in
             try MeetingScreenshotRecord
                 .filter(Column("meetingId") == meetingId)

--- a/Sources/Dahlia/Database/MeetingScreenshotRecord.swift
+++ b/Sources/Dahlia/Database/MeetingScreenshotRecord.swift
@@ -2,7 +2,7 @@ import Foundation
 import GRDB
 
 /// スクリーンショットを表す GRDB レコード。
-struct MeetingScreenshotRecord: Codable, FetchableRecord, PersistableRecord {
+struct MeetingScreenshotRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     static let databaseTableName = "screenshots"
 
     var id: UUID

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -207,6 +207,7 @@ final class CaptionViewModel: ObservableObject {
     private var automaticScreenshotTask: Task<Void, Never>?
     private var lastSavedAutomaticScreenshotFingerprint: ScreenshotFingerprint?
     private var meetingLoadTask: Task<Void, Never>?
+    private var screenshotReloadGeneration = 0
     private var isSynchronizingSelectedLocale = false
     private let availableInputDevicesProvider: @Sendable () -> [MicrophoneDevice]
     private let defaultInputDeviceIDProvider: @Sendable () -> AudioDeviceID?
@@ -1684,6 +1685,9 @@ final class CaptionViewModel: ObservableObject {
 
     /// DB からスクリーンショット一覧を再読み込みする。
     func reloadScreenshots() {
+        screenshotReloadGeneration += 1
+        let generation = screenshotReloadGeneration
+
         guard let meetingId = currentMeetingId,
               let dbQueue = currentDbQueue else {
             screenshots = []
@@ -1694,7 +1698,9 @@ final class CaptionViewModel: ObservableObject {
                 let repo = MeetingRepository(dbQueue: dbQueue)
                 return (try? repo.fetchScreenshots(forMeetingId: meetingId)) ?? []
             }.value
-            guard let self, self.currentMeetingId == meetingId else { return }
+            guard let self,
+                  self.currentMeetingId == meetingId,
+                  self.screenshotReloadGeneration == generation else { return }
             self.screenshots = screenshots
         }
     }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -1614,7 +1614,7 @@ final class CaptionViewModel: ObservableObject {
             try record.insert(db)
         }
         if shouldRefreshVisibleScreenshots {
-            reloadScreenshots()
+            appendVisibleScreenshot(record)
         }
     }
 
@@ -1689,8 +1689,24 @@ final class CaptionViewModel: ObservableObject {
             screenshots = []
             return
         }
-        let repo = MeetingRepository(dbQueue: dbQueue)
-        screenshots = (try? repo.fetchScreenshots(forMeetingId: meetingId)) ?? []
+        Task { [weak self, meetingId, dbQueue] in
+            let screenshots = await Task.detached(priority: .userInitiated) {
+                let repo = MeetingRepository(dbQueue: dbQueue)
+                return (try? repo.fetchScreenshots(forMeetingId: meetingId)) ?? []
+            }.value
+            guard let self, self.currentMeetingId == meetingId else { return }
+            self.screenshots = screenshots
+        }
+    }
+
+    private func appendVisibleScreenshot(_ screenshot: MeetingScreenshotRecord) {
+        guard currentMeetingId == screenshot.meetingId else { return }
+        if let index = screenshots.firstIndex(where: { $0.id == screenshot.id }) {
+            screenshots[index] = screenshot
+        } else {
+            let insertIndex = screenshots.firstIndex { $0.capturedAt > screenshot.capturedAt } ?? screenshots.endIndex
+            screenshots.insert(screenshot, at: insertIndex)
+        }
     }
 
     func deleteScreenshot(_ screenshot: MeetingScreenshotRecord) {

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ImageIO
 import SwiftUI
 
 private extension View {
@@ -122,16 +123,17 @@ private struct ScreenshotThumbnailView: View {
     let timestamp: String
     let viewModel: CaptionViewModel
     @Binding var expandedScreenshot: MeetingScreenshotRecord?
+    @State private var thumbnailImage: CGImage?
 
     var body: some View {
         VStack(spacing: 4) {
-            if let nsImage = NSImage(data: screenshot.imageData) {
+            if let thumbnailImage {
                 Button {
                     withAnimation(.easeOut(duration: 0.15)) {
                         expandedScreenshot = screenshot
                     }
                 } label: {
-                    Image(nsImage: nsImage)
+                    Image(decorative: thumbnailImage, scale: 1)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .clipShape(RoundedRectangle(cornerRadius: 6))
@@ -140,6 +142,11 @@ private struct ScreenshotThumbnailView: View {
                 .buttonStyle(.plain)
                 .pointerStyle(.link)
                 .accessibilityLabel(L10n.open)
+            } else {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.primary.opacity(0.05))
+                    .aspectRatio(16 / 9, contentMode: .fit)
+                    .accessibilityHidden(true)
             }
             HStack {
                 Text(timestamp)
@@ -157,6 +164,25 @@ private struct ScreenshotThumbnailView: View {
         }
         .padding(6)
         .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 8))
+        .task(id: screenshot.id) {
+            thumbnailImage = nil
+            thumbnailImage = await Self.makeThumbnail(from: screenshot.imageData)
+        }
+    }
+
+    private nonisolated static func makeThumbnail(from data: Data) async -> CGImage? {
+        await Task.detached(priority: .userInitiated) {
+            let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+            guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else { return nil }
+
+            let thumbnailOptions = [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceCreateThumbnailWithTransform: true,
+                kCGImageSourceShouldCacheImmediately: true,
+                kCGImageSourceThumbnailMaxPixelSize: 600,
+            ] as CFDictionary
+            return CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions)
+        }.value
     }
 }
 


### PR DESCRIPTION
## Summary

- avoid reloading every screenshot BLOB after saving a new screenshot
- append newly saved screenshots to the visible list instead
- generate screenshot thumbnails off the main thread with ImageIO before rendering them in SwiftUI

## Root Cause

Sentry issue DAHLIA-APP-1 reported app hangs in SwiftUI `AG::Graph::UpdateStack::update`. The latest event was in release `com.dahlia.app@0.1.1+10`; the app dSYM was missing in Sentry, but the timing aligned with automatic screenshot capture. The screenshot tab was doing full-image BLOB reloads and synchronous `NSImage(data:)` decoding during SwiftUI updates, which can block the main thread as screenshots accumulate.

## Validation

- `swift build` passed
- `swift test` exited 0, but this machine has `xcode-select` set to Command Line Tools, so SwiftPM built the test bundle without the `Test run with N tests` summary. `xcrun xctest` is unavailable in this environment.