### PR TITLE
Update toolbar actions and bump version

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>11</string>
+    <string>12</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.2.0</string>
+    <string>0.2.1</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -1129,7 +1129,8 @@ final class CaptionViewModel: ObservableObject {
 
     /// 手動で要約を実行できるかどうか。
     var canGenerateSummary: Bool {
-        guard currentMeetingId != nil,
+        guard !isListening,
+              currentMeetingId != nil,
               currentVaultURL != nil else { return false }
         return !store.segments.isEmpty
     }

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -7,6 +7,8 @@ struct ContentView: View {
     let recordingCoordinator: RecordingCoordinator
     var onSelectVault: (VaultRecord) -> Void = { _ in }
 
+    @Environment(\.openWindow) private var openWindow
+
     var body: some View {
         NavigationSplitView {
             MeetingListSidebarView(
@@ -21,14 +23,28 @@ struct ContentView: View {
         }
         .toolbar(removing: .title)
         .toolbar {
-            ToolbarItem(placement: .navigation) {
-                if showsCalendarScheduleToolbarButton {
-                    Button(action: returnToCalendarSchedule) {
-                        Label(L10n.showUpcomingSchedule, systemImage: "calendar")
-                    }
-                    .labelStyle(.iconOnly)
-                    .help(L10n.showUpcomingSchedule)
+            ToolbarItemGroup(placement: .navigation) {
+                Button {
+                    recordingCoordinator.createEmptyMeeting()
+                } label: {
+                    Label(L10n.newMeeting, systemImage: "square.and.pencil")
                 }
+                .labelStyle(.iconOnly)
+                .help(L10n.newMeeting)
+
+                Button {
+                    openWindow(id: WindowID.projectManager)
+                } label: {
+                    Label(L10n.manageProjects, systemImage: "folder")
+                }
+                .labelStyle(.iconOnly)
+                .help(L10n.manageProjects)
+
+                Button(action: returnToCalendarSchedule) {
+                    Label(L10n.showUpcomingSchedule, systemImage: "calendar")
+                }
+                .labelStyle(.iconOnly)
+                .help(L10n.showUpcomingSchedule)
             }
         }
         .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
@@ -46,10 +62,6 @@ struct ContentView: View {
             sidebarViewModel.clearMeetingSelection()
             viewModel.clearCurrentMeeting()
         }
-    }
-
-    private var showsCalendarScheduleToolbarButton: Bool {
-        !sidebarViewModel.selectedMeetingIds.isEmpty || viewModel.hasDraftMeeting || viewModel.currentMeetingId != nil
     }
 
     @ViewBuilder

--- a/Sources/Dahlia/Views/MeetingListSidebarView.swift
+++ b/Sources/Dahlia/Views/MeetingListSidebarView.swift
@@ -60,17 +60,6 @@ struct MeetingListSidebarView: View {
             }
         }
         .listStyle(.sidebar)
-        .toolbar {
-            ToolbarItem(placement: .navigation) {
-                Button {
-                    recordingCoordinator.createEmptyMeeting()
-                } label: {
-                    Label(L10n.newMeeting, systemImage: "square.and.pencil")
-                }
-                .labelStyle(.iconOnly)
-                .help(L10n.newMeeting)
-            }
-        }
         .overlay(alignment: .bottom) {
             if viewModel.isListening {
                 RecordingStatusBar(

--- a/Tests/DahliaTests/CaptionViewModelTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelTests.swift
@@ -137,6 +137,27 @@ import GRDB
         }
 
         @Test
+        func canGenerateSummaryIsDisabledWhileListening() {
+            let viewModel = CaptionViewModel()
+            let segment = TranscriptSegment(
+                startTime: Date(),
+                text: "confirmed transcript",
+                isConfirmed: true,
+                speakerLabel: "mic"
+            )
+
+            viewModel.currentMeetingId = UUID.v7()
+            viewModel.currentVaultURL = testVaultURL
+            viewModel.store.loadSegments([segment])
+
+            #expect(viewModel.canGenerateSummary)
+
+            viewModel.isListening = true
+
+            #expect(!viewModel.canGenerateSummary)
+        }
+
+        @Test
         func beginDraftMeetingDoesNotPersistMeetingRecord() throws {
             let viewModel = CaptionViewModel()
             let database = try AppDatabaseManager(path: ":memory:")


### PR DESCRIPTION
## Summary
- Disable manual summary generation while transcription is running.
- Consolidate toolbar actions into the order: new meeting, project management, calendar.
- Bump the app version to 0.2.1 and build number to 12.

## Validation
- `swift build`
- `swift test --filter CaptionViewModelTests` (build completed, but this environment did not emit a test run summary line)