### PR TITLE
Guard summary during recording finalization

### DIFF
--- a/Sources/Dahlia/Services/RecordingCoordinator.swift
+++ b/Sources/Dahlia/Services/RecordingCoordinator.swift
@@ -13,7 +13,9 @@ final class RecordingCoordinator {
     }
 
     var canStartNewMeeting: Bool {
-        viewModel.analyzerReady
+        !viewModel.isListening
+            && !viewModel.isFinalizingRecording
+            && viewModel.analyzerReady
             && viewModel.hasEnabledAudioSource
             && sidebarViewModel.dbQueue != nil
             && sidebarViewModel.currentVault != nil

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -50,6 +50,7 @@ final class CaptionViewModel: ObservableObject {
     }
 
     @Published var isListening = false
+    @Published var isFinalizingRecording = false
     @Published var analyzerReady = false
     @Published var isPreparingAnalyzer = false
     @Published var errorMessage: String?
@@ -952,6 +953,8 @@ final class CaptionViewModel: ObservableObject {
         projectName: String? = nil,
         vaultURL: URL
     ) {
+        guard !isFinalizingRecording else { return }
+
         if isListening {
             stopListening()
         } else {
@@ -978,6 +981,8 @@ final class CaptionViewModel: ObservableObject {
         vaultURL: URL,
         appendingTo existingMeetingId: UUID? = nil
     ) async {
+        guard !isListening, !isFinalizingRecording else { return }
+
         self.currentProjectURL = projectURL
         self.currentProjectId = projectId
         self.currentProjectName = projectName
@@ -1085,6 +1090,9 @@ final class CaptionViewModel: ObservableObject {
     }
 
     func stopListening() {
+        guard isListening, !isFinalizingRecording else { return }
+
+        isFinalizingRecording = true
         stopAutomaticScreenshotCapture()
         stopActiveCaptures()
         isListening = false
@@ -1096,27 +1104,25 @@ final class CaptionViewModel: ObservableObject {
         let projectName = ctx?.projectName ?? selectedProjectName
         let vaultURL = ctx?.vaultURL ?? currentVaultURL
         let recordingStart = activeStore.timeBase
-        let segments = activeStore.segments
-        let recordingSessions = activeStore.recordingSessions
         recordingContext = nil
-
-        guard let vaultURL else { return }
 
         Task {
             await stopActivePipelines()
             persistenceService?.stop()
             persistenceService = nil
+            let segments = activeStore.segments
+            let recordingSessions = activeStore.recordingSessions
+            isFinalizingRecording = false
 
-            if let meetingId, !segments.isEmpty {
-                await exportFiles(
-                    vaultURL: vaultURL,
-                    meetingId: meetingId,
-                    projectName: projectName ?? "",
-                    createdAt: recordingStart,
-                    segments: segments,
-                    recordingSessions: recordingSessions
-                )
-            }
+            guard let vaultURL, let meetingId, !segments.isEmpty else { return }
+            await exportFiles(
+                vaultURL: vaultURL,
+                meetingId: meetingId,
+                projectName: projectName ?? "",
+                createdAt: recordingStart,
+                segments: segments,
+                recordingSessions: recordingSessions
+            )
         }
     }
 
@@ -1130,6 +1136,7 @@ final class CaptionViewModel: ObservableObject {
     /// 手動で要約を実行できるかどうか。
     var canGenerateSummary: Bool {
         guard !isListening,
+              !isFinalizingRecording,
               currentMeetingId != nil,
               currentVaultURL != nil else { return false }
         return !store.segments.isEmpty
@@ -1137,7 +1144,8 @@ final class CaptionViewModel: ObservableObject {
 
     /// プルダウンメニューから手動で要約を実行する。
     func triggerManualSummary() {
-        guard let meetingId = currentMeetingId,
+        guard canGenerateSummary,
+              let meetingId = currentMeetingId,
               let vaultURL = currentVaultURL else { return }
         let projectURL = currentProjectURL
         let transcriptText = store.exportForSummary()

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -437,6 +437,8 @@ final class CaptionViewModel: ObservableObject {
         projectName: String? = nil,
         vaultURL: URL
     ) {
+        guard !isFinalizingRecording else { return }
+
         // 録音中に録音対象のトランスクリプトを選択した場合はライブ表示に復帰
         if isListening, meetingId == recordingMeetingId {
             returnToRecordingMeeting()
@@ -504,6 +506,8 @@ final class CaptionViewModel: ObservableObject {
         projectName: String? = nil,
         vaultURL: URL
     ) {
+        guard !isFinalizingRecording else { return }
+
         resetMeetingState()
         draftMeeting = nil
 
@@ -539,6 +543,8 @@ final class CaptionViewModel: ObservableObject {
         projectName: String? = nil,
         vaultURL: URL
     ) {
+        guard !isFinalizingRecording else { return }
+
         resetMeetingState()
         let draftId = UUID.v7()
         currentMeetingId = nil
@@ -622,6 +628,8 @@ final class CaptionViewModel: ObservableObject {
     /// 現在の文字起こし表示をクリアして初期状態に戻す。
     /// 録音中はバックグラウンド録音を維持したまま表示のみクリアする。
     func clearCurrentMeeting() {
+        guard !isFinalizingRecording else { return }
+
         if isListening {
             saveRecordingContextIfNeeded()
             store = TranscriptStore()
@@ -1389,6 +1397,8 @@ final class CaptionViewModel: ObservableObject {
     }
 
     func clearText() {
+        guard !isFinalizingRecording else { return }
+
         store.clear()
         persistenceService?.reset()
         Task {

--- a/Tests/DahliaTests/CaptionViewModelTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelTests.swift
@@ -138,6 +138,38 @@ import GRDB
 
         @Test
         func canGenerateSummaryIsDisabledWhileListening() {
+            let viewModel = summaryReadyViewModel()
+
+            #expect(viewModel.canGenerateSummary)
+
+            viewModel.isListening = true
+
+            #expect(!viewModel.canGenerateSummary)
+        }
+
+        @Test
+        func canGenerateSummaryIsDisabledWhileFinalizingRecording() {
+            let viewModel = summaryReadyViewModel()
+
+            #expect(viewModel.canGenerateSummary)
+
+            viewModel.isFinalizingRecording = true
+
+            #expect(!viewModel.canGenerateSummary)
+        }
+
+        @Test
+        func manualSummaryDoesNotStartWhileFinalizingRecording() {
+            let viewModel = summaryReadyViewModel()
+            viewModel.isFinalizingRecording = true
+
+            viewModel.triggerManualSummary()
+
+            #expect(!viewModel.requestShowSummaryTab)
+            #expect(viewModel.summaryGeneratingMeetingId == nil)
+        }
+
+        private func summaryReadyViewModel() -> CaptionViewModel {
             let viewModel = CaptionViewModel()
             let segment = TranscriptSegment(
                 startTime: Date(),
@@ -150,11 +182,7 @@ import GRDB
             viewModel.currentVaultURL = testVaultURL
             viewModel.store.loadSegments([segment])
 
-            #expect(viewModel.canGenerateSummary)
-
-            viewModel.isListening = true
-
-            #expect(!viewModel.canGenerateSummary)
+            return viewModel
         }
 
         @Test

--- a/Tests/DahliaTests/CaptionViewModelTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelTests.swift
@@ -169,6 +169,58 @@ import GRDB
             #expect(viewModel.summaryGeneratingMeetingId == nil)
         }
 
+        @Test
+        func loadMeetingDoesNotResetStoreWhileFinalizingRecording() throws {
+            let viewModel = summaryReadyViewModel()
+            let originalMeetingId = try #require(viewModel.currentMeetingId)
+            let originalSegments = viewModel.store.segments
+            let dbQueue = try DatabaseQueue(path: ":memory:")
+
+            viewModel.isFinalizingRecording = true
+            viewModel.loadMeeting(
+                UUID.v7(),
+                dbQueue: dbQueue,
+                projectURL: nil,
+                projectId: nil,
+                vaultURL: testVaultURL
+            )
+
+            #expect(viewModel.currentMeetingId == originalMeetingId)
+            #expect(viewModel.store.segments == originalSegments)
+        }
+
+        @Test
+        func clearCurrentMeetingDoesNotResetStoreWhileFinalizingRecording() throws {
+            let viewModel = summaryReadyViewModel()
+            let originalMeetingId = try #require(viewModel.currentMeetingId)
+            let originalSegments = viewModel.store.segments
+
+            viewModel.isFinalizingRecording = true
+            viewModel.clearCurrentMeeting()
+
+            #expect(viewModel.currentMeetingId == originalMeetingId)
+            #expect(viewModel.store.segments == originalSegments)
+        }
+
+        @Test
+        func createEmptyMeetingDoesNotResetStoreWhileFinalizingRecording() throws {
+            let viewModel = summaryReadyViewModel()
+            let originalMeetingId = try #require(viewModel.currentMeetingId)
+            let originalSegments = viewModel.store.segments
+
+            viewModel.isFinalizingRecording = true
+            try viewModel.createEmptyMeeting(
+                dbQueue: DatabaseQueue(path: ":memory:"),
+                projectURL: nil,
+                vaultId: UUID.v7(),
+                projectId: nil,
+                vaultURL: testVaultURL
+            )
+
+            #expect(viewModel.currentMeetingId == originalMeetingId)
+            #expect(viewModel.store.segments == originalSegments)
+        }
+
         private func summaryReadyViewModel() -> CaptionViewModel {
             let viewModel = CaptionViewModel()
             let segment = TranscriptSegment(


### PR DESCRIPTION
## Summary
- Add an explicit recording finalization state while speech pipelines drain on stop.
- Keep manual summary generation and new recording starts disabled until finalization completes.
- Snapshot finalized transcript segments after pipeline shutdown so stop-time exports include the meeting tail.

## Root Cause
`stopListening()` cleared `isListening` before `stopActivePipelines()` awaited speech analyzer finalization. That briefly re-enabled manual summary generation, allowing summaries to snapshot the transcript before final segments landed.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app swift test --filter CaptionViewModelTests`