### PR TITLE
Default vault picker to Documents meetings

### DIFF
--- a/Sources/Dahlia/Views/VaultPickerView.swift
+++ b/Sources/Dahlia/Views/VaultPickerView.swift
@@ -8,6 +8,12 @@ struct VaultPickerView: View {
     @State private var vaults: [VaultRecord] = []
     @State private var showFolderPicker = false
 
+    private static var defaultVaultURL: URL {
+        let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Documents", isDirectory: true)
+        return documentsURL.appendingPathComponent("Meetings", isDirectory: true)
+    }
+
     private var repository: MeetingRepository? {
         appDatabase.map { MeetingRepository(dbQueue: $0.dbQueue) }
     }
@@ -88,6 +94,7 @@ struct VaultPickerView: View {
                 registerVault(url: url)
             }
         }
+        .fileDialogDefaultDirectory(Self.defaultVaultURL)
     }
 
     private func actionRow(


### PR DESCRIPTION
## Summary

- Set the vault folder picker's default directory to the macOS user Documents folder plus `Meetings`.
- Keep the existing folder-opening flow unchanged.

## Impact

New vault registration starts from `~/Documents/Meetings` while still letting the user choose any folder.

## Validation

- `swift build`