### PR TITLE
リアルタイム／バッチ選択式の文字起こしを追加

### DIFF
--- a/Sources/Dahlia/Audio/AudioCaptureManager.swift
+++ b/Sources/Dahlia/Audio/AudioCaptureManager.swift
@@ -110,7 +110,11 @@ final class AudioCaptureManager {
     }
 
     /// マイクキャプチャを開始する。
-    func startCapture(targetFormat: AVAudioFormat, selectedDeviceID: AudioDeviceID? = nil) throws {
+    func startCapture(
+        targetFormat: AVAudioFormat,
+        selectedDeviceID: AudioDeviceID? = nil,
+        bufferSize: AVAudioFrameCount = 4096
+    ) throws {
         self.captureFormat = targetFormat
         let inputNode = engine.inputNode
 
@@ -133,7 +137,6 @@ final class AudioCaptureManager {
         conv.sampleRateConverterQuality = AVAudioQuality.medium.rawValue
         self.converter = conv
 
-        let bufferSize: AVAudioFrameCount = 4096
         inputNode.installTap(onBus: 0, bufferSize: bufferSize, format: hardwareFormat) {
             [weak self] buffer, _ in
             self?.processAudioBuffer(buffer)

--- a/Sources/Dahlia/Audio/BatchAudioFileWriter.swift
+++ b/Sources/Dahlia/Audio/BatchAudioFileWriter.swift
@@ -1,0 +1,131 @@
+@preconcurrency import AVFoundation
+import Foundation
+import os
+
+/// 音声コールバックをブロックせず、CAFへ直列に追記するWriter。
+actor BatchAudioFileWriter {
+    private struct AudioChunk {
+        let data: Data
+        let frameCount: AVAudioFrameCount
+    }
+
+    // SwiftFormatのmodifier順と、無効なSwiftLint modifier_order設定のfallbackが競合する。
+    // swiftlint:disable modifier_order
+    private nonisolated let continuation: AsyncStream<AudioChunk>.Continuation
+    private nonisolated let frameCounter = OSAllocatedUnfairLock(initialState: Int64(0))
+    private nonisolated let callbackError = OSAllocatedUnfairLock<String?>(initialState: nil)
+    // swiftlint:enable modifier_order
+
+    private let stream: AsyncStream<AudioChunk>
+    private let partialURL: URL
+    private let finalURL: URL
+    private let format: AVAudioFormat
+    private var audioFile: AVAudioFile?
+    private var writerTask: Task<Void, Never>?
+    private var writeError: Error?
+
+    nonisolated var appendedFrameCount: Int64 {
+        frameCounter.withLock { $0 }
+    }
+
+    init(partialURL: URL, finalURL: URL, format: AVAudioFormat) {
+        let pair = AsyncStream.makeStream(of: AudioChunk.self)
+        stream = pair.stream
+        continuation = pair.continuation
+        self.partialURL = partialURL
+        self.finalURL = finalURL
+        self.format = format
+    }
+
+    func start() throws {
+        try FileManager.default.createDirectory(
+            at: partialURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if FileManager.default.fileExists(atPath: partialURL.path) {
+            try FileManager.default.removeItem(at: partialURL)
+        }
+        audioFile = try AVAudioFile(
+            forWriting: partialURL,
+            settings: format.settings,
+            commonFormat: .pcmFormatInt16,
+            interleaved: false
+        )
+
+        writerTask = Task { [weak self, stream] in
+            for await chunk in stream {
+                await self?.consume(chunk)
+            }
+        }
+    }
+
+    nonisolated func appendBuffer(_ buffer: AVAudioPCMBuffer) {
+        guard buffer.format.commonFormat == .pcmFormatInt16,
+              buffer.format.channelCount == 1,
+              let channelData = buffer.int16ChannelData else {
+            callbackError.withLock { $0 = BatchAudioFileWriterError.incompatibleBuffer.localizedDescription }
+            return
+        }
+
+        let frameCount = buffer.frameLength
+        guard frameCount > 0 else { return }
+        let byteCount = Int(frameCount) * MemoryLayout<Int16>.size
+        let data = Data(bytes: channelData[0], count: byteCount)
+        frameCounter.withLock { $0 += Int64(frameCount) }
+        continuation.yield(AudioChunk(data: data, frameCount: frameCount))
+    }
+
+    func finish() async throws -> Int64 {
+        await closeWriter()
+
+        if let callbackMessage = callbackError.withLock({ $0 }) {
+            throw BatchAudioFileWriterError.writeFailed(callbackMessage)
+        }
+        if let writeError {
+            throw BatchAudioFileWriterError.writeFailed(writeError.localizedDescription)
+        }
+
+        if FileManager.default.fileExists(atPath: finalURL.path) {
+            try FileManager.default.removeItem(at: finalURL)
+        }
+        try FileManager.default.moveItem(at: partialURL, to: finalURL)
+        return appendedFrameCount
+    }
+
+    func cancelAndDelete() async {
+        await closeWriter()
+        try? FileManager.default.removeItem(at: partialURL)
+        try? FileManager.default.removeItem(at: finalURL)
+    }
+
+    private func closeWriter() async {
+        continuation.finish()
+        await writerTask?.value
+        writerTask = nil
+        audioFile = nil
+    }
+
+    private func write(_ chunk: AudioChunk) throws {
+        guard writeError == nil, let audioFile else { return }
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: chunk.frameCount),
+              let channelData = buffer.int16ChannelData else {
+            throw BatchAudioFileWriterError.incompatibleBuffer
+        }
+
+        let destination = UnsafeMutableRawBufferPointer(
+            start: channelData[0],
+            count: chunk.data.count
+        )
+        chunk.data.copyBytes(to: destination)
+        buffer.frameLength = chunk.frameCount
+        try audioFile.write(from: buffer)
+    }
+
+    private func consume(_ chunk: AudioChunk) {
+        do {
+            try write(chunk)
+        } catch {
+            writeError = error
+        }
+    }
+}

--- a/Sources/Dahlia/Audio/BatchAudioFileWriterError.swift
+++ b/Sources/Dahlia/Audio/BatchAudioFileWriterError.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum BatchAudioFileWriterError: LocalizedError {
+    case incompatibleBuffer
+    case writeFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .incompatibleBuffer:
+            L10n.batchAudioBufferInvalid
+        case let .writeFailed(message):
+            L10n.batchAudioWriteFailed(message)
+        }
+    }
+}

--- a/Sources/Dahlia/Audio/BatchAudioRecordingSession.swift
+++ b/Sources/Dahlia/Audio/BatchAudioRecordingSession.swift
@@ -1,0 +1,162 @@
+@preconcurrency import AVFoundation
+import Foundation
+import GRDB
+
+/// ひとつのバッチ録音セッションで、音源ごとの単一CAFとrangeを管理する。
+@MainActor
+final class BatchAudioRecordingSession {
+    let targetFormat: AVAudioFormat
+
+    private let dbQueue: DatabaseQueue
+    private let managedRootURL: URL
+    private let meetingId: UUID
+    private let recordingSessionId: UUID
+    private let recordingStartTime: Date
+    private var writers: [RecordingAudioSource: BatchAudioFileWriter] = [:]
+    private var fileRecords: [RecordingAudioSource: RecordingAudioFileRecord] = [:]
+    private var activeRanges: [RecordingAudioSource: RecordingAudioRangeRecord] = [:]
+
+    init(
+        dbQueue: DatabaseQueue,
+        managedRootURL: URL = BatchAudioStorage.managedRootURL,
+        meetingId: UUID,
+        recordingSessionId: UUID,
+        recordingStartTime: Date,
+        sampleRate: Double
+    ) throws {
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw AudioCaptureError.invalidHardwareFormat
+        }
+        self.dbQueue = dbQueue
+        self.managedRootURL = managedRootURL
+        self.meetingId = meetingId
+        self.recordingSessionId = recordingSessionId
+        self.recordingStartTime = recordingStartTime
+        self.targetFormat = format
+    }
+
+    func beginRange(source: RecordingAudioSource, locale: Locale, at date: Date = .now) async throws -> BatchAudioFileWriter {
+        try await endRange(source: source)
+        let writer = try await writer(for: source)
+        let audioFile = try fileRecord(for: source)
+        let now = Date.now
+        let range = RecordingAudioRangeRecord(
+            id: .v7(),
+            audioFileId: audioFile.id,
+            startFrame: writer.appendedFrameCount,
+            frameCount: nil,
+            sessionOffsetSeconds: max(0, date.timeIntervalSince(recordingStartTime)),
+            localeIdentifier: locale.identifier,
+            createdAt: now,
+            updatedAt: now
+        )
+        try await dbQueue.write { db in
+            try range.insert(db)
+        }
+        activeRanges[source] = range
+        return writer
+    }
+
+    func endActiveRanges() async throws {
+        for source in Array(activeRanges.keys) {
+            try await endRange(source: source)
+        }
+    }
+
+    func finish() async throws {
+        try await endActiveRanges()
+        for (source, writer) in writers {
+            let totalFrames = try await writer.finish()
+            guard var fileRecord = fileRecords[source] else { continue }
+            let now = Date.now
+            fileRecord.finalizedAt = now
+            fileRecord.totalFrameCount = totalFrames
+            fileRecord.updatedAt = now
+            let updatedRecord = fileRecord
+            try await dbQueue.write { db in
+                try updatedRecord.update(db)
+            }
+            fileRecords[source] = fileRecord
+        }
+    }
+
+    func cancelAndDelete() async {
+        for writer in writers.values {
+            await writer.cancelAndDelete()
+        }
+        try? await dbQueue.write { db in
+            _ = try RecordingAudioFileRecord
+                .filter(Column("recordingSessionId") == recordingSessionId)
+                .deleteAll(db)
+        }
+    }
+
+    private func writer(for source: RecordingAudioSource) async throws -> BatchAudioFileWriter {
+        if let writer = writers[source] {
+            return writer
+        }
+
+        let relativePath = BatchAudioStorage.managedRelativePath(
+            meetingId: meetingId,
+            sessionId: recordingSessionId,
+            source: source
+        )
+        let now = Date.now
+        let record = RecordingAudioFileRecord(
+            id: .v7(),
+            recordingSessionId: recordingSessionId,
+            source: source,
+            storageLocation: .managed,
+            relativePath: relativePath,
+            sampleRate: targetFormat.sampleRate,
+            channelCount: Int(targetFormat.channelCount),
+            finalizedAt: nil,
+            totalFrameCount: nil,
+            createdAt: now,
+            updatedAt: now
+        )
+        try await dbQueue.write { db in
+            try record.insert(db)
+        }
+
+        let writer = BatchAudioFileWriter(
+            partialURL: BatchAudioStorage.partialURL(baseURL: managedRootURL, relativePath: relativePath),
+            finalURL: BatchAudioStorage.finalURL(baseURL: managedRootURL, relativePath: relativePath),
+            format: targetFormat
+        )
+        do {
+            try await writer.start()
+        } catch {
+            try? await dbQueue.write { db in
+                _ = try RecordingAudioFileRecord.deleteOne(db, key: record.id)
+            }
+            throw error
+        }
+        writers[source] = writer
+        fileRecords[source] = record
+        return writer
+    }
+
+    private func fileRecord(for source: RecordingAudioSource) throws -> RecordingAudioFileRecord {
+        guard let record = fileRecords[source] else {
+            throw BatchAudioFileWriterError.incompatibleBuffer
+        }
+        return record
+    }
+
+    private func endRange(source: RecordingAudioSource) async throws {
+        guard var range = activeRanges.removeValue(forKey: source),
+              let writer = writers[source] else { return }
+        range.frameCount = max(0, writer.appendedFrameCount - range.startFrame)
+        range.updatedAt = .now
+        let updatedRange = range
+        try await dbQueue.write { db in
+            try updatedRange.update(db)
+        }
+    }
+}

--- a/Sources/Dahlia/Audio/BatchAudioStorage.swift
+++ b/Sources/Dahlia/Audio/BatchAudioStorage.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+enum BatchAudioStorage {
+    /// クラッシュ復旧対象のCAFは、OSの自動削除対象にならないApplication Supportへ置く。
+    static var managedRootURL: URL {
+        AppDatabaseManager.databaseURL
+            .deletingLastPathComponent()
+            .appending(path: "BatchAudio", directoryHint: .isDirectory)
+    }
+
+    static func managedRelativePath(meetingId: UUID, sessionId: UUID, source: RecordingAudioSource) -> String {
+        "\(meetingId.uuidString)/\(sessionId.uuidString)/\(source.fileName)"
+    }
+
+    static func vaultRelativePath(meetingId: UUID, sessionId: UUID, source: RecordingAudioSource) -> String {
+        "_dahlia/audio/\(managedRelativePath(meetingId: meetingId, sessionId: sessionId, source: source))"
+    }
+
+    static func finalURL(baseURL: URL, relativePath: String) -> URL {
+        baseURL.appending(path: relativePath)
+    }
+
+    static func partialURL(baseURL: URL, relativePath: String) -> URL {
+        finalURL(baseURL: baseURL, relativePath: relativePath)
+            .deletingPathExtension()
+            .appendingPathExtension("partial.caf")
+    }
+
+    static func finalURL(
+        for file: RecordingAudioFileRecord,
+        managedRootURL: URL = managedRootURL,
+        vaultURL: URL
+    ) -> URL {
+        finalURL(
+            baseURL: baseURL(for: file.storageLocation, managedRootURL: managedRootURL, vaultURL: vaultURL),
+            relativePath: file.relativePath
+        )
+    }
+
+    static func partialURL(
+        for file: RecordingAudioFileRecord,
+        managedRootURL: URL = managedRootURL,
+        vaultURL: URL
+    ) -> URL {
+        partialURL(
+            baseURL: baseURL(for: file.storageLocation, managedRootURL: managedRootURL, vaultURL: vaultURL),
+            relativePath: file.relativePath
+        )
+    }
+
+    static func existingURL(
+        for file: RecordingAudioFileRecord,
+        managedRootURL: URL = managedRootURL,
+        vaultURL: URL
+    ) -> URL? {
+        let finalURL = finalURL(for: file, managedRootURL: managedRootURL, vaultURL: vaultURL)
+        if FileManager.default.fileExists(atPath: finalURL.path) {
+            return finalURL
+        }
+        let partialURL = partialURL(for: file, managedRootURL: managedRootURL, vaultURL: vaultURL)
+        return FileManager.default.fileExists(atPath: partialURL.path) ? partialURL : nil
+    }
+
+    static func removeFiles(baseURL: URL, relativePaths: [String]) {
+        for relativePath in relativePaths {
+            guard let finalURL = safeURL(baseURL: baseURL, relativePath: relativePath) else { continue }
+            try? FileManager.default.removeItem(at: finalURL)
+            try? FileManager.default.removeItem(
+                at: finalURL.deletingPathExtension().appendingPathExtension("partial.caf")
+            )
+        }
+    }
+
+    static func removeFiles(
+        _ files: [RecordingAudioFileRecord],
+        managedRootURL: URL = managedRootURL,
+        vaultURL: URL
+    ) {
+        for location in RecordingAudioStorageLocation.allCases {
+            let relativePaths = files
+                .filter { $0.storageLocation == location }
+                .map(\.relativePath)
+            removeFiles(
+                baseURL: baseURL(for: location, managedRootURL: managedRootURL, vaultURL: vaultURL),
+                relativePaths: relativePaths
+            )
+        }
+    }
+
+    static func baseURL(
+        for location: RecordingAudioStorageLocation,
+        managedRootURL: URL = managedRootURL,
+        vaultURL: URL
+    ) -> URL {
+        switch location {
+        case .managed:
+            managedRootURL
+        case .vault:
+            vaultURL
+        }
+    }
+
+    private static func safeURL(baseURL: URL, relativePath: String) -> URL? {
+        guard !relativePath.isEmpty, !relativePath.hasPrefix("/") else { return nil }
+        let standardizedBaseURL = baseURL.standardizedFileURL.resolvingSymlinksInPath()
+        let candidateURL = standardizedBaseURL
+            .appending(path: relativePath)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        let directoryPrefix = standardizedBaseURL.path.hasSuffix("/")
+            ? standardizedBaseURL.path
+            : standardizedBaseURL.path + "/"
+        guard candidateURL.path.hasPrefix(directoryPrefix) else { return nil }
+        return candidateURL
+    }
+}

--- a/Sources/Dahlia/Audio/BatchAudioStorage.swift
+++ b/Sources/Dahlia/Audio/BatchAudioStorage.swift
@@ -68,6 +68,7 @@ enum BatchAudioStorage {
             try? FileManager.default.removeItem(
                 at: finalURL.deletingPathExtension().appendingPathExtension("partial.caf")
             )
+            removeEmptyParentDirectories(of: finalURL, stoppingAt: baseURL)
         }
     }
 
@@ -112,5 +113,23 @@ enum BatchAudioStorage {
             : standardizedBaseURL.path + "/"
         guard candidateURL.path.hasPrefix(directoryPrefix) else { return nil }
         return candidateURL
+    }
+
+    private static func removeEmptyParentDirectories(of fileURL: URL, stoppingAt baseURL: URL) {
+        let standardizedBaseURL = baseURL.standardizedFileURL.resolvingSymlinksInPath()
+        let directoryPrefix = standardizedBaseURL.path.hasSuffix("/")
+            ? standardizedBaseURL.path
+            : standardizedBaseURL.path + "/"
+        var directoryURL = fileURL.deletingLastPathComponent()
+
+        while directoryURL.path.hasPrefix(directoryPrefix) {
+            do {
+                guard try FileManager.default.contentsOfDirectory(atPath: directoryURL.path).isEmpty else { return }
+                try FileManager.default.removeItem(at: directoryURL)
+                directoryURL = directoryURL.deletingLastPathComponent()
+            } catch {
+                return
+            }
+        }
     }
 }

--- a/Sources/Dahlia/DahliaApp.swift
+++ b/Sources/Dahlia/DahliaApp.swift
@@ -113,6 +113,7 @@ struct DahliaApp: App {
         guard let db = try? AppDatabaseManager() else { return }
         appDatabase = db
         sidebarViewModel.setAppDatabase(db)
+        viewModel.configureBatchTranscription(dbQueue: db.dbQueue)
 
         let repo = MeetingRepository(dbQueue: db.dbQueue)
         if let lastVault = try? repo.fetchLastOpenedVault() {

--- a/Sources/Dahlia/Database/AppDatabaseManager.swift
+++ b/Sources/Dahlia/Database/AppDatabaseManager.swift
@@ -65,6 +65,18 @@ final class AppDatabaseManager: Sendable {
             try addSummaryDocumentColumnIfNeeded(in: db)
         }
 
+        migrator.registerMigration("v10_batchTranscription") { db in
+            try addBatchTranscriptionSchemaIfNeeded(in: db)
+        }
+
+        migrator.registerMigration("v11_batchAudioStorageLocation") { db in
+            try addBatchAudioStorageLocationIfNeeded(in: db)
+        }
+
+        migrator.registerMigration("v12_batchTranscriptionDiscard") { db in
+            try addBatchDiscardedAtColumnIfNeeded(in: db)
+        }
+
         return migrator
     }()
 
@@ -352,6 +364,111 @@ final class AppDatabaseManager: Sendable {
 
     private static func addSummaryDocumentColumnIfNeeded(in db: Database) throws {
         try addColumnIfNeeded(in: db, table: "summaries", column: "document", type: .text)
+    }
+
+    private static func addBatchTranscriptionSchemaIfNeeded(in db: Database) throws {
+        guard try db.tableExists("recording_sessions") else { return }
+
+        let columns = try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('recording_sessions')")
+        let requiredColumns = [
+            "transcriptionMode",
+            "retainAudioAfterBatch",
+            "batchCompletedAt",
+            "batchLastError",
+            "batchLastAttemptAt",
+            "batchAttemptCount",
+        ]
+        if requiredColumns.contains(where: { !columns.contains($0) }) {
+            try db.alter(table: "recording_sessions") { table in
+                if !columns.contains("transcriptionMode") {
+                    table.add(column: "transcriptionMode", .text)
+                        .notNull()
+                        .defaults(to: TranscriptionMode.realtime.rawValue)
+                }
+                if !columns.contains("retainAudioAfterBatch") {
+                    table.add(column: "retainAudioAfterBatch", .boolean)
+                        .notNull()
+                        .defaults(to: false)
+                }
+                if !columns.contains("batchCompletedAt") {
+                    table.add(column: "batchCompletedAt", .datetime)
+                }
+                if !columns.contains("batchLastError") {
+                    table.add(column: "batchLastError", .text)
+                }
+                if !columns.contains("batchLastAttemptAt") {
+                    table.add(column: "batchLastAttemptAt", .datetime)
+                }
+                if !columns.contains("batchAttemptCount") {
+                    table.add(column: "batchAttemptCount", .integer)
+                        .notNull()
+                        .defaults(to: 0)
+                }
+            }
+        }
+
+        if try !db.tableExists("recording_audio_files") {
+            try db.create(table: "recording_audio_files") { table in
+                table.primaryKey("id", .blob)
+                table.column("recordingSessionId", .blob).notNull()
+                    .references("recording_sessions", onDelete: .cascade)
+                table.column("source", .text).notNull()
+                table.column("relativePath", .text).notNull()
+                table.column("sampleRate", .double).notNull()
+                table.column("channelCount", .integer).notNull()
+                table.column("finalizedAt", .datetime)
+                table.column("totalFrameCount", .integer)
+                table.column("createdAt", .datetime).notNull()
+                table.column("updatedAt", .datetime).notNull()
+                table.uniqueKey(["recordingSessionId", "source"])
+            }
+            try db.create(
+                index: "recording_audio_files_on_recordingSessionId",
+                on: "recording_audio_files",
+                columns: ["recordingSessionId"]
+            )
+        }
+
+        if try !db.tableExists("recording_audio_ranges") {
+            try db.create(table: "recording_audio_ranges") { table in
+                table.primaryKey("id", .blob)
+                table.column("audioFileId", .blob).notNull()
+                    .references("recording_audio_files", onDelete: .cascade)
+                table.column("startFrame", .integer).notNull()
+                table.column("frameCount", .integer)
+                table.column("sessionOffsetSeconds", .double).notNull()
+                table.column("localeIdentifier", .text).notNull()
+                table.column("createdAt", .datetime).notNull()
+                table.column("updatedAt", .datetime).notNull()
+            }
+            try db.create(
+                index: "recording_audio_ranges_on_audioFileId_startFrame",
+                on: "recording_audio_ranges",
+                columns: ["audioFileId", "startFrame"]
+            )
+        }
+    }
+
+    private static func addBatchAudioStorageLocationIfNeeded(in db: Database) throws {
+        guard try db.tableExists("recording_audio_files") else { return }
+        let columns = try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('recording_audio_files')")
+        guard !columns.contains("storageLocation") else { return }
+
+        // v10までのCAFはVaultへ直接保存していたため、既存行はvaultとして扱う。
+        try db.alter(table: "recording_audio_files") { table in
+            table.add(column: "storageLocation", .text)
+                .notNull()
+                .defaults(to: RecordingAudioStorageLocation.vault.rawValue)
+        }
+    }
+
+    private static func addBatchDiscardedAtColumnIfNeeded(in db: Database) throws {
+        try addColumnIfNeeded(
+            in: db,
+            table: "recording_sessions",
+            column: "batchDiscardedAt",
+            type: .datetime
+        )
     }
 
     private static func createRecordingSessionsTableIfNeeded(in db: Database) throws {

--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -62,9 +62,11 @@ final class MeetingRepository {
 
     /// 保管庫を登録解除する（関連プロジェクト・ミーティングもカスケード削除）。
     func deleteVault(id: UUID) throws {
+        let audioTargets = try BatchAudioCleanupService.deletionTargets(vaultId: id, dbQueue: dbQueue)
         try dbQueue.write { db in
             _ = try VaultRecord.deleteOne(db, key: id)
         }
+        BatchAudioCleanupService.deleteFiles(audioTargets)
     }
 
     /// 保管庫の最終オープン日時を更新する。
@@ -276,17 +278,34 @@ final class MeetingRepository {
     }
 
     func deleteMeeting(id: UUID) throws {
+        let audioTargets = try BatchAudioCleanupService.deletionTargets(meetingIds: [id], dbQueue: dbQueue)
         try dbQueue.write { db in
             _ = try MeetingRecord.deleteOne(db, key: id)
         }
+        BatchAudioCleanupService.deleteFiles(audioTargets)
+    }
+
+    /// 復旧不能なバッチ録音を明示的に破棄し、要約生成のブロック対象から外す。
+    @discardableResult
+    func discardFailedBatchSession(
+        id: UUID,
+        managedRootURL: URL = BatchAudioStorage.managedRootURL
+    ) throws -> Bool {
+        try BatchTranscriptionDiscardService.discardFailedSession(
+            id: id,
+            dbQueue: dbQueue,
+            managedRootURL: managedRootURL
+        )
     }
 
     /// 複数のミーティングを一括削除する。
     func deleteMeetings(ids: Set<UUID>) throws {
         guard !ids.isEmpty else { return }
+        let audioTargets = try BatchAudioCleanupService.deletionTargets(meetingIds: ids, dbQueue: dbQueue)
         try dbQueue.write { db in
             _ = try MeetingRecord.filter(ids.contains(Column("id"))).deleteAll(db)
         }
+        BatchAudioCleanupService.deleteFiles(audioTargets)
     }
 
     func moveMeeting(id: UUID, toProjectId: UUID?) throws {

--- a/Sources/Dahlia/Database/RecordingAudioFileRecord.swift
+++ b/Sources/Dahlia/Database/RecordingAudioFileRecord.swift
@@ -1,0 +1,19 @@
+import Foundation
+import GRDB
+
+/// バッチ文字起こし用CAFファイルの永続メタデータ。
+struct RecordingAudioFileRecord: Codable, FetchableRecord, PersistableRecord, Equatable {
+    static let databaseTableName = "recording_audio_files"
+
+    var id: UUID
+    var recordingSessionId: UUID
+    var source: RecordingAudioSource
+    var storageLocation: RecordingAudioStorageLocation = .managed
+    var relativePath: String
+    var sampleRate: Double
+    var channelCount: Int
+    var finalizedAt: Date?
+    var totalFrameCount: Int64?
+    var createdAt: Date
+    var updatedAt: Date
+}

--- a/Sources/Dahlia/Database/RecordingAudioRangeRecord.swift
+++ b/Sources/Dahlia/Database/RecordingAudioRangeRecord.swift
@@ -1,0 +1,16 @@
+import Foundation
+import GRDB
+
+/// 単一CAF内の音声区間と録音セッション時刻・ロケールの対応。
+struct RecordingAudioRangeRecord: Codable, FetchableRecord, PersistableRecord, Equatable {
+    static let databaseTableName = "recording_audio_ranges"
+
+    var id: UUID
+    var audioFileId: UUID
+    var startFrame: Int64
+    var frameCount: Int64?
+    var sessionOffsetSeconds: TimeInterval
+    var localeIdentifier: String
+    var createdAt: Date
+    var updatedAt: Date
+}

--- a/Sources/Dahlia/Database/RecordingSessionRecord.swift
+++ b/Sources/Dahlia/Database/RecordingSessionRecord.swift
@@ -13,4 +13,11 @@ struct RecordingSessionRecord: Codable, FetchableRecord, PersistableRecord, Equa
     var offsetSeconds: TimeInterval
     var createdAt: Date
     var updatedAt: Date
+    var transcriptionMode: TranscriptionMode = .realtime
+    var retainAudioAfterBatch = false
+    var batchCompletedAt: Date?
+    var batchLastError: String?
+    var batchLastAttemptAt: Date?
+    var batchAttemptCount = 0
+    var batchDiscardedAt: Date?
 }

--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -110,6 +110,8 @@ final class AppSettings: ObservableObject {
     // MARK: - 音声認識設定
 
     @AppStorage("transcriptionLocale") var transcriptionLocale: String = Locale.current.identifier
+    @AppStorage(TranscriptionMode.userDefaultsKey) var transcriptionModeRawValue = TranscriptionMode.realtime.rawValue
+    @AppStorage("retainAudioAfterBatchTranscription") var retainAudioAfterBatchTranscription = false
     @AppStorage("transcriptTranslationEnabled") var transcriptTranslationEnabled = true
     @AppStorage("transcriptTranslationTargetLanguage") var transcriptTranslationTargetLanguage = TranscriptTranslationLanguage.defaultIdentifier
     @AppStorage("liveSubtitleOverlayEnabled") var liveSubtitleOverlayEnabled = false
@@ -120,6 +122,11 @@ final class AppSettings: ObservableObject {
         AppSettings.defaultAutomaticScreenshotIntervalSeconds
     @AppStorage(AppSettings.automaticScreenshotChangeThresholdPercentUserDefaultsKey) private var storedAutomaticScreenshotChangeThresholdPercent =
         AppSettings.defaultAutomaticScreenshotChangeThresholdPercent
+
+    var transcriptionMode: TranscriptionMode {
+        get { TranscriptionMode(rawValue: transcriptionModeRawValue) ?? .realtime }
+        set { transcriptionModeRawValue = newValue.rawValue }
+    }
 
     var automaticScreenshotIntervalSeconds: Int {
         get {

--- a/Sources/Dahlia/Models/BatchTranscriptionState.swift
+++ b/Sources/Dahlia/Models/BatchTranscriptionState.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// バッチ処理の表示状態。DBの事実と実行中Coordinatorから都度導出する。
+enum BatchTranscriptionState: Equatable {
+    case recording(sessionId: UUID)
+    case queued(sessionId: UUID)
+    case running(sessionId: UUID)
+    case completed(sessionId: UUID)
+    case failed(sessionId: UUID, message: String)
+
+    var sessionId: UUID {
+        switch self {
+        case let .recording(sessionId),
+             let .queued(sessionId),
+             let .running(sessionId),
+             let .completed(sessionId),
+             let .failed(sessionId, _):
+            sessionId
+        }
+    }
+
+    var blocksSummaryGeneration: Bool {
+        switch self {
+        case .recording, .queued, .running, .failed:
+            true
+        case .completed:
+            false
+        }
+    }
+
+    static func derive(from session: RecordingSessionRecord, isRunning: Bool = false) -> Self? {
+        guard session.transcriptionMode == .batch,
+              session.batchDiscardedAt == nil else { return nil }
+        if session.batchCompletedAt != nil {
+            return .completed(sessionId: session.id)
+        }
+        if isRunning {
+            return .running(sessionId: session.id)
+        }
+        if let error = session.batchLastError?.nilIfBlank {
+            return .failed(sessionId: session.id, message: error)
+        }
+        if session.endedAt == nil {
+            return .recording(sessionId: session.id)
+        }
+        return .queued(sessionId: session.id)
+    }
+}

--- a/Sources/Dahlia/Models/BatchTranscriptionUpdate.swift
+++ b/Sources/Dahlia/Models/BatchTranscriptionUpdate.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct BatchTranscriptionUpdate {
+    let meetingId: UUID
+    let state: BatchTranscriptionState
+}

--- a/Sources/Dahlia/Models/RecordingAudioSource.swift
+++ b/Sources/Dahlia/Models/RecordingAudioSource.swift
@@ -1,0 +1,16 @@
+import Foundation
+import GRDB
+
+enum RecordingAudioSource: String, Codable, DatabaseValueConvertible {
+    case microphone
+    case system
+
+    var speakerLabel: String {
+        switch self {
+        case .microphone: "mic"
+        case .system: "system"
+        }
+    }
+
+    var fileName: String { "\(rawValue).caf" }
+}

--- a/Sources/Dahlia/Models/RecordingAudioStorageLocation.swift
+++ b/Sources/Dahlia/Models/RecordingAudioStorageLocation.swift
@@ -1,0 +1,8 @@
+import Foundation
+import GRDB
+
+/// CAFがアプリ管理領域とVaultのどちらにあるかを表す。
+enum RecordingAudioStorageLocation: String, Codable, CaseIterable, DatabaseValueConvertible {
+    case managed
+    case vault
+}

--- a/Sources/Dahlia/Models/TranscriptionMode.swift
+++ b/Sources/Dahlia/Models/TranscriptionMode.swift
@@ -1,0 +1,30 @@
+import Foundation
+import GRDB
+
+/// 録音セッションで使用する文字起こし方式。
+enum TranscriptionMode: String, CaseIterable, Codable, DatabaseValueConvertible, Identifiable {
+    case realtime
+    case batch
+
+    nonisolated static let userDefaultsKey = "transcriptionMode"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .realtime:
+            L10n.realtimeTranscription
+        case .batch:
+            L10n.batchTranscription
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .realtime:
+            L10n.realtimeTranscriptionDescription
+        case .batch:
+            L10n.batchTranscriptionDescription
+        }
+    }
+}

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -408,3 +408,28 @@
 "Change Folder" = "Change Folder";
 "Select This Folder" = "Select This Folder";
 "The summary was saved locally, but uploading to Google Drive failed." = "The summary was saved locally, but uploading to Google Drive failed.";
+
+/* Batch Transcription */
+"Transcription Method" = "Transcription Method";
+"Real-time" = "Real-time";
+"After Recording" = "After Recording";
+"Show the transcript while recording. Audio files are not saved." = "Show the transcript while recording. Audio files are not saved.";
+"Record audio first, then create a higher-accuracy transcript after recording stops." = "Record audio first, then create a higher-accuracy transcript after recording stops.";
+"Keep Audio After Transcription" = "Keep Audio After Transcription";
+"Keep the CAF audio files in the vault after batch transcription succeeds." = "Keep the CAF audio files in the vault after batch transcription succeeds.";
+"No transcript yet." = "No transcript yet.";
+"Recording audio for transcription after recording stops…" = "Recording audio for transcription after recording stops…";
+"Waiting to transcribe the recording…" = "Waiting to transcribe the recording…";
+"Creating a high-accuracy transcript…" = "Creating a high-accuracy transcript…";
+"High-accuracy transcription completed." = "High-accuracy transcription completed.";
+"Batch transcription failed: %@" = "Batch transcription failed: %@";
+"Retry Batch Transcription" = "Retry Batch Transcription";
+"Discard Failed Recording" = "Discard Failed Recording";
+"Discard this failed recording?" = "Discard this failed recording?";
+"The untranscribed audio will be deleted. Existing transcript content will be kept." = "The untranscribed audio will be deleted. Existing transcript content will be kept.";
+"Cancel" = "Cancel";
+"The recorded audio format is invalid." = "The recorded audio format is invalid.";
+"Could not save the recording: %@" = "Could not save the recording: %@";
+"No compatible audio format is available." = "No compatible audio format is available.";
+"The recorded audio range is invalid or damaged." = "The recorded audio range is invalid or damaged.";
+"Speech analysis could not read the recorded audio." = "Speech analysis could not read the recorded audio.";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -408,3 +408,28 @@
 "Change Folder" = "フォルダを変更";
 "Select This Folder" = "このフォルダを選択";
 "The summary was saved locally, but uploading to Google Drive failed." = "要約はローカルに保存されましたが、Google Drive へのアップロードに失敗しました。";
+
+/* Batch Transcription */
+"Transcription Method" = "文字起こし方式";
+"Real-time" = "リアルタイム";
+"After Recording" = "録音後に処理";
+"Show the transcript while recording. Audio files are not saved." = "録音中に文字起こしを表示します。音声ファイルは保存しません。";
+"Record audio first, then create a higher-accuracy transcript after recording stops." = "先に音声を録音し、録音終了後に高精度な文字起こしを作成します。";
+"Keep Audio After Transcription" = "文字起こし後も音声を残す";
+"Keep the CAF audio files in the vault after batch transcription succeeds." = "バッチ文字起こし成功後もCAF音声ファイルを保管庫に残します。";
+"No transcript yet." = "文字起こしはまだありません。";
+"Recording audio for transcription after recording stops…" = "録音終了後の文字起こし用に音声を保存しています…";
+"Waiting to transcribe the recording…" = "録音の文字起こしを待機しています…";
+"Creating a high-accuracy transcript…" = "高精度な文字起こしを作成しています…";
+"High-accuracy transcription completed." = "高精度な文字起こしが完了しました。";
+"Batch transcription failed: %@" = "バッチ文字起こしに失敗しました: %@";
+"Retry Batch Transcription" = "バッチ文字起こしを再試行";
+"Discard Failed Recording" = "失敗した録音を破棄";
+"Discard this failed recording?" = "失敗した録音を破棄しますか？";
+"The untranscribed audio will be deleted. Existing transcript content will be kept." = "文字起こしできなかった音声を削除します。既存の文字起こし内容は保持されます。";
+"Cancel" = "キャンセル";
+"The recorded audio format is invalid." = "録音音声の形式が不正です。";
+"Could not save the recording: %@" = "録音を保存できませんでした: %@";
+"No compatible audio format is available." = "互換性のある音声形式を利用できません。";
+"The recorded audio range is invalid or damaged." = "録音音声の範囲が不正または破損しています。";
+"Speech analysis could not read the recorded audio." = "音声解析で録音データを読み取れませんでした。";

--- a/Sources/Dahlia/Services/BatchAudioCleanupService.swift
+++ b/Sources/Dahlia/Services/BatchAudioCleanupService.swift
@@ -1,0 +1,104 @@
+import Foundation
+import GRDB
+
+/// DB削除前に一時CAFの場所を確保し、DBコミット後に対象ファイルだけを削除する。
+enum BatchAudioCleanupService {
+    struct DeletionTarget {
+        let baseURL: URL
+        let relativePath: String
+    }
+
+    static func deletionTargets(
+        meetingIds: Set<UUID>,
+        dbQueue: DatabaseQueue
+    ) throws -> [DeletionTarget] {
+        guard !meetingIds.isEmpty else { return [] }
+        return try dbQueue.read { db in
+            var arguments = StatementArguments(meetingIds)
+            arguments += [RecordingAudioStorageLocation.managed.rawValue]
+            let rows = try Row.fetchAll(
+                db,
+                sql: """
+                SELECT vaults.path AS vaultPath,
+                       recording_audio_files.storageLocation AS storageLocation,
+                       recording_audio_files.relativePath AS relativePath
+                FROM recording_audio_files
+                JOIN recording_sessions ON recording_sessions.id = recording_audio_files.recordingSessionId
+                JOIN meetings ON meetings.id = recording_sessions.meetingId
+                JOIN vaults ON vaults.id = meetings.vaultId
+                WHERE meetings.id IN (\(meetingIds.map { _ in "?" }.joined(separator: ",")))
+                  AND (
+                    recording_audio_files.storageLocation = ?
+                    OR recording_sessions.retainAudioAfterBatch = 0
+                  )
+                """,
+                arguments: arguments
+            )
+            return rows.compactMap { row in
+                guard let location = RecordingAudioStorageLocation(rawValue: row["storageLocation"]) else { return nil }
+                let vaultURL = URL(fileURLWithPath: row["vaultPath"])
+                return DeletionTarget(
+                    baseURL: BatchAudioStorage.baseURL(for: location, vaultURL: vaultURL),
+                    relativePath: row["relativePath"]
+                )
+            }
+        }
+    }
+
+    static func deletionTargets(
+        vaultId: UUID,
+        dbQueue: DatabaseQueue
+    ) throws -> [DeletionTarget] {
+        let meetingIds = try dbQueue.read { db in
+            try UUID.fetchAll(
+                db,
+                sql: "SELECT id FROM meetings WHERE vaultId = ?",
+                arguments: [vaultId]
+            )
+        }
+        return try deletionTargets(meetingIds: Set(meetingIds), dbQueue: dbQueue)
+    }
+
+    static func deletionTargets(
+        recordingSessionId: UUID,
+        dbQueue: DatabaseQueue,
+        managedRootURL: URL = BatchAudioStorage.managedRootURL
+    ) throws -> [DeletionTarget] {
+        try dbQueue.read { db in
+            let rows = try Row.fetchAll(
+                db,
+                sql: """
+                SELECT vaults.path AS vaultPath,
+                       recording_audio_files.storageLocation AS storageLocation,
+                       recording_audio_files.relativePath AS relativePath
+                FROM recording_audio_files
+                JOIN recording_sessions ON recording_sessions.id = recording_audio_files.recordingSessionId
+                JOIN meetings ON meetings.id = recording_sessions.meetingId
+                JOIN vaults ON vaults.id = meetings.vaultId
+                WHERE recording_sessions.id = ?
+                """,
+                arguments: [recordingSessionId]
+            )
+            return rows.compactMap { row in
+                guard let location = RecordingAudioStorageLocation(rawValue: row["storageLocation"]) else { return nil }
+                return DeletionTarget(
+                    baseURL: BatchAudioStorage.baseURL(
+                        for: location,
+                        managedRootURL: managedRootURL,
+                        vaultURL: URL(fileURLWithPath: row["vaultPath"])
+                    ),
+                    relativePath: row["relativePath"]
+                )
+            }
+        }
+    }
+
+    static func deleteFiles(_ targets: [DeletionTarget]) {
+        for target in targets {
+            BatchAudioStorage.removeFiles(
+                baseURL: target.baseURL,
+                relativePaths: [target.relativePath]
+            )
+        }
+    }
+}

--- a/Sources/Dahlia/Services/BatchAudioCleanupService.swift
+++ b/Sources/Dahlia/Services/BatchAudioCleanupService.swift
@@ -10,12 +10,19 @@ enum BatchAudioCleanupService {
 
     static func deletionTargets(
         meetingIds: Set<UUID>,
-        dbQueue: DatabaseQueue
+        dbQueue: DatabaseQueue,
+        includeVaultAudio: Bool = true
     ) throws -> [DeletionTarget] {
         guard !meetingIds.isEmpty else { return [] }
         return try dbQueue.read { db in
             var arguments = StatementArguments(meetingIds)
-            arguments += [RecordingAudioStorageLocation.managed.rawValue]
+            let storageCondition: String
+            if includeVaultAudio {
+                storageCondition = ""
+            } else {
+                storageCondition = "AND recording_audio_files.storageLocation = ?"
+                arguments += [RecordingAudioStorageLocation.managed.rawValue]
+            }
             let rows = try Row.fetchAll(
                 db,
                 sql: """
@@ -27,10 +34,7 @@ enum BatchAudioCleanupService {
                 JOIN meetings ON meetings.id = recording_sessions.meetingId
                 JOIN vaults ON vaults.id = meetings.vaultId
                 WHERE meetings.id IN (\(meetingIds.map { _ in "?" }.joined(separator: ",")))
-                  AND (
-                    recording_audio_files.storageLocation = ?
-                    OR recording_sessions.retainAudioAfterBatch = 0
-                  )
+                \(storageCondition)
                 """,
                 arguments: arguments
             )
@@ -56,7 +60,12 @@ enum BatchAudioCleanupService {
                 arguments: [vaultId]
             )
         }
-        return try deletionTargets(meetingIds: Set(meetingIds), dbQueue: dbQueue)
+        // Vault登録解除ではユーザーが明示的に保持したVault内ファイルを削除しない。
+        return try deletionTargets(
+            meetingIds: Set(meetingIds),
+            dbQueue: dbQueue,
+            includeVaultAudio: false
+        )
     }
 
     static func deletionTargets(

--- a/Sources/Dahlia/Services/BatchAudioRetentionService.swift
+++ b/Sources/Dahlia/Services/BatchAudioRetentionService.swift
@@ -1,0 +1,150 @@
+@preconcurrency import AVFoundation
+import Foundation
+import GRDB
+
+/// 文字起こし完了後、保持対象のCAFをアプリ管理領域からVaultへ安全に移管する。
+enum BatchAudioRetentionService {
+    private struct Job {
+        let session: RecordingSessionRecord
+        let meetingId: UUID
+        let vaultURL: URL
+        let files: [RecordingAudioFileRecord]
+    }
+
+    static func retainCompletedAudio(
+        sessionId: UUID,
+        dbQueue: DatabaseQueue,
+        managedRootURL: URL = BatchAudioStorage.managedRootURL
+    ) throws {
+        let job = try fetchJob(sessionId: sessionId, dbQueue: dbQueue)
+        guard job.session.retainAudioAfterBatch,
+              job.session.batchCompletedAt != nil else { return }
+
+        let retainedFiles = try job.files.map { file in
+            try prepareForRetention(file, job: job, managedRootURL: managedRootURL)
+        }
+
+        // 全ファイルのコピーが確定してから、DB上の参照先を一括でVaultへ切り替える。
+        try dbQueue.write { db in
+            for file in retainedFiles {
+                try file.update(db)
+            }
+        }
+
+        // DBコミット後に管理領域を掃除する。失敗しても起動時の再評価で再試行できる。
+        BatchAudioStorage.removeFiles(
+            baseURL: managedRootURL,
+            relativePaths: job.files.map {
+                BatchAudioStorage.managedRelativePath(
+                    meetingId: job.meetingId,
+                    sessionId: job.session.id,
+                    source: $0.source
+                )
+            }
+        )
+    }
+
+    private static func prepareForRetention(
+        _ originalFile: RecordingAudioFileRecord,
+        job: Job,
+        managedRootURL: URL
+    ) throws -> RecordingAudioFileRecord {
+        let vaultRelativePath = BatchAudioStorage.vaultRelativePath(
+            meetingId: job.meetingId,
+            sessionId: job.session.id,
+            source: originalFile.source
+        )
+        let vaultURL = BatchAudioStorage.finalURL(baseURL: job.vaultURL, relativePath: vaultRelativePath)
+
+        guard originalFile.storageLocation == .managed else {
+            guard try isExpectedCAF(at: vaultURL, frameCount: originalFile.totalFrameCount) else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+            return originalFile
+        }
+
+        guard let sourceURL = BatchAudioStorage.existingURL(
+            for: originalFile,
+            managedRootURL: managedRootURL,
+            vaultURL: job.vaultURL
+        ) else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        try ensureRetainedCopy(
+            sourceURL: sourceURL,
+            destinationURL: vaultURL,
+            expectedFrameCount: originalFile.totalFrameCount
+        )
+        var retainedFile = originalFile
+        retainedFile.storageLocation = .vault
+        retainedFile.relativePath = vaultRelativePath
+        retainedFile.updatedAt = .now
+        return retainedFile
+    }
+
+    private static func ensureRetainedCopy(
+        sourceURL: URL,
+        destinationURL: URL,
+        expectedFrameCount: Int64?
+    ) throws {
+        if FileManager.default.fileExists(atPath: destinationURL.path) {
+            guard try isExpectedCAF(at: destinationURL, frameCount: expectedFrameCount) else {
+                throw CocoaError(.fileWriteFileExists)
+            }
+            return
+        }
+        guard FileManager.default.fileExists(atPath: sourceURL.path) else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+
+        try FileManager.default.createDirectory(
+            at: destinationURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let stagingURL = destinationURL
+            .deletingPathExtension()
+            .appendingPathExtension("retaining.caf")
+        if FileManager.default.fileExists(atPath: stagingURL.path) {
+            try FileManager.default.removeItem(at: stagingURL)
+        }
+        do {
+            try FileManager.default.copyItem(at: sourceURL, to: stagingURL)
+            guard try isExpectedCAF(at: stagingURL, frameCount: expectedFrameCount) else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+            try FileManager.default.moveItem(at: stagingURL, to: destinationURL)
+        } catch {
+            try? FileManager.default.removeItem(at: stagingURL)
+            throw error
+        }
+    }
+
+    private static func isExpectedCAF(at url: URL, frameCount: Int64?) throws -> Bool {
+        let audioFile = try AVAudioFile(forReading: url)
+        guard audioFile.length > 0 else { return false }
+        return frameCount.map { audioFile.length == $0 } ?? true
+    }
+
+    private static func fetchJob(sessionId: UUID, dbQueue: DatabaseQueue) throws -> Job {
+        try dbQueue.read { db in
+            guard let session = try RecordingSessionRecord.fetchOne(db, key: sessionId),
+                  let meeting = try MeetingRecord.fetchOne(db, key: session.meetingId),
+                  let vault = try VaultRecord.fetchOne(db, key: meeting.vaultId) else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            let files = try RecordingAudioFileRecord
+                .filter(Column("recordingSessionId") == sessionId)
+                .order(Column("source").asc)
+                .fetchAll(db)
+            guard !files.isEmpty else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            return Job(
+                session: session,
+                meetingId: meeting.id,
+                vaultURL: vault.url,
+                files: files
+            )
+        }
+    }
+}

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -1,0 +1,329 @@
+import Foundation
+import GRDB
+
+/// 未完了のバッチセッションを直列実行し、成功結果だけをDBへ反映する。
+actor BatchTranscriptionCoordinator {
+    typealias StateHandler = @Sendable (BatchTranscriptionUpdate) async -> Void
+
+    private struct Job {
+        let session: RecordingSessionRecord
+        let meeting: MeetingRecord
+        let vault: VaultRecord
+        let projectName: String
+        let files: [RecordingAudioFileRecord]
+        let rangesByFileId: [UUID: [RecordingAudioRangeRecord]]
+    }
+
+    private struct TranslationConfiguration {
+        let isEnabled: Bool
+        let targetLanguage: String
+    }
+
+    private let dbQueue: DatabaseQueue
+    private let managedRootURL: URL
+    private let translationService = TranscriptTranslationService()
+    private let onStateChange: StateHandler
+    private var pendingSessionIds: [UUID] = []
+    private var runningSessionId: UUID?
+    private var processorTask: Task<Void, Never>?
+
+    init(
+        dbQueue: DatabaseQueue,
+        managedRootURL: URL = BatchAudioStorage.managedRootURL,
+        onStateChange: @escaping StateHandler
+    ) {
+        self.dbQueue = dbQueue
+        self.managedRootURL = managedRootURL
+        self.onStateChange = onStateChange
+    }
+
+    func recoverAndEnqueue() async {
+        BatchTranscriptionRecoveryService.reconcileCompletedAudioFiles(
+            dbQueue: dbQueue,
+            managedRootURL: managedRootURL
+        )
+        let sessionIds = await (try? dbQueue.read { db in
+            try RecordingSessionRecord
+                .filter(Column("transcriptionMode") == TranscriptionMode.batch.rawValue)
+                .filter(Column("batchCompletedAt") == nil)
+                .filter(Column("batchDiscardedAt") == nil)
+                .order(Column("startedAt").asc)
+                .fetchAll(db)
+                .map(\.id)
+        }) ?? []
+
+        for sessionId in sessionIds {
+            do {
+                try BatchTranscriptionRecoveryService.recoverAudioMetadataIfNeeded(
+                    sessionId: sessionId,
+                    dbQueue: dbQueue,
+                    managedRootURL: managedRootURL
+                )
+                enqueue(sessionId: sessionId)
+            } catch {
+                await recordFailure(sessionId: sessionId, error: error)
+            }
+        }
+    }
+
+    func enqueue(sessionId: UUID) {
+        guard runningSessionId != sessionId, !pendingSessionIds.contains(sessionId) else { return }
+        pendingSessionIds.append(sessionId)
+        guard processorTask == nil else { return }
+        processorTask = Task { [weak self] in
+            await self?.processQueue()
+        }
+    }
+
+    func isRunning(sessionId: UUID) -> Bool {
+        runningSessionId == sessionId
+    }
+
+    func recordRecordingFailure(sessionId: UUID, error: Error) async {
+        await recordFailure(sessionId: sessionId, error: error)
+    }
+
+    private func processQueue() async {
+        while !pendingSessionIds.isEmpty {
+            let sessionId = pendingSessionIds.removeFirst()
+            runningSessionId = sessionId
+            do {
+                let meetingId = try meetingId(for: sessionId)
+                await notify(meetingId: meetingId, state: .running(sessionId: sessionId))
+                try await process(sessionId: sessionId)
+                await notify(meetingId: meetingId, state: .completed(sessionId: sessionId))
+            } catch {
+                await recordFailure(sessionId: sessionId, error: error)
+            }
+            runningSessionId = nil
+        }
+        processorTask = nil
+    }
+
+    private func process(sessionId: UUID) async throws {
+        // 手動再試行でもpartial CAFを確定し、実フレーム数へメタデータを揃えてから解析する。
+        try BatchTranscriptionRecoveryService.recoverAudioMetadataIfNeeded(
+            sessionId: sessionId,
+            dbQueue: dbQueue,
+            managedRootURL: managedRootURL
+        )
+        try await markAttemptStarted(sessionId: sessionId)
+        let job = try fetchJob(sessionId: sessionId)
+        let segments = try await transcribe(job: job)
+        let records = segments.map { TranscriptSegmentRecord(from: $0, meetingId: job.meeting.id, defaultSessionId: job.session.id) }
+        let completedAt = Date.now
+        try BatchTranscriptionPersistence.complete(
+            sessionId: job.session.id,
+            meetingId: job.meeting.id,
+            records: records,
+            completedAt: completedAt,
+            dbQueue: dbQueue
+        )
+
+        performPostProcessing(for: job)
+    }
+
+    private func performPostProcessing(for job: Job) {
+        do {
+            try exportTranscript(for: job)
+        } catch {
+            ErrorReportingService.capture(error, context: ["source": "batchTranscriptExport"])
+        }
+        guard job.session.retainAudioAfterBatch else {
+            BatchAudioStorage.removeFiles(
+                job.files,
+                managedRootURL: managedRootURL,
+                vaultURL: job.vault.url
+            )
+            return
+        }
+        do {
+            try BatchAudioRetentionService.retainCompletedAudio(
+                sessionId: job.session.id,
+                dbQueue: dbQueue,
+                managedRootURL: managedRootURL
+            )
+        } catch {
+            ErrorReportingService.capture(error, context: ["source": "batchAudioRetention"])
+        }
+    }
+
+    private func markAttemptStarted(sessionId: UUID) async throws {
+        let attemptDate = Date.now
+        try await dbQueue.write { db in
+            try db.execute(
+                sql: """
+                UPDATE recording_sessions
+                SET batchLastAttemptAt = ?, batchAttemptCount = batchAttemptCount + 1,
+                    batchLastError = NULL, updatedAt = ?
+                WHERE id = ?
+                """,
+                arguments: [attemptDate, attemptDate, sessionId]
+            )
+        }
+    }
+
+    private func transcribe(job: Job) async throws -> [TranscriptSegment] {
+        var segments: [TranscriptSegment] = []
+        let translationConfiguration = await MainActor.run {
+            TranslationConfiguration(
+                isEnabled: AppSettings.shared.transcriptTranslationEnabled,
+                targetLanguage: AppSettings.shared.transcriptTranslationTargetLanguage
+            )
+        }
+
+        for file in job.files {
+            guard let audioURL = BatchAudioStorage.existingURL(
+                for: file,
+                managedRootURL: managedRootURL,
+                vaultURL: job.vault.url
+            ) else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            for range in job.rangesByFileId[file.id] ?? [] {
+                try await segments.append(contentsOf: transcribe(
+                    range: range,
+                    file: file,
+                    audioURL: audioURL,
+                    session: job.session,
+                    translationConfiguration: translationConfiguration
+                ))
+            }
+        }
+        return segments.sorted { lhs, rhs in
+            if lhs.startTime == rhs.startTime {
+                return (lhs.speakerLabel ?? "") < (rhs.speakerLabel ?? "")
+            }
+            return lhs.startTime < rhs.startTime
+        }
+    }
+
+    private func transcribe(
+        range: RecordingAudioRangeRecord,
+        file: RecordingAudioFileRecord,
+        audioURL: URL,
+        session: RecordingSessionRecord,
+        translationConfiguration: TranslationConfiguration
+    ) async throws -> [TranscriptSegment] {
+        guard let frameCount = range.frameCount else {
+            throw BatchSpeechTranscriberError.invalidAudioRange
+        }
+        var segments = try await BatchSpeechTranscriberService.transcribe(
+            BatchSpeechTranscriptionRequest(
+                audioURL: audioURL,
+                startFrame: range.startFrame,
+                frameCount: frameCount,
+                locale: Locale(identifier: range.localeIdentifier),
+                source: file.source,
+                recordingSessionId: session.id,
+                recordingStartTime: session.startedAt,
+                sessionOffsetSeconds: range.sessionOffsetSeconds
+            )
+        )
+        guard translationConfiguration.isEnabled,
+              TranscriptTranslationLanguage.shouldTranslate(
+                  transcriptionLocaleIdentifier: range.localeIdentifier,
+                  targetLanguageIdentifier: translationConfiguration.targetLanguage
+              ) else { return segments }
+
+        for index in segments.indices {
+            segments[index].translatedText = await translationService.translate(
+                segments[index].text,
+                from: range.localeIdentifier,
+                to: translationConfiguration.targetLanguage
+            )
+        }
+        return segments
+    }
+
+    private func fetchJob(sessionId: UUID) throws -> Job {
+        try dbQueue.read { db in
+            guard let session = try RecordingSessionRecord.fetchOne(db, key: sessionId),
+                  let meeting = try MeetingRecord.fetchOne(db, key: session.meetingId),
+                  let vault = try VaultRecord.fetchOne(db, key: meeting.vaultId) else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            let projectName: String = if let projectId = meeting.projectId,
+                                         let project = try ProjectRecord.fetchOne(db, key: projectId) {
+                project.name
+            } else {
+                ""
+            }
+            let files = try RecordingAudioFileRecord
+                .filter(Column("recordingSessionId") == sessionId)
+                .order(Column("source").asc)
+                .fetchAll(db)
+            guard !files.isEmpty else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            var rangesByFileId: [UUID: [RecordingAudioRangeRecord]] = [:]
+            for file in files {
+                rangesByFileId[file.id] = try RecordingAudioRangeRecord
+                    .filter(Column("audioFileId") == file.id)
+                    .order(Column("startFrame").asc)
+                    .fetchAll(db)
+            }
+            return Job(
+                session: session,
+                meeting: meeting,
+                vault: vault,
+                projectName: projectName,
+                files: files,
+                rangesByFileId: rangesByFileId
+            )
+        }
+    }
+
+    private func exportTranscript(for job: Job) throws {
+        let detail = try dbQueue.read { db in
+            let segments = try TranscriptSegmentRecord
+                .filter(Column("meetingId") == job.meeting.id)
+                .order(Column("startTime").asc)
+                .fetchAll(db)
+            let sessions = try RecordingSessionRecord
+                .filter(Column("meetingId") == job.meeting.id)
+                .order(Column("offsetSeconds").asc, Column("startedAt").asc)
+                .fetchAll(db)
+            return (segments, sessions)
+        }
+        _ = try TranscriptExportService.exportTranscript(
+            vaultURL: job.vault.url,
+            meetingId: job.meeting.id,
+            projectName: job.projectName,
+            createdAt: job.meeting.createdAt,
+            segments: detail.0.map(TranscriptSegment.init(from:)),
+            recordingSessions: detail.1.map(RecordingSessionTimeline.init)
+        )
+    }
+
+    private func meetingId(for sessionId: UUID) throws -> UUID {
+        try dbQueue.read { db in
+            guard let meetingId = try UUID.fetchOne(
+                db,
+                sql: "SELECT meetingId FROM recording_sessions WHERE id = ?",
+                arguments: [sessionId]
+            ) else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            return meetingId
+        }
+    }
+
+    private func recordFailure(sessionId: UUID, error: Error) async {
+        let message = error.localizedDescription
+        try? await dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE recording_sessions SET batchLastError = ?, updatedAt = ? WHERE id = ?",
+                arguments: [message, Date.now, sessionId]
+            )
+        }
+        if let meetingId = try? meetingId(for: sessionId) {
+            await notify(meetingId: meetingId, state: .failed(sessionId: sessionId, message: message))
+        }
+        ErrorReportingService.capture(error, context: ["source": "batchTranscription"])
+    }
+
+    private func notify(meetingId: UUID, state: BatchTranscriptionState) async {
+        await onStateChange(BatchTranscriptionUpdate(meetingId: meetingId, state: state))
+    }
+}

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -5,6 +5,8 @@ import GRDB
 actor BatchTranscriptionCoordinator {
     typealias StateHandler = @Sendable (BatchTranscriptionUpdate) async -> Void
 
+    static let maximumAutomaticAttemptCount = 3
+
     private struct Job {
         let session: RecordingSessionRecord
         let meeting: MeetingRecord
@@ -49,21 +51,21 @@ actor BatchTranscriptionCoordinator {
                 .filter(Column("batchDiscardedAt") == nil)
                 .order(Column("startedAt").asc)
                 .fetchAll(db)
+                .filter(Self.shouldAutomaticallyRetry)
                 .map(\.id)
         }) ?? []
 
         for sessionId in sessionIds {
-            do {
-                try BatchTranscriptionRecoveryService.recoverAudioMetadataIfNeeded(
-                    sessionId: sessionId,
-                    dbQueue: dbQueue,
-                    managedRootURL: managedRootURL
-                )
-                enqueue(sessionId: sessionId)
-            } catch {
-                await recordFailure(sessionId: sessionId, error: error)
-            }
+            enqueue(sessionId: sessionId)
         }
+    }
+
+    static func shouldAutomaticallyRetry(_ session: RecordingSessionRecord) -> Bool {
+        guard session.transcriptionMode == .batch,
+              session.batchCompletedAt == nil,
+              session.batchDiscardedAt == nil else { return false }
+        guard session.batchLastError?.nilIfBlank != nil else { return true }
+        return session.batchAttemptCount < maximumAutomaticAttemptCount
     }
 
     func enqueue(sessionId: UUID) {
@@ -101,13 +103,13 @@ actor BatchTranscriptionCoordinator {
     }
 
     private func process(sessionId: UUID) async throws {
+        try await markAttemptStarted(sessionId: sessionId)
         // 手動再試行でもpartial CAFを確定し、実フレーム数へメタデータを揃えてから解析する。
         try BatchTranscriptionRecoveryService.recoverAudioMetadataIfNeeded(
             sessionId: sessionId,
             dbQueue: dbQueue,
             managedRootURL: managedRootURL
         )
-        try await markAttemptStarted(sessionId: sessionId)
         let job = try fetchJob(sessionId: sessionId)
         let segments = try await transcribe(job: job)
         let records = segments.map { TranscriptSegmentRecord(from: $0, meetingId: job.meeting.id, defaultSessionId: job.session.id) }

--- a/Sources/Dahlia/Services/BatchTranscriptionDiscardService.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionDiscardService.swift
@@ -1,0 +1,43 @@
+import Foundation
+import GRDB
+
+/// 復旧不能なバッチ録音を破棄し、文字起こし待ちの対象から外す。
+enum BatchTranscriptionDiscardService {
+    static func discardFailedSession(
+        id: UUID,
+        dbQueue: DatabaseQueue,
+        managedRootURL: URL = BatchAudioStorage.managedRootURL
+    ) throws -> Bool {
+        let audioTargets = try BatchAudioCleanupService.deletionTargets(
+            recordingSessionId: id,
+            dbQueue: dbQueue,
+            managedRootURL: managedRootURL
+        )
+        let discarded = try dbQueue.write { db in
+            guard var session = try RecordingSessionRecord.fetchOne(db, key: id),
+                  session.transcriptionMode == .batch,
+                  session.batchCompletedAt == nil,
+                  session.batchDiscardedAt == nil,
+                  session.batchLastError?.nilIfBlank != nil else { return false }
+
+            let now = Date.now
+            session.batchDiscardedAt = now
+            session.batchLastError = nil
+            session.updatedAt = now
+            try session.update(db)
+
+            // 失敗時は通常セグメントが存在しないが、旧版等の部分結果も残さない。
+            _ = try TranscriptSegmentRecord
+                .filter(Column("sessionId") == id)
+                .deleteAll(db)
+            _ = try RecordingAudioFileRecord
+                .filter(Column("recordingSessionId") == id)
+                .deleteAll(db)
+            return true
+        }
+        if discarded {
+            BatchAudioCleanupService.deleteFiles(audioTargets)
+        }
+        return discarded
+    }
+}

--- a/Sources/Dahlia/Services/BatchTranscriptionPersistence.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionPersistence.swift
@@ -1,0 +1,38 @@
+import Foundation
+import GRDB
+
+/// バッチ結果一式と完了事実を同じSQLiteトランザクションで確定する。
+enum BatchTranscriptionPersistence {
+    static func complete(
+        sessionId: UUID,
+        meetingId: UUID,
+        records: [TranscriptSegmentRecord],
+        completedAt: Date,
+        dbQueue: DatabaseQueue
+    ) throws {
+        try dbQueue.write { db in
+            guard try RecordingSessionRecord.fetchOne(db, key: sessionId) != nil,
+                  try MeetingRecord.fetchOne(db, key: meetingId) != nil else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            _ = try TranscriptSegmentRecord
+                .filter(Column("sessionId") == sessionId)
+                .deleteAll(db)
+            for record in records {
+                try record.insert(db)
+            }
+            try db.execute(
+                sql: """
+                UPDATE recording_sessions
+                SET batchCompletedAt = ?, batchLastError = NULL, updatedAt = ?
+                WHERE id = ?
+                """,
+                arguments: [completedAt, completedAt, sessionId]
+            )
+            try db.execute(
+                sql: "UPDATE meetings SET status = ?, updatedAt = ? WHERE id = ?",
+                arguments: [MeetingStatus.ready.rawValue, completedAt, meetingId]
+            )
+        }
+    }
+}

--- a/Sources/Dahlia/Services/BatchTranscriptionRecoveryService.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionRecoveryService.swift
@@ -1,0 +1,201 @@
+@preconcurrency import AVFoundation
+import Foundation
+import GRDB
+
+/// クラッシュ後のpartial CAF確定と、完了後に残った音声の移管・掃除を行う。
+enum BatchTranscriptionRecoveryService {
+    private struct RecoveryJob {
+        let session: RecordingSessionRecord
+        let vaultURL: URL
+        let files: [RecordingAudioFileRecord]
+        let rangesByFileId: [UUID: [RecordingAudioRangeRecord]]
+    }
+
+    private struct CompletedAudioJob {
+        let session: RecordingSessionRecord
+        let vaultURL: URL
+        let files: [RecordingAudioFileRecord]
+    }
+
+    static func recoverAudioMetadataIfNeeded(
+        sessionId: UUID,
+        dbQueue: DatabaseQueue,
+        managedRootURL: URL = BatchAudioStorage.managedRootURL
+    ) throws {
+        let job = try fetchJob(sessionId: sessionId, dbQueue: dbQueue)
+        var maximumDuration: TimeInterval = 0
+        for file in job.files {
+            let duration = try recoverAudioFileMetadata(
+                file: file,
+                ranges: job.rangesByFileId[file.id] ?? [],
+                vaultURL: job.vaultURL,
+                managedRootURL: managedRootURL,
+                dbQueue: dbQueue
+            )
+            maximumDuration = max(maximumDuration, duration)
+        }
+
+        if job.session.endedAt == nil {
+            guard maximumDuration > 0 else {
+                throw BatchSpeechTranscriberError.invalidAudioRange
+            }
+            let endedAt = job.session.startedAt.addingTimeInterval(maximumDuration)
+            try dbQueue.write { db in
+                let updatedAt = Date.now
+                try db.execute(
+                    sql: """
+                    UPDATE recording_sessions
+                    SET endedAt = ?, duration = ?, updatedAt = ?
+                    WHERE id = ?
+                    """,
+                    arguments: [endedAt, maximumDuration, updatedAt, job.session.id]
+                )
+                try db.execute(
+                    sql: """
+                    UPDATE meetings
+                    SET duration = (
+                        SELECT COALESCE(SUM(duration), 0)
+                        FROM recording_sessions
+                        WHERE meetingId = ?
+                    ), updatedAt = ?
+                    WHERE id = ?
+                    """,
+                    arguments: [job.session.meetingId, updatedAt, job.session.meetingId]
+                )
+            }
+        }
+    }
+
+    private static func recoverAudioFileMetadata(
+        file originalFile: RecordingAudioFileRecord,
+        ranges originalRanges: [RecordingAudioRangeRecord],
+        vaultURL: URL,
+        managedRootURL: URL,
+        dbQueue: DatabaseQueue
+    ) throws -> TimeInterval {
+        var file = originalFile
+        guard let audioURL = BatchAudioStorage.existingURL(
+            for: file,
+            managedRootURL: managedRootURL,
+            vaultURL: vaultURL
+        ) else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        let frameLength = try AVAudioFile(forReading: audioURL).length
+        guard frameLength > 0 else {
+            throw BatchSpeechTranscriberError.invalidAudioRange
+        }
+
+        if audioURL.lastPathComponent.hasSuffix(".partial.caf") {
+            let finalURL = BatchAudioStorage.finalURL(
+                for: file,
+                managedRootURL: managedRootURL,
+                vaultURL: vaultURL
+            )
+            if !FileManager.default.fileExists(atPath: finalURL.path) {
+                try FileManager.default.moveItem(at: audioURL, to: finalURL)
+            }
+        }
+
+        let now = Date.now
+        file.totalFrameCount = frameLength
+        file.finalizedAt = file.finalizedAt ?? now
+        file.updatedAt = now
+        var ranges = originalRanges
+        for index in ranges.indices where ranges[index].frameCount == nil {
+            ranges[index].frameCount = max(0, frameLength - ranges[index].startFrame)
+            ranges[index].updatedAt = now
+        }
+        try dbQueue.write { db in
+            try file.update(db)
+            for range in ranges {
+                try range.update(db)
+            }
+        }
+        return ranges.reduce(0) { maximumDuration, range in
+            let duration = Double(range.frameCount ?? 0) / file.sampleRate
+            return max(maximumDuration, range.sessionOffsetSeconds + duration)
+        }
+    }
+
+    static func reconcileCompletedAudioFiles(
+        dbQueue: DatabaseQueue,
+        managedRootURL: URL = BatchAudioStorage.managedRootURL
+    ) {
+        let jobs: [CompletedAudioJob]
+        do {
+            jobs = try fetchCompletedAudioJobs(dbQueue: dbQueue)
+        } catch {
+            ErrorReportingService.capture(error, context: ["source": "batchAudioRecovery"])
+            return
+        }
+
+        for job in jobs {
+            guard job.session.retainAudioAfterBatch else {
+                BatchAudioStorage.removeFiles(
+                    job.files,
+                    managedRootURL: managedRootURL,
+                    vaultURL: job.vaultURL
+                )
+                continue
+            }
+            do {
+                try BatchAudioRetentionService.retainCompletedAudio(
+                    sessionId: job.session.id,
+                    dbQueue: dbQueue,
+                    managedRootURL: managedRootURL
+                )
+            } catch {
+                ErrorReportingService.capture(error, context: ["source": "batchAudioRetentionRecovery"])
+            }
+        }
+    }
+
+    private static func fetchCompletedAudioJobs(dbQueue: DatabaseQueue) throws -> [CompletedAudioJob] {
+        try dbQueue.read { db in
+            let sessions = try RecordingSessionRecord
+                .filter(Column("transcriptionMode") == TranscriptionMode.batch.rawValue)
+                .filter(Column("batchCompletedAt") != nil)
+                .fetchAll(db)
+            return try sessions.map { session in
+                guard let meeting = try MeetingRecord.fetchOne(db, key: session.meetingId),
+                      let vault = try VaultRecord.fetchOne(db, key: meeting.vaultId) else {
+                    throw CocoaError(.fileNoSuchFile)
+                }
+                let files = try RecordingAudioFileRecord
+                    .filter(Column("recordingSessionId") == session.id)
+                    .fetchAll(db)
+                return CompletedAudioJob(session: session, vaultURL: vault.url, files: files)
+            }
+        }
+    }
+
+    private static func fetchJob(sessionId: UUID, dbQueue: DatabaseQueue) throws -> RecoveryJob {
+        try dbQueue.read { db in
+            guard let session = try RecordingSessionRecord.fetchOne(db, key: sessionId),
+                  let meeting = try MeetingRecord.fetchOne(db, key: session.meetingId),
+                  let vault = try VaultRecord.fetchOne(db, key: meeting.vaultId) else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            let files = try RecordingAudioFileRecord
+                .filter(Column("recordingSessionId") == sessionId)
+                .fetchAll(db)
+            guard !files.isEmpty else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            var rangesByFileId: [UUID: [RecordingAudioRangeRecord]] = [:]
+            for file in files {
+                rangesByFileId[file.id] = try RecordingAudioRangeRecord
+                    .filter(Column("audioFileId") == file.id)
+                    .order(Column("startFrame").asc)
+                    .fetchAll(db)
+            }
+            return RecoveryJob(
+                session: session,
+                vaultURL: vault.url,
+                files: files,
+                rangesByFileId: rangesByFileId
+            )
+        }
+    }
+}

--- a/Sources/Dahlia/Services/MeetingPersistenceService.swift
+++ b/Sources/Dahlia/Services/MeetingPersistenceService.swift
@@ -13,9 +13,14 @@ final class MeetingPersistenceService {
     private var persistedSegmentIds: Set<UUID> = []
     private var persistedSegmentTranslations: [UUID: String?] = [:]
     private var recordingSession: RecordingSessionRecord
+    private let createsMeeting: Bool
 
     var recordingSessionId: UUID {
         recordingSession.id
+    }
+
+    private var isRealtime: Bool {
+        recordingSession.transcriptionMode == .realtime
     }
 
     /// 新規ミーティングを作成して録音を開始する。
@@ -26,22 +31,23 @@ final class MeetingPersistenceService {
         projectId: UUID?,
         initialName: String,
         calendarEvent: CalendarEvent? = nil,
-        recordingSessionId: UUID = .v7()
+        recordingSessionId: UUID = .v7(),
+        transcriptionMode: TranscriptionMode = .realtime,
+        retainAudioAfterBatch: Bool = false
     ) throws {
         self.store = store
         self.dbQueue = dbQueue
         self.meetingId = .v7()
+        self.createsMeeting = true
 
         let now = store.recordingStartTime ?? Date()
-        let session = RecordingSessionRecord(
+        let session = Self.makeRecordingSession(
             id: recordingSessionId,
             meetingId: meetingId,
             startedAt: now,
-            endedAt: nil,
-            duration: nil,
             offsetSeconds: 0,
-            createdAt: now,
-            updatedAt: now
+            transcriptionMode: transcriptionMode,
+            retainAudioAfterBatch: retainAudioAfterBatch
         )
         self.recordingSession = session
         let trimmedInitialName = initialName.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -51,7 +57,7 @@ final class MeetingPersistenceService {
             vaultId: vaultId,
             projectId: projectId,
             name: trimmedInitialName,
-            status: .ready,
+            status: transcriptionMode == .realtime ? .ready : .transcriptNotFound,
             createdAt: now,
             updatedAt: now
         )
@@ -75,21 +81,22 @@ final class MeetingPersistenceService {
         existingSegmentIds: Set<UUID>,
         recordingStartDate: Date = Date(),
         recordingOffsetSeconds: TimeInterval = 0,
-        recordingSessionId: UUID = .v7()
+        recordingSessionId: UUID = .v7(),
+        transcriptionMode: TranscriptionMode = .realtime,
+        retainAudioAfterBatch: Bool = false
     ) throws {
         self.store = store
         self.dbQueue = dbQueue
         self.meetingId = existingMeetingId
+        self.createsMeeting = false
         self.persistedSegmentIds = existingSegmentIds
-        let session = RecordingSessionRecord(
+        let session = Self.makeRecordingSession(
             id: recordingSessionId,
             meetingId: existingMeetingId,
             startedAt: recordingStartDate,
-            endedAt: nil,
-            duration: nil,
             offsetSeconds: recordingOffsetSeconds,
-            createdAt: recordingStartDate,
-            updatedAt: recordingStartDate
+            transcriptionMode: transcriptionMode,
+            retainAudioAfterBatch: retainAudioAfterBatch
         )
         self.recordingSession = session
 
@@ -101,6 +108,7 @@ final class MeetingPersistenceService {
     }
 
     private func startObserving() {
+        guard isRealtime else { return }
         cancellable = store.$segments
             .debounce(for: .milliseconds(500), scheduler: RunLoop.main)
             .sink { [weak self] segments in
@@ -144,27 +152,43 @@ final class MeetingPersistenceService {
     /// 監視を停止し、最終保存とミーティング完了の記録を行う。
     func stop() {
         cancellable = nil
-        persistNewConfirmedSegments(store.segments)
+        if isRealtime {
+            persistNewConfirmedSegments(store.segments)
+        }
 
-        let now = Date()
+        let now = Date.now
         let duration = max(0, now.timeIntervalSince(recordingSession.startedAt))
         recordingSession.endedAt = now
         recordingSession.duration = duration
         recordingSession.updatedAt = now
 
-        try? dbQueue.write { db in
-            try recordingSession.update(db)
+        let persistedSession = try? dbQueue.write { db -> RecordingSessionRecord? in
+            // バッチ処理が先に記録したエラーや試行情報を、録音開始時点の値で上書きしない。
+            try db.execute(
+                sql: """
+                UPDATE recording_sessions
+                SET endedAt = ?, duration = ?, updatedAt = ?
+                WHERE id = ?
+                """,
+                arguments: [now, duration, now, recordingSession.id]
+            )
             let totalDuration = try Double.fetchOne(
                 db,
                 sql: "SELECT COALESCE(SUM(duration), 0) FROM recording_sessions WHERE meetingId = ?",
                 arguments: [meetingId]
             ) ?? duration
             if var record = try MeetingRecord.fetchOne(db, key: meetingId) {
-                record.status = .ready
+                if isRealtime {
+                    record.status = .ready
+                }
                 record.duration = totalDuration
                 record.updatedAt = now
                 try record.update(db)
             }
+            return try RecordingSessionRecord.fetchOne(db, key: recordingSession.id)
+        }
+        if let persistedSession {
+            recordingSession = persistedSession
         }
         store.upsertRecordingSession(RecordingSessionTimeline(from: recordingSession))
     }
@@ -173,5 +197,42 @@ final class MeetingPersistenceService {
     func reset() {
         persistedSegmentIds.removeAll()
         startObserving()
+    }
+
+    /// 録音開始に失敗したセッションを取り消す。
+    func cancel() {
+        cancellable = nil
+        let sessionId = recordingSession.id
+        let meetingId = meetingId
+        let createsMeeting = createsMeeting
+        try? dbQueue.write { db in
+            if createsMeeting {
+                _ = try MeetingRecord.deleteOne(db, key: meetingId)
+            } else {
+                _ = try RecordingSessionRecord.deleteOne(db, key: sessionId)
+            }
+        }
+    }
+
+    private static func makeRecordingSession(
+        id: UUID,
+        meetingId: UUID,
+        startedAt: Date,
+        offsetSeconds: TimeInterval,
+        transcriptionMode: TranscriptionMode,
+        retainAudioAfterBatch: Bool
+    ) -> RecordingSessionRecord {
+        RecordingSessionRecord(
+            id: id,
+            meetingId: meetingId,
+            startedAt: startedAt,
+            endedAt: nil,
+            duration: nil,
+            offsetSeconds: offsetSeconds,
+            createdAt: startedAt,
+            updatedAt: startedAt,
+            transcriptionMode: transcriptionMode,
+            retainAudioAfterBatch: retainAudioAfterBatch
+        )
     }
 }

--- a/Sources/Dahlia/Speech/BatchSpeechTranscriberError.swift
+++ b/Sources/Dahlia/Speech/BatchSpeechTranscriberError.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum BatchSpeechTranscriberError: LocalizedError {
+    case audioFormatUnavailable
+    case invalidAudioRange
+    case analysisDidNotAdvance
+
+    var errorDescription: String? {
+        switch self {
+        case .audioFormatUnavailable:
+            L10n.batchAudioFormatUnavailable
+        case .invalidAudioRange:
+            L10n.batchAudioRangeInvalid
+        case .analysisDidNotAdvance:
+            L10n.batchAnalysisDidNotAdvance
+        }
+    }
+}

--- a/Sources/Dahlia/Speech/BatchSpeechTranscriberService.swift
+++ b/Sources/Dahlia/Speech/BatchSpeechTranscriberService.swift
@@ -1,0 +1,123 @@
+@preconcurrency import AVFoundation
+import CoreMedia
+import Foundation
+import Speech
+
+/// CAFの指定rangeを精度優先のSpeechTranscriberで文字起こしする。
+enum BatchSpeechTranscriberService {
+    static func preferredSampleRate(locale: Locale) async throws -> Double {
+        let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
+        try await installAssetsIfNeeded(for: transcriber)
+        guard let format = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber]) else {
+            throw BatchSpeechTranscriberError.audioFormatUnavailable
+        }
+        return format.sampleRate
+    }
+
+    static func transcribe(_ request: BatchSpeechTranscriptionRequest) async throws -> [TranscriptSegment] {
+        guard request.startFrame >= 0, request.frameCount > 0 else { return [] }
+        let rangeURL = try extractRange(
+            from: request.audioURL,
+            startFrame: request.startFrame,
+            frameCount: request.frameCount
+        )
+        defer { try? FileManager.default.removeItem(at: rangeURL) }
+
+        let transcriber = SpeechTranscriber(locale: request.locale, preset: .transcription)
+        try await installAssetsIfNeeded(for: transcriber)
+        let analyzer = SpeechAnalyzer(modules: [transcriber])
+        let audioFile = try AVAudioFile(forReading: rangeURL)
+
+        let resultTask = Task<[TranscriptSegment], Error> {
+            var segments: [TranscriptSegment] = []
+            for try await result in transcriber.results where result.isFinal {
+                guard let text = SpeechTranscriberService.normalizedTranscriptText(String(result.text.characters)) else {
+                    continue
+                }
+                let startSeconds = result.range.start.seconds
+                let endSeconds = result.range.end.seconds
+                let absoluteStart = request.recordingStartTime.addingTimeInterval(
+                    request.sessionOffsetSeconds + (startSeconds.isFinite ? startSeconds : 0)
+                )
+                let absoluteEnd = request.recordingStartTime.addingTimeInterval(
+                    request.sessionOffsetSeconds + (endSeconds.isFinite ? endSeconds : 0)
+                )
+                segments.append(
+                    TranscriptSegment(
+                        sessionId: request.recordingSessionId,
+                        startTime: absoluteStart,
+                        endTime: absoluteEnd,
+                        text: text,
+                        isConfirmed: true,
+                        speakerLabel: request.source.speakerLabel
+                    )
+                )
+            }
+            return segments
+        }
+
+        do {
+            guard let lastSampleTime = try await analyzer.analyzeSequence(from: audioFile) else {
+                throw BatchSpeechTranscriberError.analysisDidNotAdvance
+            }
+            try await analyzer.finalizeAndFinish(through: lastSampleTime)
+            return try await resultTask.value
+        } catch {
+            await analyzer.cancelAndFinishNow()
+            resultTask.cancel()
+            throw error
+        }
+    }
+
+    private static func installAssetsIfNeeded(for transcriber: SpeechTranscriber) async throws {
+        let status = await AssetInventory.status(forModules: [transcriber])
+        if status < .installed,
+           let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
+            try await request.downloadAndInstall()
+        }
+    }
+
+    private static func extractRange(from sourceURL: URL, startFrame: Int64, frameCount: Int64) throws -> URL {
+        let source = try AVAudioFile(forReading: sourceURL)
+        guard startFrame < source.length else {
+            throw BatchSpeechTranscriberError.invalidAudioRange
+        }
+        let availableFrames = min(frameCount, source.length - startFrame)
+        guard availableFrames > 0 else {
+            throw BatchSpeechTranscriberError.invalidAudioRange
+        }
+
+        let destinationURL = FileManager.default.temporaryDirectory
+            .appending(path: "dahlia-batch-\(UUID.v7().uuidString).caf")
+        source.framePosition = startFrame
+
+        do {
+            let destination = try AVAudioFile(
+                forWriting: destinationURL,
+                settings: source.processingFormat.settings,
+                commonFormat: source.processingFormat.commonFormat,
+                interleaved: source.processingFormat.isInterleaved
+            )
+            let capacity: AVAudioFrameCount = 16384
+            guard let buffer = AVAudioPCMBuffer(pcmFormat: source.processingFormat, frameCapacity: capacity) else {
+                throw BatchSpeechTranscriberError.audioFormatUnavailable
+            }
+
+            var remaining = availableFrames
+            while remaining > 0 {
+                let requested = AVAudioFrameCount(min(Int64(capacity), remaining))
+                try source.read(into: buffer, frameCount: requested)
+                guard buffer.frameLength > 0 else {
+                    throw BatchSpeechTranscriberError.invalidAudioRange
+                }
+                try destination.write(from: buffer)
+                remaining -= Int64(buffer.frameLength)
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: destinationURL)
+            throw error
+        }
+
+        return destinationURL
+    }
+}

--- a/Sources/Dahlia/Speech/BatchSpeechTranscriptionRequest.swift
+++ b/Sources/Dahlia/Speech/BatchSpeechTranscriptionRequest.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct BatchSpeechTranscriptionRequest {
+    let audioURL: URL
+    let startFrame: Int64
+    let frameCount: Int64
+    let locale: Locale
+    let source: RecordingAudioSource
+    let recordingSessionId: UUID
+    let recordingStartTime: Date
+    let sessionOffsetSeconds: TimeInterval
+}

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -234,6 +234,31 @@ enum L10n {
     static var notesPlaceholder: String { String(localized: "NotesPlaceholder", bundle: bundle) }
     static var screenshots: String { String(localized: "Screenshots", bundle: bundle) }
     static var transcript: String { String(localized: "Transcript", bundle: bundle) }
+    static var transcriptEmpty: String { String(localized: "No transcript yet.", bundle: bundle) }
+    static var batchRecordingInProgress: String { String(localized: "Recording audio for transcription after recording stops…", bundle: bundle) }
+    static var batchTranscriptionQueued: String { String(localized: "Waiting to transcribe the recording…", bundle: bundle) }
+    static var batchTranscriptionRunning: String { String(localized: "Creating a high-accuracy transcript…", bundle: bundle) }
+    static var batchTranscriptionCompleted: String { String(localized: "High-accuracy transcription completed.", bundle: bundle) }
+    static func batchTranscriptionFailed(_ reason: String) -> String {
+        String(localized: "Batch transcription failed: \(reason)", bundle: bundle)
+    }
+
+    static var retryBatchTranscription: String { String(localized: "Retry Batch Transcription", bundle: bundle) }
+    static var discardFailedBatchRecording: String { String(localized: "Discard Failed Recording", bundle: bundle) }
+    static var discardFailedBatchRecordingConfirmation: String { String(localized: "Discard this failed recording?", bundle: bundle) }
+    static var discardFailedBatchRecordingDescription: String { String(
+        localized: "The untranscribed audio will be deleted. Existing transcript content will be kept.",
+        bundle: bundle
+    ) }
+    static var cancel: String { String(localized: "Cancel", bundle: bundle) }
+    static var batchAudioBufferInvalid: String { String(localized: "The recorded audio format is invalid.", bundle: bundle) }
+    static func batchAudioWriteFailed(_ reason: String) -> String {
+        String(localized: "Could not save the recording: \(reason)", bundle: bundle)
+    }
+
+    static var batchAudioFormatUnavailable: String { String(localized: "No compatible audio format is available.", bundle: bundle) }
+    static var batchAudioRangeInvalid: String { String(localized: "The recorded audio range is invalid or damaged.", bundle: bundle) }
+    static var batchAnalysisDidNotAdvance: String { String(localized: "Speech analysis could not read the recorded audio.", bundle: bundle) }
     static var assignee: String { String(localized: "Assignee", bundle: bundle) }
     static var assignToMe: String { String(localized: "Assign to me", bundle: bundle) }
     static var editAssignee: String { String(localized: "Edit assignee", bundle: bundle) }
@@ -276,6 +301,22 @@ enum L10n {
     ) }
     static var transcriptionSettingsDescription: String { String(
         localized: "Choose which languages appear when starting transcription.",
+        bundle: bundle
+    ) }
+    static var transcriptionMethod: String { String(localized: "Transcription Method", bundle: bundle) }
+    static var realtimeTranscription: String { String(localized: "Real-time", bundle: bundle) }
+    static var batchTranscription: String { String(localized: "After Recording", bundle: bundle) }
+    static var realtimeTranscriptionDescription: String { String(
+        localized: "Show the transcript while recording. Audio files are not saved.",
+        bundle: bundle
+    ) }
+    static var batchTranscriptionDescription: String { String(
+        localized: "Record audio first, then create a higher-accuracy transcript after recording stops.",
+        bundle: bundle
+    ) }
+    static var retainBatchAudio: String { String(localized: "Keep Audio After Transcription", bundle: bundle) }
+    static var retainBatchAudioDescription: String { String(
+        localized: "Keep the CAF audio files in the vault after batch transcription succeeds.",
         bundle: bundle
     ) }
     static var transcriptTranslation: String { String(localized: "Transcript Translation", bundle: bundle) }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -36,6 +36,20 @@ private struct RecordingContext {
     let projectName: String?
     let vaultURL: URL?
     let dbQueue: DatabaseQueue?
+    let batchTranscriptionState: BatchTranscriptionState?
+}
+
+private struct PersistenceStartRequest {
+    let dbQueue: DatabaseQueue
+    let vaultId: UUID
+    let projectId: UUID?
+    let existingMeetingId: UUID?
+    let appendContext: MeetingRepository.AppendRecordingContext?
+    let recordingStartTime: Date
+    let recordingSessionId: UUID
+    let transcriptionMode: TranscriptionMode
+    let retainAudioAfterBatch: Bool
+    let draftMeeting: DraftMeeting?
 }
 
 /// 音声キャプチャ → Speech フレームワーク文字起こし → UI 更新を統括するビューモデル。
@@ -54,6 +68,8 @@ final class CaptionViewModel: ObservableObject {
     @Published var isFinalizingRecording = false
     @Published var analyzerReady = false
     @Published var isPreparingAnalyzer = false
+    @Published private(set) var activeTranscriptionMode: TranscriptionMode?
+    @Published private(set) var batchTranscriptionState: BatchTranscriptionState?
     @Published var errorMessage: String?
     @Published var availableMicrophones: [MicrophoneDevice] = []
     @Published var microphoneSelection: MicrophoneSelection = .systemDefault
@@ -173,6 +189,10 @@ final class CaptionViewModel: ObservableObject {
     /// マイクが有効か。
     var isMicEnabled: Bool { selectedMicrophoneID != nil }
 
+    var isBatchRecording: Bool {
+        isListening && activeTranscriptionMode == .batch
+    }
+
     /// 少なくとも 1 つの音声ソースが有効か。
     var hasEnabledAudioSource: Bool { isMicEnabled || isSystemAudioEnabled }
 
@@ -213,6 +233,8 @@ final class CaptionViewModel: ObservableObject {
     private var systemAudioManager: SystemAudioCaptureManager?
     private var pipelines: [(service: SpeechTranscriberService, bridge: AudioBufferBridge)] = []
     private var persistenceService: MeetingPersistenceService?
+    private var batchAudioRecordingSession: BatchAudioRecordingSession?
+    private var batchTranscriptionCoordinator: BatchTranscriptionCoordinator?
     private var settingsCancellable: AnyCancellable?
     private var storeSegmentsCancellable: AnyCancellable?
     private var transcriptionLocaleCancellable: AnyCancellable?
@@ -280,6 +302,87 @@ final class CaptionViewModel: ObservableObject {
                 self?.handleAutomaticScreenshotIntervalChange()
             }
             .store(in: &automaticScreenshotSettingsCancellables)
+    }
+
+    func configureBatchTranscription(dbQueue: DatabaseQueue) {
+        guard batchTranscriptionCoordinator == nil else { return }
+        let coordinator = BatchTranscriptionCoordinator(dbQueue: dbQueue) { [weak self] update in
+            await self?.handleBatchTranscriptionUpdate(update)
+        }
+        batchTranscriptionCoordinator = coordinator
+        Task {
+            await coordinator.recoverAndEnqueue()
+        }
+    }
+
+    func retryBatchTranscription() {
+        guard case let .failed(sessionId, _) = batchTranscriptionState,
+              let coordinator = batchTranscriptionCoordinator else { return }
+        batchTranscriptionState = .queued(sessionId: sessionId)
+        Task {
+            await coordinator.enqueue(sessionId: sessionId)
+        }
+    }
+
+    func discardFailedBatchTranscription() {
+        guard case let .failed(sessionId, _) = batchTranscriptionState,
+              let meetingId = currentMeetingId,
+              let dbQueue = currentDbQueue else { return }
+        Task {
+            do {
+                let repository = MeetingRepository(dbQueue: dbQueue)
+                guard try repository.discardFailedBatchSession(id: sessionId) else { return }
+                try refreshBatchTranscriptionState(meetingId: meetingId, dbQueue: dbQueue)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func refreshBatchTranscriptionState(meetingId: UUID, dbQueue: DatabaseQueue) throws {
+        let sessions = try dbQueue.read { db in
+            try RecordingSessionRecord
+                .filter(Column("meetingId") == meetingId)
+                .order(Column("startedAt").asc)
+                .fetchAll(db)
+        }
+        guard currentMeetingId == meetingId else { return }
+        batchTranscriptionState = sessions
+            .reversed()
+            .compactMap { BatchTranscriptionState.derive(from: $0) }
+            .first(where: \.blocksSummaryGeneration)
+    }
+
+    private func handleBatchTranscriptionUpdate(_ update: BatchTranscriptionUpdate) async {
+        guard currentMeetingId == update.meetingId,
+              !(isBatchRecording && recordingMeetingId == update.meetingId) else { return }
+        batchTranscriptionState = update.state
+        guard case .completed = update.state, !isListening else { return }
+        await reloadCurrentMeetingAfterBatchCompletion(meetingId: update.meetingId)
+    }
+
+    private func reloadCurrentMeetingAfterBatchCompletion(meetingId: UUID) async {
+        guard let dbQueue = currentDbQueue,
+              let vaultURL = currentVaultURL,
+              currentMeetingId == meetingId else { return }
+        let projectURL = currentProjectURL
+        do {
+            let loaded = try await Task.detached(priority: .userInitiated) {
+                try Self.fetchLoadedMeetingData(
+                    meetingId: meetingId,
+                    dbQueue: dbQueue,
+                    projectURL: projectURL,
+                    vaultURL: vaultURL
+                )
+            }.value
+            guard currentMeetingId == meetingId, !isListening else { return }
+            store.recordingStartTime = loaded.createdAt
+            store.loadRecordingSessions(loaded.recordingSessions)
+            store.loadSegments(loaded.segments)
+            applyLoadedDetail(loaded)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 
     private func bindStoreSegments() {
@@ -399,6 +502,7 @@ final class CaptionViewModel: ObservableObject {
 
     private struct LoadedMeetingData {
         let createdAt: Date?
+        let recordingSessionRecords: [RecordingSessionRecord]
         let recordingSessions: [RecordingSessionTimeline]
         let segments: [TranscriptSegment]
         let screenshots: [MeetingScreenshotRecord]
@@ -427,6 +531,7 @@ final class CaptionViewModel: ObservableObject {
 
         return LoadedMeetingData(
             createdAt: detail.meeting?.createdAt,
+            recordingSessionRecords: detail.recordingSessions,
             recordingSessions: recordingSessions,
             segments: segments,
             screenshots: detail.screenshots,
@@ -657,6 +762,7 @@ final class CaptionViewModel: ObservableObject {
         currentProjectName = nil
         currentVaultURL = nil
         draftMeeting = nil
+        batchTranscriptionState = nil
     }
 
     /// 録音対象のトランスクリプトに表示を復帰する。
@@ -673,6 +779,7 @@ final class CaptionViewModel: ObservableObject {
         currentProjectName = ctx.projectName
         currentVaultURL = ctx.vaultURL
         currentDbQueue = ctx.dbQueue
+        batchTranscriptionState = ctx.batchTranscriptionState
         draftMeeting = nil
 
         store = ctx.store
@@ -717,7 +824,20 @@ final class CaptionViewModel: ObservableObject {
         hasNote = loaded.note != nil
         currentNoteCreatedAt = loaded.note?.createdAt
         lastSavedNoteText = noteText
+        batchTranscriptionState = loaded.recordingSessionRecords
+            .reversed()
+            .compactMap { BatchTranscriptionState.derive(from: $0) }
+            .first(where: \.blocksSummaryGeneration)
         setupNoteAutoSave()
+
+        guard let coordinator = batchTranscriptionCoordinator,
+              let visibleState = batchTranscriptionState else { return }
+        Task {
+            if await coordinator.isRunning(sessionId: visibleState.sessionId),
+               batchTranscriptionState?.sessionId == visibleState.sessionId {
+                batchTranscriptionState = .running(sessionId: visibleState.sessionId)
+            }
+        }
     }
 
     // MARK: - Private Helpers
@@ -732,7 +852,8 @@ final class CaptionViewModel: ObservableObject {
             projectId: currentProjectId,
             projectName: currentProjectName,
             vaultURL: currentVaultURL,
-            dbQueue: currentDbQueue
+            dbQueue: currentDbQueue,
+            batchTranscriptionState: batchTranscriptionState
         )
     }
 
@@ -745,6 +866,7 @@ final class CaptionViewModel: ObservableObject {
         resetNoteState()
         resetSummaryState()
         draftMeeting = nil
+        batchTranscriptionState = nil
     }
 
     private func resetSummaryState() {
@@ -857,51 +979,76 @@ final class CaptionViewModel: ObservableObject {
     private func rebuildPipelines(reason: PipelineRebuildReason) async -> Bool {
         await stopActivePipelines()
         stopActiveCaptures()
-
-        let primaryLocale = resolvedSelectedLocale()
         do {
-            try await SpeechTranscriberService.ensureModelInstalled(locale: primaryLocale)
+            try await batchAudioRecordingSession?.endActiveRanges()
         } catch {
             setPipelineRebuildError(error, reason: reason)
             return false
         }
 
-        var sourceErrors: [Error] = []
-        let recordingStartTime = Date()
-        let recordingSessionId = persistenceService?.recordingSessionId ?? UUID.v7()
-
-        if isMicEnabled {
+        let primaryLocale = resolvedSelectedLocale()
+        let sourceError: Error?
+        if activeTranscriptionMode == .batch {
+            sourceError = await firstAudioSourceError(
+                startMicrophone: { try await self.startMicrophoneBatchCapture(locale: primaryLocale) },
+                startSystemAudio: { try await self.startSystemAudioBatchCapture(locale: primaryLocale) }
+            )
+        } else {
             do {
-                try await startMicrophonePipeline(
-                    locale: primaryLocale,
-                    recordingStartTime: recordingStartTime,
-                    recordingSessionId: recordingSessionId
-                )
+                try await SpeechTranscriberService.ensureModelInstalled(locale: primaryLocale)
             } catch {
-                sourceErrors.append(error)
+                setPipelineRebuildError(error, reason: reason)
+                return false
             }
+            let recordingStartTime = Date.now
+            let recordingSessionId = persistenceService?.recordingSessionId ?? .v7()
+            sourceError = await firstAudioSourceError(
+                startMicrophone: {
+                    try await self.startMicrophonePipeline(
+                        locale: primaryLocale,
+                        recordingStartTime: recordingStartTime,
+                        recordingSessionId: recordingSessionId
+                    )
+                },
+                startSystemAudio: {
+                    try await self.startSystemAudioPipeline(
+                        locale: primaryLocale,
+                        recordingStartTime: recordingStartTime,
+                        recordingSessionId: recordingSessionId
+                    )
+                }
+            )
+            analyzerReady = true
         }
 
-        if isSystemAudioEnabled {
-            do {
-                try await startSystemAudioPipeline(
-                    locale: primaryLocale,
-                    recordingStartTime: recordingStartTime,
-                    recordingSessionId: recordingSessionId
-                )
-            } catch {
-                sourceErrors.append(error)
-            }
-        }
-
-        analyzerReady = true
-        if let firstError = sourceErrors.first {
-            setPipelineRebuildError(firstError, reason: reason)
+        if let sourceError {
+            setPipelineRebuildError(sourceError, reason: reason)
             return false
         }
-
         errorMessage = nil
         return true
+    }
+
+    private func firstAudioSourceError(
+        startMicrophone: () async throws -> Void,
+        startSystemAudio: () async throws -> Void
+    ) async -> Error? {
+        var errors: [Error] = []
+        if isMicEnabled {
+            do {
+                try await startMicrophone()
+            } catch {
+                errors.append(error)
+            }
+        }
+        if isSystemAudioEnabled {
+            do {
+                try await startSystemAudio()
+            } catch {
+                errors.append(error)
+            }
+        }
+        return errors.first
     }
 
     private func setPipelineRebuildError(_ error: Error, reason: PipelineRebuildReason) {
@@ -963,6 +1110,214 @@ final class CaptionViewModel: ObservableObject {
         pipelines.append((service: service, bridge: bridge))
     }
 
+    private func startMicrophoneBatchCapture(locale: Locale) async throws {
+        let hasMicPermission = await AudioCaptureManager.requestMicrophonePermission()
+        guard hasMicPermission else {
+            throw AudioCaptureError.microphonePermissionDenied
+        }
+        guard let batchAudioRecordingSession else {
+            throw BatchAudioFileWriterError.incompatibleBuffer
+        }
+        let writer = try await batchAudioRecordingSession.beginRange(source: .microphone, locale: locale)
+        let manager = AudioCaptureManager()
+        manager.onAudioBuffer = { [writer] buffer in
+            writer.appendBuffer(buffer)
+        }
+        try manager.startCapture(
+            targetFormat: batchAudioRecordingSession.targetFormat,
+            selectedDeviceID: selectedMicrophoneID,
+            bufferSize: 1024
+        )
+        audioManager = manager
+    }
+
+    private func startSystemAudioBatchCapture(locale: Locale) async throws {
+        let hasPermission = await SystemAudioCaptureManager.requestPermission()
+        guard hasPermission else {
+            throw SystemAudioCaptureError.screenRecordingPermissionDenied
+        }
+        guard let batchAudioRecordingSession else {
+            throw BatchAudioFileWriterError.incompatibleBuffer
+        }
+        let writer = try await batchAudioRecordingSession.beginRange(source: .system, locale: locale)
+        let manager = SystemAudioCaptureManager()
+        manager.onAudioBuffer = { [writer] buffer in
+            writer.appendBuffer(buffer)
+        }
+        manager.onStreamStopped = { [weak self] error in
+            Task { @MainActor in
+                self?.errorMessage = error?.localizedDescription ?? L10n.systemAudioCaptureStopped
+                if self?.audioManager == nil {
+                    self?.stopListening()
+                }
+            }
+        }
+        try await manager.startCapture(targetFormat: batchAudioRecordingSession.targetFormat)
+        systemAudioManager = manager
+    }
+
+    private func prepareRecordingStart(
+        existingMeetingId: UUID?,
+        dbQueue: DatabaseQueue,
+        recordingStartTime: Date
+    ) -> MeetingRepository.AppendRecordingContext? {
+        pipelines.removeAll()
+        persistenceService = nil
+        batchAudioRecordingSession = nil
+        stopAutomaticScreenshotCapture()
+
+        guard let existingMeetingId else {
+            store.recordingStartTime = recordingStartTime
+            return nil
+        }
+
+        let repository = MeetingRepository(dbQueue: dbQueue)
+        let context = try? repository.fetchAppendRecordingContext(forMeetingId: existingMeetingId)
+        if let sessions = context?.recordingSessions, !sessions.isEmpty {
+            store.loadRecordingSessions(sessions.map(RecordingSessionTimeline.init))
+        }
+        guard store.recordingStartTime == nil else { return context }
+        if let firstSegmentStartTime = context?.firstSegmentStartTime {
+            store.recordingStartTime = context?.meetingCreatedAt ?? firstSegmentStartTime
+        } else {
+            store.recordingStartTime = recordingStartTime
+            try? repository.updateMeetingCreatedAt(id: existingMeetingId, createdAt: recordingStartTime)
+        }
+        return context
+    }
+
+    private func prepareCapture(
+        mode: TranscriptionMode,
+        locale: Locale,
+        recordingStartTime: Date,
+        recordingSessionId: UUID
+    ) async throws -> Double? {
+        guard mode == .realtime else {
+            return try await BatchSpeechTranscriberService.preferredSampleRate(locale: locale)
+        }
+
+        try await SpeechTranscriberService.ensureModelInstalled(locale: locale)
+        if isMicEnabled {
+            try await startMicrophonePipeline(
+                locale: locale,
+                recordingStartTime: recordingStartTime,
+                recordingSessionId: recordingSessionId
+            )
+        }
+        if isSystemAudioEnabled {
+            try await startSystemAudioPipeline(
+                locale: locale,
+                recordingStartTime: recordingStartTime,
+                recordingSessionId: recordingSessionId
+            )
+        }
+        return nil
+    }
+
+    private func startBatchRecordingIfNeeded(
+        sampleRate: Double?,
+        dbQueue: DatabaseQueue,
+        meetingId: UUID?,
+        recordingSessionId: UUID,
+        recordingStartTime: Date,
+        locale: Locale
+    ) async throws {
+        guard let sampleRate, let meetingId else { return }
+        let recordingSession = try BatchAudioRecordingSession(
+            dbQueue: dbQueue,
+            meetingId: meetingId,
+            recordingSessionId: recordingSessionId,
+            recordingStartTime: recordingStartTime,
+            sampleRate: sampleRate
+        )
+        batchAudioRecordingSession = recordingSession
+        if isMicEnabled {
+            try await startMicrophoneBatchCapture(locale: locale)
+        }
+        if isSystemAudioEnabled {
+            try await startSystemAudioBatchCapture(locale: locale)
+        }
+        batchTranscriptionState = .recording(sessionId: recordingSessionId)
+    }
+
+    private func canStartRecording() -> Bool {
+        guard analyzerReady else {
+            errorMessage = L10n.speechRecognitionNotReady
+            return false
+        }
+        guard hasEnabledAudioSource else {
+            errorMessage = L10n.noAudioSourceSelected
+            return false
+        }
+        return true
+    }
+
+    private func markRecordingStarted() {
+        isListening = true
+        errorMessage = nil
+        syncAutomaticScreenshotCaptureState()
+    }
+
+    private func startPersistence(_ request: PersistenceStartRequest) throws {
+        if let existingMeetingId = request.existingMeetingId {
+            persistenceService = try MeetingPersistenceService(
+                store: store,
+                dbQueue: request.dbQueue,
+                existingMeetingId: existingMeetingId,
+                existingSegmentIds: request.appendContext?.segmentIds ?? [],
+                recordingStartDate: request.recordingStartTime,
+                recordingOffsetSeconds: request.appendContext?.nextOffsetSeconds ?? 0,
+                recordingSessionId: request.recordingSessionId,
+                transcriptionMode: request.transcriptionMode,
+                retainAudioAfterBatch: request.retainAudioAfterBatch
+            )
+            currentMeetingId = existingMeetingId
+            return
+        }
+
+        let initialName = request.draftMeeting?.title.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        persistenceService = try MeetingPersistenceService(
+            store: store,
+            dbQueue: request.dbQueue,
+            vaultId: request.vaultId,
+            projectId: request.projectId,
+            initialName: initialName,
+            calendarEvent: request.draftMeeting?.linkedCalendarEvent,
+            recordingSessionId: request.recordingSessionId,
+            transcriptionMode: request.transcriptionMode,
+            retainAudioAfterBatch: request.retainAudioAfterBatch
+        )
+        currentMeetingId = persistenceService?.meetingId
+    }
+
+    private func completePersistenceStart(existingMeetingId: UUID?) {
+        guard existingMeetingId == nil else { return }
+        draftMeeting = nil
+        setupNoteAutoSave()
+        saveNoteImmediately()
+    }
+
+    private func handleRecordingStartFailure(
+        _ error: Error,
+        existingMeetingId: UUID?,
+        previousBatchTranscriptionState: BatchTranscriptionState?
+    ) async {
+        errorMessage = error.localizedDescription
+        ErrorReportingService.capture(error, context: ["source": "startListening"])
+        await stopActivePipelines()
+        stopActiveCaptures()
+        stopAutomaticScreenshotCapture()
+        await batchAudioRecordingSession?.cancelAndDelete()
+        batchAudioRecordingSession = nil
+        persistenceService?.cancel()
+        persistenceService = nil
+        activeTranscriptionMode = nil
+        batchTranscriptionState = previousBatchTranscriptionState
+        if existingMeetingId == nil {
+            currentMeetingId = nil
+        }
+    }
+
     // MARK: - Recording Control
 
     func toggleListening(
@@ -1002,6 +1357,7 @@ final class CaptionViewModel: ObservableObject {
         appendingTo existingMeetingId: UUID? = nil
     ) async {
         guard !isListening, !isFinalizingRecording else { return }
+        let previousBatchTranscriptionState = batchTranscriptionState
 
         self.currentProjectURL = projectURL
         self.currentProjectId = projectId
@@ -1010,102 +1366,60 @@ final class CaptionViewModel: ObservableObject {
         self.currentDbQueue = dbQueue
         resetSummaryState()
         let activeDraftMeeting = draftMeeting
-        guard analyzerReady else {
-            errorMessage = L10n.speechRecognitionNotReady
-            return
-        }
+        guard canStartRecording() else { return }
 
-        guard hasEnabledAudioSource else {
-            errorMessage = L10n.noAudioSourceSelected
-            return
-        }
-
-        pipelines.removeAll()
         let recordingStartTime = Date()
         let recordingSessionId = UUID.v7()
-        let appendContext: MeetingRepository.AppendRecordingContext?
-        if let existingMeetingId {
-            let repo = MeetingRepository(dbQueue: dbQueue)
-            appendContext = try? repo.fetchAppendRecordingContext(forMeetingId: existingMeetingId)
-            if let recordingSessions = appendContext?.recordingSessions, !recordingSessions.isEmpty {
-                store.loadRecordingSessions(recordingSessions.map(RecordingSessionTimeline.init))
-            }
-            if store.recordingStartTime == nil {
-                if let firstSegmentStartTime = appendContext?.firstSegmentStartTime {
-                    store.recordingStartTime = appendContext?.meetingCreatedAt ?? firstSegmentStartTime
-                } else {
-                    store.recordingStartTime = recordingStartTime
-                    try? repo.updateMeetingCreatedAt(id: existingMeetingId, createdAt: recordingStartTime)
-                }
-            }
-        } else {
-            appendContext = nil
-            store.recordingStartTime = recordingStartTime
-        }
-        persistenceService = nil
-        stopAutomaticScreenshotCapture()
-
+        let appendContext = prepareRecordingStart(
+            existingMeetingId: existingMeetingId,
+            dbQueue: dbQueue,
+            recordingStartTime: recordingStartTime
+        )
         do {
+            let transcriptionMode = AppSettings.shared.transcriptionMode
+            let retainAudioAfterBatch = transcriptionMode == .batch
+                && AppSettings.shared.retainAudioAfterBatchTranscription
+            activeTranscriptionMode = transcriptionMode
             let primaryLocale = resolvedSelectedLocale()
-            try await SpeechTranscriberService.ensureModelInstalled(locale: primaryLocale)
+            let batchSampleRate = try await prepareCapture(
+                mode: transcriptionMode,
+                locale: primaryLocale,
+                recordingStartTime: recordingStartTime,
+                recordingSessionId: recordingSessionId
+            )
 
-            if isMicEnabled {
-                try await startMicrophonePipeline(
-                    locale: primaryLocale,
-                    recordingStartTime: recordingStartTime,
-                    recordingSessionId: recordingSessionId
-                )
-            }
-            if isSystemAudioEnabled {
-                try await startSystemAudioPipeline(
-                    locale: primaryLocale,
-                    recordingStartTime: recordingStartTime,
-                    recordingSessionId: recordingSessionId
-                )
-            }
-
-            if let existingMeetingId {
-                // 追記モード: 既存セグメント ID を取得して PersistenceService に渡す
-                persistenceService = try MeetingPersistenceService(
-                    store: store,
-                    dbQueue: dbQueue,
-                    existingMeetingId: existingMeetingId,
-                    existingSegmentIds: appendContext?.segmentIds ?? [],
-                    recordingStartDate: recordingStartTime,
-                    recordingOffsetSeconds: appendContext?.nextOffsetSeconds ?? 0,
-                    recordingSessionId: recordingSessionId
-                )
-                currentMeetingId = existingMeetingId
-            } else {
-                let initialName = activeDraftMeeting?.title.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                persistenceService = try MeetingPersistenceService(
-                    store: store,
+            try startPersistence(
+                PersistenceStartRequest(
                     dbQueue: dbQueue,
                     vaultId: vaultId,
                     projectId: projectId,
-                    initialName: initialName,
-                    calendarEvent: activeDraftMeeting?.linkedCalendarEvent,
-                    recordingSessionId: recordingSessionId
+                    existingMeetingId: existingMeetingId,
+                    appendContext: appendContext,
+                    recordingStartTime: recordingStartTime,
+                    recordingSessionId: recordingSessionId,
+                    transcriptionMode: transcriptionMode,
+                    retainAudioAfterBatch: retainAudioAfterBatch,
+                    draftMeeting: activeDraftMeeting
                 )
-                currentMeetingId = persistenceService?.meetingId
-                draftMeeting = nil
-                setupNoteAutoSave()
-                saveNoteImmediately()
-            }
+            )
 
-            self.isListening = true
-            self.errorMessage = nil
-            syncAutomaticScreenshotCaptureState()
+            try await startBatchRecordingIfNeeded(
+                sampleRate: batchSampleRate,
+                dbQueue: dbQueue,
+                meetingId: currentMeetingId,
+                recordingSessionId: recordingSessionId,
+                recordingStartTime: recordingStartTime,
+                locale: primaryLocale
+            )
+
+            completePersistenceStart(existingMeetingId: existingMeetingId)
+            markRecordingStarted()
         } catch {
-            self.errorMessage = error.localizedDescription
-            ErrorReportingService.capture(error, context: ["source": "startListening"])
-            await stopActivePipelines()
-            stopActiveCaptures()
-            stopAutomaticScreenshotCapture()
-            persistenceService = nil
-            if existingMeetingId == nil {
-                currentMeetingId = nil
-            }
+            await handleRecordingStartFailure(
+                error,
+                existingMeetingId: existingMeetingId,
+                previousBatchTranscriptionState: previousBatchTranscriptionState
+            )
         }
     }
 
@@ -1123,17 +1437,48 @@ final class CaptionViewModel: ObservableObject {
         let meetingId = ctx?.meetingId ?? currentMeetingId
         let projectName = ctx?.projectName ?? selectedProjectName
         let vaultURL = ctx?.vaultURL ?? currentVaultURL
+        let dbQueue = ctx?.dbQueue ?? currentDbQueue
         let recordingStart = activeStore.timeBase
+        let transcriptionMode = activeTranscriptionMode ?? .realtime
+        let recordingSessionId = persistenceService?.recordingSessionId
+        let batchRecordingSession = batchAudioRecordingSession
+        batchAudioRecordingSession = nil
         recordingContext = nil
 
         Task {
             await stopActivePipelines()
+            await finishBatchRecording(
+                batchRecordingSession,
+                recordingSessionId: recordingSessionId,
+                meetingId: meetingId
+            )
             persistenceService?.stop()
             persistenceService = nil
-            let segments = activeStore.segments
+            activeTranscriptionMode = nil
+            var segments = activeStore.segments
             let recordingSessions = activeStore.recordingSessions
             isFinalizingRecording = false
 
+            if transcriptionMode == .batch, let recordingSessionId {
+                await completeBatchRecording(
+                    sessionId: recordingSessionId,
+                    meetingId: meetingId,
+                    vaultURL: vaultURL,
+                    dbQueue: dbQueue
+                )
+                return
+            }
+
+            if let meetingId, let dbQueue {
+                segments = await mergedSegmentsForExport(
+                    meetingId: meetingId,
+                    dbQueue: dbQueue,
+                    activeSegments: segments
+                )
+                if currentMeetingId == meetingId {
+                    activeStore.loadSegments(segments)
+                }
+            }
             guard let vaultURL, let meetingId, !segments.isEmpty else { return }
             await exportFiles(
                 vaultURL: vaultURL,
@@ -1143,6 +1488,92 @@ final class CaptionViewModel: ObservableObject {
                 segments: segments,
                 recordingSessions: recordingSessions
             )
+        }
+    }
+
+    private func finishBatchRecording(
+        _ recordingSession: BatchAudioRecordingSession?,
+        recordingSessionId: UUID?,
+        meetingId: UUID?
+    ) async {
+        do {
+            try await recordingSession?.finish()
+        } catch {
+            if let recordingSessionId,
+               let coordinator = batchTranscriptionCoordinator {
+                await coordinator.recordRecordingFailure(sessionId: recordingSessionId, error: error)
+            }
+            if currentMeetingId == meetingId, let recordingSessionId {
+                batchTranscriptionState = .failed(
+                    sessionId: recordingSessionId,
+                    message: error.localizedDescription
+                )
+            }
+        }
+    }
+
+    private func completeBatchRecording(
+        sessionId: UUID,
+        meetingId: UUID?,
+        vaultURL: URL?,
+        dbQueue: DatabaseQueue?
+    ) async {
+        let recordingFailed = isFailedBatchState(for: sessionId)
+        if currentMeetingId == meetingId, !recordingFailed {
+            batchTranscriptionState = .queued(sessionId: sessionId)
+        }
+        if !recordingFailed, let coordinator = batchTranscriptionCoordinator {
+            await coordinator.enqueue(sessionId: sessionId)
+        }
+        if let vaultURL, let meetingId, let dbQueue {
+            await exportBatchScreenshots(
+                vaultURL: vaultURL,
+                meetingId: meetingId,
+                dbQueue: dbQueue
+            )
+        }
+    }
+
+    private func isFailedBatchState(for sessionId: UUID) -> Bool {
+        guard case let .failed(failedSessionId, _) = batchTranscriptionState else { return false }
+        return failedSessionId == sessionId
+    }
+
+    private func exportBatchScreenshots(vaultURL: URL, meetingId: UUID, dbQueue: DatabaseQueue) async {
+        let screenshots = await Task.detached(priority: .utility) {
+            let repository = MeetingRepository(dbQueue: dbQueue)
+            return (try? repository.fetchScreenshots(forMeetingId: meetingId)) ?? []
+        }.value
+        guard !screenshots.isEmpty else { return }
+        _ = await Task.detached(priority: .utility) {
+            try? ScreenshotExportService.exportScreenshots(
+                vaultURL: vaultURL,
+                screenshots: screenshots
+            )
+        }.value
+    }
+
+    private func mergedSegmentsForExport(
+        meetingId: UUID,
+        dbQueue: DatabaseQueue,
+        activeSegments: [TranscriptSegment]
+    ) async -> [TranscriptSegment] {
+        let persistedSegments = await (try? dbQueue.read { db in
+            try TranscriptSegmentRecord
+                .filter(Column("meetingId") == meetingId)
+                .order(Column("startTime").asc)
+                .fetchAll(db)
+                .map(TranscriptSegment.init(from:))
+        }) ?? []
+        var segmentsById = Dictionary(uniqueKeysWithValues: persistedSegments.map { ($0.id, $0) })
+        for segment in activeSegments {
+            segmentsById[segment.id] = segment
+        }
+        return segmentsById.values.sorted { lhs, rhs in
+            if lhs.startTime == rhs.startTime {
+                return lhs.id.uuidString < rhs.id.uuidString
+            }
+            return lhs.startTime < rhs.startTime
         }
     }
 
@@ -1158,7 +1589,8 @@ final class CaptionViewModel: ObservableObject {
         guard !isListening,
               !isFinalizingRecording,
               currentMeetingId != nil,
-              currentVaultURL != nil else { return false }
+              currentVaultURL != nil,
+              batchTranscriptionState?.blocksSummaryGeneration != true else { return false }
         return !store.segments.isEmpty
     }
 

--- a/Sources/Dahlia/Views/BatchTranscriptionStatusView.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionStatusView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct BatchTranscriptionStatusView: View {
+    let state: BatchTranscriptionState
+    let retry: () -> Void
+    let discard: () -> Void
+
+    @State private var isShowingDiscardConfirmation = false
+
+    var body: some View {
+        HStack {
+            switch state {
+            case .recording:
+                ProgressView()
+                    .controlSize(.small)
+                Text(L10n.batchRecordingInProgress)
+            case .queued:
+                ProgressView()
+                    .controlSize(.small)
+                Text(L10n.batchTranscriptionQueued)
+            case .running:
+                ProgressView()
+                    .controlSize(.small)
+                Text(L10n.batchTranscriptionRunning)
+            case .completed:
+                Label(L10n.batchTranscriptionCompleted, systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            case let .failed(_, message):
+                Label(L10n.batchTranscriptionFailed(message), systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Spacer()
+                Button(L10n.retryBatchTranscription, action: retry)
+                Button(
+                    L10n.discardFailedBatchRecording,
+                    role: .destructive,
+                    action: showDiscardConfirmation
+                )
+            }
+        }
+        .font(.callout)
+        .padding()
+        .background(.quaternary)
+        .accessibilityElement(children: .contain)
+        .confirmationDialog(
+            L10n.discardFailedBatchRecordingConfirmation,
+            isPresented: $isShowingDiscardConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(L10n.discardFailedBatchRecording, role: .destructive, action: discard)
+            Button(L10n.cancel, role: .cancel) {}
+        } message: {
+            Text(L10n.discardFailedBatchRecordingDescription)
+        }
+    }
+
+    private func showDiscardConfirmation() {
+        isShowingDiscardConfirmation = true
+    }
+}

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -435,8 +435,13 @@ struct ControlPanelView: View {
                     TranscriptTabView(
                         store: viewModel.store,
                         isListening: viewModel.isListening,
-                        showsRecordingIndicator: viewModel.isListening && !viewModel.isViewingOtherWhileRecording,
-                        showsTranslatedText: appSettings.isTranscriptTranslationEffectivelyEnabled
+                        showsRecordingIndicator: viewModel.isListening
+                            && !viewModel.isBatchRecording
+                            && !viewModel.isViewingOtherWhileRecording,
+                        showsTranslatedText: appSettings.isTranscriptTranslationEffectivelyEnabled,
+                        batchTranscriptionState: viewModel.batchTranscriptionState,
+                        retryBatchTranscription: viewModel.retryBatchTranscription,
+                        discardFailedBatchTranscription: viewModel.discardFailedBatchTranscription
                     )
                 }
             }

--- a/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
@@ -11,6 +11,28 @@ struct TranscriptionSettingsView: View {
     var body: some View {
         Form {
             Section {
+                Picker(selection: $settings.transcriptionModeRawValue) {
+                    ForEach(TranscriptionMode.allCases) { mode in
+                        Text(mode.displayName).tag(mode.rawValue)
+                    }
+                } label: {
+                    Text(L10n.transcriptionMethod)
+                    Text(settings.transcriptionMode.description)
+                }
+                .pickerStyle(.radioGroup)
+
+                if settings.transcriptionMode == .batch {
+                    Toggle(isOn: $settings.retainAudioAfterBatchTranscription) {
+                        Text(L10n.retainBatchAudio)
+                        Text(L10n.retainBatchAudioDescription)
+                    }
+                    .toggleStyle(.switch)
+                }
+            } header: {
+                Text(L10n.transcriptionMethod)
+            }
+
+            Section {
                 Toggle(isOn: $settings.transcriptTranslationEnabled) {
                     Text(L10n.transcriptTranslation)
                     Text(L10n.transcriptTranslationDescription)

--- a/Sources/Dahlia/Views/TranscriptTabView.swift
+++ b/Sources/Dahlia/Views/TranscriptTabView.swift
@@ -21,6 +21,9 @@ struct TranscriptTabView: View {
     let isListening: Bool
     let showsRecordingIndicator: Bool
     let showsTranslatedText: Bool
+    let batchTranscriptionState: BatchTranscriptionState?
+    let retryBatchTranscription: () -> Void
+    let discardFailedBatchTranscription: () -> Void
 
     @State private var shouldFollowLatest = true
     @State private var windowSize = WindowMetrics.initialWindowSize
@@ -49,12 +52,20 @@ struct TranscriptTabView: View {
     }
 
     var body: some View {
-        Group {
-            if store.segments.isEmpty, !isListening {
+        VStack(spacing: 0) {
+            if let batchTranscriptionState {
+                BatchTranscriptionStatusView(
+                    state: batchTranscriptionState,
+                    retry: retryBatchTranscription,
+                    discard: discardFailedBatchTranscription
+                )
+            }
+
+            if store.segments.isEmpty, !isListening || batchTranscriptionState != nil {
                 ContentUnavailableView {
                     Label(L10n.transcript, systemImage: "waveform.badge.microphone")
                 } description: {
-                    Text("文字起こしはまだありません")
+                    Text(L10n.transcriptEmpty)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {

--- a/Tests/DahliaTests/AppDatabaseManagerTests.swift
+++ b/Tests/DahliaTests/AppDatabaseManagerTests.swift
@@ -3,737 +3,761 @@ import GRDB
 @testable import Dahlia
 
 #if canImport(Testing)
-import Testing
+    import Testing
 
-@MainActor
-struct AppDatabaseManagerTests {
-    @Test
-    func initializesInMemoryDatabaseWithGoogleDriveFolderColumn() throws {
-        let database = try AppDatabaseManager(path: ":memory:")
+    @MainActor
+    struct AppDatabaseManagerTests {
+        @Test
+        func initializesInMemoryDatabaseWithGoogleDriveFolderColumn() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
 
-        let columns = try database.dbQueue.read { db in
-            try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('projects')")
+            let columns = try database.dbQueue.read { db in
+                try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('projects')")
+            }
+
+            #expect(columns.contains("googleDriveFolderId"))
         }
 
-        #expect(columns.contains("googleDriveFolderId"))
-    }
+        @Test
+        func initializesInMemoryDatabaseWithSummaryGoogleFileIdColumn() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
 
-    @Test
-    func initializesInMemoryDatabaseWithSummaryGoogleFileIdColumn() throws {
-        let database = try AppDatabaseManager(path: ":memory:")
+            let columns = try database.dbQueue.read { db in
+                try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
+            }
 
-        let columns = try database.dbQueue.read { db in
-            try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
+            #expect(columns.contains("googleFileId"))
         }
 
-        #expect(columns.contains("googleFileId"))
-    }
+        @Test
+        func initializesInMemoryDatabaseWithSummaryDocumentColumn() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
 
-    @Test
-    func initializesInMemoryDatabaseWithSummaryDocumentColumn() throws {
-        let database = try AppDatabaseManager(path: ":memory:")
+            let columns = try database.dbQueue.read { db in
+                try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
+            }
 
-        let columns = try database.dbQueue.read { db in
-            try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
+            #expect(columns.contains("document"))
         }
 
-        #expect(columns.contains("document"))
-    }
+        @Test
+        func initializesInMemoryDatabaseWithTranscriptTranslatedTextColumn() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
 
-    @Test
-    func initializesInMemoryDatabaseWithTranscriptTranslatedTextColumn() throws {
-        let database = try AppDatabaseManager(path: ":memory:")
+            let columns = try database.dbQueue.read { db in
+                try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('transcript_segments')")
+            }
 
-        let columns = try database.dbQueue.read { db in
-            try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('transcript_segments')")
+            #expect(columns.contains("translatedText"))
         }
 
-        #expect(columns.contains("translatedText"))
-    }
+        @Test
+        func initializesInMemoryDatabaseWithRecordingSessionsSchema() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
 
-    @Test
-    func initializesInMemoryDatabaseWithRecordingSessionsSchema() throws {
-        let database = try AppDatabaseManager(path: ":memory:")
-
-        let result = try database.dbQueue.read { db in
-            try (
-                db.tableExists("recording_sessions"),
-                String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('transcript_segments')"),
-                String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('screenshots')")
-            )
-        }
-
-        #expect(result.0)
-        #expect(result.1.contains("sessionId"))
-        #expect(result.2.contains("sessionId"))
-    }
-
-    @Test
-    func existingV7DatabaseBackfillsRecordingSessionsWithoutDataLoss() throws {
-        let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("sqlite")
-        let meetingID = UUID.v7()
-        let segmentID = UUID.v7()
-        let screenshotID = UUID.v7()
-        let meetingStart = Date(timeIntervalSince1970: 1_776_384_000)
-        let segmentStart = meetingStart.addingTimeInterval(5)
-        let segmentEnd = meetingStart.addingTimeInterval(20)
-
-        defer { try? FileManager.default.removeItem(at: databaseURL) }
-
-        let legacyQueue = try DatabaseQueue(path: databaseURL.path)
-        try legacyQueue.write { db in
-            try db.execute(
-                sql: """
-                CREATE TABLE meetings (
-                    id BLOB PRIMARY KEY,
-                    vaultId BLOB NOT NULL,
-                    projectId BLOB,
-                    name TEXT NOT NULL DEFAULT '',
-                    status TEXT NOT NULL DEFAULT 'READY',
-                    duration DOUBLE,
-                    createdAt DATETIME NOT NULL,
-                    updatedAt DATETIME NOT NULL
+            let result = try database.dbQueue.read { db in
+                try (
+                    db.tableExists("recording_sessions"),
+                    String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('transcript_segments')"),
+                    String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('screenshots')")
                 )
-                """
-            )
-            try db.execute(
-                sql: """
-                CREATE TABLE transcript_segments (
-                    id BLOB PRIMARY KEY,
-                    meetingId BLOB NOT NULL,
-                    startTime DATETIME NOT NULL,
-                    endTime DATETIME,
-                    text TEXT NOT NULL,
-                    translatedText TEXT,
-                    isConfirmed BOOLEAN NOT NULL DEFAULT 0,
-                    speakerLabel TEXT
+            }
+
+            #expect(result.0)
+            #expect(result.1.contains("sessionId"))
+            #expect(result.2.contains("sessionId"))
+        }
+
+        @Test
+        func initializesBatchTranscriptionSchema() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
+
+            let result = try database.dbQueue.read { db in
+                try (
+                    String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('recording_sessions')"),
+                    String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('recording_audio_files')"),
+                    db.tableExists("recording_audio_ranges")
                 )
-                """
-            )
-            try db.execute(
-                sql: """
-                CREATE TABLE screenshots (
-                    id BLOB PRIMARY KEY,
-                    meetingId BLOB NOT NULL,
-                    capturedAt DATETIME NOT NULL,
-                    imageData BLOB NOT NULL,
-                    mimeType TEXT NOT NULL
+            }
+
+            #expect(result.0.contains("transcriptionMode"))
+            #expect(result.0.contains("retainAudioAfterBatch"))
+            #expect(result.0.contains("batchCompletedAt"))
+            #expect(result.0.contains("batchLastError"))
+            #expect(result.0.contains("batchLastAttemptAt"))
+            #expect(result.0.contains("batchAttemptCount"))
+            #expect(result.0.contains("batchDiscardedAt"))
+            #expect(result.1.contains("storageLocation"))
+            #expect(result.2)
+        }
+
+        @Test
+        func existingV7DatabaseBackfillsRecordingSessionsWithoutDataLoss() throws {
+            let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("sqlite")
+            let meetingID = UUID.v7()
+            let segmentID = UUID.v7()
+            let screenshotID = UUID.v7()
+            let meetingStart = Date(timeIntervalSince1970: 1_776_384_000)
+            let segmentStart = meetingStart.addingTimeInterval(5)
+            let segmentEnd = meetingStart.addingTimeInterval(20)
+
+            defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+            let legacyQueue = try DatabaseQueue(path: databaseURL.path)
+            try legacyQueue.write { db in
+                try db.execute(
+                    sql: """
+                    CREATE TABLE meetings (
+                        id BLOB PRIMARY KEY,
+                        vaultId BLOB NOT NULL,
+                        projectId BLOB,
+                        name TEXT NOT NULL DEFAULT '',
+                        status TEXT NOT NULL DEFAULT 'READY',
+                        duration DOUBLE,
+                        createdAt DATETIME NOT NULL,
+                        updatedAt DATETIME NOT NULL
+                    )
+                    """
                 )
-                """
-            )
-            try db.create(table: "grdb_migrations") { t in
-                t.column("identifier", .text).primaryKey()
-            }
-            for migration in [
-                "v3_googleDriveFolderSchema",
-                "v4_instructionsSchema",
-                "v5_summaryGoogleFileId",
-                "v6_transcriptSegmentTranslation",
-                "v7_normalizeLegacyMeetingStatus",
-            ] {
-                try db.execute(sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)", arguments: [migration])
-            }
-            try db.execute(
-                sql: """
-                INSERT INTO meetings (id, vaultId, name, status, duration, createdAt, updatedAt)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                """,
-                arguments: [meetingID, UUID.v7(), "Legacy", MeetingStatus.ready.rawValue, nil as TimeInterval?, meetingStart, meetingStart]
-            )
-            try db.execute(
-                sql: """
-                INSERT INTO transcript_segments (id, meetingId, startTime, endTime, text, isConfirmed, speakerLabel)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                """,
-                arguments: [segmentID, meetingID, segmentStart, segmentEnd, "Hello world", true, "mic"]
-            )
-            try db.execute(
-                sql: """
-                INSERT INTO screenshots (id, meetingId, capturedAt, imageData, mimeType)
-                VALUES (?, ?, ?, ?, ?)
-                """,
-                arguments: [screenshotID, meetingID, segmentStart, Data([0x00]), "image/png"]
-            )
-        }
-
-        let migrated = try AppDatabaseManager(path: databaseURL.path)
-        let result = try migrated.dbQueue.read { db in
-            let sessions = try RecordingSessionRecord.filter(Column("meetingId") == meetingID).fetchAll(db)
-            let segment = try TranscriptSegmentRecord.fetchOne(db, key: segmentID)
-            let screenshot = try MeetingScreenshotRecord.fetchOne(db, key: screenshotID)
-            return try (
-                sessions,
-                #require(segment),
-                #require(screenshot)
-            )
-        }
-
-        let session = try #require(result.0.first)
-        #expect(result.0.count == 1)
-        #expect(session.startedAt == segmentStart)
-        #expect(session.duration == 15)
-        #expect(session.offsetSeconds == 0)
-        #expect(result.1.sessionId == session.id)
-        #expect(result.1.text == "Hello world")
-        #expect(result.2.sessionId == session.id)
-    }
-
-    @Test
-    func repositoryUpdatesProjectGoogleDriveFolder() throws {
-        let database = try AppDatabaseManager(path: ":memory:")
-        let repository = MeetingRepository(dbQueue: database.dbQueue)
-        let vault = VaultRecord(
-            id: .v7(),
-            path: "/tmp/test-vault",
-            name: "Test Vault",
-            createdAt: Date(),
-            lastOpenedAt: Date()
-        )
-        try repository.insertVault(vault)
-
-        let project = try repository.fetchOrCreateProject(name: "Project A", vaultId: vault.id)
-        try repository.updateProjectGoogleDriveFolder(id: project.id, folderId: "folder-123")
-
-        let fetchedProject = try repository.fetchProject(id: project.id)
-        let updatedProject = try #require(fetchedProject)
-        #expect(updatedProject.googleDriveFolderId == "folder-123")
-    }
-
-    @Test
-    func initializesInstructionsTableWithConstraints() throws {
-        let database = try AppDatabaseManager(path: ":memory:")
-
-        let columnNames = try database.dbQueue.read { db in
-            try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('instructions')")
-        }
-        let hasCompositeUniqueIndex = try database.dbQueue.read { db in
-            try Int.fetchOne(
-                db,
-                sql: """
-                SELECT COUNT(*)
-                FROM (
-                    SELECT il.name
-                    FROM pragma_index_list('instructions') AS il
-                    JOIN pragma_index_info(il.name) AS ii
-                    WHERE il."unique" = 1
-                    GROUP BY il.name
-                    HAVING group_concat(ii.name, ',') = 'vaultId,name'
+                try db.execute(
+                    sql: """
+                    CREATE TABLE transcript_segments (
+                        id BLOB PRIMARY KEY,
+                        meetingId BLOB NOT NULL,
+                        startTime DATETIME NOT NULL,
+                        endTime DATETIME,
+                        text TEXT NOT NULL,
+                        translatedText TEXT,
+                        isConfirmed BOOLEAN NOT NULL DEFAULT 0,
+                        speakerLabel TEXT
+                    )
+                    """
                 )
-                """
-            )
-        }
-
-        #expect(columnNames.contains("vaultId"))
-        #expect(columnNames.contains("name"))
-        #expect(columnNames.contains("content"))
-        #expect(hasCompositeUniqueIndex == 1)
-    }
-
-    @Test
-    func existingV3DatabaseMigratesInstructionsTable() throws {
-        let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("sqlite")
-
-        defer { try? FileManager.default.removeItem(at: databaseURL) }
-
-        let legacyQueue = try DatabaseQueue(path: databaseURL.path)
-        try legacyQueue.write { db in
-            try db.create(table: "vaults") { t in
-                t.primaryKey("id", .blob)
-                t.column("path", .text).notNull().unique()
-                t.column("name", .text).notNull()
-                t.column("createdAt", .datetime).notNull()
-                t.column("lastOpenedAt", .datetime).notNull()
-            }
-            try db.create(table: "grdb_migrations") { t in
-                t.column("identifier", .text).primaryKey()
-            }
-            try db.execute(
-                sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
-                arguments: ["v3_googleDriveFolderSchema"]
-            )
-        }
-
-        let migrated = try AppDatabaseManager(path: databaseURL.path)
-        let tables = try migrated.dbQueue.read { db in
-            try String.fetchAll(db, sql: "SELECT name FROM sqlite_master WHERE type = 'table'")
-        }
-
-        #expect(tables.contains("instructions"))
-    }
-
-    @Test
-    func existingV3DatabasePreservesExistingDataDuringMigration() throws {
-        let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("sqlite")
-        let legacyVaultID = UUID.v7()
-        let createdAt = Date.now
-
-        defer { try? FileManager.default.removeItem(at: databaseURL) }
-
-        let legacyQueue = try DatabaseQueue(path: databaseURL.path)
-        try legacyQueue.write { db in
-            try db.create(table: "vaults") { t in
-                t.primaryKey("id", .blob)
-                t.column("path", .text).notNull().unique()
-                t.column("name", .text).notNull()
-                t.column("createdAt", .datetime).notNull()
-                t.column("lastOpenedAt", .datetime).notNull()
-            }
-            try db.create(table: "grdb_migrations") { t in
-                t.column("identifier", .text).primaryKey()
-            }
-            try db.execute(
-                sql: """
-                INSERT INTO vaults (id, path, name, createdAt, lastOpenedAt)
-                VALUES (?, ?, ?, ?, ?)
-                """,
-                arguments: [legacyVaultID, "/tmp/legacy-vault", "Legacy Vault", createdAt, createdAt]
-            )
-            try db.execute(
-                sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
-                arguments: ["v3_googleDriveFolderSchema"]
-            )
-        }
-
-        let migrated = try AppDatabaseManager(path: databaseURL.path)
-        let migratedVault = try migrated.dbQueue.read { db in
-            try Row.fetchOne(
-                db,
-                sql: "SELECT id, path, name FROM vaults WHERE id = ?",
-                arguments: [legacyVaultID]
-            )
-        }
-
-        #expect(migratedVault != nil)
-        #expect(migratedVault?["path"] == "/tmp/legacy-vault")
-        #expect(migratedVault?["name"] == "Legacy Vault")
-    }
-
-    @Test
-    func existingV4DatabaseMigratesSummaryGoogleFileIdColumn() throws {
-        let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("sqlite")
-
-        defer { try? FileManager.default.removeItem(at: databaseURL) }
-
-        let legacyQueue = try DatabaseQueue(path: databaseURL.path)
-        try legacyQueue.write { db in
-            try db.create(table: "summaries") { t in
-                t.primaryKey("meetingId", .blob)
-                t.column("title", .text).notNull().defaults(to: "")
-                t.column("summary", .text).notNull()
-                t.column("createdAt", .datetime).notNull()
-            }
-            try db.create(table: "grdb_migrations") { t in
-                t.column("identifier", .text).primaryKey()
-            }
-            try db.execute(
-                sql: "INSERT INTO grdb_migrations (identifier) VALUES (?), (?)",
-                arguments: ["v3_googleDriveFolderSchema", "v4_instructionsSchema"]
-            )
-        }
-
-        let migrated = try AppDatabaseManager(path: databaseURL.path)
-        let columns = try migrated.dbQueue.read { db in
-            try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
-        }
-
-        #expect(columns.contains("googleFileId"))
-    }
-
-    @Test
-    func existingV5DatabaseMigratesTranscriptTranslatedTextColumnWithoutDataLoss() throws {
-        let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("sqlite")
-        let segmentID = UUID.v7()
-        let meetingID = UUID.v7()
-        let startTime = Date(timeIntervalSince1970: 1_776_384_000)
-
-        defer { try? FileManager.default.removeItem(at: databaseURL) }
-
-        let legacyQueue = try DatabaseQueue(path: databaseURL.path)
-        try legacyQueue.write { db in
-            try db.execute(
-                sql: """
-                CREATE TABLE transcript_segments (
-                    id BLOB PRIMARY KEY,
-                    meetingId BLOB NOT NULL,
-                    startTime DATETIME NOT NULL,
-                    endTime DATETIME,
-                    text TEXT NOT NULL,
-                    isConfirmed BOOLEAN NOT NULL DEFAULT 0,
-                    speakerLabel TEXT
+                try db.execute(
+                    sql: """
+                    CREATE TABLE screenshots (
+                        id BLOB PRIMARY KEY,
+                        meetingId BLOB NOT NULL,
+                        capturedAt DATETIME NOT NULL,
+                        imageData BLOB NOT NULL,
+                        mimeType TEXT NOT NULL
+                    )
+                    """
                 )
-                """
-            )
-            try db.create(table: "grdb_migrations") { t in
-                t.column("identifier", .text).primaryKey()
-            }
-            try db.execute(
-                sql: """
-                INSERT INTO transcript_segments (id, meetingId, startTime, text, isConfirmed, speakerLabel)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                arguments: [segmentID, meetingID, startTime, "Hello world", true, "mic"]
-            )
-            try db.execute(
-                sql: "INSERT INTO grdb_migrations (identifier) VALUES (?), (?), (?)",
-                arguments: ["v3_googleDriveFolderSchema", "v4_instructionsSchema", "v5_summaryGoogleFileId"]
-            )
-        }
-
-        let migrated = try AppDatabaseManager(path: databaseURL.path)
-        let result = try migrated.dbQueue.read { db in
-            try (
-                String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('transcript_segments')"),
-                Row.fetchOne(db, sql: "SELECT text, translatedText FROM transcript_segments WHERE id = ?", arguments: [segmentID])
-            )
-        }
-
-        #expect(result.0.contains("translatedText"))
-        #expect(result.1?["text"] == "Hello world")
-        #expect(result.1?["translatedText"] == nil as String?)
-    }
-
-    @Test
-    func existingV8DatabaseAddsSummaryDocumentColumnWithoutBackfill() throws {
-        let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("sqlite")
-        let meetingID = UUID.v7()
-        let screenshotID = UUID.v7()
-        let missingScreenshotID = UUID.v7()
-        let createdAt = Date(timeIntervalSince1970: 1_783_536_000)
-
-        defer { try? FileManager.default.removeItem(at: databaseURL) }
-
-        let legacyQueue = try DatabaseQueue(path: databaseURL.path)
-        try legacyQueue.write { db in
-            try db.create(table: "screenshots") { t in
-                t.primaryKey("id", .blob)
-                t.column("meetingId", .blob).notNull()
-                t.column("sessionId", .blob)
-                t.column("capturedAt", .datetime).notNull()
-                t.column("imageData", .blob).notNull()
-                t.column("mimeType", .text).notNull()
-            }
-            try db.create(table: "summaries") { t in
-                t.primaryKey("meetingId", .blob)
-                t.column("title", .text).notNull().defaults(to: "")
-                t.column("summary", .text).notNull()
-                t.column("googleFileId", .text)
-                t.column("createdAt", .datetime).notNull()
-            }
-            try db.execute(
-                sql: """
-                INSERT INTO screenshots (id, meetingId, sessionId, capturedAt, imageData, mimeType)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                arguments: [screenshotID, meetingID, nil as UUID?, createdAt, Data([0x00]), "image/jpeg"]
-            )
-            try db.execute(
-                sql: """
-                INSERT INTO summaries (meetingId, title, summary, googleFileId, createdAt)
-                VALUES (?, ?, ?, ?, ?)
-                """,
-                arguments: [
-                    meetingID,
-                    "Legacy",
-                    "## Summary\n\n![[\(screenshotID.uuidString).jpeg|Valid]]\n\n![[\(missingScreenshotID.uuidString).jpeg]]",
-                    "google-123",
-                    createdAt,
-                ]
-            )
-            try db.create(table: "grdb_migrations") { t in
-                t.column("identifier", .text).primaryKey()
-            }
-            try db.execute(
-                sql: """
-                INSERT INTO grdb_migrations (identifier)
-                VALUES (?), (?), (?), (?), (?), (?)
-                """,
-                arguments: [
+                try db.create(table: "grdb_migrations") { t in
+                    t.column("identifier", .text).primaryKey()
+                }
+                for migration in [
                     "v3_googleDriveFolderSchema",
                     "v4_instructionsSchema",
                     "v5_summaryGoogleFileId",
                     "v6_transcriptSegmentTranslation",
                     "v7_normalizeLegacyMeetingStatus",
-                    "v8_recordingSessions",
-                ]
-            )
+                ] {
+                    try db.execute(sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)", arguments: [migration])
+                }
+                try db.execute(
+                    sql: """
+                    INSERT INTO meetings (id, vaultId, name, status, duration, createdAt, updatedAt)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    arguments: [meetingID, UUID.v7(), "Legacy", MeetingStatus.ready.rawValue, nil as TimeInterval?, meetingStart, meetingStart]
+                )
+                try db.execute(
+                    sql: """
+                    INSERT INTO transcript_segments (id, meetingId, startTime, endTime, text, isConfirmed, speakerLabel)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    arguments: [segmentID, meetingID, segmentStart, segmentEnd, "Hello world", true, "mic"]
+                )
+                try db.execute(
+                    sql: """
+                    INSERT INTO screenshots (id, meetingId, capturedAt, imageData, mimeType)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    arguments: [screenshotID, meetingID, segmentStart, Data([0x00]), "image/png"]
+                )
+            }
+
+            let migrated = try AppDatabaseManager(path: databaseURL.path)
+            let result = try migrated.dbQueue.read { db in
+                let sessions = try RecordingSessionRecord.filter(Column("meetingId") == meetingID).fetchAll(db)
+                let segment = try TranscriptSegmentRecord.fetchOne(db, key: segmentID)
+                let screenshot = try MeetingScreenshotRecord.fetchOne(db, key: screenshotID)
+                return try (
+                    sessions,
+                    #require(segment),
+                    #require(screenshot)
+                )
+            }
+
+            let session = try #require(result.0.first)
+            #expect(result.0.count == 1)
+            #expect(session.startedAt == segmentStart)
+            #expect(session.duration == 15)
+            #expect(session.offsetSeconds == 0)
+            #expect(session.transcriptionMode == .realtime)
+            #expect(result.1.sessionId == session.id)
+            #expect(result.1.text == "Hello world")
+            #expect(result.2.sessionId == session.id)
         }
 
-        let migrated = try AppDatabaseManager(path: databaseURL.path)
-        let result = try migrated.dbQueue.read { db in
-            try (
-                String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')"),
-                Row.fetchOne(db, sql: "SELECT title, summary, document, googleFileId FROM summaries WHERE meetingId = ?", arguments: [meetingID])
+        @Test
+        func repositoryUpdatesProjectGoogleDriveFolder() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
+            let repository = MeetingRepository(dbQueue: database.dbQueue)
+            let vault = VaultRecord(
+                id: .v7(),
+                path: "/tmp/test-vault",
+                name: "Test Vault",
+                createdAt: Date(),
+                lastOpenedAt: Date()
             )
+            try repository.insertVault(vault)
+
+            let project = try repository.fetchOrCreateProject(name: "Project A", vaultId: vault.id)
+            try repository.updateProjectGoogleDriveFolder(id: project.id, folderId: "folder-123")
+
+            let fetchedProject = try repository.fetchProject(id: project.id)
+            let updatedProject = try #require(fetchedProject)
+            #expect(updatedProject.googleDriveFolderId == "folder-123")
         }
 
-        #expect(result.0.contains("document"))
-        #expect(result.1?["title"] == "Legacy")
-        #expect(result.1?["summary"] == "## Summary\n\n![[\(screenshotID.uuidString).jpeg|Valid]]\n\n![[\(missingScreenshotID.uuidString).jpeg]]")
-        #expect(result.1?["document"] == nil as String?)
-        #expect(result.1?["googleFileId"] == "google-123")
+        @Test
+        func initializesInstructionsTableWithConstraints() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
+
+            let columnNames = try database.dbQueue.read { db in
+                try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('instructions')")
+            }
+            let hasCompositeUniqueIndex = try database.dbQueue.read { db in
+                try Int.fetchOne(
+                    db,
+                    sql: """
+                    SELECT COUNT(*)
+                    FROM (
+                        SELECT il.name
+                        FROM pragma_index_list('instructions') AS il
+                        JOIN pragma_index_info(il.name) AS ii
+                        WHERE il."unique" = 1
+                        GROUP BY il.name
+                        HAVING group_concat(ii.name, ',') = 'vaultId,name'
+                    )
+                    """
+                )
+            }
+
+            #expect(columnNames.contains("vaultId"))
+            #expect(columnNames.contains("name"))
+            #expect(columnNames.contains("content"))
+            #expect(hasCompositeUniqueIndex == 1)
+        }
+
+        @Test
+        func existingV3DatabaseMigratesInstructionsTable() throws {
+            let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("sqlite")
+
+            defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+            let legacyQueue = try DatabaseQueue(path: databaseURL.path)
+            try legacyQueue.write { db in
+                try db.create(table: "vaults") { t in
+                    t.primaryKey("id", .blob)
+                    t.column("path", .text).notNull().unique()
+                    t.column("name", .text).notNull()
+                    t.column("createdAt", .datetime).notNull()
+                    t.column("lastOpenedAt", .datetime).notNull()
+                }
+                try db.create(table: "grdb_migrations") { t in
+                    t.column("identifier", .text).primaryKey()
+                }
+                try db.execute(
+                    sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
+                    arguments: ["v3_googleDriveFolderSchema"]
+                )
+            }
+
+            let migrated = try AppDatabaseManager(path: databaseURL.path)
+            let tables = try migrated.dbQueue.read { db in
+                try String.fetchAll(db, sql: "SELECT name FROM sqlite_master WHERE type = 'table'")
+            }
+
+            #expect(tables.contains("instructions"))
+        }
+
+        @Test
+        func existingV3DatabasePreservesExistingDataDuringMigration() throws {
+            let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("sqlite")
+            let legacyVaultID = UUID.v7()
+            let createdAt = Date.now
+
+            defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+            let legacyQueue = try DatabaseQueue(path: databaseURL.path)
+            try legacyQueue.write { db in
+                try db.create(table: "vaults") { t in
+                    t.primaryKey("id", .blob)
+                    t.column("path", .text).notNull().unique()
+                    t.column("name", .text).notNull()
+                    t.column("createdAt", .datetime).notNull()
+                    t.column("lastOpenedAt", .datetime).notNull()
+                }
+                try db.create(table: "grdb_migrations") { t in
+                    t.column("identifier", .text).primaryKey()
+                }
+                try db.execute(
+                    sql: """
+                    INSERT INTO vaults (id, path, name, createdAt, lastOpenedAt)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    arguments: [legacyVaultID, "/tmp/legacy-vault", "Legacy Vault", createdAt, createdAt]
+                )
+                try db.execute(
+                    sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
+                    arguments: ["v3_googleDriveFolderSchema"]
+                )
+            }
+
+            let migrated = try AppDatabaseManager(path: databaseURL.path)
+            let migratedVault = try migrated.dbQueue.read { db in
+                try Row.fetchOne(
+                    db,
+                    sql: "SELECT id, path, name FROM vaults WHERE id = ?",
+                    arguments: [legacyVaultID]
+                )
+            }
+
+            #expect(migratedVault != nil)
+            #expect(migratedVault?["path"] == "/tmp/legacy-vault")
+            #expect(migratedVault?["name"] == "Legacy Vault")
+        }
+
+        @Test
+        func existingV4DatabaseMigratesSummaryGoogleFileIdColumn() throws {
+            let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("sqlite")
+
+            defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+            let legacyQueue = try DatabaseQueue(path: databaseURL.path)
+            try legacyQueue.write { db in
+                try db.create(table: "summaries") { t in
+                    t.primaryKey("meetingId", .blob)
+                    t.column("title", .text).notNull().defaults(to: "")
+                    t.column("summary", .text).notNull()
+                    t.column("createdAt", .datetime).notNull()
+                }
+                try db.create(table: "grdb_migrations") { t in
+                    t.column("identifier", .text).primaryKey()
+                }
+                try db.execute(
+                    sql: "INSERT INTO grdb_migrations (identifier) VALUES (?), (?)",
+                    arguments: ["v3_googleDriveFolderSchema", "v4_instructionsSchema"]
+                )
+            }
+
+            let migrated = try AppDatabaseManager(path: databaseURL.path)
+            let columns = try migrated.dbQueue.read { db in
+                try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
+            }
+
+            #expect(columns.contains("googleFileId"))
+        }
+
+        @Test
+        func existingV5DatabaseMigratesTranscriptTranslatedTextColumnWithoutDataLoss() throws {
+            let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("sqlite")
+            let segmentID = UUID.v7()
+            let meetingID = UUID.v7()
+            let startTime = Date(timeIntervalSince1970: 1_776_384_000)
+
+            defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+            let legacyQueue = try DatabaseQueue(path: databaseURL.path)
+            try legacyQueue.write { db in
+                try db.execute(
+                    sql: """
+                    CREATE TABLE transcript_segments (
+                        id BLOB PRIMARY KEY,
+                        meetingId BLOB NOT NULL,
+                        startTime DATETIME NOT NULL,
+                        endTime DATETIME,
+                        text TEXT NOT NULL,
+                        isConfirmed BOOLEAN NOT NULL DEFAULT 0,
+                        speakerLabel TEXT
+                    )
+                    """
+                )
+                try db.create(table: "grdb_migrations") { t in
+                    t.column("identifier", .text).primaryKey()
+                }
+                try db.execute(
+                    sql: """
+                    INSERT INTO transcript_segments (id, meetingId, startTime, text, isConfirmed, speakerLabel)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    arguments: [segmentID, meetingID, startTime, "Hello world", true, "mic"]
+                )
+                try db.execute(
+                    sql: "INSERT INTO grdb_migrations (identifier) VALUES (?), (?), (?)",
+                    arguments: ["v3_googleDriveFolderSchema", "v4_instructionsSchema", "v5_summaryGoogleFileId"]
+                )
+            }
+
+            let migrated = try AppDatabaseManager(path: databaseURL.path)
+            let result = try migrated.dbQueue.read { db in
+                try (
+                    String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('transcript_segments')"),
+                    Row.fetchOne(db, sql: "SELECT text, translatedText FROM transcript_segments WHERE id = ?", arguments: [segmentID])
+                )
+            }
+
+            #expect(result.0.contains("translatedText"))
+            #expect(result.1?["text"] == "Hello world")
+            #expect(result.1?["translatedText"] == nil as String?)
+        }
+
+        @Test
+        func existingV8DatabaseAddsSummaryDocumentColumnWithoutBackfill() throws {
+            let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("sqlite")
+            let meetingID = UUID.v7()
+            let screenshotID = UUID.v7()
+            let missingScreenshotID = UUID.v7()
+            let createdAt = Date(timeIntervalSince1970: 1_783_536_000)
+
+            defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+            let legacyQueue = try DatabaseQueue(path: databaseURL.path)
+            try legacyQueue.write { db in
+                try db.create(table: "screenshots") { t in
+                    t.primaryKey("id", .blob)
+                    t.column("meetingId", .blob).notNull()
+                    t.column("sessionId", .blob)
+                    t.column("capturedAt", .datetime).notNull()
+                    t.column("imageData", .blob).notNull()
+                    t.column("mimeType", .text).notNull()
+                }
+                try db.create(table: "summaries") { t in
+                    t.primaryKey("meetingId", .blob)
+                    t.column("title", .text).notNull().defaults(to: "")
+                    t.column("summary", .text).notNull()
+                    t.column("googleFileId", .text)
+                    t.column("createdAt", .datetime).notNull()
+                }
+                try db.execute(
+                    sql: """
+                    INSERT INTO screenshots (id, meetingId, sessionId, capturedAt, imageData, mimeType)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    arguments: [screenshotID, meetingID, nil as UUID?, createdAt, Data([0x00]), "image/jpeg"]
+                )
+                try db.execute(
+                    sql: """
+                    INSERT INTO summaries (meetingId, title, summary, googleFileId, createdAt)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    arguments: [
+                        meetingID,
+                        "Legacy",
+                        "## Summary\n\n![[\(screenshotID.uuidString).jpeg|Valid]]\n\n![[\(missingScreenshotID.uuidString).jpeg]]",
+                        "google-123",
+                        createdAt,
+                    ]
+                )
+                try db.create(table: "grdb_migrations") { t in
+                    t.column("identifier", .text).primaryKey()
+                }
+                try db.execute(
+                    sql: """
+                    INSERT INTO grdb_migrations (identifier)
+                    VALUES (?), (?), (?), (?), (?), (?)
+                    """,
+                    arguments: [
+                        "v3_googleDriveFolderSchema",
+                        "v4_instructionsSchema",
+                        "v5_summaryGoogleFileId",
+                        "v6_transcriptSegmentTranslation",
+                        "v7_normalizeLegacyMeetingStatus",
+                        "v8_recordingSessions",
+                    ]
+                )
+            }
+
+            let migrated = try AppDatabaseManager(path: databaseURL.path)
+            let result = try migrated.dbQueue.read { db in
+                try (
+                    String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')"),
+                    Row.fetchOne(db, sql: "SELECT title, summary, document, googleFileId FROM summaries WHERE meetingId = ?", arguments: [meetingID])
+                )
+            }
+
+            #expect(result.0.contains("document"))
+            #expect(result.1?["title"] == "Legacy")
+            #expect(result.1?["summary"] == "## Summary\n\n![[\(screenshotID.uuidString).jpeg|Valid]]\n\n![[\(missingScreenshotID.uuidString).jpeg]]")
+            #expect(result.1?["document"] == nil as String?)
+            #expect(result.1?["googleFileId"] == "google-123")
+        }
     }
-}
 
 #elseif canImport(XCTest)
-import XCTest
+    import XCTest
 
-@MainActor
-final class AppDatabaseManagerTests: XCTestCase {
-    func testInitializesInMemoryDatabaseWithGoogleDriveFolderColumn() throws {
-        let database = try AppDatabaseManager(path: ":memory:")
+    @MainActor
+    final class AppDatabaseManagerTests: XCTestCase {
+        func testInitializesInMemoryDatabaseWithGoogleDriveFolderColumn() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
 
-        let columns = try database.dbQueue.read { db in
-            try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('projects')")
+            let columns = try database.dbQueue.read { db in
+                try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('projects')")
+            }
+
+            XCTAssertTrue(columns.contains("googleDriveFolderId"))
         }
 
-        XCTAssertTrue(columns.contains("googleDriveFolderId"))
-    }
+        func testInitializesInMemoryDatabaseWithSummaryGoogleFileIdColumn() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
 
-    func testInitializesInMemoryDatabaseWithSummaryGoogleFileIdColumn() throws {
-        let database = try AppDatabaseManager(path: ":memory:")
+            let columns = try database.dbQueue.read { db in
+                try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
+            }
 
-        let columns = try database.dbQueue.read { db in
-            try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
+            XCTAssertTrue(columns.contains("googleFileId"))
         }
 
-        XCTAssertTrue(columns.contains("googleFileId"))
-    }
+        func testInitializesInMemoryDatabaseWithTranscriptTranslatedTextColumn() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
 
-    func testInitializesInMemoryDatabaseWithTranscriptTranslatedTextColumn() throws {
-        let database = try AppDatabaseManager(path: ":memory:")
+            let columns = try database.dbQueue.read { db in
+                try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('transcript_segments')")
+            }
 
-        let columns = try database.dbQueue.read { db in
-            try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('transcript_segments')")
+            XCTAssertTrue(columns.contains("translatedText"))
         }
 
-        XCTAssertTrue(columns.contains("translatedText"))
-    }
+        func testRepositoryUpdatesProjectGoogleDriveFolder() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
+            let repository = MeetingRepository(dbQueue: database.dbQueue)
+            let vault = VaultRecord(
+                id: .v7(),
+                path: "/tmp/test-vault",
+                name: "Test Vault",
+                createdAt: Date(),
+                lastOpenedAt: Date()
+            )
+            try repository.insertVault(vault)
 
-    func testRepositoryUpdatesProjectGoogleDriveFolder() throws {
-        let database = try AppDatabaseManager(path: ":memory:")
-        let repository = MeetingRepository(dbQueue: database.dbQueue)
-        let vault = VaultRecord(
-            id: .v7(),
-            path: "/tmp/test-vault",
-            name: "Test Vault",
-            createdAt: Date(),
-            lastOpenedAt: Date()
-        )
-        try repository.insertVault(vault)
+            let project = try repository.fetchOrCreateProject(name: "Project A", vaultId: vault.id)
+            try repository.updateProjectGoogleDriveFolder(id: project.id, folderId: "folder-123")
 
-        let project = try repository.fetchOrCreateProject(name: "Project A", vaultId: vault.id)
-        try repository.updateProjectGoogleDriveFolder(id: project.id, folderId: "folder-123")
-
-        let updatedProject = try XCTUnwrap(repository.fetchProject(id: project.id))
-        XCTAssertEqual(updatedProject.googleDriveFolderId, "folder-123")
-    }
-
-    func testInitializesInstructionsTableWithConstraints() throws {
-        let database = try AppDatabaseManager(path: ":memory:")
-
-        let columnNames = try database.dbQueue.read { db in
-            try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('instructions')")
+            let updatedProject = try XCTUnwrap(repository.fetchProject(id: project.id))
+            XCTAssertEqual(updatedProject.googleDriveFolderId, "folder-123")
         }
-        let hasCompositeUniqueIndex = try database.dbQueue.read { db in
-            try Int.fetchOne(
-                db,
-                sql: """
-                SELECT COUNT(*)
-                FROM (
-                    SELECT il.name
-                    FROM pragma_index_list('instructions') AS il
-                    JOIN pragma_index_info(il.name) AS ii
-                    WHERE il."unique" = 1
-                    GROUP BY il.name
-                    HAVING group_concat(ii.name, ',') = 'vaultId,name'
+
+        func testInitializesInstructionsTableWithConstraints() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
+
+            let columnNames = try database.dbQueue.read { db in
+                try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('instructions')")
+            }
+            let hasCompositeUniqueIndex = try database.dbQueue.read { db in
+                try Int.fetchOne(
+                    db,
+                    sql: """
+                    SELECT COUNT(*)
+                    FROM (
+                        SELECT il.name
+                        FROM pragma_index_list('instructions') AS il
+                        JOIN pragma_index_info(il.name) AS ii
+                        WHERE il."unique" = 1
+                        GROUP BY il.name
+                        HAVING group_concat(ii.name, ',') = 'vaultId,name'
+                    )
+                    """
                 )
-                """
-            )
-        }
-
-        XCTAssertTrue(columnNames.contains("vaultId"))
-        XCTAssertTrue(columnNames.contains("name"))
-        XCTAssertTrue(columnNames.contains("content"))
-        XCTAssertEqual(hasCompositeUniqueIndex, 1)
-    }
-
-    func testExistingV3DatabaseMigratesInstructionsTable() throws {
-        let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("sqlite")
-
-        defer { try? FileManager.default.removeItem(at: databaseURL) }
-
-        let legacyQueue = try DatabaseQueue(path: databaseURL.path)
-        try legacyQueue.write { db in
-            try db.create(table: "vaults") { t in
-                t.primaryKey("id", .blob)
-                t.column("path", .text).notNull().unique()
-                t.column("name", .text).notNull()
-                t.column("createdAt", .datetime).notNull()
-                t.column("lastOpenedAt", .datetime).notNull()
             }
-            try db.create(table: "grdb_migrations") { t in
-                t.column("identifier", .text).primaryKey()
-            }
-            try db.execute(
-                sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
-                arguments: ["v3_googleDriveFolderSchema"]
-            )
+
+            XCTAssertTrue(columnNames.contains("vaultId"))
+            XCTAssertTrue(columnNames.contains("name"))
+            XCTAssertTrue(columnNames.contains("content"))
+            XCTAssertEqual(hasCompositeUniqueIndex, 1)
         }
 
-        let migrated = try AppDatabaseManager(path: databaseURL.path)
-        let tables = try migrated.dbQueue.read { db in
-            try String.fetchAll(db, sql: "SELECT name FROM sqlite_master WHERE type = 'table'")
-        }
+        func testExistingV3DatabaseMigratesInstructionsTable() throws {
+            let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("sqlite")
 
-        XCTAssertTrue(tables.contains("instructions"))
-    }
+            defer { try? FileManager.default.removeItem(at: databaseURL) }
 
-    func testExistingV3DatabasePreservesExistingDataDuringMigration() throws {
-        let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("sqlite")
-        let legacyVaultID = UUID.v7()
-        let createdAt = Date.now
-
-        defer { try? FileManager.default.removeItem(at: databaseURL) }
-
-        let legacyQueue = try DatabaseQueue(path: databaseURL.path)
-        try legacyQueue.write { db in
-            try db.create(table: "vaults") { t in
-                t.primaryKey("id", .blob)
-                t.column("path", .text).notNull().unique()
-                t.column("name", .text).notNull()
-                t.column("createdAt", .datetime).notNull()
-                t.column("lastOpenedAt", .datetime).notNull()
-            }
-            try db.create(table: "grdb_migrations") { t in
-                t.column("identifier", .text).primaryKey()
-            }
-            try db.execute(
-                sql: """
-                INSERT INTO vaults (id, path, name, createdAt, lastOpenedAt)
-                VALUES (?, ?, ?, ?, ?)
-                """,
-                arguments: [legacyVaultID, "/tmp/legacy-vault", "Legacy Vault", createdAt, createdAt]
-            )
-            try db.execute(
-                sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
-                arguments: ["v3_googleDriveFolderSchema"]
-            )
-        }
-
-        let migrated = try AppDatabaseManager(path: databaseURL.path)
-        let migratedVault = try migrated.dbQueue.read { db in
-            try Row.fetchOne(
-                db,
-                sql: "SELECT id, path, name FROM vaults WHERE id = ?",
-                arguments: [legacyVaultID]
-            )
-        }
-
-        XCTAssertNotNil(migratedVault)
-        XCTAssertEqual(migratedVault?["path"], "/tmp/legacy-vault")
-        XCTAssertEqual(migratedVault?["name"], "Legacy Vault")
-    }
-
-    func testExistingV4DatabaseMigratesSummaryGoogleFileIdColumn() throws {
-        let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("sqlite")
-
-        defer { try? FileManager.default.removeItem(at: databaseURL) }
-
-        let legacyQueue = try DatabaseQueue(path: databaseURL.path)
-        try legacyQueue.write { db in
-            try db.create(table: "summaries") { t in
-                t.primaryKey("meetingId", .blob)
-                t.column("title", .text).notNull().defaults(to: "")
-                t.column("summary", .text).notNull()
-                t.column("createdAt", .datetime).notNull()
-            }
-            try db.create(table: "grdb_migrations") { t in
-                t.column("identifier", .text).primaryKey()
-            }
-            try db.execute(
-                sql: "INSERT INTO grdb_migrations (identifier) VALUES (?), (?)",
-                arguments: ["v3_googleDriveFolderSchema", "v4_instructionsSchema"]
-            )
-        }
-
-        let migrated = try AppDatabaseManager(path: databaseURL.path)
-        let columns = try migrated.dbQueue.read { db in
-            try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
-        }
-
-        XCTAssertTrue(columns.contains("googleFileId"))
-    }
-
-    func testExistingV5DatabaseMigratesTranscriptTranslatedTextColumnWithoutDataLoss() throws {
-        let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("sqlite")
-        let segmentID = UUID.v7()
-        let meetingID = UUID.v7()
-        let startTime = Date(timeIntervalSince1970: 1_776_384_000)
-
-        defer { try? FileManager.default.removeItem(at: databaseURL) }
-
-        let legacyQueue = try DatabaseQueue(path: databaseURL.path)
-        try legacyQueue.write { db in
-            try db.execute(
-                sql: """
-                CREATE TABLE transcript_segments (
-                    id BLOB PRIMARY KEY,
-                    meetingId BLOB NOT NULL,
-                    startTime DATETIME NOT NULL,
-                    endTime DATETIME,
-                    text TEXT NOT NULL,
-                    isConfirmed BOOLEAN NOT NULL DEFAULT 0,
-                    speakerLabel TEXT
+            let legacyQueue = try DatabaseQueue(path: databaseURL.path)
+            try legacyQueue.write { db in
+                try db.create(table: "vaults") { t in
+                    t.primaryKey("id", .blob)
+                    t.column("path", .text).notNull().unique()
+                    t.column("name", .text).notNull()
+                    t.column("createdAt", .datetime).notNull()
+                    t.column("lastOpenedAt", .datetime).notNull()
+                }
+                try db.create(table: "grdb_migrations") { t in
+                    t.column("identifier", .text).primaryKey()
+                }
+                try db.execute(
+                    sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
+                    arguments: ["v3_googleDriveFolderSchema"]
                 )
-                """
-            )
-            try db.create(table: "grdb_migrations") { t in
-                t.column("identifier", .text).primaryKey()
             }
-            try db.execute(
-                sql: """
-                INSERT INTO transcript_segments (id, meetingId, startTime, text, isConfirmed, speakerLabel)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                arguments: [segmentID, meetingID, startTime, "Hello world", true, "mic"]
-            )
-            try db.execute(
-                sql: "INSERT INTO grdb_migrations (identifier) VALUES (?), (?), (?)",
-                arguments: ["v3_googleDriveFolderSchema", "v4_instructionsSchema", "v5_summaryGoogleFileId"]
-            )
+
+            let migrated = try AppDatabaseManager(path: databaseURL.path)
+            let tables = try migrated.dbQueue.read { db in
+                try String.fetchAll(db, sql: "SELECT name FROM sqlite_master WHERE type = 'table'")
+            }
+
+            XCTAssertTrue(tables.contains("instructions"))
         }
 
-        let migrated = try AppDatabaseManager(path: databaseURL.path)
-        let result = try migrated.dbQueue.read { db in
-            try (
-                String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('transcript_segments')"),
-                Row.fetchOne(db, sql: "SELECT text, translatedText FROM transcript_segments WHERE id = ?", arguments: [segmentID])
-            )
+        func testExistingV3DatabasePreservesExistingDataDuringMigration() throws {
+            let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("sqlite")
+            let legacyVaultID = UUID.v7()
+            let createdAt = Date.now
+
+            defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+            let legacyQueue = try DatabaseQueue(path: databaseURL.path)
+            try legacyQueue.write { db in
+                try db.create(table: "vaults") { t in
+                    t.primaryKey("id", .blob)
+                    t.column("path", .text).notNull().unique()
+                    t.column("name", .text).notNull()
+                    t.column("createdAt", .datetime).notNull()
+                    t.column("lastOpenedAt", .datetime).notNull()
+                }
+                try db.create(table: "grdb_migrations") { t in
+                    t.column("identifier", .text).primaryKey()
+                }
+                try db.execute(
+                    sql: """
+                    INSERT INTO vaults (id, path, name, createdAt, lastOpenedAt)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    arguments: [legacyVaultID, "/tmp/legacy-vault", "Legacy Vault", createdAt, createdAt]
+                )
+                try db.execute(
+                    sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
+                    arguments: ["v3_googleDriveFolderSchema"]
+                )
+            }
+
+            let migrated = try AppDatabaseManager(path: databaseURL.path)
+            let migratedVault = try migrated.dbQueue.read { db in
+                try Row.fetchOne(
+                    db,
+                    sql: "SELECT id, path, name FROM vaults WHERE id = ?",
+                    arguments: [legacyVaultID]
+                )
+            }
+
+            XCTAssertNotNil(migratedVault)
+            XCTAssertEqual(migratedVault?["path"], "/tmp/legacy-vault")
+            XCTAssertEqual(migratedVault?["name"], "Legacy Vault")
         }
 
-        XCTAssertTrue(result.0.contains("translatedText"))
-        XCTAssertEqual(result.1?["text"], "Hello world")
-        XCTAssertNil(result.1?["translatedText"] as String?)
+        func testExistingV4DatabaseMigratesSummaryGoogleFileIdColumn() throws {
+            let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("sqlite")
+
+            defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+            let legacyQueue = try DatabaseQueue(path: databaseURL.path)
+            try legacyQueue.write { db in
+                try db.create(table: "summaries") { t in
+                    t.primaryKey("meetingId", .blob)
+                    t.column("title", .text).notNull().defaults(to: "")
+                    t.column("summary", .text).notNull()
+                    t.column("createdAt", .datetime).notNull()
+                }
+                try db.create(table: "grdb_migrations") { t in
+                    t.column("identifier", .text).primaryKey()
+                }
+                try db.execute(
+                    sql: "INSERT INTO grdb_migrations (identifier) VALUES (?), (?)",
+                    arguments: ["v3_googleDriveFolderSchema", "v4_instructionsSchema"]
+                )
+            }
+
+            let migrated = try AppDatabaseManager(path: databaseURL.path)
+            let columns = try migrated.dbQueue.read { db in
+                try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
+            }
+
+            XCTAssertTrue(columns.contains("googleFileId"))
+        }
+
+        func testExistingV5DatabaseMigratesTranscriptTranslatedTextColumnWithoutDataLoss() throws {
+            let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("sqlite")
+            let segmentID = UUID.v7()
+            let meetingID = UUID.v7()
+            let startTime = Date(timeIntervalSince1970: 1_776_384_000)
+
+            defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+            let legacyQueue = try DatabaseQueue(path: databaseURL.path)
+            try legacyQueue.write { db in
+                try db.execute(
+                    sql: """
+                    CREATE TABLE transcript_segments (
+                        id BLOB PRIMARY KEY,
+                        meetingId BLOB NOT NULL,
+                        startTime DATETIME NOT NULL,
+                        endTime DATETIME,
+                        text TEXT NOT NULL,
+                        isConfirmed BOOLEAN NOT NULL DEFAULT 0,
+                        speakerLabel TEXT
+                    )
+                    """
+                )
+                try db.create(table: "grdb_migrations") { t in
+                    t.column("identifier", .text).primaryKey()
+                }
+                try db.execute(
+                    sql: """
+                    INSERT INTO transcript_segments (id, meetingId, startTime, text, isConfirmed, speakerLabel)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    arguments: [segmentID, meetingID, startTime, "Hello world", true, "mic"]
+                )
+                try db.execute(
+                    sql: "INSERT INTO grdb_migrations (identifier) VALUES (?), (?), (?)",
+                    arguments: ["v3_googleDriveFolderSchema", "v4_instructionsSchema", "v5_summaryGoogleFileId"]
+                )
+            }
+
+            let migrated = try AppDatabaseManager(path: databaseURL.path)
+            let result = try migrated.dbQueue.read { db in
+                try (
+                    String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('transcript_segments')"),
+                    Row.fetchOne(db, sql: "SELECT text, translatedText FROM transcript_segments WHERE id = ?", arguments: [segmentID])
+                )
+            }
+
+            XCTAssertTrue(result.0.contains("translatedText"))
+            XCTAssertEqual(result.1?["text"], "Hello world")
+            XCTAssertNil(result.1?["translatedText"] as String?)
+        }
     }
-}
 #endif

--- a/Tests/DahliaTests/BatchAudioRecordingSessionTests.swift
+++ b/Tests/DahliaTests/BatchAudioRecordingSessionTests.swift
@@ -1,0 +1,84 @@
+@preconcurrency import AVFoundation
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct BatchAudioRecordingSessionTests {
+        @Test
+        func localeChangesCreateRangesInOneCAF() async throws {
+            let fixture = try BatchAudioTestFixture(name: "Batch")
+            defer { fixture.removeFiles() }
+
+            let recorder = try BatchAudioRecordingSession(
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL,
+                meetingId: fixture.meeting.id,
+                recordingSessionId: fixture.session.id,
+                recordingStartTime: fixture.now,
+                sampleRate: 16000
+            )
+            let firstWriter = try await recorder.beginRange(
+                source: .microphone,
+                locale: Locale(identifier: "ja_JP"),
+                at: fixture.now
+            )
+            try firstWriter.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 160))
+            try await recorder.endActiveRanges()
+
+            let secondWriter = try await recorder.beginRange(
+                source: .microphone,
+                locale: Locale(identifier: "en_US"),
+                at: fixture.now.addingTimeInterval(1)
+            )
+            #expect(firstWriter === secondWriter)
+            try secondWriter.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 160))
+            try await recorder.finish()
+
+            let result = try await fixture.database.dbQueue.read { db in
+                let files = try RecordingAudioFileRecord
+                    .filter(Column("recordingSessionId") == fixture.session.id)
+                    .fetchAll(db)
+                let ranges = try RecordingAudioRangeRecord.order(Column("startFrame").asc).fetchAll(db)
+                return (files, ranges)
+            }
+            let file = try #require(result.0.first)
+            #expect(result.0.count == 1)
+            #expect(file.storageLocation == .managed)
+            #expect(file.totalFrameCount == 320)
+            #expect(result.1.count == 2)
+            #expect(result.1.map(\.localeIdentifier) == ["ja_JP", "en_US"])
+            #expect(result.1.map(\.startFrame) == [0, 160])
+            #expect(result.1.map(\.frameCount) == [160, 160])
+
+            let finalURL = BatchAudioStorage.finalURL(baseURL: fixture.managedRootURL, relativePath: file.relativePath)
+            let partialURL = BatchAudioStorage.partialURL(baseURL: fixture.managedRootURL, relativePath: file.relativePath)
+            #expect(FileManager.default.fileExists(atPath: finalURL.path))
+            #expect(!FileManager.default.fileExists(atPath: partialURL.path))
+            let vaultAudioURL = BatchAudioStorage.finalURL(
+                baseURL: fixture.vaultURL,
+                relativePath: BatchAudioStorage.vaultRelativePath(
+                    meetingId: fixture.meeting.id,
+                    sessionId: fixture.session.id,
+                    source: .microphone
+                )
+            )
+            #expect(!FileManager.default.fileExists(atPath: vaultAudioURL.path))
+            let audioFile = try AVAudioFile(forReading: finalURL)
+            #expect(audioFile.length == 320)
+        }
+
+        private func makeBuffer(format: AVAudioFormat, frameCount: AVAudioFrameCount) throws -> AVAudioPCMBuffer {
+            let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount))
+            buffer.frameLength = frameCount
+            let channel = try #require(buffer.int16ChannelData?[0])
+            for index in 0 ..< Int(frameCount) {
+                channel[index] = Int16(index % 100)
+            }
+            return buffer
+        }
+    }
+#endif

--- a/Tests/DahliaTests/BatchAudioRetentionServiceTests.swift
+++ b/Tests/DahliaTests/BatchAudioRetentionServiceTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct BatchAudioRetentionServiceTests {
+        @Test
+        func retainedAudioMovesFromManagedStorageToVaultAndSurvivesMeetingDeletion() throws {
+            let now = Date(timeIntervalSince1970: 1_776_384_000)
+            let fixture = try BatchAudioTestFixture(
+                name: "Retention",
+                meetingStatus: .ready,
+                endedAt: now.addingTimeInterval(0.02),
+                duration: 0.02,
+                retainAudioAfterBatch: true,
+                batchCompletedAt: now
+            )
+            defer { fixture.removeFiles() }
+            let audioRecord = fixture.makeAudioRecord(finalizedAt: now, totalFrameCount: 320)
+            try fixture.database.dbQueue.write { db in
+                try audioRecord.insert(db)
+            }
+
+            let managedURL = BatchAudioStorage.finalURL(
+                baseURL: fixture.managedRootURL,
+                relativePath: fixture.managedRelativePath
+            )
+            try BatchAudioTestFixture.writeCAF(url: managedURL, frameCount: 320)
+
+            try BatchAudioRetentionService.retainCompletedAudio(
+                sessionId: fixture.session.id,
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL
+            )
+
+            let retainedRecord = try #require(
+                fixture.database.dbQueue.read { db in
+                    try RecordingAudioFileRecord.fetchOne(db, key: audioRecord.id)
+                }
+            )
+            let retainedURL = BatchAudioStorage.finalURL(
+                for: retainedRecord,
+                managedRootURL: fixture.managedRootURL,
+                vaultURL: fixture.vaultURL
+            )
+            #expect(retainedRecord.storageLocation == .vault)
+            #expect(retainedRecord.relativePath == BatchAudioStorage.vaultRelativePath(
+                meetingId: fixture.meeting.id,
+                sessionId: fixture.session.id,
+                source: .microphone
+            ))
+            #expect(!FileManager.default.fileExists(atPath: managedURL.path))
+            #expect(FileManager.default.fileExists(atPath: retainedURL.path))
+
+            let repository = MeetingRepository(dbQueue: fixture.database.dbQueue)
+            try repository.deleteMeeting(id: fixture.meeting.id)
+            #expect(FileManager.default.fileExists(atPath: retainedURL.path))
+        }
+
+        @Test
+        func retainedAudioAcceptsRecoveredPartialCAF() throws {
+            let now = Date(timeIntervalSince1970: 1_776_384_000)
+            let fixture = try BatchAudioTestFixture(
+                name: "PartialRetention",
+                meetingStatus: .ready,
+                endedAt: now.addingTimeInterval(0.02),
+                duration: 0.02,
+                retainAudioAfterBatch: true,
+                batchCompletedAt: now
+            )
+            defer { fixture.removeFiles() }
+            let audioRecord = fixture.makeAudioRecord(finalizedAt: nil, totalFrameCount: 320)
+            try fixture.database.dbQueue.write { db in
+                try audioRecord.insert(db)
+            }
+
+            let partialURL = BatchAudioStorage.partialURL(
+                baseURL: fixture.managedRootURL,
+                relativePath: fixture.managedRelativePath
+            )
+            try BatchAudioTestFixture.writeCAF(url: partialURL, frameCount: 320)
+
+            try BatchAudioRetentionService.retainCompletedAudio(
+                sessionId: fixture.session.id,
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL
+            )
+
+            let retainedRecord = try #require(
+                fixture.database.dbQueue.read { db in
+                    try RecordingAudioFileRecord.fetchOne(db, key: audioRecord.id)
+                }
+            )
+            let retainedURL = BatchAudioStorage.finalURL(
+                for: retainedRecord,
+                managedRootURL: fixture.managedRootURL,
+                vaultURL: fixture.vaultURL
+            )
+            #expect(retainedRecord.storageLocation == .vault)
+            #expect(FileManager.default.fileExists(atPath: retainedURL.path))
+            #expect(!FileManager.default.fileExists(atPath: partialURL.path))
+        }
+    }
+#endif

--- a/Tests/DahliaTests/BatchAudioRetentionServiceTests.swift
+++ b/Tests/DahliaTests/BatchAudioRetentionServiceTests.swift
@@ -8,7 +8,7 @@ import GRDB
     @MainActor
     struct BatchAudioRetentionServiceTests {
         @Test
-        func retainedAudioMovesFromManagedStorageToVaultAndSurvivesMeetingDeletion() throws {
+        func retainedAudioMovesToVaultAndIsDeletedWithMeeting() throws {
             let now = Date(timeIntervalSince1970: 1_776_384_000)
             let fixture = try BatchAudioTestFixture(
                 name: "Retention",
@@ -53,11 +53,15 @@ import GRDB
                 source: .microphone
             ))
             #expect(!FileManager.default.fileExists(atPath: managedURL.path))
+            #expect(!FileManager.default.fileExists(atPath: managedURL.deletingLastPathComponent().path))
+            #expect(FileManager.default.fileExists(atPath: fixture.managedRootURL.path))
             #expect(FileManager.default.fileExists(atPath: retainedURL.path))
 
             let repository = MeetingRepository(dbQueue: fixture.database.dbQueue)
             try repository.deleteMeeting(id: fixture.meeting.id)
-            #expect(FileManager.default.fileExists(atPath: retainedURL.path))
+            #expect(!FileManager.default.fileExists(atPath: retainedURL.path))
+            #expect(!FileManager.default.fileExists(atPath: retainedURL.deletingLastPathComponent().path))
+            #expect(FileManager.default.fileExists(atPath: fixture.vaultURL.path))
         }
 
         @Test
@@ -102,6 +106,50 @@ import GRDB
             #expect(retainedRecord.storageLocation == .vault)
             #expect(FileManager.default.fileExists(atPath: retainedURL.path))
             #expect(!FileManager.default.fileExists(atPath: partialURL.path))
+            #expect(!FileManager.default.fileExists(atPath: partialURL.deletingLastPathComponent().path))
+        }
+
+        @Test
+        func retainedAudioSurvivesVaultUnregistration() throws {
+            let now = Date(timeIntervalSince1970: 1_776_384_000)
+            let fixture = try BatchAudioTestFixture(
+                name: "VaultUnregistration",
+                meetingStatus: .ready,
+                endedAt: now.addingTimeInterval(0.02),
+                duration: 0.02,
+                retainAudioAfterBatch: true,
+                batchCompletedAt: now
+            )
+            defer { fixture.removeFiles() }
+            let audioRecord = fixture.makeAudioRecord(finalizedAt: now, totalFrameCount: 320)
+            try fixture.database.dbQueue.write { db in
+                try audioRecord.insert(db)
+            }
+            let managedURL = BatchAudioStorage.finalURL(
+                baseURL: fixture.managedRootURL,
+                relativePath: fixture.managedRelativePath
+            )
+            try BatchAudioTestFixture.writeCAF(url: managedURL, frameCount: 320)
+            try BatchAudioRetentionService.retainCompletedAudio(
+                sessionId: fixture.session.id,
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL
+            )
+            let retainedRecord = try #require(
+                fixture.database.dbQueue.read { db in
+                    try RecordingAudioFileRecord.fetchOne(db, key: audioRecord.id)
+                }
+            )
+            let retainedURL = BatchAudioStorage.finalURL(
+                for: retainedRecord,
+                managedRootURL: fixture.managedRootURL,
+                vaultURL: fixture.vaultURL
+            )
+
+            let repository = MeetingRepository(dbQueue: fixture.database.dbQueue)
+            try repository.deleteVault(id: fixture.meeting.vaultId)
+
+            #expect(FileManager.default.fileExists(atPath: retainedURL.path))
         }
     }
 #endif

--- a/Tests/DahliaTests/BatchAudioTestFixture.swift
+++ b/Tests/DahliaTests/BatchAudioTestFixture.swift
@@ -1,0 +1,109 @@
+@preconcurrency import AVFoundation
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct BatchAudioTestFixture {
+        let database: AppDatabaseManager
+        let testRootURL: URL
+        let managedRootURL: URL
+        let vaultURL: URL
+        let now: Date
+        let meeting: MeetingRecord
+        let session: RecordingSessionRecord
+
+        init(
+            name: String,
+            meetingStatus: MeetingStatus = .transcriptNotFound,
+            endedAt: Date? = nil,
+            duration: TimeInterval? = nil,
+            retainAudioAfterBatch: Bool = false,
+            batchCompletedAt: Date? = nil
+        ) throws {
+            database = try AppDatabaseManager(path: ":memory:")
+            testRootURL = FileManager.default.temporaryDirectory
+                .appending(path: "dahlia-\(name)-test-\(UUID.v7().uuidString)", directoryHint: .isDirectory)
+            managedRootURL = testRootURL.appending(path: "Managed", directoryHint: .isDirectory)
+            vaultURL = testRootURL.appending(path: "Vault", directoryHint: .isDirectory)
+            now = Date(timeIntervalSince1970: 1_776_384_000)
+
+            let vault = VaultRecord(id: .v7(), path: vaultURL.path, name: "Test", createdAt: now, lastOpenedAt: now)
+            meeting = MeetingRecord(
+                id: .v7(),
+                vaultId: vault.id,
+                projectId: nil,
+                name: name,
+                status: meetingStatus,
+                duration: duration,
+                createdAt: now,
+                updatedAt: now
+            )
+            session = RecordingSessionRecord(
+                id: .v7(),
+                meetingId: meeting.id,
+                startedAt: now,
+                endedAt: endedAt,
+                duration: duration,
+                offsetSeconds: 0,
+                createdAt: now,
+                updatedAt: now,
+                transcriptionMode: .batch,
+                retainAudioAfterBatch: retainAudioAfterBatch,
+                batchCompletedAt: batchCompletedAt
+            )
+            try database.dbQueue.write { db in
+                try vault.insert(db)
+                try meeting.insert(db)
+                try session.insert(db)
+            }
+        }
+
+        var managedRelativePath: String {
+            BatchAudioStorage.managedRelativePath(
+                meetingId: meeting.id,
+                sessionId: session.id,
+                source: .microphone
+            )
+        }
+
+        func makeAudioRecord(finalizedAt: Date?, totalFrameCount: Int64?) -> RecordingAudioFileRecord {
+            RecordingAudioFileRecord(
+                id: .v7(),
+                recordingSessionId: session.id,
+                source: .microphone,
+                storageLocation: .managed,
+                relativePath: managedRelativePath,
+                sampleRate: 16000,
+                channelCount: 1,
+                finalizedAt: finalizedAt,
+                totalFrameCount: totalFrameCount,
+                createdAt: now,
+                updatedAt: now
+            )
+        }
+
+        func removeFiles() {
+            try? FileManager.default.removeItem(at: testRootURL)
+        }
+
+        static func writeCAF(url: URL, frameCount: AVAudioFrameCount) throws {
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            let format = try #require(
+                AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: 16000, channels: 1, interleaved: false)
+            )
+            let file = try AVAudioFile(
+                forWriting: url,
+                settings: format.settings,
+                commonFormat: .pcmFormatInt16,
+                interleaved: false
+            )
+            let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount))
+            buffer.frameLength = frameCount
+            try file.write(from: buffer)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/BatchTranscriptionDiscardTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionDiscardTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct BatchTranscriptionDiscardTests {
+        @Test
+        func discardingFailedSessionDeletesAudioAndPreservesTimelineAndExistingTranscript() throws {
+            let fixture = try BatchAudioTestFixture(
+                name: "Discard",
+                meetingStatus: .ready,
+                endedAt: Date(timeIntervalSince1970: 1_776_384_010),
+                duration: 10
+            )
+            defer { fixture.removeFiles() }
+            var failedSession = fixture.session
+            failedSession.batchLastError = "Audio is damaged"
+            let audioRecord = fixture.makeAudioRecord(finalizedAt: nil, totalFrameCount: nil)
+            let existingSegment = TranscriptSegmentRecord(
+                id: .v7(),
+                meetingId: fixture.meeting.id,
+                sessionId: nil,
+                startTime: fixture.now,
+                endTime: fixture.now.addingTimeInterval(1),
+                text: "Existing transcript",
+                translatedText: nil,
+                isConfirmed: true,
+                speakerLabel: "mic"
+            )
+            try fixture.database.dbQueue.write { db in
+                try failedSession.update(db)
+                try audioRecord.insert(db)
+                try existingSegment.insert(db)
+            }
+            let partialURL = BatchAudioStorage.partialURL(
+                baseURL: fixture.managedRootURL,
+                relativePath: fixture.managedRelativePath
+            )
+            try BatchAudioTestFixture.writeCAF(url: partialURL, frameCount: 320)
+
+            let repository = MeetingRepository(dbQueue: fixture.database.dbQueue)
+            let discarded = try repository.discardFailedBatchSession(
+                id: failedSession.id,
+                managedRootURL: fixture.managedRootURL
+            )
+
+            let result = try fixture.database.dbQueue.read { db in
+                let session = try RecordingSessionRecord.fetchOne(db, key: failedSession.id)
+                let audioFileCount = try RecordingAudioFileRecord.fetchCount(db)
+                let segment = try TranscriptSegmentRecord.fetchOne(db, key: existingSegment.id)
+                return try (#require(session), audioFileCount, #require(segment))
+            }
+            #expect(discarded)
+            #expect(result.0.batchDiscardedAt != nil)
+            #expect(result.0.batchLastError == nil)
+            #expect(result.0.duration == 10)
+            #expect(BatchTranscriptionState.derive(from: result.0) == nil)
+            #expect(result.1 == 0)
+            #expect(result.2.text == "Existing transcript")
+            #expect(!FileManager.default.fileExists(atPath: partialURL.path))
+        }
+    }
+#endif

--- a/Tests/DahliaTests/BatchTranscriptionPersistenceTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionPersistenceTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct BatchTranscriptionPersistenceTests {
+        private typealias PersistenceState = (
+            records: [TranscriptSegmentRecord],
+            session: RecordingSessionRecord,
+            meeting: MeetingRecord
+        )
+
+        @Test
+        func completionIsAtomicAndRetryReplacesOnlyItsSession() throws {
+            let now = Date(timeIntervalSince1970: 1_776_384_000)
+            let fixture = try BatchAudioTestFixture(
+                name: "Batch",
+                endedAt: now.addingTimeInterval(10),
+                duration: 10
+            )
+            defer { fixture.removeFiles() }
+            let staleRecord = makeRecord(
+                id: .v7(),
+                meetingId: fixture.meeting.id,
+                sessionId: fixture.session.id,
+                text: "stale",
+                now: now
+            )
+            try fixture.database.dbQueue.write { db in
+                try staleRecord.insert(db)
+            }
+
+            let duplicateId = UUID.v7()
+            let duplicateRecords = [
+                makeRecord(id: duplicateId, meetingId: fixture.meeting.id, sessionId: fixture.session.id, text: "first", now: now),
+                makeRecord(id: duplicateId, meetingId: fixture.meeting.id, sessionId: fixture.session.id, text: "duplicate", now: now),
+            ]
+            #expect(throws: (any Error).self) {
+                try BatchTranscriptionPersistence.complete(
+                    sessionId: fixture.session.id,
+                    meetingId: fixture.meeting.id,
+                    records: duplicateRecords,
+                    completedAt: now.addingTimeInterval(20),
+                    dbQueue: fixture.database.dbQueue
+                )
+            }
+
+            let rolledBack = try fetchState(fixture)
+            #expect(rolledBack.records.map(\.text) == ["stale"])
+            #expect(rolledBack.session.batchCompletedAt == nil)
+            #expect(rolledBack.meeting.status == .transcriptNotFound)
+
+            let completedAt = now.addingTimeInterval(30)
+            let finalRecord = makeRecord(
+                id: .v7(),
+                meetingId: fixture.meeting.id,
+                sessionId: fixture.session.id,
+                text: "final",
+                now: now
+            )
+            try BatchTranscriptionPersistence.complete(
+                sessionId: fixture.session.id,
+                meetingId: fixture.meeting.id,
+                records: [finalRecord],
+                completedAt: completedAt,
+                dbQueue: fixture.database.dbQueue
+            )
+
+            let completed = try fetchState(fixture)
+            #expect(completed.records.map(\.text) == ["final"])
+            #expect(completed.session.batchCompletedAt == completedAt)
+            #expect(completed.meeting.status == .ready)
+        }
+
+        private func fetchState(_ fixture: BatchAudioTestFixture) throws -> PersistenceState {
+            try fixture.database.dbQueue.read { db in
+                let records = try TranscriptSegmentRecord
+                    .filter(Column("sessionId") == fixture.session.id)
+                    .fetchAll(db)
+                let currentSession = try RecordingSessionRecord.fetchOne(db, key: fixture.session.id)
+                let currentMeeting = try MeetingRecord.fetchOne(db, key: fixture.meeting.id)
+                let session = try #require(currentSession)
+                let meeting = try #require(currentMeeting)
+                return (records, session, meeting)
+            }
+        }
+
+        private func makeRecord(
+            id: UUID,
+            meetingId: UUID,
+            sessionId: UUID,
+            text: String,
+            now: Date
+        ) -> TranscriptSegmentRecord {
+            TranscriptSegmentRecord(
+                id: id,
+                meetingId: meetingId,
+                sessionId: sessionId,
+                startTime: now,
+                endTime: now.addingTimeInterval(1),
+                text: text,
+                translatedText: nil,
+                isConfirmed: true,
+                speakerLabel: "mic"
+            )
+        }
+    }
+#endif

--- a/Tests/DahliaTests/BatchTranscriptionRecoveryServiceTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionRecoveryServiceTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct BatchTranscriptionRecoveryServiceTests {
+        @Test
+        func recoversPartialCAFAndOpenRangeAfterCrash() throws {
+            let fixture = try BatchAudioTestFixture(name: "Recovery")
+            defer { fixture.removeFiles() }
+            let audioRecord = fixture.makeAudioRecord(finalizedAt: nil, totalFrameCount: nil)
+            let range = RecordingAudioRangeRecord(
+                id: .v7(),
+                audioFileId: audioRecord.id,
+                startFrame: 0,
+                frameCount: nil,
+                sessionOffsetSeconds: 0,
+                localeIdentifier: "ja_JP",
+                createdAt: fixture.now,
+                updatedAt: fixture.now
+            )
+            try fixture.database.dbQueue.write { db in
+                try audioRecord.insert(db)
+                try range.insert(db)
+            }
+
+            let partialURL = BatchAudioStorage.partialURL(
+                baseURL: fixture.managedRootURL,
+                relativePath: fixture.managedRelativePath
+            )
+            try BatchAudioTestFixture.writeCAF(url: partialURL, frameCount: 320)
+            try BatchTranscriptionRecoveryService.recoverAudioMetadataIfNeeded(
+                sessionId: fixture.session.id,
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL
+            )
+
+            let result = try fixture.database.dbQueue.read { db in
+                let recoveredSession = try RecordingSessionRecord.fetchOne(db, key: fixture.session.id)
+                let recoveredMeeting = try MeetingRecord.fetchOne(db, key: fixture.meeting.id)
+                let recoveredFile = try RecordingAudioFileRecord.fetchOne(db, key: audioRecord.id)
+                let recoveredRange = try RecordingAudioRangeRecord.fetchOne(db, key: range.id)
+                return try (
+                    #require(recoveredSession),
+                    #require(recoveredMeeting),
+                    #require(recoveredFile),
+                    #require(recoveredRange)
+                )
+            }
+            #expect(result.0.endedAt == fixture.now.addingTimeInterval(0.02))
+            #expect(result.0.duration == 0.02)
+            #expect(result.1.duration == 0.02)
+            #expect(result.2.totalFrameCount == 320)
+            #expect(result.3.frameCount == 320)
+            #expect(!FileManager.default.fileExists(atPath: partialURL.path))
+            let finalURL = BatchAudioStorage.finalURL(
+                baseURL: fixture.managedRootURL,
+                relativePath: fixture.managedRelativePath
+            )
+            #expect(FileManager.default.fileExists(atPath: finalURL.path))
+        }
+    }
+#endif

--- a/Tests/DahliaTests/BatchTranscriptionStateTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionStateTests.swift
@@ -52,5 +52,32 @@ import Foundation
 
             #expect(BatchTranscriptionState.derive(from: session) == nil)
         }
+
+        @Test
+        func automaticRetryStopsAfterThreeRecordedFailures() {
+            let now = Date(timeIntervalSince1970: 1_776_384_000)
+            var session = RecordingSessionRecord(
+                id: .v7(),
+                meetingId: .v7(),
+                startedAt: now,
+                endedAt: now.addingTimeInterval(10),
+                duration: 10,
+                offsetSeconds: 0,
+                createdAt: now,
+                updatedAt: now,
+                transcriptionMode: .batch,
+                batchLastError: "damaged",
+                batchAttemptCount: 2
+            )
+
+            #expect(BatchTranscriptionCoordinator.shouldAutomaticallyRetry(session))
+
+            session.batchAttemptCount = BatchTranscriptionCoordinator.maximumAutomaticAttemptCount
+            #expect(!BatchTranscriptionCoordinator.shouldAutomaticallyRetry(session))
+
+            // 実行中クラッシュでエラーが記録されなかったセッションは、回数にかかわらず復旧対象にする。
+            session.batchLastError = nil
+            #expect(BatchTranscriptionCoordinator.shouldAutomaticallyRetry(session))
+        }
     }
 #endif

--- a/Tests/DahliaTests/BatchTranscriptionStateTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionStateTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct BatchTranscriptionStateTests {
+        @Test
+        func derivesStateFromDurableFacts() {
+            let now = Date(timeIntervalSince1970: 1_776_384_000)
+            var session = RecordingSessionRecord(
+                id: .v7(),
+                meetingId: .v7(),
+                startedAt: now,
+                endedAt: nil,
+                duration: nil,
+                offsetSeconds: 0,
+                createdAt: now,
+                updatedAt: now,
+                transcriptionMode: .batch
+            )
+
+            #expect(BatchTranscriptionState.derive(from: session) == .recording(sessionId: session.id))
+
+            session.endedAt = now.addingTimeInterval(10)
+            #expect(BatchTranscriptionState.derive(from: session) == .queued(sessionId: session.id))
+            #expect(BatchTranscriptionState.derive(from: session, isRunning: true) == .running(sessionId: session.id))
+
+            session.batchLastError = "damaged"
+            #expect(BatchTranscriptionState.derive(from: session) == .failed(sessionId: session.id, message: "damaged"))
+
+            session.batchCompletedAt = now.addingTimeInterval(20)
+            #expect(BatchTranscriptionState.derive(from: session) == .completed(sessionId: session.id))
+
+            session.batchDiscardedAt = now.addingTimeInterval(30)
+            #expect(BatchTranscriptionState.derive(from: session) == nil)
+        }
+
+        @Test
+        func realtimeSessionHasNoBatchState() {
+            let now = Date(timeIntervalSince1970: 1_776_384_000)
+            let session = RecordingSessionRecord(
+                id: .v7(),
+                meetingId: .v7(),
+                startedAt: now,
+                endedAt: now,
+                duration: 0,
+                offsetSeconds: 0,
+                createdAt: now,
+                updatedAt: now
+            )
+
+            #expect(BatchTranscriptionState.derive(from: session) == nil)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/MeetingPersistenceServiceTests.swift
+++ b/Tests/DahliaTests/MeetingPersistenceServiceTests.swift
@@ -3,329 +3,392 @@ import GRDB
 @testable import Dahlia
 
 #if canImport(Testing)
-import Testing
+    import Testing
 
-@MainActor
-struct MeetingPersistenceServiceTests {
-    @Test
-    func newMeetingStartsPersistedAsReady() throws {
-        let database = try makeDatabase()
-        let store = TranscriptStore()
-        let startDate = Date(timeIntervalSince1970: 1_776_384_000)
-        store.recordingStartTime = startDate
+    @MainActor
+    struct MeetingPersistenceServiceTests {
+        @Test
+        func newMeetingStartsPersistedAsReady() throws {
+            let database = try makeDatabase()
+            let store = TranscriptStore()
+            let startDate = Date(timeIntervalSince1970: 1_776_384_000)
+            store.recordingStartTime = startDate
 
-        let service = try MeetingPersistenceService(
-            store: store,
-            dbQueue: database.dbQueue,
-            vaultId: testVault.id,
-            projectId: nil,
-            initialName: "Runtime status meeting"
-        )
-
-        let persisted = try database.dbQueue.read { db in
-            let meeting = try MeetingRecord.fetchOne(db, key: service.meetingId)
-            return try #require(meeting)
-        }
-
-        #expect(persisted.status == .ready)
-    }
-
-    @Test
-    func appendModeDoesNotChangePersistedStatusOnStart() throws {
-        let database = try makeDatabase()
-        let meetingId = UUID.v7()
-        let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
-
-        try database.dbQueue.write { db in
-            try MeetingRecord(
-                id: meetingId,
+            let service = try MeetingPersistenceService(
+                store: store,
+                dbQueue: database.dbQueue,
                 vaultId: testVault.id,
                 projectId: nil,
-                name: "Existing meeting",
-                status: .transcriptNotFound,
-                duration: nil,
-                createdAt: createdAt,
-                updatedAt: createdAt
-            ).insert(db)
-        }
-
-        _ = try MeetingPersistenceService(
-            store: TranscriptStore(),
-            dbQueue: database.dbQueue,
-            existingMeetingId: meetingId,
-            existingSegmentIds: []
-        )
-
-        let persisted = try database.dbQueue.read { db in
-            let meeting = try MeetingRecord.fetchOne(db, key: meetingId)
-            return try #require(meeting)
-        }
-
-        #expect(persisted.status == .transcriptNotFound)
-        #expect(persisted.updatedAt == createdAt)
-    }
-
-    @Test
-    func appendModeDurationUsesSessionStartDate() throws {
-        let database = try makeDatabase()
-        let meetingId = UUID.v7()
-        let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
-        let sessionStartDate = Date()
-        let store = TranscriptStore()
-        store.recordingStartTime = createdAt
-
-        try database.dbQueue.write { db in
-            try MeetingRecord(
-                id: meetingId,
-                vaultId: testVault.id,
-                projectId: nil,
-                name: "Existing meeting",
-                status: .ready,
-                duration: nil,
-                createdAt: createdAt,
-                updatedAt: createdAt
-            ).insert(db)
-        }
-
-        let service = try MeetingPersistenceService(
-            store: store,
-            dbQueue: database.dbQueue,
-            existingMeetingId: meetingId,
-            existingSegmentIds: [],
-            recordingStartDate: sessionStartDate
-        )
-        service.stop()
-
-        let persisted = try database.dbQueue.read { db in
-            let meeting = try MeetingRecord.fetchOne(db, key: meetingId)
-            return try #require(meeting)
-        }
-
-        #expect((persisted.duration ?? .greatestFiniteMagnitude) < 10)
-    }
-
-    @Test
-    func appendModePersistsSegmentsWithNewRecordingSessionOffset() async throws {
-        let database = try makeDatabase()
-        let meetingId = UUID.v7()
-        let firstSessionId = UUID.v7()
-        let secondSessionStart = Date()
-        let firstSessionStart = secondSessionStart.addingTimeInterval(-300)
-        let store = TranscriptStore()
-        store.recordingStartTime = firstSessionStart
-
-        try await database.dbQueue.write { db in
-            try MeetingRecord(
-                id: meetingId,
-                vaultId: testVault.id,
-                projectId: nil,
-                name: "Existing meeting",
-                status: .ready,
-                duration: 10,
-                createdAt: firstSessionStart,
-                updatedAt: firstSessionStart.addingTimeInterval(10)
-            ).insert(db)
-            try RecordingSessionRecord(
-                id: firstSessionId,
-                meetingId: meetingId,
-                startedAt: firstSessionStart,
-                endedAt: firstSessionStart.addingTimeInterval(10),
-                duration: 10,
-                offsetSeconds: 0,
-                createdAt: firstSessionStart,
-                updatedAt: firstSessionStart.addingTimeInterval(10)
-            ).insert(db)
-        }
-
-        let service = try MeetingPersistenceService(
-            store: store,
-            dbQueue: database.dbQueue,
-            existingMeetingId: meetingId,
-            existingSegmentIds: [],
-            recordingStartDate: secondSessionStart,
-            recordingOffsetSeconds: 10
-        )
-        let segment = TranscriptSegment(
-            startTime: secondSessionStart.addingTimeInterval(3),
-            text: "After pause",
-            isConfirmed: true,
-            speakerLabel: "mic"
-        )
-
-        store.loadSegments([segment])
-        service.stop()
-
-        let persisted = try await waitForAppendPersistence(
-            database: database,
-            meetingId: meetingId,
-            segmentId: segment.id
-        )
-        let segmentRecord = try #require(persisted.segment)
-        let meetingRecord = try #require(persisted.meeting)
-
-        let secondSession = try #require(persisted.sessions.first(where: { $0.id == service.recordingSessionId }))
-        #expect(secondSession.offsetSeconds == 10)
-        #expect(segmentRecord.sessionId == secondSession.id)
-        #expect((meetingRecord.duration ?? 0) >= 10)
-        #expect((meetingRecord.duration ?? 0) < 20)
-    }
-
-    @Test
-    func newMeetingPersistsLinkedCalendarEvent() throws {
-        let database = try makeDatabase()
-        let store = TranscriptStore()
-        let startDate = Date(timeIntervalSince1970: 1_776_384_000)
-        store.recordingStartTime = startDate
-
-        let service = try MeetingPersistenceService(
-            store: store,
-            dbQueue: database.dbQueue,
-            vaultId: testVault.id,
-            projectId: nil,
-            initialName: "Design review",
-            calendarEvent: fixtureEvent(startDate: startDate)
-        )
-        service.stop()
-
-        let persisted = try database.dbQueue.read { db in
-            let meeting = try MeetingRecord.fetchOne(db, key: service.meetingId)
-            let calendarEvent = try CalendarEventRecord.filter(Column("meetingId") == service.meetingId).fetchOne(db)
-            return try (
-                #require(meeting),
-                #require(calendarEvent)
+                initialName: "Runtime status meeting"
             )
+
+            let persisted = try database.dbQueue.read { db in
+                let meeting = try MeetingRecord.fetchOne(db, key: service.meetingId)
+                return try #require(meeting)
+            }
+
+            #expect(persisted.status == .ready)
         }
 
-        #expect(persisted.0.name == "Design review")
-        #expect(persisted.1.platform == "GoogleCalendar")
-        #expect(persisted.1.platformId == "event-1")
-        #expect(persisted.1.description == "Review launch checklist")
-        #expect(persisted.1.icalUid == "event-1@google.com")
-        #expect(persisted.1.start == startDate)
-        #expect(persisted.1.end == startDate.addingTimeInterval(3600))
-        #expect(persisted.1.meetingUrl == "https://meet.google.com/test-link")
-    }
+        @Test
+        func batchMeetingDoesNotPersistRealtimeSegments() throws {
+            let database = try makeDatabase()
+            let store = TranscriptStore()
+            let startDate = Date(timeIntervalSince1970: 1_776_384_000)
+            store.recordingStartTime = startDate
 
-    @Test
-    func newMeetingPersistsLinkedMacCalendarEventPlatform() throws {
-        let database = try makeDatabase()
-        let store = TranscriptStore()
-        let startDate = Date(timeIntervalSince1970: 1_776_384_000)
-        store.recordingStartTime = startDate
-
-        let service = try MeetingPersistenceService(
-            store: store,
-            dbQueue: database.dbQueue,
-            vaultId: testVault.id,
-            projectId: nil,
-            initialName: "Mac event review",
-            calendarEvent: fixtureMacCalendarEvent(startDate: startDate)
-        )
-        service.stop()
-
-        let persisted = try database.dbQueue.read { db in
-            let calendarEvent = try CalendarEventRecord.filter(Column("meetingId") == service.meetingId).fetchOne(db)
-            return try #require(calendarEvent)
-        }
-
-        #expect(persisted.platform == "MacOSCalendar")
-        #expect(persisted.platformId == "mac-event-1::1776384000")
-        #expect(persisted.description == "Local calendar notes")
-        #expect(persisted.icalUid == "mac-event-1@local")
-    }
-
-    @Test
-    func appendModeDoesNotCreateAdditionalCalendarEvent() throws {
-        let database = try makeDatabase()
-        let meetingId = UUID.v7()
-        let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
-
-        try database.dbQueue.write { db in
-            try MeetingRecord(
-                id: meetingId,
+            let service = try MeetingPersistenceService(
+                store: store,
+                dbQueue: database.dbQueue,
                 vaultId: testVault.id,
                 projectId: nil,
-                name: "Existing meeting",
-                status: .ready,
-                duration: 120,
-                createdAt: createdAt,
-                updatedAt: createdAt
-            ).insert(db)
-            try CalendarEventRecord(
-                meetingId: meetingId,
-                createdAt: createdAt,
-                updatedAt: createdAt,
-                platform: "GoogleCalendar",
-                platformId: "event-1",
-                description: "Review launch checklist",
-                icalUid: "event-1@google.com",
-                start: createdAt,
-                end: createdAt.addingTimeInterval(3600),
-                meetingUrl: "https://meet.google.com/test-link"
-            ).insert(db)
+                initialName: "Batch meeting",
+                transcriptionMode: .batch,
+                retainAudioAfterBatch: true
+            )
+            store.addSegment(
+                TranscriptSegment(
+                    startTime: startDate,
+                    text: "Must not be persisted",
+                    isConfirmed: true,
+                    speakerLabel: "mic"
+                )
+            )
+            service.stop()
+
+            let result = try database.dbQueue.read { db in
+                let meeting = try MeetingRecord.fetchOne(db, key: service.meetingId)
+                let session = try RecordingSessionRecord.fetchOne(db, key: service.recordingSessionId)
+                let segmentCount = try TranscriptSegmentRecord
+                    .filter(Column("meetingId") == service.meetingId)
+                    .fetchCount(db)
+                return try (#require(meeting), #require(session), segmentCount)
+            }
+
+            #expect(result.0.status == .transcriptNotFound)
+            #expect(result.1.transcriptionMode == .batch)
+            #expect(result.1.retainAudioAfterBatch)
+            #expect(result.2 == 0)
         }
 
-        let service = try MeetingPersistenceService(
-            store: TranscriptStore(),
-            dbQueue: database.dbQueue,
-            existingMeetingId: meetingId,
-            existingSegmentIds: []
-        )
-        service.stop()
-
-        let calendarEventCount = try database.dbQueue.read { db in
-            try CalendarEventRecord.fetchCount(db)
-        }
-
-        #expect(calendarEventCount == 1)
-    }
-
-    @Test
-    func calendarEventConstraintsEnforceUniquenessAndCascadeDelete() throws {
-        let database = try makeDatabase()
-        let firstMeetingId = UUID.v7()
-        let secondMeetingId = UUID.v7()
-        let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
-
-        try database.dbQueue.write { db in
-            try MeetingRecord(
-                id: firstMeetingId,
+        @Test
+        func batchStopPreservesFailureMetadataWrittenDuringFinalization() throws {
+            let database = try makeDatabase()
+            let store = TranscriptStore()
+            store.recordingStartTime = Date(timeIntervalSince1970: 1_776_384_000)
+            let service = try MeetingPersistenceService(
+                store: store,
+                dbQueue: database.dbQueue,
                 vaultId: testVault.id,
                 projectId: nil,
-                name: "First",
-                status: .ready,
-                duration: nil,
-                createdAt: createdAt,
-                updatedAt: createdAt
-            ).insert(db)
-            try MeetingRecord(
-                id: secondMeetingId,
-                vaultId: testVault.id,
-                projectId: nil,
-                name: "Second",
-                status: .ready,
-                duration: nil,
-                createdAt: createdAt,
-                updatedAt: createdAt
-            ).insert(db)
-            try CalendarEventRecord(
-                meetingId: firstMeetingId,
-                createdAt: createdAt,
-                updatedAt: createdAt,
-                platform: "GoogleCalendar",
-                platformId: "event-1",
-                description: "",
-                icalUid: nil,
-                start: createdAt,
-                end: createdAt.addingTimeInterval(3600),
-                meetingUrl: nil
-            ).insert(db)
-        }
-
-        #expect(throws: Error.self) {
+                initialName: "Failed batch meeting",
+                transcriptionMode: .batch
+            )
+            let attemptDate = Date(timeIntervalSince1970: 1_776_384_030)
             try database.dbQueue.write { db in
+                try db.execute(
+                    sql: """
+                    UPDATE recording_sessions
+                    SET batchLastError = ?, batchLastAttemptAt = ?, batchAttemptCount = ?
+                    WHERE id = ?
+                    """,
+                    arguments: ["CAF write failed", attemptDate, 2, service.recordingSessionId]
+                )
+            }
+
+            service.stop()
+
+            let session = try database.dbQueue.read { db in
+                let record = try RecordingSessionRecord.fetchOne(db, key: service.recordingSessionId)
+                return try #require(record)
+            }
+            #expect(session.endedAt != nil)
+            #expect(session.duration != nil)
+            #expect(session.batchLastError == "CAF write failed")
+            #expect(session.batchLastAttemptAt == attemptDate)
+            #expect(session.batchAttemptCount == 2)
+        }
+
+        @Test
+        func appendModeDoesNotChangePersistedStatusOnStart() throws {
+            let database = try makeDatabase()
+            let meetingId = UUID.v7()
+            let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
+
+            try database.dbQueue.write { db in
+                try MeetingRecord(
+                    id: meetingId,
+                    vaultId: testVault.id,
+                    projectId: nil,
+                    name: "Existing meeting",
+                    status: .transcriptNotFound,
+                    duration: nil,
+                    createdAt: createdAt,
+                    updatedAt: createdAt
+                ).insert(db)
+            }
+
+            _ = try MeetingPersistenceService(
+                store: TranscriptStore(),
+                dbQueue: database.dbQueue,
+                existingMeetingId: meetingId,
+                existingSegmentIds: []
+            )
+
+            let persisted = try database.dbQueue.read { db in
+                let meeting = try MeetingRecord.fetchOne(db, key: meetingId)
+                return try #require(meeting)
+            }
+
+            #expect(persisted.status == .transcriptNotFound)
+            #expect(persisted.updatedAt == createdAt)
+        }
+
+        @Test
+        func appendModeDurationUsesSessionStartDate() throws {
+            let database = try makeDatabase()
+            let meetingId = UUID.v7()
+            let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
+            let sessionStartDate = Date()
+            let store = TranscriptStore()
+            store.recordingStartTime = createdAt
+
+            try database.dbQueue.write { db in
+                try MeetingRecord(
+                    id: meetingId,
+                    vaultId: testVault.id,
+                    projectId: nil,
+                    name: "Existing meeting",
+                    status: .ready,
+                    duration: nil,
+                    createdAt: createdAt,
+                    updatedAt: createdAt
+                ).insert(db)
+            }
+
+            let service = try MeetingPersistenceService(
+                store: store,
+                dbQueue: database.dbQueue,
+                existingMeetingId: meetingId,
+                existingSegmentIds: [],
+                recordingStartDate: sessionStartDate
+            )
+            service.stop()
+
+            let persisted = try database.dbQueue.read { db in
+                let meeting = try MeetingRecord.fetchOne(db, key: meetingId)
+                return try #require(meeting)
+            }
+
+            #expect((persisted.duration ?? .greatestFiniteMagnitude) < 10)
+        }
+
+        @Test
+        func appendModePersistsSegmentsWithNewRecordingSessionOffset() async throws {
+            let database = try makeDatabase()
+            let meetingId = UUID.v7()
+            let firstSessionId = UUID.v7()
+            let secondSessionStart = Date()
+            let firstSessionStart = secondSessionStart.addingTimeInterval(-300)
+            let store = TranscriptStore()
+            store.recordingStartTime = firstSessionStart
+
+            try await database.dbQueue.write { db in
+                try MeetingRecord(
+                    id: meetingId,
+                    vaultId: testVault.id,
+                    projectId: nil,
+                    name: "Existing meeting",
+                    status: .ready,
+                    duration: 10,
+                    createdAt: firstSessionStart,
+                    updatedAt: firstSessionStart.addingTimeInterval(10)
+                ).insert(db)
+                try RecordingSessionRecord(
+                    id: firstSessionId,
+                    meetingId: meetingId,
+                    startedAt: firstSessionStart,
+                    endedAt: firstSessionStart.addingTimeInterval(10),
+                    duration: 10,
+                    offsetSeconds: 0,
+                    createdAt: firstSessionStart,
+                    updatedAt: firstSessionStart.addingTimeInterval(10)
+                ).insert(db)
+            }
+
+            let service = try MeetingPersistenceService(
+                store: store,
+                dbQueue: database.dbQueue,
+                existingMeetingId: meetingId,
+                existingSegmentIds: [],
+                recordingStartDate: secondSessionStart,
+                recordingOffsetSeconds: 10
+            )
+            let segment = TranscriptSegment(
+                startTime: secondSessionStart.addingTimeInterval(3),
+                text: "After pause",
+                isConfirmed: true,
+                speakerLabel: "mic"
+            )
+
+            store.loadSegments([segment])
+            service.stop()
+
+            let persisted = try await waitForAppendPersistence(
+                database: database,
+                meetingId: meetingId,
+                segmentId: segment.id
+            )
+            let segmentRecord = try #require(persisted.segment)
+            let meetingRecord = try #require(persisted.meeting)
+
+            let secondSession = try #require(persisted.sessions.first(where: { $0.id == service.recordingSessionId }))
+            #expect(secondSession.offsetSeconds == 10)
+            #expect(segmentRecord.sessionId == secondSession.id)
+            #expect((meetingRecord.duration ?? 0) >= 10)
+            #expect((meetingRecord.duration ?? 0) < 20)
+        }
+
+        @Test
+        func newMeetingPersistsLinkedCalendarEvent() throws {
+            let database = try makeDatabase()
+            let store = TranscriptStore()
+            let startDate = Date(timeIntervalSince1970: 1_776_384_000)
+            store.recordingStartTime = startDate
+
+            let service = try MeetingPersistenceService(
+                store: store,
+                dbQueue: database.dbQueue,
+                vaultId: testVault.id,
+                projectId: nil,
+                initialName: "Design review",
+                calendarEvent: fixtureEvent(startDate: startDate)
+            )
+            service.stop()
+
+            let persisted = try database.dbQueue.read { db in
+                let meeting = try MeetingRecord.fetchOne(db, key: service.meetingId)
+                let calendarEvent = try CalendarEventRecord.filter(Column("meetingId") == service.meetingId).fetchOne(db)
+                return try (
+                    #require(meeting),
+                    #require(calendarEvent)
+                )
+            }
+
+            #expect(persisted.0.name == "Design review")
+            #expect(persisted.1.platform == "GoogleCalendar")
+            #expect(persisted.1.platformId == "event-1")
+            #expect(persisted.1.description == "Review launch checklist")
+            #expect(persisted.1.icalUid == "event-1@google.com")
+            #expect(persisted.1.start == startDate)
+            #expect(persisted.1.end == startDate.addingTimeInterval(3600))
+            #expect(persisted.1.meetingUrl == "https://meet.google.com/test-link")
+        }
+
+        @Test
+        func newMeetingPersistsLinkedMacCalendarEventPlatform() throws {
+            let database = try makeDatabase()
+            let store = TranscriptStore()
+            let startDate = Date(timeIntervalSince1970: 1_776_384_000)
+            store.recordingStartTime = startDate
+
+            let service = try MeetingPersistenceService(
+                store: store,
+                dbQueue: database.dbQueue,
+                vaultId: testVault.id,
+                projectId: nil,
+                initialName: "Mac event review",
+                calendarEvent: fixtureMacCalendarEvent(startDate: startDate)
+            )
+            service.stop()
+
+            let persisted = try database.dbQueue.read { db in
+                let calendarEvent = try CalendarEventRecord.filter(Column("meetingId") == service.meetingId).fetchOne(db)
+                return try #require(calendarEvent)
+            }
+
+            #expect(persisted.platform == "MacOSCalendar")
+            #expect(persisted.platformId == "mac-event-1::1776384000")
+            #expect(persisted.description == "Local calendar notes")
+            #expect(persisted.icalUid == "mac-event-1@local")
+        }
+
+        @Test
+        func appendModeDoesNotCreateAdditionalCalendarEvent() throws {
+            let database = try makeDatabase()
+            let meetingId = UUID.v7()
+            let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
+
+            try database.dbQueue.write { db in
+                try MeetingRecord(
+                    id: meetingId,
+                    vaultId: testVault.id,
+                    projectId: nil,
+                    name: "Existing meeting",
+                    status: .ready,
+                    duration: 120,
+                    createdAt: createdAt,
+                    updatedAt: createdAt
+                ).insert(db)
                 try CalendarEventRecord(
-                    meetingId: secondMeetingId,
+                    meetingId: meetingId,
+                    createdAt: createdAt,
+                    updatedAt: createdAt,
+                    platform: "GoogleCalendar",
+                    platformId: "event-1",
+                    description: "Review launch checklist",
+                    icalUid: "event-1@google.com",
+                    start: createdAt,
+                    end: createdAt.addingTimeInterval(3600),
+                    meetingUrl: "https://meet.google.com/test-link"
+                ).insert(db)
+            }
+
+            let service = try MeetingPersistenceService(
+                store: TranscriptStore(),
+                dbQueue: database.dbQueue,
+                existingMeetingId: meetingId,
+                existingSegmentIds: []
+            )
+            service.stop()
+
+            let calendarEventCount = try database.dbQueue.read { db in
+                try CalendarEventRecord.fetchCount(db)
+            }
+
+            #expect(calendarEventCount == 1)
+        }
+
+        @Test
+        func calendarEventConstraintsEnforceUniquenessAndCascadeDelete() throws {
+            let database = try makeDatabase()
+            let firstMeetingId = UUID.v7()
+            let secondMeetingId = UUID.v7()
+            let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
+
+            try database.dbQueue.write { db in
+                try MeetingRecord(
+                    id: firstMeetingId,
+                    vaultId: testVault.id,
+                    projectId: nil,
+                    name: "First",
+                    status: .ready,
+                    duration: nil,
+                    createdAt: createdAt,
+                    updatedAt: createdAt
+                ).insert(db)
+                try MeetingRecord(
+                    id: secondMeetingId,
+                    vaultId: testVault.id,
+                    projectId: nil,
+                    name: "Second",
+                    status: .ready,
+                    duration: nil,
+                    createdAt: createdAt,
+                    updatedAt: createdAt
+                ).insert(db)
+                try CalendarEventRecord(
+                    meetingId: firstMeetingId,
                     createdAt: createdAt,
                     updatedAt: createdAt,
                     platform: "GoogleCalendar",
@@ -337,291 +400,291 @@ struct MeetingPersistenceServiceTests {
                     meetingUrl: nil
                 ).insert(db)
             }
+
+            #expect(throws: Error.self) {
+                try database.dbQueue.write { db in
+                    try CalendarEventRecord(
+                        meetingId: secondMeetingId,
+                        createdAt: createdAt,
+                        updatedAt: createdAt,
+                        platform: "GoogleCalendar",
+                        platformId: "event-1",
+                        description: "",
+                        icalUid: nil,
+                        start: createdAt,
+                        end: createdAt.addingTimeInterval(3600),
+                        meetingUrl: nil
+                    ).insert(db)
+                }
+            }
+
+            let repository = MeetingRepository(dbQueue: database.dbQueue)
+            try repository.deleteMeeting(id: firstMeetingId)
+
+            let calendarEventCount = try database.dbQueue.read { db in
+                try CalendarEventRecord.fetchCount(db)
+            }
+
+            #expect(calendarEventCount == 0)
         }
 
-        let repository = MeetingRepository(dbQueue: database.dbQueue)
-        try repository.deleteMeeting(id: firstMeetingId)
+        @Test
+        func fetchMeetingIdForCalendarEventReturnsPersistedMeeting() throws {
+            let database = try makeDatabase()
+            let meetingId = UUID.v7()
+            let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
 
-        let calendarEventCount = try database.dbQueue.read { db in
-            try CalendarEventRecord.fetchCount(db)
+            try database.dbQueue.write { db in
+                try MeetingRecord(
+                    id: meetingId,
+                    vaultId: testVault.id,
+                    projectId: nil,
+                    name: "Existing meeting",
+                    status: .ready,
+                    duration: nil,
+                    createdAt: createdAt,
+                    updatedAt: createdAt
+                ).insert(db)
+                try CalendarEventRecord(
+                    meetingId: meetingId,
+                    createdAt: createdAt,
+                    updatedAt: createdAt,
+                    platform: "GoogleCalendar",
+                    platformId: "event-1",
+                    description: "",
+                    icalUid: nil,
+                    start: createdAt,
+                    end: createdAt.addingTimeInterval(3600),
+                    meetingUrl: nil
+                ).insert(db)
+            }
+
+            let repository = MeetingRepository(dbQueue: database.dbQueue)
+            let resolvedMeetingId = try repository.fetchMeetingIdForCalendarEvent(
+                platform: "GoogleCalendar",
+                platformId: "event-1"
+            )
+
+            #expect(resolvedMeetingId == meetingId)
         }
 
-        #expect(calendarEventCount == 0)
-    }
+        @Test
+        func stopPersistsTranslatedTextWhenAvailableBeforeInsert() throws {
+            let database = try makeDatabase()
+            let store = TranscriptStore()
+            let startDate = Date(timeIntervalSince1970: 1_776_384_000)
+            store.recordingStartTime = startDate
 
-    @Test
-    func fetchMeetingIdForCalendarEventReturnsPersistedMeeting() throws {
-        let database = try makeDatabase()
-        let meetingId = UUID.v7()
-        let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
-
-        try database.dbQueue.write { db in
-            try MeetingRecord(
-                id: meetingId,
+            let service = try MeetingPersistenceService(
+                store: store,
+                dbQueue: database.dbQueue,
                 vaultId: testVault.id,
                 projectId: nil,
-                name: "Existing meeting",
-                status: .ready,
-                duration: nil,
-                createdAt: createdAt,
-                updatedAt: createdAt
-            ).insert(db)
-            try CalendarEventRecord(
-                meetingId: meetingId,
-                createdAt: createdAt,
-                updatedAt: createdAt,
-                platform: "GoogleCalendar",
-                platformId: "event-1",
-                description: "",
-                icalUid: nil,
-                start: createdAt,
-                end: createdAt.addingTimeInterval(3600),
-                meetingUrl: nil
-            ).insert(db)
-        }
-
-        let repository = MeetingRepository(dbQueue: database.dbQueue)
-        let resolvedMeetingId = try repository.fetchMeetingIdForCalendarEvent(
-            platform: "GoogleCalendar",
-            platformId: "event-1"
-        )
-
-        #expect(resolvedMeetingId == meetingId)
-    }
-
-    @Test
-    func stopPersistsTranslatedTextWhenAvailableBeforeInsert() throws {
-        let database = try makeDatabase()
-        let store = TranscriptStore()
-        let startDate = Date(timeIntervalSince1970: 1_776_384_000)
-        store.recordingStartTime = startDate
-
-        let service = try MeetingPersistenceService(
-            store: store,
-            dbQueue: database.dbQueue,
-            vaultId: testVault.id,
-            projectId: nil,
-            initialName: "Translated meeting"
-        )
-        let segment = TranscriptSegment(
-            startTime: startDate,
-            text: "Hello world",
-            translatedText: "こんにちは、世界",
-            isConfirmed: true,
-            speakerLabel: "mic"
-        )
-
-        store.loadSegments([segment])
-        service.stop()
-
-        let persisted = try database.dbQueue.read { db in
-            let segmentRecord = try TranscriptSegmentRecord.fetchOne(db, key: segment.id)
-            return try #require(segmentRecord)
-        }
-
-        #expect(persisted.text == "Hello world")
-        #expect(persisted.translatedText == "こんにちは、世界")
-    }
-
-    @Test
-    func translatedTextUpdatesExistingPersistedSegment() async throws {
-        let database = try makeDatabase()
-        let store = TranscriptStore()
-        let startDate = Date(timeIntervalSince1970: 1_776_384_000)
-        store.recordingStartTime = startDate
-
-        let service = try MeetingPersistenceService(
-            store: store,
-            dbQueue: database.dbQueue,
-            vaultId: testVault.id,
-            projectId: nil,
-            initialName: "Translated meeting"
-        )
-        let segment = TranscriptSegment(
-            startTime: startDate,
-            text: "Hello world",
-            isConfirmed: true,
-            speakerLabel: "mic"
-        )
-
-        store.loadSegments([segment])
-        try await Task.sleep(for: .milliseconds(700))
-
-        store.updateTranslatedText(for: segment.id, translatedText: "こんにちは、世界")
-        try await Task.sleep(for: .milliseconds(700))
-        service.stop()
-
-        let persisted = try await database.dbQueue.read { db in
-            let segmentRecord = try TranscriptSegmentRecord.fetchOne(db, key: segment.id)
-            return try #require(segmentRecord)
-        }
-
-        #expect(persisted.translatedText == "こんにちは、世界")
-    }
-
-    @Test
-    func unconfirmedTranslatedTextIsNotPersisted() throws {
-        let database = try makeDatabase()
-        let store = TranscriptStore()
-        let startDate = Date(timeIntervalSince1970: 1_776_384_000)
-        store.recordingStartTime = startDate
-
-        let service = try MeetingPersistenceService(
-            store: store,
-            dbQueue: database.dbQueue,
-            vaultId: testVault.id,
-            projectId: nil,
-            initialName: "Preview meeting"
-        )
-
-        store.updateUnconfirmedSegment(
-            TranscriptSegment(
+                initialName: "Translated meeting"
+            )
+            let segment = TranscriptSegment(
                 startTime: startDate,
-                text: "Preview",
-                translatedText: "プレビュー",
-                isConfirmed: false,
+                text: "Hello world",
+                translatedText: "こんにちは、世界",
+                isConfirmed: true,
                 speakerLabel: "mic"
-            ),
-            forSource: "mic"
-        )
-        service.stop()
+            )
 
-        let persistedCount = try database.dbQueue.read { db in
-            try TranscriptSegmentRecord.fetchCount(db)
+            store.loadSegments([segment])
+            service.stop()
+
+            let persisted = try database.dbQueue.read { db in
+                let segmentRecord = try TranscriptSegmentRecord.fetchOne(db, key: segment.id)
+                return try #require(segmentRecord)
+            }
+
+            #expect(persisted.text == "Hello world")
+            #expect(persisted.translatedText == "こんにちは、世界")
         }
 
-        #expect(persistedCount == 0)
+        @Test
+        func translatedTextUpdatesExistingPersistedSegment() async throws {
+            let database = try makeDatabase()
+            let store = TranscriptStore()
+            let startDate = Date(timeIntervalSince1970: 1_776_384_000)
+            store.recordingStartTime = startDate
+
+            let service = try MeetingPersistenceService(
+                store: store,
+                dbQueue: database.dbQueue,
+                vaultId: testVault.id,
+                projectId: nil,
+                initialName: "Translated meeting"
+            )
+            let segment = TranscriptSegment(
+                startTime: startDate,
+                text: "Hello world",
+                isConfirmed: true,
+                speakerLabel: "mic"
+            )
+
+            store.loadSegments([segment])
+            try await Task.sleep(for: .milliseconds(700))
+
+            store.updateTranslatedText(for: segment.id, translatedText: "こんにちは、世界")
+            try await Task.sleep(for: .milliseconds(700))
+            service.stop()
+
+            let persisted = try await database.dbQueue.read { db in
+                let segmentRecord = try TranscriptSegmentRecord.fetchOne(db, key: segment.id)
+                return try #require(segmentRecord)
+            }
+
+            #expect(persisted.translatedText == "こんにちは、世界")
+        }
+
+        @Test
+        func unconfirmedTranslatedTextIsNotPersisted() throws {
+            let database = try makeDatabase()
+            let store = TranscriptStore()
+            let startDate = Date(timeIntervalSince1970: 1_776_384_000)
+            store.recordingStartTime = startDate
+
+            let service = try MeetingPersistenceService(
+                store: store,
+                dbQueue: database.dbQueue,
+                vaultId: testVault.id,
+                projectId: nil,
+                initialName: "Preview meeting"
+            )
+
+            store.updateUnconfirmedSegment(
+                TranscriptSegment(
+                    startTime: startDate,
+                    text: "Preview",
+                    translatedText: "プレビュー",
+                    isConfirmed: false,
+                    speakerLabel: "mic"
+                ),
+                forSource: "mic"
+            )
+            service.stop()
+
+            let persistedCount = try database.dbQueue.read { db in
+                try TranscriptSegmentRecord.fetchCount(db)
+            }
+
+            #expect(persistedCount == 0)
+        }
     }
-}
 
 #elseif canImport(XCTest)
-import XCTest
+    import XCTest
 
-@MainActor
-final class MeetingPersistenceServiceTests: XCTestCase {
-    func testNewMeetingPersistsLinkedCalendarEvent() throws {
-        let database = try makeDatabase()
-        let store = TranscriptStore()
-        let startDate = Date(timeIntervalSince1970: 1_776_384_000)
-        store.recordingStartTime = startDate
+    @MainActor
+    final class MeetingPersistenceServiceTests: XCTestCase {
+        func testNewMeetingPersistsLinkedCalendarEvent() throws {
+            let database = try makeDatabase()
+            let store = TranscriptStore()
+            let startDate = Date(timeIntervalSince1970: 1_776_384_000)
+            store.recordingStartTime = startDate
 
-        let service = try MeetingPersistenceService(
-            store: store,
-            dbQueue: database.dbQueue,
-            vaultId: testVault.id,
-            projectId: nil,
-            initialName: "Design review",
-            calendarEvent: fixtureEvent(startDate: startDate)
-        )
-        service.stop()
-
-        let persisted = try database.dbQueue.read { db in
-            try (
-                XCTUnwrap(MeetingRecord.fetchOne(db, key: service.meetingId)),
-                XCTUnwrap(CalendarEventRecord.filter(Column("meetingId") == service.meetingId).fetchOne(db))
+            let service = try MeetingPersistenceService(
+                store: store,
+                dbQueue: database.dbQueue,
+                vaultId: testVault.id,
+                projectId: nil,
+                initialName: "Design review",
+                calendarEvent: fixtureEvent(startDate: startDate)
             )
+            service.stop()
+
+            let persisted = try database.dbQueue.read { db in
+                try (
+                    XCTUnwrap(MeetingRecord.fetchOne(db, key: service.meetingId)),
+                    XCTUnwrap(CalendarEventRecord.filter(Column("meetingId") == service.meetingId).fetchOne(db))
+                )
+            }
+
+            XCTAssertEqual(persisted.0.name, "Design review")
+            XCTAssertEqual(persisted.1.platform, "GoogleCalendar")
+            XCTAssertEqual(persisted.1.platformId, "event-1")
+            XCTAssertEqual(persisted.1.description, "Review launch checklist")
+            XCTAssertEqual(persisted.1.icalUid, "event-1@google.com")
+            XCTAssertEqual(persisted.1.start, startDate)
+            XCTAssertEqual(persisted.1.end, startDate.addingTimeInterval(3600))
+            XCTAssertEqual(persisted.1.meetingUrl, "https://meet.google.com/test-link")
         }
 
-        XCTAssertEqual(persisted.0.name, "Design review")
-        XCTAssertEqual(persisted.1.platform, "GoogleCalendar")
-        XCTAssertEqual(persisted.1.platformId, "event-1")
-        XCTAssertEqual(persisted.1.description, "Review launch checklist")
-        XCTAssertEqual(persisted.1.icalUid, "event-1@google.com")
-        XCTAssertEqual(persisted.1.start, startDate)
-        XCTAssertEqual(persisted.1.end, startDate.addingTimeInterval(3600))
-        XCTAssertEqual(persisted.1.meetingUrl, "https://meet.google.com/test-link")
-    }
+        func testAppendModeDoesNotCreateAdditionalCalendarEvent() throws {
+            let database = try makeDatabase()
+            let meetingId = UUID.v7()
+            let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
 
-    func testAppendModeDoesNotCreateAdditionalCalendarEvent() throws {
-        let database = try makeDatabase()
-        let meetingId = UUID.v7()
-        let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
-
-        try database.dbQueue.write { db in
-            try MeetingRecord(
-                id: meetingId,
-                vaultId: testVault.id,
-                projectId: nil,
-                name: "Existing meeting",
-                status: .ready,
-                duration: 120,
-                createdAt: createdAt,
-                updatedAt: createdAt
-            ).insert(db)
-            try CalendarEventRecord(
-                meetingId: meetingId,
-                createdAt: createdAt,
-                updatedAt: createdAt,
-                platform: "GoogleCalendar",
-                platformId: "event-1",
-                description: "Review launch checklist",
-                icalUid: "event-1@google.com",
-                start: createdAt,
-                end: createdAt.addingTimeInterval(3600),
-                meetingUrl: "https://meet.google.com/test-link"
-            ).insert(db)
-        }
-
-        let service = try MeetingPersistenceService(
-            store: TranscriptStore(),
-            dbQueue: database.dbQueue,
-            existingMeetingId: meetingId,
-            existingSegmentIds: []
-        )
-        service.stop()
-
-        let calendarEventCount = try database.dbQueue.read { db in
-            try CalendarEventRecord.fetchCount(db)
-        }
-
-        XCTAssertEqual(calendarEventCount, 1)
-    }
-
-    func testCalendarEventConstraintsEnforceUniquenessAndCascadeDelete() throws {
-        let database = try makeDatabase()
-        let firstMeetingId = UUID.v7()
-        let secondMeetingId = UUID.v7()
-        let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
-
-        try database.dbQueue.write { db in
-            try MeetingRecord(
-                id: firstMeetingId,
-                vaultId: testVault.id,
-                projectId: nil,
-                name: "First",
-                status: .ready,
-                duration: nil,
-                createdAt: createdAt,
-                updatedAt: createdAt
-            ).insert(db)
-            try MeetingRecord(
-                id: secondMeetingId,
-                vaultId: testVault.id,
-                projectId: nil,
-                name: "Second",
-                status: .ready,
-                duration: nil,
-                createdAt: createdAt,
-                updatedAt: createdAt
-            ).insert(db)
-            try CalendarEventRecord(
-                meetingId: firstMeetingId,
-                createdAt: createdAt,
-                updatedAt: createdAt,
-                platform: "GoogleCalendar",
-                platformId: "event-1",
-                description: "",
-                icalUid: nil,
-                start: createdAt,
-                end: createdAt.addingTimeInterval(3600),
-                meetingUrl: nil
-            ).insert(db)
-        }
-
-        XCTAssertThrowsError(
             try database.dbQueue.write { db in
+                try MeetingRecord(
+                    id: meetingId,
+                    vaultId: testVault.id,
+                    projectId: nil,
+                    name: "Existing meeting",
+                    status: .ready,
+                    duration: 120,
+                    createdAt: createdAt,
+                    updatedAt: createdAt
+                ).insert(db)
                 try CalendarEventRecord(
-                    meetingId: secondMeetingId,
+                    meetingId: meetingId,
+                    createdAt: createdAt,
+                    updatedAt: createdAt,
+                    platform: "GoogleCalendar",
+                    platformId: "event-1",
+                    description: "Review launch checklist",
+                    icalUid: "event-1@google.com",
+                    start: createdAt,
+                    end: createdAt.addingTimeInterval(3600),
+                    meetingUrl: "https://meet.google.com/test-link"
+                ).insert(db)
+            }
+
+            let service = try MeetingPersistenceService(
+                store: TranscriptStore(),
+                dbQueue: database.dbQueue,
+                existingMeetingId: meetingId,
+                existingSegmentIds: []
+            )
+            service.stop()
+
+            let calendarEventCount = try database.dbQueue.read { db in
+                try CalendarEventRecord.fetchCount(db)
+            }
+
+            XCTAssertEqual(calendarEventCount, 1)
+        }
+
+        func testCalendarEventConstraintsEnforceUniquenessAndCascadeDelete() throws {
+            let database = try makeDatabase()
+            let firstMeetingId = UUID.v7()
+            let secondMeetingId = UUID.v7()
+            let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
+
+            try database.dbQueue.write { db in
+                try MeetingRecord(
+                    id: firstMeetingId,
+                    vaultId: testVault.id,
+                    projectId: nil,
+                    name: "First",
+                    status: .ready,
+                    duration: nil,
+                    createdAt: createdAt,
+                    updatedAt: createdAt
+                ).insert(db)
+                try MeetingRecord(
+                    id: secondMeetingId,
+                    vaultId: testVault.id,
+                    projectId: nil,
+                    name: "Second",
+                    status: .ready,
+                    duration: nil,
+                    createdAt: createdAt,
+                    updatedAt: createdAt
+                ).insert(db)
+                try CalendarEventRecord(
+                    meetingId: firstMeetingId,
                     createdAt: createdAt,
                     updatedAt: createdAt,
                     platform: "GoogleCalendar",
@@ -633,156 +696,172 @@ final class MeetingPersistenceServiceTests: XCTestCase {
                     meetingUrl: nil
                 ).insert(db)
             }
-        )
 
-        let repository = MeetingRepository(dbQueue: database.dbQueue)
-        try repository.deleteMeeting(id: firstMeetingId)
+            XCTAssertThrowsError(
+                try database.dbQueue.write { db in
+                    try CalendarEventRecord(
+                        meetingId: secondMeetingId,
+                        createdAt: createdAt,
+                        updatedAt: createdAt,
+                        platform: "GoogleCalendar",
+                        platformId: "event-1",
+                        description: "",
+                        icalUid: nil,
+                        start: createdAt,
+                        end: createdAt.addingTimeInterval(3600),
+                        meetingUrl: nil
+                    ).insert(db)
+                }
+            )
 
-        let calendarEventCount = try database.dbQueue.read { db in
-            try CalendarEventRecord.fetchCount(db)
+            let repository = MeetingRepository(dbQueue: database.dbQueue)
+            try repository.deleteMeeting(id: firstMeetingId)
+
+            let calendarEventCount = try database.dbQueue.read { db in
+                try CalendarEventRecord.fetchCount(db)
+            }
+
+            XCTAssertEqual(calendarEventCount, 0)
         }
 
-        XCTAssertEqual(calendarEventCount, 0)
-    }
+        func testFetchMeetingIdForCalendarEventReturnsPersistedMeeting() throws {
+            let database = try makeDatabase()
+            let meetingId = UUID.v7()
+            let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
 
-    func testFetchMeetingIdForCalendarEventReturnsPersistedMeeting() throws {
-        let database = try makeDatabase()
-        let meetingId = UUID.v7()
-        let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
+            try database.dbQueue.write { db in
+                try MeetingRecord(
+                    id: meetingId,
+                    vaultId: testVault.id,
+                    projectId: nil,
+                    name: "Existing meeting",
+                    status: .ready,
+                    duration: nil,
+                    createdAt: createdAt,
+                    updatedAt: createdAt
+                ).insert(db)
+                try CalendarEventRecord(
+                    meetingId: meetingId,
+                    createdAt: createdAt,
+                    updatedAt: createdAt,
+                    platform: "GoogleCalendar",
+                    platformId: "event-1",
+                    description: "",
+                    icalUid: nil,
+                    start: createdAt,
+                    end: createdAt.addingTimeInterval(3600),
+                    meetingUrl: nil
+                ).insert(db)
+            }
 
-        try database.dbQueue.write { db in
-            try MeetingRecord(
-                id: meetingId,
+            let repository = MeetingRepository(dbQueue: database.dbQueue)
+            let resolvedMeetingId = try repository.fetchMeetingIdForCalendarEvent(
+                platform: "GoogleCalendar",
+                platformId: "event-1"
+            )
+
+            XCTAssertEqual(resolvedMeetingId, meetingId)
+        }
+
+        func testStopPersistsTranslatedTextWhenAvailableBeforeInsert() throws {
+            let database = try makeDatabase()
+            let store = TranscriptStore()
+            let startDate = Date(timeIntervalSince1970: 1_776_384_000)
+            store.recordingStartTime = startDate
+
+            let service = try MeetingPersistenceService(
+                store: store,
+                dbQueue: database.dbQueue,
                 vaultId: testVault.id,
                 projectId: nil,
-                name: "Existing meeting",
-                status: .ready,
-                duration: nil,
-                createdAt: createdAt,
-                updatedAt: createdAt
-            ).insert(db)
-            try CalendarEventRecord(
-                meetingId: meetingId,
-                createdAt: createdAt,
-                updatedAt: createdAt,
-                platform: "GoogleCalendar",
-                platformId: "event-1",
-                description: "",
-                icalUid: nil,
-                start: createdAt,
-                end: createdAt.addingTimeInterval(3600),
-                meetingUrl: nil
-            ).insert(db)
-        }
-
-        let repository = MeetingRepository(dbQueue: database.dbQueue)
-        let resolvedMeetingId = try repository.fetchMeetingIdForCalendarEvent(
-            platform: "GoogleCalendar",
-            platformId: "event-1"
-        )
-
-        XCTAssertEqual(resolvedMeetingId, meetingId)
-    }
-
-    func testStopPersistsTranslatedTextWhenAvailableBeforeInsert() throws {
-        let database = try makeDatabase()
-        let store = TranscriptStore()
-        let startDate = Date(timeIntervalSince1970: 1_776_384_000)
-        store.recordingStartTime = startDate
-
-        let service = try MeetingPersistenceService(
-            store: store,
-            dbQueue: database.dbQueue,
-            vaultId: testVault.id,
-            projectId: nil,
-            initialName: "Translated meeting"
-        )
-        let segment = TranscriptSegment(
-            startTime: startDate,
-            text: "Hello world",
-            translatedText: "こんにちは、世界",
-            isConfirmed: true,
-            speakerLabel: "mic"
-        )
-
-        store.loadSegments([segment])
-        service.stop()
-
-        let persisted = try database.dbQueue.read { db in
-            try XCTUnwrap(TranscriptSegmentRecord.fetchOne(db, key: segment.id))
-        }
-
-        XCTAssertEqual(persisted.text, "Hello world")
-        XCTAssertEqual(persisted.translatedText, "こんにちは、世界")
-    }
-
-    func testTranslatedTextUpdatesExistingPersistedSegment() async throws {
-        let database = try makeDatabase()
-        let store = TranscriptStore()
-        let startDate = Date(timeIntervalSince1970: 1_776_384_000)
-        store.recordingStartTime = startDate
-
-        let service = try MeetingPersistenceService(
-            store: store,
-            dbQueue: database.dbQueue,
-            vaultId: testVault.id,
-            projectId: nil,
-            initialName: "Translated meeting"
-        )
-        let segment = TranscriptSegment(
-            startTime: startDate,
-            text: "Hello world",
-            isConfirmed: true,
-            speakerLabel: "mic"
-        )
-
-        store.loadSegments([segment])
-        try await Task.sleep(for: .milliseconds(700))
-
-        store.updateTranslatedText(for: segment.id, translatedText: "こんにちは、世界")
-        try await Task.sleep(for: .milliseconds(700))
-        service.stop()
-
-        let persisted = try database.dbQueue.read { db in
-            try XCTUnwrap(TranscriptSegmentRecord.fetchOne(db, key: segment.id))
-        }
-
-        XCTAssertEqual(persisted.translatedText, "こんにちは、世界")
-    }
-
-    func testUnconfirmedTranslatedTextIsNotPersisted() throws {
-        let database = try makeDatabase()
-        let store = TranscriptStore()
-        let startDate = Date(timeIntervalSince1970: 1_776_384_000)
-        store.recordingStartTime = startDate
-
-        let service = try MeetingPersistenceService(
-            store: store,
-            dbQueue: database.dbQueue,
-            vaultId: testVault.id,
-            projectId: nil,
-            initialName: "Preview meeting"
-        )
-
-        store.updateUnconfirmedSegment(
-            TranscriptSegment(
+                initialName: "Translated meeting"
+            )
+            let segment = TranscriptSegment(
                 startTime: startDate,
-                text: "Preview",
-                translatedText: "プレビュー",
-                isConfirmed: false,
+                text: "Hello world",
+                translatedText: "こんにちは、世界",
+                isConfirmed: true,
                 speakerLabel: "mic"
-            ),
-            forSource: "mic"
-        )
-        service.stop()
+            )
 
-        let persistedCount = try database.dbQueue.read { db in
-            try TranscriptSegmentRecord.fetchCount(db)
+            store.loadSegments([segment])
+            service.stop()
+
+            let persisted = try database.dbQueue.read { db in
+                try XCTUnwrap(TranscriptSegmentRecord.fetchOne(db, key: segment.id))
+            }
+
+            XCTAssertEqual(persisted.text, "Hello world")
+            XCTAssertEqual(persisted.translatedText, "こんにちは、世界")
         }
 
-        XCTAssertEqual(persistedCount, 0)
+        func testTranslatedTextUpdatesExistingPersistedSegment() async throws {
+            let database = try makeDatabase()
+            let store = TranscriptStore()
+            let startDate = Date(timeIntervalSince1970: 1_776_384_000)
+            store.recordingStartTime = startDate
+
+            let service = try MeetingPersistenceService(
+                store: store,
+                dbQueue: database.dbQueue,
+                vaultId: testVault.id,
+                projectId: nil,
+                initialName: "Translated meeting"
+            )
+            let segment = TranscriptSegment(
+                startTime: startDate,
+                text: "Hello world",
+                isConfirmed: true,
+                speakerLabel: "mic"
+            )
+
+            store.loadSegments([segment])
+            try await Task.sleep(for: .milliseconds(700))
+
+            store.updateTranslatedText(for: segment.id, translatedText: "こんにちは、世界")
+            try await Task.sleep(for: .milliseconds(700))
+            service.stop()
+
+            let persisted = try database.dbQueue.read { db in
+                try XCTUnwrap(TranscriptSegmentRecord.fetchOne(db, key: segment.id))
+            }
+
+            XCTAssertEqual(persisted.translatedText, "こんにちは、世界")
+        }
+
+        func testUnconfirmedTranslatedTextIsNotPersisted() throws {
+            let database = try makeDatabase()
+            let store = TranscriptStore()
+            let startDate = Date(timeIntervalSince1970: 1_776_384_000)
+            store.recordingStartTime = startDate
+
+            let service = try MeetingPersistenceService(
+                store: store,
+                dbQueue: database.dbQueue,
+                vaultId: testVault.id,
+                projectId: nil,
+                initialName: "Preview meeting"
+            )
+
+            store.updateUnconfirmedSegment(
+                TranscriptSegment(
+                    startTime: startDate,
+                    text: "Preview",
+                    translatedText: "プレビュー",
+                    isConfirmed: false,
+                    speakerLabel: "mic"
+                ),
+                forSource: "mic"
+            )
+            service.stop()
+
+            let persistedCount = try database.dbQueue.read { db in
+                try TranscriptSegmentRecord.fetchCount(db)
+            }
+
+            XCTAssertEqual(persistedCount, 0)
+        }
     }
-}
 #endif
 
 private let testVault = VaultRecord(


### PR DESCRIPTION
## 概要

録音セッションごとに、リアルタイム文字起こしと録音後のバッチ文字起こしを排他的に選択できるようにします。

## 変更内容

- グローバル設定に `realtime` / `batch` を追加し、録音開始時の選択をセッションへ固定
- バッチ録音では音源ごとにmono Int16 PCMのCAFをApplication Support配下へ作成
- 成功後に保持設定がONの場合のみVaultへ移管し、OFFの場合は管理領域から削除
- CAFのrange、ロケール、音源、フレーム位置をSQLiteへ保存
- バッチ処理を全体で直列実行し、結果と完了時刻を単一トランザクションで反映
- partial CAF、クラッシュした録音セッション、失敗後の手動再試行を復旧
- 復旧不能な録音を明示的に破棄し、既存文字起こしを保持したまま要約生成を再度有効化
- リアルタイム録音では従来どおりCAFを作成せず、逐次文字起こしを保存
- 日本語・英語の設定画面、録音中表示、バッチ状態表示を追加

## 背景・影響

リアルタイム結果を後からバッチ結果で上書きするハイブリッド方式ではなく、セッション単位の選択式にすることで、結果照合やセグメント差し替えを不要にします。バッチモードでは録音中の字幕は表示されません。

クラッシュやCAF書き込み失敗時は音声を残し、再起動後または手動操作で復旧します。録音終了時の部分更新、partial CAFの確定、Meeting durationの再集計も含め、レビューで見つかった失敗経路を修正しています。

## 検証

- `swift build`
- `swift test`: Swift Testing 184件、XCTest 3件成功
- SwiftFormat: 142ファイル中、要修正0
- 今回追加・変更した小規模ファイル群のSwiftLint: 違反0
- `git diff --check`
