### PR TITLE
Vault 管理画面を SwiftUI 標準構成に改善

### DIFF
--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 "Close" = "Close";
 "Search" = "Search";
 "Actions" = "Actions";
+"Status" = "Status";
 "Dahlia" = "Dahlia";
 "Language" = "Language";
 "Expand" = "Expand";
@@ -274,9 +275,25 @@
 /* Vault Picker */
 "Create New Vault" = "Create New Vault";
 "Create a new folder to use as a vault." = "Create a new folder to use as a vault.";
+"Add Vault" = "Add Vault";
 "Open Folder as Vault" = "Open Folder as Vault";
 "Select an existing folder to use as a vault." = "Select an existing folder to use as a vault.";
 "Remove Vault" = "Remove Vault";
+"Open a different vault before removing this one." = "Open a different vault before removing this one.";
+"Remove %@?" = "Remove %@?";
+"Dahlia will remove this vault and its meeting history from the app. Audio files managed outside the vault folder will also be deleted. Files inside the vault folder are not changed." = "Dahlia will remove this vault and its meeting history from the app. Audio files managed outside the vault folder will also be deleted. Files inside the vault folder are not changed.";
+"Vault Details" = "Vault Details";
+"Vault Name" = "Vault Name";
+"Open Vault" = "Open Vault";
+"Use this vault for recordings and sync." = "Use this vault for recordings and sync.";
+"Select a vault to view its details." = "Select a vault to view its details.";
+"No Vaults" = "No Vaults";
+"Add a folder to start recording and syncing meetings." = "Add a folder to start recording and syncing meetings.";
+"Vault Operation Failed" = "Vault Operation Failed";
+"Could not select the vault folder." = "Could not select the vault folder.";
+"Could not load vaults." = "Could not load vaults.";
+"Could not add the vault." = "Could not add the vault.";
+"Could not remove the vault." = "Could not remove the vault.";
 "Open" = "Open";
 "Loading supported languages..." = "Loading supported languages...";
 "Search languages..." = "Search languages...";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 "Close" = "閉じる";
 "Search" = "検索";
 "Actions" = "操作";
+"Status" = "状態";
 "Dahlia" = "Dahlia";
 "Language" = "言語";
 "Expand" = "展開";
@@ -274,9 +275,25 @@
 /* Vault Picker */
 "Create New Vault" = "保管庫を新規作成する";
 "Create a new folder to use as a vault." = "新しいフォルダを作成して保管庫として使用します。";
+"Add Vault" = "保管庫を追加";
 "Open Folder as Vault" = "保管庫としてフォルダを開く";
 "Select an existing folder to use as a vault." = "既存のフォルダを選択して保管庫として使用します。";
 "Remove Vault" = "保管庫を登録解除";
+"Open a different vault before removing this one." = "登録を解除するには、先に別の保管庫を開いてください。";
+"Remove %@?" = "「%@」の登録を解除しますか？";
+"Dahlia will remove this vault and its meeting history from the app. Audio files managed outside the vault folder will also be deleted. Files inside the vault folder are not changed." = "この保管庫とミーティング履歴が Dahlia から削除され、保管庫の外で Dahlia が管理する音声ファイルも削除されます。保管庫フォルダ内のファイルは変更されません。";
+"Vault Details" = "保管庫の詳細";
+"Vault Name" = "保管庫名";
+"Open Vault" = "この保管庫を開く";
+"Use this vault for recordings and sync." = "録音と同期にこの保管庫を使用します。";
+"Select a vault to view its details." = "詳細を表示する保管庫を選択してください。";
+"No Vaults" = "保管庫がありません";
+"Add a folder to start recording and syncing meetings." = "録音とミーティングの同期を始めるには、フォルダを追加してください。";
+"Vault Operation Failed" = "保管庫を操作できませんでした";
+"Could not select the vault folder." = "保管庫のフォルダを選択できませんでした。";
+"Could not load vaults." = "保管庫を読み込めませんでした。";
+"Could not add the vault." = "保管庫を追加できませんでした。";
+"Could not remove the vault." = "保管庫の登録を解除できませんでした。";
 "Open" = "開く";
 "Loading supported languages..." = "対応言語を読み込み中...";
 "Search languages..." = "言語を検索...";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -36,6 +36,7 @@ enum L10n {
     static var close: String { String(localized: "Close", bundle: bundle) }
     static var search: String { String(localized: "Search", bundle: bundle) }
     static var actions: String { String(localized: "Actions", bundle: bundle) }
+    static var status: String { String(localized: "Status", bundle: bundle) }
     static var dahlia: String { String(localized: "Dahlia", bundle: bundle) }
     static var language: String { String(localized: "Language", bundle: bundle) }
     static var join: String { String(localized: "Join", bundle: bundle) }
@@ -576,9 +577,38 @@ enum L10n {
 
     static var createNewVault: String { String(localized: "Create New Vault", bundle: bundle) }
     static var createNewVaultDescription: String { String(localized: "Create a new folder to use as a vault.", bundle: bundle) }
+    static var addVault: String { String(localized: "Add Vault", bundle: bundle) }
     static var openFolderAsVault: String { String(localized: "Open Folder as Vault", bundle: bundle) }
     static var openFolderAsVaultDescription: String { String(localized: "Select an existing folder to use as a vault.", bundle: bundle) }
     static var removeVault: String { String(localized: "Remove Vault", bundle: bundle) }
+    static var currentVaultRemoveDescription: String { String(
+        localized: "Open a different vault before removing this one.",
+        bundle: bundle
+    ) }
+    static func removeVaultConfirmation(_ name: String) -> String { String(localized: "Remove \(name)?", bundle: bundle) }
+    static var removeVaultConfirmationDescription: String { String(
+        localized: """
+        Dahlia will remove this vault and its meeting history from the app. \
+        Audio files managed outside the vault folder will also be deleted. \
+        Files inside the vault folder are not changed.
+        """,
+        bundle: bundle
+    ) }
+    static var vaultDetails: String { String(localized: "Vault Details", bundle: bundle) }
+    static var vaultName: String { String(localized: "Vault Name", bundle: bundle) }
+    static var openVault: String { String(localized: "Open Vault", bundle: bundle) }
+    static var openVaultDescription: String { String(localized: "Use this vault for recordings and sync.", bundle: bundle) }
+    static var selectVaultDescription: String { String(localized: "Select a vault to view its details.", bundle: bundle) }
+    static var noVaults: String { String(localized: "No Vaults", bundle: bundle) }
+    static var noVaultsDescription: String { String(
+        localized: "Add a folder to start recording and syncing meetings.",
+        bundle: bundle
+    ) }
+    static var vaultOperationFailed: String { String(localized: "Vault Operation Failed", bundle: bundle) }
+    static var vaultFolderSelectionFailed: String { String(localized: "Could not select the vault folder.", bundle: bundle) }
+    static var vaultLoadFailed: String { String(localized: "Could not load vaults.", bundle: bundle) }
+    static var vaultAddFailed: String { String(localized: "Could not add the vault.", bundle: bundle) }
+    static var vaultRemoveFailed: String { String(localized: "Could not remove the vault.", bundle: bundle) }
     static var open: String { String(localized: "Open", bundle: bundle) }
     static var loadingLanguages: String { String(localized: "Loading supported languages...", bundle: bundle) }
     static var searchLanguages: String { String(localized: "Search languages...", bundle: bundle) }

--- a/Sources/Dahlia/Views/VaultDetailView.swift
+++ b/Sources/Dahlia/Views/VaultDetailView.swift
@@ -33,6 +33,7 @@ struct VaultDetailView: View {
                 Section {
                     Button(L10n.openVault, systemImage: "folder", action: onOpen)
                         .buttonStyle(.borderedProminent)
+                        .disabled(isCurrentVault)
                 } footer: {
                     Text(L10n.openVaultDescription)
                 }

--- a/Sources/Dahlia/Views/VaultDetailView.swift
+++ b/Sources/Dahlia/Views/VaultDetailView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct VaultDetailView: View {
+    let vault: VaultRecord?
+    let hasRegisteredVaults: Bool
+    let isCurrentVault: Bool
+    let onOpen: () -> Void
+    let onAdd: () -> Void
+
+    var body: some View {
+        if let vault {
+            Form {
+                Section(L10n.vaultDetails) {
+                    LabeledContent(L10n.vaultName, value: vault.name)
+                    LabeledContent(L10n.location) {
+                        Text(vault.path)
+                            .lineLimit(2)
+                            .truncationMode(.middle)
+                            .textSelection(.enabled)
+                    }
+
+                    if isCurrentVault {
+                        LabeledContent {
+                            Label(L10n.currentVault, systemImage: "checkmark.circle.fill")
+                                .foregroundStyle(.secondary)
+                        } label: {
+                            Text(L10n.status)
+                            Text(L10n.currentVaultRemoveDescription)
+                        }
+                    }
+                }
+
+                Section {
+                    Button(L10n.openVault, systemImage: "folder", action: onOpen)
+                        .buttonStyle(.borderedProminent)
+                } footer: {
+                    Text(L10n.openVaultDescription)
+                }
+            }
+            .formStyle(.grouped)
+            .navigationTitle(vault.name)
+        } else if hasRegisteredVaults {
+            ContentUnavailableView {
+                Label(L10n.noVaultSelected, systemImage: "externaldrive")
+            } description: {
+                Text(L10n.selectVaultDescription)
+            }
+        } else {
+            ContentUnavailableView {
+                Label(L10n.noVaults, systemImage: "externaldrive.badge.plus")
+            } description: {
+                Text(L10n.noVaultsDescription)
+            } actions: {
+                Button(L10n.openFolderAsVault, systemImage: "folder.badge.plus", action: onAdd)
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+}

--- a/Sources/Dahlia/Views/VaultPickerView.swift
+++ b/Sources/Dahlia/Views/VaultPickerView.swift
@@ -1,177 +1,149 @@
+import Combine
 import SwiftUI
 
-/// Obsidian 風の保管庫登録・選択画面。
+/// 保管庫の登録・選択・登録解除を行う画面。
 struct VaultPickerView: View {
     let appDatabase: AppDatabaseManager?
     let onVaultSelected: (VaultRecord) -> Void
 
+    @ObservedObject private var settings = AppSettings.shared
     @State private var vaults: [VaultRecord] = []
-    @State private var showFolderPicker = false
+    @State private var selectedVaultId: UUID?
+    @State private var isShowingFolderPicker = false
+    @State private var isShowingError = false
+    @State private var errorMessage = ""
 
-    private static var defaultVaultURL: URL {
-        let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
-            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Documents", isDirectory: true)
-        return documentsURL.appendingPathComponent("Meetings", isDirectory: true)
-    }
+    private static let defaultVaultURL = URL.documentsDirectory
+        .appending(path: "Meetings", directoryHint: .isDirectory)
 
     private var repository: MeetingRepository? {
         appDatabase.map { MeetingRepository(dbQueue: $0.dbQueue) }
     }
 
+    private var selectedVault: VaultRecord? {
+        guard let selectedVaultId else { return nil }
+        return vaults.first(where: { $0.id == selectedVaultId })
+    }
+
     var body: some View {
-        HStack(spacing: 0) {
-            vaultList
-            Divider()
-            mainPanel
+        NavigationSplitView(columnVisibility: .constant(.all)) {
+            VaultSidebarView(
+                vaults: vaults,
+                selectedVaultId: $selectedVaultId,
+                currentVaultId: settings.currentVault?.id,
+                onAdd: showFolderPicker,
+                onRemove: removeVault
+            )
+            .navigationSplitViewColumnWidth(min: 220, ideal: 280, max: 360)
+        } detail: {
+            VaultDetailView(
+                vault: selectedVault,
+                hasRegisteredVaults: !vaults.isEmpty,
+                isCurrentVault: selectedVault?.id == settings.currentVault?.id,
+                onOpen: openSelectedVault,
+                onAdd: showFolderPicker
+            )
         }
-        .frame(minWidth: 820, minHeight: 460)
-        .task { loadVaults() }
-    }
-
-    // MARK: - Left: Vault List
-
-    private var vaultList: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            List {
-                ForEach(vaults) { vault in
-                    VaultRow(vault: vault) {
-                        onVaultSelected(vault)
-                    }
-                    .contextMenu {
-                        Button(L10n.removeVault, role: .destructive) {
-                            deleteVault(vault)
-                        }
-                    }
-                }
-            }
-            .listStyle(.sidebar)
+        .frame(minWidth: 720, minHeight: 460)
+        .task(id: appDatabase != nil) {
+            loadVaults()
         }
-        .frame(width: 260)
-    }
-
-    // MARK: - Right: Main Panel
-
-    private var mainPanel: some View {
-        VStack(spacing: 32) {
-            Spacer()
-
-            // App branding
-            VStack(spacing: 8) {
-                Image(systemName: "waveform.circle.fill")
-                    .font(.system(size: 64))
-                    .foregroundStyle(.tint)
-                Text("Dahlia")
-                    .font(.largeTitle.bold())
-            }
-
-            Spacer()
-
-            // Actions
-            VStack(spacing: 0) {
-                actionRow(
-                    title: L10n.openFolderAsVault,
-                    description: L10n.openFolderAsVaultDescription
-                ) {
-                    Button(L10n.open) {
-                        showFolderPicker = true
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(repository == nil)
-                }
-            }
-            .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 8))
-            .padding(.horizontal, 40)
-
-            Spacer()
-        }
-        .frame(maxWidth: .infinity)
         .fileImporter(
-            isPresented: $showFolderPicker,
+            isPresented: $isShowingFolderPicker,
             allowedContentTypes: [.folder],
-            allowsMultipleSelection: false
-        ) { result in
-            if case let .success(urls) = result, let url = urls.first {
-                registerVault(url: url)
-            }
-        }
+            allowsMultipleSelection: false,
+            onCompletion: handleFolderImport
+        )
         .fileDialogDefaultDirectory(Self.defaultVaultURL)
-    }
-
-    private func actionRow(
-        title: String,
-        description: String,
-        @ViewBuilder action: () -> some View
-    ) -> some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.headline)
-                Text(description)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            Spacer()
-            action()
+        .alert(L10n.vaultOperationFailed, isPresented: $isShowingError) {} message: {
+            Text(errorMessage)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
     }
 
-    // MARK: - Actions
+    private func showFolderPicker() {
+        isShowingFolderPicker = true
+    }
 
-    private func loadVaults() {
-        vaults = (try? repository?.fetchAllVaults()) ?? []
+    private func handleFolderImport(_ result: Result<[URL], any Error>) {
+        switch result {
+        case let .success(urls):
+            guard let url = urls.first else { return }
+            registerVault(url: url)
+        case let .failure(error):
+            guard (error as? CocoaError)?.code != .userCancelled else { return }
+            presentError(L10n.vaultFolderSelectionFailed, error: error, source: "folderImport")
+        }
+    }
+
+    private func loadVaults(preferredSelection: UUID? = nil) {
+        guard let repository else {
+            vaults = []
+            selectedVaultId = nil
+            return
+        }
+
+        do {
+            let loadedVaults = try repository.fetchAllVaults()
+            let preferredIds = [preferredSelection, selectedVaultId, settings.currentVault?.id].compactMap(\.self)
+            vaults = loadedVaults
+            selectedVaultId = preferredIds.first(where: { id in
+                loadedVaults.contains(where: { $0.id == id })
+            }) ?? loadedVaults.first?.id
+        } catch {
+            presentError(L10n.vaultLoadFailed, error: error, source: "loadVaults")
+        }
     }
 
     private func registerVault(url: URL) {
-        guard repository != nil else { return }
-        let now = Date()
+        guard let repository else { return }
+
+        let normalizedURL = url.standardizedFileURL
+        if let existingVault = vaults.first(where: { $0.url.standardizedFileURL == normalizedURL }) {
+            selectedVaultId = existingVault.id
+            onVaultSelected(existingVault)
+            return
+        }
+
+        let now = Date.now
         let vault = VaultRecord(
             id: .v7(),
-            path: url.path,
-            name: url.lastPathComponent,
+            path: normalizedURL.path,
+            name: normalizedURL.lastPathComponent,
             createdAt: now,
             lastOpenedAt: now
         )
-        try? repository?.insertVault(vault)
-        loadVaults()
-        onVaultSelected(vault)
-    }
 
-    private func deleteVault(_ vault: VaultRecord) {
-        try? repository?.deleteVault(id: vault.id)
-        loadVaults()
-    }
-}
-
-// MARK: - Vault Row
-
-private struct VaultRow: View {
-    let vault: VaultRecord
-    let onOpen: () -> Void
-    @State private var isHovered = false
-
-    var body: some View {
-        Button(action: onOpen) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(vault.name)
-                    .font(.headline)
-                Text(vault.path)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.vertical, 4)
-            .contentShape(Rectangle())
+        do {
+            try repository.insertVault(vault)
+            loadVaults(preferredSelection: vault.id)
+            onVaultSelected(vault)
+        } catch {
+            presentError(L10n.vaultAddFailed, error: error, source: "registerVault")
         }
-        .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
-        .pointerStyle(.link)
-        .background(
-            RoundedRectangle(cornerRadius: 4)
-                .fill(isHovered ? Color.primary.opacity(0.06) : Color.clear)
-        )
+    }
+
+    private func removeVault(_ vault: VaultRecord) {
+        guard let repository else { return }
+
+        do {
+            try repository.deleteVault(id: vault.id)
+            vaults.removeAll(where: { $0.id == vault.id })
+            if selectedVaultId == vault.id {
+                selectedVaultId = vaults.first?.id
+            }
+        } catch {
+            presentError(L10n.vaultRemoveFailed, error: error, source: "removeVault")
+        }
+    }
+
+    private func openSelectedVault() {
+        guard let selectedVault else { return }
+        onVaultSelected(selectedVault)
+    }
+
+    private func presentError(_ message: String, error: any Error, source: String) {
+        errorMessage = message
+        isShowingError = true
+        ErrorReportingService.capture(error, context: ["source": source])
     }
 }

--- a/Sources/Dahlia/Views/VaultSidebarView.swift
+++ b/Sources/Dahlia/Views/VaultSidebarView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct VaultSidebarView: View {
+    let vaults: [VaultRecord]
+    @Binding var selectedVaultId: UUID?
+    let currentVaultId: UUID?
+    let onAdd: () -> Void
+    let onRemove: (VaultRecord) -> Void
+
+    @State private var isShowingRemovalConfirmation = false
+
+    private var selectedVault: VaultRecord? {
+        guard let selectedVaultId else { return nil }
+        return vaults.first(where: { $0.id == selectedVaultId })
+    }
+
+    var body: some View {
+        List(selection: $selectedVaultId) {
+            ForEach(vaults) { vault in
+                HStack {
+                    Label {
+                        VStack(alignment: .leading) {
+                            Text(vault.name)
+                            Text(vault.path)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                    } icon: {
+                        Image(systemName: "externaldrive")
+                    }
+
+                    Spacer()
+
+                    if vault.id == currentVaultId {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                            .accessibilityLabel(L10n.currentVault)
+                    }
+                }
+                .tag(vault.id)
+            }
+        }
+        .listStyle(.sidebar)
+        .navigationTitle(L10n.vault)
+        .onDeleteCommand(perform: requestRemoval)
+        .toolbar {
+            ToolbarItemGroup {
+                Button(L10n.addVault, systemImage: "plus", action: onAdd)
+                    .help(L10n.openFolderAsVaultDescription)
+
+                Button(L10n.removeVault, systemImage: "minus", action: requestRemoval)
+                    .disabled(selectedVault == nil || selectedVault?.id == currentVaultId)
+                    .help(selectedVault?.id == currentVaultId ? L10n.currentVaultRemoveDescription : L10n.removeVault)
+                    .confirmationDialog(
+                        L10n.removeVaultConfirmation(selectedVault?.name ?? ""),
+                        isPresented: $isShowingRemovalConfirmation,
+                        titleVisibility: .visible
+                    ) {
+                        Button(L10n.removeVault, role: .destructive, action: confirmRemoval)
+                        Button(L10n.cancel, role: .cancel) {}
+                    } message: {
+                        Text(L10n.removeVaultConfirmationDescription)
+                    }
+            }
+        }
+        .toolbar(removing: .sidebarToggle)
+    }
+
+    private func requestRemoval() {
+        guard let selectedVault, selectedVault.id != currentVaultId else { return }
+        isShowingRemovalConfirmation = true
+    }
+
+    private func confirmRemoval() {
+        guard let selectedVault else { return }
+        onRemove(selectedVault)
+    }
+}


### PR DESCRIPTION
## 概要

- Vault 管理画面を `NavigationSplitView`、選択可能な `List`、詳細 `Form` で再構成
- 行クリックによる即時切り替えをやめ、選択と「開く」操作を分離
- 空状態、登録解除の確認、エラー表示、使用中 Vault の表示を標準 SwiftUI コンポーネントで追加
- サイドバーを常時表示に固定し、標準の折りたたみボタンを削除
- VoiceOver 向けラベルと日本語・英語のローカライズを追加

## 背景

従来画面は独自の分割レイアウトと hover 表現を使い、Vault 行を1回クリックすると即座に切り替わっていました。また、登録・解除処理のエラーが無視され、解除時の影響も表示されていませんでした。macOS の標準的な選択・詳細・明示アクションの操作モデルへ揃えています。

## 影響

- 使用中の Vault は別の Vault を開くまで登録解除できません
- Vault 登録解除時は、アプリ内履歴と Vault 外で管理する音声ファイルへの影響を確認ダイアログで案内します
- DB マイグレーションや外部依存の変更はありません

## 検証

- `swift build`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test`（XCTest 3件 + Swift Testing 186件、すべて成功）
- SwiftFormat
- 変更した Vault View の SwiftLint