### PR TITLE
バッチ文字起こしとライブ字幕を並列化

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundleVersion</key>
     <string>12</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.2.1</string>
+    <string>0.3.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/AGENTS.md
+++ b/Sources/Dahlia/AGENTS.md
@@ -6,33 +6,35 @@
 AudioCaptureManager (マイク / AVAudioEngine)
 SystemAudioCaptureManager (システム音声 / ScreenCaptureKit)
     ↓ onAudioBuffer コールバック
-AudioBufferBridge → AsyncStream<AnalyzerInput>
-    ↓
-SpeechTranscriberService (actor、音声ソースごとに 1 つ)
-    ↓ results AsyncSequence
-TranscriptStore (@MainActor、speakerLabel ごとに 200ms スロットル)
+AudioSourcePipeline → CapturedAudioChunk (セッション相対時刻付き)
+    ↓ AudioFrameRouter (音源ごとに物理capture 1回)
+    ├─ BatchAudioFileWriter (欠落禁止)
+    └─ AudioBufferBridge → SpeechTranscriberService (低遅延、音源ごとに最大1つ)
+        ↓ TranscriptionEvent
+        ├─ TranscriptStore (realtimeの正本)
+        └─ LiveCaptionStore (録音中だけの一時字幕)
     ↓ Combine .debounce(500ms)
 MeetingPersistenceService → GRDB/SQLite (確定済みセグメントを差分 INSERT)
 ```
 
-音声ソースごとに独立した `(SpeechTranscriberService, AudioBufferBridge)` パイプラインを持ち、`CaptionViewModel.pipelines` が管理する。
+`RecordingSessionController` actor が capture、recognizer、CAF recorder、batch scheduler を所有する。`CaptionViewModel` はセッション要求、UI状態、storeへのイベント投影、Meeting persistenceを担当し、AVFoundation/Speechの実行リソースを保持しない。
 
 ## 主要コンポーネント
 
 | レイヤ | コンポーネント |
 |--------|----------------|
-| **Audio** | `AudioCaptureManager`（マイク）、`SystemAudioCaptureManager`（システム音声）、`AudioBufferBridge` |
+| **Audio** | `AudioCaptureManager`（マイク）、`SystemAudioCaptureManager`（システム音声）、`AudioSourcePipeline`、`AudioFrameRouter`、`AudioBufferBridge` |
 | **Speech** | `SpeechTranscriberService`（actor）、`PreviewTranslationCoordinator` |
 | **Storage** | `TranscriptStore`、`MeetingPersistenceService`、`MeetingRepository`、`AppDatabaseManager` |
 | **LLM** | `LLMService`（OpenAI 互換 API）、`SummaryService`（`SummaryDocument` 構造化出力のマルチモーダル要約） |
-| **Services** | `VaultSyncService`（FSEvents）、`MeetingDetectionService`（3 層検出）、`RecordingCoordinator`、`LiveSubtitleOverlayCoordinator`、`KeychainService`、Google Calendar/Drive クライアント、`LiveSubtitleOverlayService`、各種 Export |
-| **ViewModels** | `CaptionViewModel`（録音制御・パイプライン管理）、`SidebarViewModel`（GRDB ValueObservation でミーティング一覧と設定補助データを監視） |
+| **Services** | `RecordingSessionController`（録音runtime）、`VaultSyncService`（FSEvents）、`MeetingDetectionService`（3 層検出）、`RecordingCoordinator`、`LiveSubtitleOverlayCoordinator`、`KeychainService`、Google Calendar/Drive クライアント、各種 Export |
+| **ViewModels** | `CaptionViewModel`（UI・Meeting状態・store投影）、`SidebarViewModel`（GRDB ValueObservation でミーティング一覧と設定補助データを監視） |
 | **Views** | `ContentView`（NavigationSplitView）→ `MeetingListSidebarView` + `ControlPanelView` + `SettingsView` + `MenuBarExtra` |
 
 ## 並行処理規約
 
 - ViewModel / Store / Repository は `@MainActor`。
-- `SpeechTranscriberService` は `actor`。
+- `RecordingSessionController` / `SpeechTranscriberService` / capture adapter は `actor`。
 - `@unchecked Sendable` は ScreenCaptureKit のデリゲートのみに限定する。
 - Apple フレームワークの Sendable 警告は `@preconcurrency import` で抑制する。
 

--- a/Sources/Dahlia/Audio/AVAudioAnalyzerInputConverter.swift
+++ b/Sources/Dahlia/Audio/AVAudioAnalyzerInputConverter.swift
@@ -1,0 +1,30 @@
+@preconcurrency import AVFoundation
+import CoreMedia
+import Speech
+
+/// macOS 26 向けの `AnalyzerInputConverting` 実装。
+/// 公式の `AnalyzerInputConverter` が利用可能になるまでの adapter。
+final class AVAudioAnalyzerInputConverter: AnalyzerInputConverting {
+    private let analyzerFormat: AVAudioFormat
+    private let converter: AVAudioConverter
+
+    init(sourceFormat: AVAudioFormat, analyzerFormat: AVAudioFormat) throws {
+        guard let converter = AVAudioConverter(from: sourceFormat, to: analyzerFormat) else {
+            throw AudioCaptureError.converterCreationFailed
+        }
+        converter.sampleRateConverterQuality = AVAudioQuality.medium.rawValue
+        self.analyzerFormat = analyzerFormat
+        self.converter = converter
+    }
+
+    func convert(_ buffer: AVAudioPCMBuffer, at startTime: CMTime) throws -> [AnalyzerInput] {
+        guard let converted = AudioConverter.convert(buffer, to: analyzerFormat, using: converter) else {
+            throw AudioCaptureError.converterCreationFailed
+        }
+        return [AnalyzerInput(buffer: converted, bufferStartTime: startTime)]
+    }
+
+    func finish() throws -> [AnalyzerInput] {
+        []
+    }
+}

--- a/Sources/Dahlia/Audio/AnalyzerInputConverting.swift
+++ b/Sources/Dahlia/Audio/AnalyzerInputConverting.swift
@@ -1,0 +1,17 @@
+@preconcurrency import AVFoundation
+import CoreMedia
+import Speech
+
+typealias AnalyzerInputConverterFactory = @Sendable (
+    _ sourceFormat: AVAudioFormat,
+    _ analyzerFormat: AVAudioFormat
+) throws -> any AnalyzerInputConverting
+
+/// Capture 形式のバッファを SpeechAnalyzer 入力へ変換する境界。
+///
+/// macOS SDK で `AnalyzerInputConverter` が利用可能になった時は、
+/// この protocol に適合する adapter と差し替える。
+protocol AnalyzerInputConverting: AnyObject, Sendable {
+    func convert(_ buffer: AVAudioPCMBuffer, at startTime: CMTime) throws -> [AnalyzerInput]
+    func finish() throws -> [AnalyzerInput]
+}

--- a/Sources/Dahlia/Audio/AudioBufferBridge.swift
+++ b/Sources/Dahlia/Audio/AudioBufferBridge.swift
@@ -6,40 +6,102 @@ import Speech
 /// オーディオキャプチャコールバックから SpeechAnalyzer が消費する
 /// AsyncStream<AnalyzerInput> へのブリッジ。
 /// AudioCaptureManager / SystemAudioCaptureManager の onAudioBuffer コールバックから
-/// appendBuffer() を呼び出し、SpeechAnalyzer.start(inputSequence:) に stream を渡す。
-final class AudioBufferBridge: @unchecked Sendable {
+/// append(_:) を呼び出し、SpeechAnalyzer.start(inputSequence:) に stream を渡す。
+final class AudioBufferBridge: Sendable {
+    enum BufferingMode: Equatable {
+        case lossless
+        case lowLatency(maximumInputCount: Int)
+    }
+
     let stream: AsyncStream<AnalyzerInput>
     private let continuation: AsyncStream<AnalyzerInput>.Continuation
 
-    /// 累積サンプル数（bufferStartTime 計算用）
-    private var cumulativeSampleCount: Int64 = 0
-    private let sampleRate: Double
+    private let inputConverter: AnalyzerInputConverting?
+    private let bufferingMode: BufferingMode
     private let lock = OSAllocatedUnfairLock()
 
-    init(sampleRate: Double) {
-        self.sampleRate = sampleRate
-        let (stream, continuation) = AsyncStream.makeStream(
-            of: AnalyzerInput.self,
-            bufferingPolicy: .bufferingNewest(64)
-        )
+    /// Capture と SpeechAnalyzer の形式が異なる場合に、ライブ分岐内でのみ変換する。
+    /// batch + live では固定形式の CAF 録音を維持しつつ、同じバッファをライブ認識に利用できる。
+    init(
+        sourceFormat: AVAudioFormat,
+        analyzerFormat: AVAudioFormat,
+        inputConverter: AnalyzerInputConverting? = nil,
+        bufferingMode: BufferingMode = .lossless
+    ) throws {
+        self.bufferingMode = bufferingMode
+        if sourceFormat == analyzerFormat {
+            self.inputConverter = nil
+        } else {
+            guard let inputConverter else {
+                throw AudioCaptureError.converterCreationFailed
+            }
+            self.inputConverter = inputConverter
+        }
+
+        let (stream, continuation) = Self.makeStream(bufferingMode: bufferingMode)
         self.stream = stream
         self.continuation = continuation
     }
 
     /// オーディオキャプチャコールバックから呼ばれる。スレッドセーフ。
-    func appendBuffer(_ buffer: AVAudioPCMBuffer) {
-        let startTime: CMTime = lock.withLock {
-            let time = CMTime(value: cumulativeSampleCount, timescale: CMTimeScale(sampleRate))
-            cumulativeSampleCount += Int64(buffer.frameLength)
-            return time
-        }
+    @discardableResult
+    func append(_ chunk: CapturedAudioChunk) -> Bool {
+        lock.withLock {
+            let inputs: [AnalyzerInput]
+            do {
+                if let inputConverter {
+                    inputs = try inputConverter.convert(chunk.buffer, at: chunk.sessionRelativeStartTime)
+                } else {
+                    inputs = [AnalyzerInput(
+                        buffer: chunk.buffer,
+                        bufferStartTime: chunk.sessionRelativeStartTime
+                    )]
+                }
+            } catch {
+                return false
+            }
 
-        let input = AnalyzerInput(buffer: buffer, bufferStartTime: startTime)
-        continuation.yield(input)
+            var accepted = true
+            for input in inputs {
+                switch continuation.yield(input) {
+                case .enqueued:
+                    break
+                case .dropped:
+                    if case .lossless = bufferingMode {
+                        accepted = false
+                    }
+                case .terminated:
+                    accepted = false
+                @unknown default:
+                    accepted = false
+                }
+            }
+            return accepted
+        }
     }
 
     /// オーディオ入力の終了を通知する。
     func finish() {
-        continuation.finish()
+        lock.withLock {
+            if let inputConverter,
+               let pendingInputs = try? inputConverter.finish() {
+                for input in pendingInputs {
+                    continuation.yield(input)
+                }
+            }
+            continuation.finish()
+        }
+    }
+
+    private static func makeStream(
+        bufferingMode: BufferingMode
+    ) -> (stream: AsyncStream<AnalyzerInput>, continuation: AsyncStream<AnalyzerInput>.Continuation) {
+        let bufferingPolicy: AsyncStream<AnalyzerInput>.Continuation.BufferingPolicy = switch bufferingMode {
+        case .lossless:
+            .unbounded
+        case let .lowLatency(maximumInputCount):
+            .bufferingNewest(max(1, maximumInputCount))
+        }
+        return AsyncStream.makeStream(of: AnalyzerInput.self, bufferingPolicy: bufferingPolicy)
     }
 }

--- a/Sources/Dahlia/Audio/AudioFrameRouter.swift
+++ b/Sources/Dahlia/Audio/AudioFrameRouter.swift
@@ -1,0 +1,164 @@
+@preconcurrency import AVFoundation
+import os
+
+/// 1つの物理キャプチャから batch 録音とライブ認識へ同じバッファを分配する。
+/// batch は欠落検知付き writer へ同期投入し、live の変換・認識は bounded worker queue へ分離する。
+final class AudioFrameRouter: Sendable {
+    typealias BatchConsumer = @Sendable (CapturedAudioChunk) -> Void
+    typealias LiveConsumer = @Sendable (CapturedAudioChunk) -> Bool
+    typealias LiveFailureHandler = @Sendable () -> Void
+
+    private struct Consumers {
+        let batch: BatchConsumer?
+        let liveWorker: LiveAudioFrameWorker?
+    }
+
+    private struct State {
+        var batchConsumer: BatchConsumer?
+        var liveWorker: LiveAudioFrameWorker?
+        var liveFailureHandler: LiveFailureHandler?
+        var liveGeneration: UInt64 = 0
+        var inFlightRouteCount = 0
+        var idleWaiters: [CheckedContinuation<Void, Never>] = []
+        var workersWaitingForRouteCompletion: [LiveAudioFrameWorker] = []
+        var retiredWorkers: [LiveAudioFrameWorker] = []
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    func setBatchConsumer(_ consumer: BatchConsumer?) {
+        state.withLock { $0.batchConsumer = consumer }
+    }
+
+    func setLiveConsumer(
+        _ consumer: LiveConsumer?,
+        bufferingMode: LiveAudioFrameWorker.BufferingMode = .lossless,
+        onFailure: LiveFailureHandler? = nil
+    ) {
+        let generation = state.withLock { state in
+            state.liveGeneration &+= 1
+            return state.liveGeneration
+        }
+        let newWorker = consumer.map { consumer in
+            LiveAudioFrameWorker(bufferingMode: bufferingMode, consumer: consumer) { [weak self] in
+                self?.liveWorkerFailed(generation: generation)
+            }
+        }
+
+        let workersToFinish = state.withLock { state -> [LiveAudioFrameWorker] in
+            guard state.liveGeneration == generation else {
+                return newWorker.map { [$0] } ?? []
+            }
+            let workersToFinish = retireCurrentLiveWorker(state: &state)
+            state.liveWorker = newWorker
+            state.liveFailureHandler = onFailure
+            return workersToFinish
+        }
+        workersToFinish.forEach { $0.finish() }
+    }
+
+    func removeAllConsumers() {
+        let workersToFinish = state.withLock { state -> [LiveAudioFrameWorker] in
+            state.batchConsumer = nil
+            state.liveGeneration &+= 1
+            return retireCurrentLiveWorker(state: &state)
+        }
+        workersToFinish.forEach { $0.finish() }
+    }
+
+    func removeLiveConsumerAndWait() async {
+        setLiveConsumer(nil)
+        await waitUntilIdle()
+    }
+
+    /// consumer を切り離した後、lock 外へ取り出された callback と retired live worker の完了を待つ。
+    func waitUntilIdle() async {
+        await waitForRouteCallbacks()
+
+        while true {
+            let workers = state.withLock { state -> [LiveAudioFrameWorker] in
+                state.retiredWorkers
+            }
+            guard !workers.isEmpty else { return }
+            workers.forEach { $0.finish() }
+            for worker in workers {
+                await worker.waitUntilFinished()
+            }
+            state.withLock { state in
+                state.retiredWorkers.removeAll { retiredWorker in
+                    workers.contains { $0 === retiredWorker }
+                }
+            }
+        }
+    }
+
+    func route(_ chunk: CapturedAudioChunk) {
+        guard let consumers: Consumers = state.withLock({ state in
+            guard state.batchConsumer != nil || state.liveWorker != nil else { return nil }
+            state.inFlightRouteCount += 1
+            return Consumers(batch: state.batchConsumer, liveWorker: state.liveWorker)
+        }) else { return }
+        defer { finishRoute() }
+
+        consumers.batch?(chunk)
+        consumers.liveWorker?.enqueue(chunk)
+    }
+
+    private func liveWorkerFailed(generation: UInt64) {
+        let result = state.withLock { state -> (workers: [LiveAudioFrameWorker], handler: LiveFailureHandler?) in
+            guard state.liveGeneration == generation else { return ([], nil) }
+            state.liveGeneration &+= 1
+            let handler = state.liveFailureHandler
+            let workers = retireCurrentLiveWorker(state: &state)
+            return (workers, handler)
+        }
+        result.workers.forEach { $0.finish() }
+        result.handler?()
+    }
+
+    private func retireCurrentLiveWorker(state: inout State) -> [LiveAudioFrameWorker] {
+        guard let worker = state.liveWorker else {
+            state.liveFailureHandler = nil
+            return []
+        }
+
+        state.liveWorker = nil
+        state.liveFailureHandler = nil
+        state.retiredWorkers.append(worker)
+        if state.inFlightRouteCount > 0 {
+            state.workersWaitingForRouteCompletion.append(worker)
+            return []
+        }
+        return [worker]
+    }
+
+    private func waitForRouteCallbacks() async {
+        await withCheckedContinuation { continuation in
+            let shouldResume = state.withLock { state in
+                guard state.inFlightRouteCount > 0 else { return true }
+                state.idleWaiters.append(continuation)
+                return false
+            }
+            if shouldResume {
+                continuation.resume()
+            }
+        }
+    }
+
+    private func finishRoute() {
+        let result = state.withLock { state -> (
+            workers: [LiveAudioFrameWorker],
+            waiters: [CheckedContinuation<Void, Never>]
+        ) in
+            state.inFlightRouteCount -= 1
+            guard state.inFlightRouteCount == 0 else { return ([], []) }
+            let workers = state.workersWaitingForRouteCompletion
+            let waiters = state.idleWaiters
+            state.workersWaitingForRouteCompletion.removeAll()
+            state.idleWaiters.removeAll()
+            return (workers, waiters)
+        }
+        result.workers.forEach { $0.finish() }
+        result.waiters.forEach { $0.resume() }
+    }
+}

--- a/Sources/Dahlia/Audio/AudioSourcePipeline.swift
+++ b/Sources/Dahlia/Audio/AudioSourcePipeline.swift
@@ -7,6 +7,7 @@ import os
 final class AudioSourcePipeline: Sendable {
     private struct ClockState {
         var nextFrame: Int64 = 0
+        var sessionRelativeOrigin: CMTime
     }
 
     let source: RecordingAudioSource
@@ -14,13 +15,11 @@ final class AudioSourcePipeline: Sendable {
     let captureFormat: AVAudioFormat
     let captureDeviceID: AudioDeviceID?
     let captureBufferSize: AVAudioFrameCount
-    let sessionRelativeOrigin: CMTime
-
-    private let clockState = OSAllocatedUnfairLock(initialState: ClockState())
+    private let clockState: OSAllocatedUnfairLock<ClockState>
     private let sampleRateTimescale: CMTimeScale
 
     var sessionRelativeOriginSeconds: TimeInterval {
-        sessionRelativeOrigin.seconds
+        clockState.withLock { $0.sessionRelativeOrigin.seconds }
     }
 
     init(
@@ -36,8 +35,16 @@ final class AudioSourcePipeline: Sendable {
         self.captureFormat = captureFormat
         self.captureDeviceID = captureDeviceID
         self.captureBufferSize = captureBufferSize
-        self.sessionRelativeOrigin = sessionRelativeOrigin
+        clockState = OSAllocatedUnfairLock(initialState: ClockState(sessionRelativeOrigin: sessionRelativeOrigin))
         sampleRateTimescale = CMTimeScale(captureFormat.sampleRate.rounded())
+    }
+
+    /// capture開始前に、先頭フレームのセッション相対時刻を確定する。
+    func setSessionRelativeOrigin(seconds: TimeInterval) {
+        clockState.withLock { state in
+            guard state.nextFrame == 0 else { return }
+            state.sessionRelativeOrigin = CMTime(seconds: max(0, seconds), preferredTimescale: 1_000_000)
+        }
     }
 
     /// capture callback ごとに呼び出し、同一音源内で単調増加するセッション相対時刻を付与する。
@@ -47,7 +54,7 @@ final class AudioSourcePipeline: Sendable {
             let chunk = CapturedAudioChunk(
                 source: source,
                 buffer: buffer,
-                sessionRelativeStartTime: CMTimeAdd(sessionRelativeOrigin, frameOffset)
+                sessionRelativeStartTime: CMTimeAdd(state.sessionRelativeOrigin, frameOffset)
             )
             state.nextFrame += Int64(buffer.frameLength)
             return chunk

--- a/Sources/Dahlia/Audio/AudioSourcePipeline.swift
+++ b/Sources/Dahlia/Audio/AudioSourcePipeline.swift
@@ -1,0 +1,56 @@
+@preconcurrency import AVFoundation
+import CoreAudio
+import CoreMedia
+import os
+
+/// 有効な音源ごとに1つだけ作られ、物理 capture と consumer の分配境界を保持する。
+final class AudioSourcePipeline: Sendable {
+    private struct ClockState {
+        var nextFrame: Int64 = 0
+    }
+
+    let source: RecordingAudioSource
+    let router: AudioFrameRouter
+    let captureFormat: AVAudioFormat
+    let captureDeviceID: AudioDeviceID?
+    let captureBufferSize: AVAudioFrameCount
+    let sessionRelativeOrigin: CMTime
+
+    private let clockState = OSAllocatedUnfairLock(initialState: ClockState())
+    private let sampleRateTimescale: CMTimeScale
+
+    var sessionRelativeOriginSeconds: TimeInterval {
+        sessionRelativeOrigin.seconds
+    }
+
+    init(
+        source: RecordingAudioSource,
+        router: AudioFrameRouter = AudioFrameRouter(),
+        captureFormat: AVAudioFormat,
+        captureDeviceID: AudioDeviceID? = nil,
+        captureBufferSize: AVAudioFrameCount = 4096,
+        sessionRelativeOrigin: CMTime = .zero
+    ) {
+        self.source = source
+        self.router = router
+        self.captureFormat = captureFormat
+        self.captureDeviceID = captureDeviceID
+        self.captureBufferSize = captureBufferSize
+        self.sessionRelativeOrigin = sessionRelativeOrigin
+        sampleRateTimescale = CMTimeScale(captureFormat.sampleRate.rounded())
+    }
+
+    /// capture callback ごとに呼び出し、同一音源内で単調増加するセッション相対時刻を付与する。
+    func capture(_ buffer: AVAudioPCMBuffer) -> CapturedAudioChunk {
+        clockState.withLock { state in
+            let frameOffset = CMTime(value: state.nextFrame, timescale: sampleRateTimescale)
+            let chunk = CapturedAudioChunk(
+                source: source,
+                buffer: buffer,
+                sessionRelativeStartTime: CMTimeAdd(sessionRelativeOrigin, frameOffset)
+            )
+            state.nextFrame += Int64(buffer.frameLength)
+            return chunk
+        }
+    }
+}

--- a/Sources/Dahlia/Audio/BatchAudioFileWriter.swift
+++ b/Sources/Dahlia/Audio/BatchAudioFileWriter.swift
@@ -4,16 +4,23 @@ import os
 
 /// 音声コールバックをブロックせず、CAFへ直列に追記するWriter。
 actor BatchAudioFileWriter {
+    private static let maximumBufferedChunkCount = 256
+
     private struct AudioChunk {
         let data: Data
         let frameCount: AVAudioFrameCount
     }
 
+    private struct CallbackState {
+        var appendedFrameCount: Int64 = 0
+        var errorMessage: String?
+        var isAcceptingBuffers = true
+    }
+
     // SwiftFormatのmodifier順と、無効なSwiftLint modifier_order設定のfallbackが競合する。
     // swiftlint:disable modifier_order
     private nonisolated let continuation: AsyncStream<AudioChunk>.Continuation
-    private nonisolated let frameCounter = OSAllocatedUnfairLock(initialState: Int64(0))
-    private nonisolated let callbackError = OSAllocatedUnfairLock<String?>(initialState: nil)
+    private nonisolated let callbackState = OSAllocatedUnfairLock(initialState: CallbackState())
     // swiftlint:enable modifier_order
 
     private let stream: AsyncStream<AudioChunk>
@@ -25,11 +32,19 @@ actor BatchAudioFileWriter {
     private var writeError: Error?
 
     nonisolated var appendedFrameCount: Int64 {
-        frameCounter.withLock { $0 }
+        callbackState.withLock { $0.appendedFrameCount }
     }
 
-    init(partialURL: URL, finalURL: URL, format: AVAudioFormat) {
-        let pair = AsyncStream.makeStream(of: AudioChunk.self)
+    init(
+        partialURL: URL,
+        finalURL: URL,
+        format: AVAudioFormat,
+        maximumBufferedChunkCount: Int = BatchAudioFileWriter.maximumBufferedChunkCount
+    ) {
+        let pair = AsyncStream.makeStream(
+            of: AudioChunk.self,
+            bufferingPolicy: .bufferingNewest(max(1, maximumBufferedChunkCount))
+        )
         stream = pair.stream
         continuation = pair.continuation
         self.partialURL = partialURL
@@ -63,7 +78,7 @@ actor BatchAudioFileWriter {
         guard buffer.format.commonFormat == .pcmFormatInt16,
               buffer.format.channelCount == 1,
               let channelData = buffer.int16ChannelData else {
-            callbackError.withLock { $0 = BatchAudioFileWriterError.incompatibleBuffer.localizedDescription }
+            callbackState.withLock { $0.errorMessage = BatchAudioFileWriterError.incompatibleBuffer.localizedDescription }
             return
         }
 
@@ -71,14 +86,35 @@ actor BatchAudioFileWriter {
         guard frameCount > 0 else { return }
         let byteCount = Int(frameCount) * MemoryLayout<Int16>.size
         let data = Data(bytes: channelData[0], count: byteCount)
-        frameCounter.withLock { $0 += Int64(frameCount) }
-        continuation.yield(AudioChunk(data: data, frameCount: frameCount))
+        callbackState.withLock { state in
+            guard state.isAcceptingBuffers else { return }
+            switch continuation.yield(AudioChunk(data: data, frameCount: frameCount)) {
+            case .enqueued:
+                state.appendedFrameCount += Int64(frameCount)
+            case .dropped:
+                state.errorMessage = L10n.batchAudioBufferOverflow
+            case .terminated:
+                state.errorMessage = L10n.batchAudioWriterClosed
+            @unknown default:
+                state.errorMessage = L10n.batchAudioWriterClosed
+            }
+        }
+    }
+
+    /// capture を切り離した後に呼び、range と CAF のフレーム数を固定する。
+    @discardableResult
+    nonisolated func seal() -> Int64 {
+        callbackState.withLock { state in
+            state.isAcceptingBuffers = false
+            return state.appendedFrameCount
+        }
     }
 
     func finish() async throws -> Int64 {
+        let finalFrameCount = seal()
         await closeWriter()
 
-        if let callbackMessage = callbackError.withLock({ $0 }) {
+        if let callbackMessage = callbackState.withLock({ $0.errorMessage }) {
             throw BatchAudioFileWriterError.writeFailed(callbackMessage)
         }
         if let writeError {
@@ -89,10 +125,11 @@ actor BatchAudioFileWriter {
             try FileManager.default.removeItem(at: finalURL)
         }
         try FileManager.default.moveItem(at: partialURL, to: finalURL)
-        return appendedFrameCount
+        return finalFrameCount
     }
 
     func cancelAndDelete() async {
+        seal()
         await closeWriter()
         try? FileManager.default.removeItem(at: partialURL)
         try? FileManager.default.removeItem(at: finalURL)

--- a/Sources/Dahlia/Audio/BatchAudioFileWriter.swift
+++ b/Sources/Dahlia/Audio/BatchAudioFileWriter.swift
@@ -43,7 +43,7 @@ actor BatchAudioFileWriter {
     ) {
         let pair = AsyncStream.makeStream(
             of: AudioChunk.self,
-            bufferingPolicy: .bufferingNewest(max(1, maximumBufferedChunkCount))
+            bufferingPolicy: .bufferingOldest(max(1, maximumBufferedChunkCount))
         )
         stream = pair.stream
         continuation = pair.continuation

--- a/Sources/Dahlia/Audio/BatchAudioRecordingSession.swift
+++ b/Sources/Dahlia/Audio/BatchAudioRecordingSession.swift
@@ -2,6 +2,37 @@
 import Foundation
 import GRDB
 
+private struct RangeRotation {
+    let source: RecordingAudioSource
+    let previousRange: RecordingAudioRangeRecord?
+    let newRange: RecordingAudioRangeRecord
+}
+
+private struct RangeRotationRequest {
+    let source: RecordingAudioSource
+    let offsetBasis: RangeOffsetBasis
+}
+
+private enum RangeOffsetBasis {
+    case fixed(TimeInterval)
+    case sourceOrigin(BatchRecordingRangeOrigin)
+
+    func sessionOffsetSeconds(boundaryFrame: Int64, sampleRate: Double) -> TimeInterval {
+        switch self {
+        case let .fixed(offset):
+            offset
+        case let .sourceOrigin(origin):
+            origin.sessionRelativeOriginSeconds
+                + Double(max(0, boundaryFrame - origin.startFrame)) / sampleRate
+        }
+    }
+}
+
+private struct RangePersistence {
+    let previousRange: RecordingAudioRangeRecord?
+    let newRange: RecordingAudioRangeRecord
+}
+
 /// ひとつのバッチ録音セッションで、音源ごとの単一CAFとrangeを管理する。
 @MainActor
 final class BatchAudioRecordingSession {
@@ -17,7 +48,6 @@ final class BatchAudioRecordingSession {
     private var writers: [RecordingAudioSource: BatchAudioFileWriter] = [:]
     private var fileRecords: [RecordingAudioSource: RecordingAudioFileRecord] = [:]
     private var activeRanges: [RecordingAudioSource: RecordingAudioRangeRecord] = [:]
-    private var firstRangeCloseError: Error?
 
     init(
         dbQueue: DatabaseQueue,
@@ -48,17 +78,43 @@ final class BatchAudioRecordingSession {
         try await writer(for: source)
     }
 
-    func beginRange(source: RecordingAudioSource, locale: Locale, at date: Date = .now) async throws -> BatchAudioFileWriter {
+    func beginRange(
+        source: RecordingAudioSource,
+        locale: Locale,
+        at date: Date = .now
+    ) async throws -> BatchAudioFileWriter {
+        try await beginRangeWithOrigin(
+            source: source,
+            locale: locale,
+            at: date,
+            continuingFromActiveRange: false
+        ).writer
+    }
+
+    func beginRangeWithOrigin(
+        source: RecordingAudioSource,
+        locale: Locale,
+        at date: Date,
+        continuingFromActiveRange: Bool
+    ) async throws -> (writer: BatchAudioFileWriter, origin: BatchRecordingRangeOrigin) {
+        let previousRange = activeRanges[source]
         try await endRange(source: source)
         let writer = try await writer(for: source)
         let audioFile = try fileRecord(for: source)
+        let startFrame = writer.appendedFrameCount
+        let sessionOffsetSeconds: TimeInterval = if continuingFromActiveRange, let previousRange {
+            previousRange.sessionOffsetSeconds
+                + Double(max(0, startFrame - previousRange.startFrame)) / targetFormat.sampleRate
+        } else {
+            max(0, date.timeIntervalSince(recordingStartTime))
+        }
         let now = Date.now
         let range = RecordingAudioRangeRecord(
             id: .v7(),
             audioFileId: audioFile.id,
-            startFrame: writer.appendedFrameCount,
+            startFrame: startFrame,
             frameCount: nil,
-            sessionOffsetSeconds: max(0, date.timeIntervalSince(recordingStartTime)),
+            sessionOffsetSeconds: sessionOffsetSeconds,
             localeIdentifier: locale.identifier,
             createdAt: now,
             updatedAt: now
@@ -67,34 +123,43 @@ final class BatchAudioRecordingSession {
             try range.insert(db)
         }
         activeRanges[source] = range
-        return writer
+        return (
+            writer,
+            BatchRecordingRangeOrigin(
+                source: source,
+                startFrame: startFrame,
+                sessionRelativeOriginSeconds: sessionOffsetSeconds
+            )
+        )
     }
 
     /// capture を止めず、同一フレーム境界で locale range を切り替える。
     func rotateRange(source: RecordingAudioSource, locale: Locale, at date: Date = .now) async throws -> BatchAudioFileWriter {
         let writer = try await writer(for: source)
-        let rotatedWriters = try await performRangeRotation(
-            [RangeRotationRequest(
-                source: source,
-                offsetBasis: .fixed(date.timeIntervalSince(recordingStartTime))
-            )],
+        _ = try await performRangeRotation(
+            [
+                RangeRotationRequest(
+                    source: source,
+                    offsetBasis: .fixed(date.timeIntervalSince(recordingStartTime))
+                ),
+            ],
             locale: locale
         )
-        return rotatedWriters[source] ?? writer
+        return writer
     }
 
     /// 複数音源の locale range を、各CAFの同一フレーム境界で原子的に切り替える。
-    /// `sessionRelativeOriginSeconds` は各CAFの先頭フレームが録音セッション内で始まる時刻。
+    /// originは各range先頭フレームと、そのフレームのセッション相対時刻を対で保持する。
     @discardableResult
     func rotateRanges(
-        _ sourceOrigins: [(source: RecordingAudioSource, sessionRelativeOriginSeconds: TimeInterval)],
+        _ sourceOrigins: [BatchRecordingRangeOrigin],
         locale: Locale
-    ) async throws -> [RecordingAudioSource: BatchAudioFileWriter] {
+    ) async throws -> [RecordingAudioSource: BatchRecordingRangeOrigin] {
         try await performRangeRotation(
             sourceOrigins.map {
                 RangeRotationRequest(
                     source: $0.source,
-                    offsetBasis: .sourceOrigin($0.sessionRelativeOriginSeconds)
+                    offsetBasis: .sourceOrigin($0)
                 )
             },
             locale: locale
@@ -104,45 +169,13 @@ final class BatchAudioRecordingSession {
     private func performRangeRotation(
         _ requests: [RangeRotationRequest],
         locale: Locale
-    ) async throws -> [RecordingAudioSource: BatchAudioFileWriter] {
+    ) async throws -> [RecordingAudioSource: BatchRecordingRangeOrigin] {
         var seenSources: Set<RecordingAudioSource> = []
         let uniqueRequests = requests.filter { seenSources.insert($0.source).inserted }
         var rotations: [RangeRotation] = []
 
         for request in uniqueRequests {
-            let source = request.source
-            let writer = try await writer(for: source)
-            let audioFile = try fileRecord(for: source)
-            let boundaryFrame = writer.appendedFrameCount
-            let now = Date.now
-            var updatedPreviousRange = activeRanges[source]
-            if var previousRange = updatedPreviousRange {
-                previousRange.frameCount = max(0, boundaryFrame - previousRange.startFrame)
-                previousRange.updatedAt = now
-                updatedPreviousRange = previousRange
-            }
-            let newRange = RecordingAudioRangeRecord(
-                id: .v7(),
-                audioFileId: audioFile.id,
-                startFrame: boundaryFrame,
-                frameCount: nil,
-                sessionOffsetSeconds: max(
-                    0,
-                    request.offsetBasis.sessionOffsetSeconds(
-                        boundaryFrame: boundaryFrame,
-                        sampleRate: targetFormat.sampleRate
-                    )
-                ),
-                localeIdentifier: locale.identifier,
-                createdAt: now,
-                updatedAt: now
-            )
-            rotations.append(RangeRotation(
-                source: source,
-                writer: writer,
-                previousRange: updatedPreviousRange,
-                newRange: newRange
-            ))
+            try await rotations.append(makeRotation(request, locale: locale))
         }
 
         let persistedRotations = rotations.map {
@@ -159,12 +192,63 @@ final class BatchAudioRecordingSession {
         for rotation in rotations {
             activeRanges[rotation.source] = rotation.newRange
         }
-        return Dictionary(uniqueKeysWithValues: rotations.map { ($0.source, $0.writer) })
+        return Dictionary(uniqueKeysWithValues: rotations.map { rotation in
+            (
+                rotation.source,
+                BatchRecordingRangeOrigin(
+                    source: rotation.source,
+                    startFrame: rotation.newRange.startFrame,
+                    sessionRelativeOriginSeconds: rotation.newRange.sessionOffsetSeconds
+                )
+            )
+        })
+    }
+
+    private func makeRotation(
+        _ request: RangeRotationRequest,
+        locale: Locale
+    ) async throws -> RangeRotation {
+        let source = request.source
+        let writer = try await writer(for: source)
+        let audioFile = try fileRecord(for: source)
+        let boundaryFrame = writer.appendedFrameCount
+        let now = Date.now
+        var previousRange = activeRanges[source]
+        if var updatedRange = previousRange {
+            updatedRange.frameCount = max(0, boundaryFrame - updatedRange.startFrame)
+            updatedRange.updatedAt = now
+            previousRange = updatedRange
+        }
+        let sessionOffsetSeconds = request.offsetBasis.sessionOffsetSeconds(
+            boundaryFrame: boundaryFrame,
+            sampleRate: targetFormat.sampleRate
+        )
+        let newRange = RecordingAudioRangeRecord(
+            id: .v7(),
+            audioFileId: audioFile.id,
+            startFrame: boundaryFrame,
+            frameCount: nil,
+            sessionOffsetSeconds: max(0, sessionOffsetSeconds),
+            localeIdentifier: locale.identifier,
+            createdAt: now,
+            updatedAt: now
+        )
+        return RangeRotation(source: source, previousRange: previousRange, newRange: newRange)
     }
 
     func endActiveRanges() async throws {
+        var firstError: Error?
         for source in Array(activeRanges.keys) {
-            try await endRange(source: source)
+            do {
+                try await endRange(source: source)
+            } catch {
+                if firstError == nil {
+                    firstError = error
+                }
+            }
+        }
+        if let firstError {
+            throw firstError
         }
     }
 
@@ -174,7 +258,7 @@ final class BatchAudioRecordingSession {
 
     func finish() async throws {
         writers.values.forEach { $0.seal() }
-        var firstError = firstRangeCloseError
+        var firstError: Error?
         do {
             try await endActiveRanges()
         } catch {
@@ -278,49 +362,12 @@ final class BatchAudioRecordingSession {
         range.frameCount = max(0, writer.appendedFrameCount - range.startFrame)
         range.updatedAt = .now
         let updatedRange = range
-        do {
-            try await dbQueue.write { db in
-                try updatedRange.update(db)
-            }
-            if activeRanges[source]?.id == updatedRange.id {
-                activeRanges.removeValue(forKey: source)
-            }
-        } catch {
-            if firstRangeCloseError == nil {
-                firstRangeCloseError = error
-            }
-            throw error
+        try await dbQueue.write { db in
+            try updatedRange.update(db)
+        }
+        if activeRanges[source]?.id == updatedRange.id {
+            activeRanges.removeValue(forKey: source)
         }
     }
 
-    private struct RangeRotation {
-        let source: RecordingAudioSource
-        let writer: BatchAudioFileWriter
-        let previousRange: RecordingAudioRangeRecord?
-        let newRange: RecordingAudioRangeRecord
-    }
-
-    private struct RangeRotationRequest {
-        let source: RecordingAudioSource
-        let offsetBasis: RangeOffsetBasis
-    }
-
-    private enum RangeOffsetBasis {
-        case fixed(TimeInterval)
-        case sourceOrigin(TimeInterval)
-
-        func sessionOffsetSeconds(boundaryFrame: Int64, sampleRate: Double) -> TimeInterval {
-            switch self {
-            case let .fixed(offset):
-                offset
-            case let .sourceOrigin(origin):
-                origin + Double(boundaryFrame) / sampleRate
-            }
-        }
-    }
-
-    private struct RangePersistence {
-        let previousRange: RecordingAudioRangeRecord?
-        let newRange: RecordingAudioRangeRecord
-    }
 }

--- a/Sources/Dahlia/Audio/BatchAudioRecordingSession.swift
+++ b/Sources/Dahlia/Audio/BatchAudioRecordingSession.swift
@@ -5,6 +5,8 @@ import GRDB
 /// ひとつのバッチ録音セッションで、音源ごとの単一CAFとrangeを管理する。
 @MainActor
 final class BatchAudioRecordingSession {
+    static let standardSampleRate = 16000.0
+
     let targetFormat: AVAudioFormat
 
     private let dbQueue: DatabaseQueue
@@ -15,6 +17,7 @@ final class BatchAudioRecordingSession {
     private var writers: [RecordingAudioSource: BatchAudioFileWriter] = [:]
     private var fileRecords: [RecordingAudioSource: RecordingAudioFileRecord] = [:]
     private var activeRanges: [RecordingAudioSource: RecordingAudioRangeRecord] = [:]
+    private var firstRangeCloseError: Error?
 
     init(
         dbQueue: DatabaseQueue,
@@ -40,6 +43,11 @@ final class BatchAudioRecordingSession {
         self.targetFormat = format
     }
 
+    /// capture の開始時刻を確定する前に、対象音源のCAF writerを準備する。
+    func prepareWriter(for source: RecordingAudioSource) async throws -> BatchAudioFileWriter {
+        try await writer(for: source)
+    }
+
     func beginRange(source: RecordingAudioSource, locale: Locale, at date: Date = .now) async throws -> BatchAudioFileWriter {
         try await endRange(source: source)
         let writer = try await writer(for: source)
@@ -62,26 +70,141 @@ final class BatchAudioRecordingSession {
         return writer
     }
 
+    /// capture を止めず、同一フレーム境界で locale range を切り替える。
+    func rotateRange(source: RecordingAudioSource, locale: Locale, at date: Date = .now) async throws -> BatchAudioFileWriter {
+        let writer = try await writer(for: source)
+        let rotatedWriters = try await performRangeRotation(
+            [RangeRotationRequest(
+                source: source,
+                offsetBasis: .fixed(date.timeIntervalSince(recordingStartTime))
+            )],
+            locale: locale
+        )
+        return rotatedWriters[source] ?? writer
+    }
+
+    /// 複数音源の locale range を、各CAFの同一フレーム境界で原子的に切り替える。
+    /// `sessionRelativeOriginSeconds` は各CAFの先頭フレームが録音セッション内で始まる時刻。
+    @discardableResult
+    func rotateRanges(
+        _ sourceOrigins: [(source: RecordingAudioSource, sessionRelativeOriginSeconds: TimeInterval)],
+        locale: Locale
+    ) async throws -> [RecordingAudioSource: BatchAudioFileWriter] {
+        try await performRangeRotation(
+            sourceOrigins.map {
+                RangeRotationRequest(
+                    source: $0.source,
+                    offsetBasis: .sourceOrigin($0.sessionRelativeOriginSeconds)
+                )
+            },
+            locale: locale
+        )
+    }
+
+    private func performRangeRotation(
+        _ requests: [RangeRotationRequest],
+        locale: Locale
+    ) async throws -> [RecordingAudioSource: BatchAudioFileWriter] {
+        var seenSources: Set<RecordingAudioSource> = []
+        let uniqueRequests = requests.filter { seenSources.insert($0.source).inserted }
+        var rotations: [RangeRotation] = []
+
+        for request in uniqueRequests {
+            let source = request.source
+            let writer = try await writer(for: source)
+            let audioFile = try fileRecord(for: source)
+            let boundaryFrame = writer.appendedFrameCount
+            let now = Date.now
+            var updatedPreviousRange = activeRanges[source]
+            if var previousRange = updatedPreviousRange {
+                previousRange.frameCount = max(0, boundaryFrame - previousRange.startFrame)
+                previousRange.updatedAt = now
+                updatedPreviousRange = previousRange
+            }
+            let newRange = RecordingAudioRangeRecord(
+                id: .v7(),
+                audioFileId: audioFile.id,
+                startFrame: boundaryFrame,
+                frameCount: nil,
+                sessionOffsetSeconds: max(
+                    0,
+                    request.offsetBasis.sessionOffsetSeconds(
+                        boundaryFrame: boundaryFrame,
+                        sampleRate: targetFormat.sampleRate
+                    )
+                ),
+                localeIdentifier: locale.identifier,
+                createdAt: now,
+                updatedAt: now
+            )
+            rotations.append(RangeRotation(
+                source: source,
+                writer: writer,
+                previousRange: updatedPreviousRange,
+                newRange: newRange
+            ))
+        }
+
+        let persistedRotations = rotations.map {
+            RangePersistence(previousRange: $0.previousRange, newRange: $0.newRange)
+        }
+        try await dbQueue.write { db in
+            for rotation in persistedRotations {
+                if let previousRange = rotation.previousRange {
+                    try previousRange.update(db)
+                }
+                try rotation.newRange.insert(db)
+            }
+        }
+        for rotation in rotations {
+            activeRanges[rotation.source] = rotation.newRange
+        }
+        return Dictionary(uniqueKeysWithValues: rotations.map { ($0.source, $0.writer) })
+    }
+
     func endActiveRanges() async throws {
         for source in Array(activeRanges.keys) {
             try await endRange(source: source)
         }
     }
 
+    func endRangeForReconfiguration(source: RecordingAudioSource) async throws {
+        try await endRange(source: source)
+    }
+
     func finish() async throws {
-        try await endActiveRanges()
-        for (source, writer) in writers {
-            let totalFrames = try await writer.finish()
-            guard var fileRecord = fileRecords[source] else { continue }
-            let now = Date.now
-            fileRecord.finalizedAt = now
-            fileRecord.totalFrameCount = totalFrames
-            fileRecord.updatedAt = now
-            let updatedRecord = fileRecord
-            try await dbQueue.write { db in
-                try updatedRecord.update(db)
+        writers.values.forEach { $0.seal() }
+        var firstError = firstRangeCloseError
+        do {
+            try await endActiveRanges()
+        } catch {
+            if firstError == nil {
+                firstError = error
             }
-            fileRecords[source] = fileRecord
+        }
+
+        for (source, writer) in writers {
+            do {
+                let totalFrames = try await writer.finish()
+                guard var fileRecord = fileRecords[source] else { continue }
+                let now = Date.now
+                fileRecord.finalizedAt = now
+                fileRecord.totalFrameCount = totalFrames
+                fileRecord.updatedAt = now
+                let updatedRecord = fileRecord
+                try await dbQueue.write { db in
+                    try updatedRecord.update(db)
+                }
+                fileRecords[source] = fileRecord
+            } catch {
+                if firstError == nil {
+                    firstError = error
+                }
+            }
+        }
+
+        if let firstError {
+            throw firstError
         }
     }
 
@@ -150,13 +273,54 @@ final class BatchAudioRecordingSession {
     }
 
     private func endRange(source: RecordingAudioSource) async throws {
-        guard var range = activeRanges.removeValue(forKey: source),
+        guard var range = activeRanges[source],
               let writer = writers[source] else { return }
         range.frameCount = max(0, writer.appendedFrameCount - range.startFrame)
         range.updatedAt = .now
         let updatedRange = range
-        try await dbQueue.write { db in
-            try updatedRange.update(db)
+        do {
+            try await dbQueue.write { db in
+                try updatedRange.update(db)
+            }
+            if activeRanges[source]?.id == updatedRange.id {
+                activeRanges.removeValue(forKey: source)
+            }
+        } catch {
+            if firstRangeCloseError == nil {
+                firstRangeCloseError = error
+            }
+            throw error
         }
+    }
+
+    private struct RangeRotation {
+        let source: RecordingAudioSource
+        let writer: BatchAudioFileWriter
+        let previousRange: RecordingAudioRangeRecord?
+        let newRange: RecordingAudioRangeRecord
+    }
+
+    private struct RangeRotationRequest {
+        let source: RecordingAudioSource
+        let offsetBasis: RangeOffsetBasis
+    }
+
+    private enum RangeOffsetBasis {
+        case fixed(TimeInterval)
+        case sourceOrigin(TimeInterval)
+
+        func sessionOffsetSeconds(boundaryFrame: Int64, sampleRate: Double) -> TimeInterval {
+            switch self {
+            case let .fixed(offset):
+                offset
+            case let .sourceOrigin(origin):
+                origin + Double(boundaryFrame) / sampleRate
+            }
+        }
+    }
+
+    private struct RangePersistence {
+        let previousRange: RecordingAudioRangeRecord?
+        let newRange: RecordingAudioRangeRecord
     }
 }

--- a/Sources/Dahlia/Audio/BatchRecordingRangeOrigin.swift
+++ b/Sources/Dahlia/Audio/BatchRecordingRangeOrigin.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// CAFの先頭フレームが録音セッション内で始まった時刻。
+struct BatchRecordingRangeOrigin {
+    let source: RecordingAudioSource
+    let sessionRelativeOriginSeconds: TimeInterval
+}

--- a/Sources/Dahlia/Audio/BatchRecordingRangeOrigin.swift
+++ b/Sources/Dahlia/Audio/BatchRecordingRangeOrigin.swift
@@ -3,5 +3,11 @@ import Foundation
 /// CAFの先頭フレームが録音セッション内で始まった時刻。
 struct BatchRecordingRangeOrigin {
     let source: RecordingAudioSource
+    let startFrame: Int64
     let sessionRelativeOriginSeconds: TimeInterval
+}
+
+struct BatchRecordingConsumerAttachment {
+    let consumer: AudioFrameRouter.BatchConsumer
+    let origin: BatchRecordingRangeOrigin
 }

--- a/Sources/Dahlia/Audio/CapturedAudioChunk.swift
+++ b/Sources/Dahlia/Audio/CapturedAudioChunk.swift
@@ -1,0 +1,14 @@
+@preconcurrency import AVFoundation
+import CoreMedia
+
+/// 物理 capture から生成された、セッション時刻付きの不変オーディオチャンク。
+/// 同じインスタンスを batch writer と progressive recognizer へ fan-out する。
+struct CapturedAudioChunk {
+    let source: RecordingAudioSource
+    let buffer: AVAudioPCMBuffer
+    let sessionRelativeStartTime: CMTime
+
+    var sessionRelativeStartSeconds: TimeInterval {
+        sessionRelativeStartTime.seconds
+    }
+}

--- a/Sources/Dahlia/Audio/DefaultAudioCaptureSessionFactory.swift
+++ b/Sources/Dahlia/Audio/DefaultAudioCaptureSessionFactory.swift
@@ -1,0 +1,26 @@
+/// macOSの実デバイスcapture sessionを生成するdefault factory。
+struct DefaultAudioCaptureSessionFactory: AudioCaptureSessionFactory {
+    func requestPermission(for source: RecordingAudioSource) async -> Bool {
+        switch source {
+        case .microphone:
+            await AudioCaptureManager.requestMicrophonePermission()
+        case .system:
+            await SystemAudioCaptureManager.requestPermission()
+        }
+    }
+
+    func makeSession(
+        for pipeline: AudioSourcePipeline,
+        onUnexpectedStop: @escaping AudioCaptureUnexpectedStopHandler
+    ) -> any AudioCaptureSession {
+        switch pipeline.source {
+        case .microphone:
+            MicrophoneAudioCaptureSession(pipeline: pipeline)
+        case .system:
+            SystemAudioCaptureSession(
+                pipeline: pipeline,
+                onUnexpectedStop: onUnexpectedStop
+            )
+        }
+    }
+}

--- a/Sources/Dahlia/Audio/DefaultBatchRecordingSession.swift
+++ b/Sources/Dahlia/Audio/DefaultBatchRecordingSession.swift
@@ -1,0 +1,59 @@
+@preconcurrency import AVFoundation
+import Foundation
+
+/// BatchAudioRecordingSessionをrouter consumer中心のprotocolへ接続するadapter。
+@MainActor
+final class DefaultBatchRecordingSession: BatchRecordingSession {
+    var targetFormat: AVAudioFormat {
+        session.targetFormat
+    }
+
+    private let session: BatchAudioRecordingSession
+
+    init(session: BatchAudioRecordingSession) {
+        self.session = session
+    }
+
+    func prepare(source: RecordingAudioSource) async throws {
+        _ = try await session.prepareWriter(for: source)
+    }
+
+    func beginRangeConsumer(
+        source: RecordingAudioSource,
+        locale: Locale,
+        at date: Date
+    ) async throws -> AudioFrameRouter.BatchConsumer {
+        let writer = try await session.beginRange(source: source, locale: locale, at: date)
+        return Self.consumer(writer: writer)
+    }
+
+    func rotateRanges(_ origins: [BatchRecordingRangeOrigin], locale: Locale) async throws {
+        try await session.rotateRanges(
+            origins.map { origin in
+                (
+                    source: origin.source,
+                    sessionRelativeOriginSeconds: origin.sessionRelativeOriginSeconds
+                )
+            },
+            locale: locale
+        )
+    }
+
+    func endRangeForReconfiguration(source: RecordingAudioSource) async throws {
+        try await session.endRangeForReconfiguration(source: source)
+    }
+
+    func finish() async throws {
+        try await session.finish()
+    }
+
+    func cancelAndDelete() async {
+        await session.cancelAndDelete()
+    }
+
+    private static func consumer(writer: BatchAudioFileWriter) -> AudioFrameRouter.BatchConsumer {
+        { chunk in
+            writer.appendBuffer(chunk.buffer)
+        }
+    }
+}

--- a/Sources/Dahlia/Audio/DefaultBatchRecordingSession.swift
+++ b/Sources/Dahlia/Audio/DefaultBatchRecordingSession.swift
@@ -21,20 +21,27 @@ final class DefaultBatchRecordingSession: BatchRecordingSession {
     func beginRangeConsumer(
         source: RecordingAudioSource,
         locale: Locale,
-        at date: Date
-    ) async throws -> AudioFrameRouter.BatchConsumer {
-        let writer = try await session.beginRange(source: source, locale: locale, at: date)
-        return Self.consumer(writer: writer)
+        at date: Date,
+        continuingFromActiveRange: Bool
+    ) async throws -> BatchRecordingConsumerAttachment {
+        let range = try await session.beginRangeWithOrigin(
+            source: source,
+            locale: locale,
+            at: date,
+            continuingFromActiveRange: continuingFromActiveRange
+        )
+        return BatchRecordingConsumerAttachment(
+            consumer: Self.consumer(writer: range.writer),
+            origin: range.origin
+        )
     }
 
-    func rotateRanges(_ origins: [BatchRecordingRangeOrigin], locale: Locale) async throws {
+    func rotateRanges(
+        _ origins: [BatchRecordingRangeOrigin],
+        locale: Locale
+    ) async throws -> [RecordingAudioSource: BatchRecordingRangeOrigin] {
         try await session.rotateRanges(
-            origins.map { origin in
-                (
-                    source: origin.source,
-                    sessionRelativeOriginSeconds: origin.sessionRelativeOriginSeconds
-                )
-            },
+            origins,
             locale: locale
         )
     }

--- a/Sources/Dahlia/Audio/DefaultBatchRecordingSessionFactory.swift
+++ b/Sources/Dahlia/Audio/DefaultBatchRecordingSessionFactory.swift
@@ -1,0 +1,24 @@
+import Foundation
+import GRDB
+
+/// CAF batch recorderを生成するdefault factory。
+struct DefaultBatchRecordingSessionFactory: BatchRecordingSessionFactory {
+    @MainActor
+    func makeSession(
+        dbQueue: DatabaseQueue,
+        managedRootURL: URL,
+        meetingId: UUID,
+        recordingSessionId: UUID,
+        recordingStartTime: Date,
+        sampleRate: Double
+    ) throws -> any BatchRecordingSession {
+        try DefaultBatchRecordingSession(session: BatchAudioRecordingSession(
+            dbQueue: dbQueue,
+            managedRootURL: managedRootURL,
+            meetingId: meetingId,
+            recordingSessionId: recordingSessionId,
+            recordingStartTime: recordingStartTime,
+            sampleRate: sampleRate
+        ))
+    }
+}

--- a/Sources/Dahlia/Audio/LiveAudioFrameWorker.swift
+++ b/Sources/Dahlia/Audio/LiveAudioFrameWorker.swift
@@ -1,0 +1,70 @@
+@preconcurrency import AVFoundation
+import os
+
+/// capture callback からライブ変換処理を切り離す低遅延 bounded queue。
+/// backlog 超過時は古いフレームを捨て、batch consumer には影響させない。
+final class LiveAudioFrameWorker: Sendable {
+    typealias Consumer = @Sendable (CapturedAudioChunk) -> Bool
+    typealias FailureHandler = @Sendable () -> Void
+
+    enum BufferingMode: Equatable {
+        case lossless
+        case lowLatency(maximumFrameCount: Int)
+    }
+
+    private struct State {
+        var isAcceptingFrames = true
+    }
+
+    private let continuation: AsyncStream<CapturedAudioChunk>.Continuation
+    private let workerTask: Task<Void, Never>
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    init(
+        bufferingMode: BufferingMode,
+        consumer: @escaping Consumer,
+        onFailure: @escaping FailureHandler
+    ) {
+        let bufferingPolicy: AsyncStream<CapturedAudioChunk>.Continuation.BufferingPolicy = switch bufferingMode {
+        case .lossless:
+            .unbounded
+        case let .lowLatency(maximumFrameCount):
+            .bufferingNewest(max(1, maximumFrameCount))
+        }
+        let pair = AsyncStream.makeStream(
+            of: CapturedAudioChunk.self,
+            bufferingPolicy: bufferingPolicy
+        )
+        continuation = pair.continuation
+        workerTask = Task.detached(priority: .userInitiated) {
+            for await chunk in pair.stream {
+                guard consumer(chunk) else {
+                    onFailure()
+                    return
+                }
+            }
+        }
+    }
+
+    func enqueue(_ chunk: CapturedAudioChunk) {
+        let isAcceptingFrames = state.withLock { $0.isAcceptingFrames }
+        guard isAcceptingFrames else { return }
+
+        continuation.yield(chunk)
+    }
+
+    func finish() {
+        let shouldFinish = state.withLock { state in
+            guard state.isAcceptingFrames else { return false }
+            state.isAcceptingFrames = false
+            return true
+        }
+        if shouldFinish {
+            continuation.finish()
+        }
+    }
+
+    func waitUntilFinished() async {
+        await workerTask.value
+    }
+}

--- a/Sources/Dahlia/Audio/MicrophoneAudioCaptureSession.swift
+++ b/Sources/Dahlia/Audio/MicrophoneAudioCaptureSession.swift
@@ -1,0 +1,26 @@
+/// AVAudioEngine captureをAudioSourcePipelineへ接続するadapter。
+actor MicrophoneAudioCaptureSession: AudioCaptureSession {
+    private let manager: AudioCaptureManager
+    private let pipeline: AudioSourcePipeline
+
+    init(pipeline: AudioSourcePipeline) {
+        self.pipeline = pipeline
+        let manager = AudioCaptureManager()
+        manager.onAudioBuffer = { [pipeline] buffer in
+            pipeline.router.route(pipeline.capture(buffer))
+        }
+        self.manager = manager
+    }
+
+    func start() throws {
+        try manager.startCapture(
+            targetFormat: pipeline.captureFormat,
+            selectedDeviceID: pipeline.captureDeviceID,
+            bufferSize: pipeline.captureBufferSize
+        )
+    }
+
+    func stop() {
+        manager.stopCapture()
+    }
+}

--- a/Sources/Dahlia/Audio/SystemAudioCaptureManager.swift
+++ b/Sources/Dahlia/Audio/SystemAudioCaptureManager.swift
@@ -85,15 +85,32 @@ final class SystemAudioCaptureManager: NSObject, @unchecked Sendable {
         Task {
             try? await stream.stopCapture()
         }
-        converter = nil
-        sourceFormat = nil
-        captureTargetFormat = nil
-        lastFormatDescription = nil
+        clearCaptureState()
+    }
+
+    /// capture停止の完了を待つ。セッションcontrollerの停止順序を保証するadapterから利用する。
+    func stopCaptureAndWait() async throws {
+        guard let stream = self.stream else { return }
+        self.stream = nil
+        do {
+            try await stream.stopCapture()
+        } catch {
+            clearCaptureState()
+            throw error
+        }
+        clearCaptureState()
     }
 
     // MARK: - Private
 
     private var lastFormatDescription: CMFormatDescription?
+
+    private func clearCaptureState() {
+        converter = nil
+        sourceFormat = nil
+        captureTargetFormat = nil
+        lastFormatDescription = nil
+    }
 
     private func processAudioSampleBuffer(_ sampleBuffer: CMSampleBuffer) {
         guard let targetFormat = captureTargetFormat else { return }

--- a/Sources/Dahlia/Audio/SystemAudioCaptureSession.swift
+++ b/Sources/Dahlia/Audio/SystemAudioCaptureSession.swift
@@ -1,0 +1,40 @@
+/// ScreenCaptureKit captureをAudioSourcePipelineへ接続するadapter。
+actor SystemAudioCaptureSession: AudioCaptureSession {
+    private let manager: SystemAudioCaptureManager
+    private let pipeline: AudioSourcePipeline
+    private let onUnexpectedStop: AudioCaptureUnexpectedStopHandler
+    private var isStopping = false
+
+    init(
+        pipeline: AudioSourcePipeline,
+        onUnexpectedStop: @escaping AudioCaptureUnexpectedStopHandler
+    ) {
+        self.pipeline = pipeline
+        self.onUnexpectedStop = onUnexpectedStop
+        let manager = SystemAudioCaptureManager()
+        manager.onAudioBuffer = { [pipeline] buffer in
+            pipeline.router.route(pipeline.capture(buffer))
+        }
+        self.manager = manager
+        manager.onStreamStopped = { [weak self] error in
+            Task {
+                await self?.streamDidStop(error: error)
+            }
+        }
+    }
+
+    func start() async throws {
+        isStopping = false
+        try await manager.startCapture(targetFormat: pipeline.captureFormat)
+    }
+
+    func stop() async throws {
+        isStopping = true
+        try await manager.stopCaptureAndWait()
+    }
+
+    private func streamDidStop(error: Error?) {
+        guard !isStopping else { return }
+        onUnexpectedStop(error)
+    }
+}

--- a/Sources/Dahlia/Models/BatchTranscriptionConfirmation.swift
+++ b/Sources/Dahlia/Models/BatchTranscriptionConfirmation.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct BatchTranscriptionConfirmation: Identifiable, Equatable {
+    let sessionId: UUID
+    let meetingId: UUID
+    let suggestedLocaleIdentifier: String
+
+    var id: UUID { sessionId }
+}

--- a/Sources/Dahlia/Models/BatchTranscriptionState.swift
+++ b/Sources/Dahlia/Models/BatchTranscriptionState.swift
@@ -3,6 +3,7 @@ import Foundation
 /// バッチ処理の表示状態。DBの事実と実行中Coordinatorから都度導出する。
 enum BatchTranscriptionState: Equatable {
     case recording(sessionId: UUID)
+    case awaitingConfirmation(sessionId: UUID)
     case queued(sessionId: UUID)
     case running(sessionId: UUID)
     case completed(sessionId: UUID)
@@ -11,6 +12,7 @@ enum BatchTranscriptionState: Equatable {
     var sessionId: UUID {
         switch self {
         case let .recording(sessionId),
+             let .awaitingConfirmation(sessionId),
              let .queued(sessionId),
              let .running(sessionId),
              let .completed(sessionId),
@@ -21,7 +23,7 @@ enum BatchTranscriptionState: Equatable {
 
     var blocksSummaryGeneration: Bool {
         switch self {
-        case .recording, .queued, .running, .failed:
+        case .recording, .awaitingConfirmation, .queued, .running, .failed:
             true
         case .completed:
             false
@@ -42,6 +44,9 @@ enum BatchTranscriptionState: Equatable {
         }
         if session.endedAt == nil {
             return .recording(sessionId: session.id)
+        }
+        if session.batchLastAttemptAt == nil {
+            return .awaitingConfirmation(sessionId: session.id)
         }
         return .queued(sessionId: session.id)
     }

--- a/Sources/Dahlia/Models/LiveCaptionStore.swift
+++ b/Sources/Dahlia/Models/LiveCaptionStore.swift
@@ -1,0 +1,111 @@
+import Combine
+import Foundation
+
+/// 現在の録音セッションに限った、一時的なライブ字幕の表示状態。
+@MainActor
+final class LiveCaptionStore: ObservableObject {
+    private static let maximumRetainedSegmentCount = 20
+
+    @Published private(set) var segments: [TranscriptSegment] = []
+    @Published private(set) var activeSessionId: UUID?
+    @Published private(set) var failureMessage: String?
+
+    /// 新しいセッションを開始する。同じセッションへの再設定は現在の字幕を維持する。
+    func start(sessionId: UUID) {
+        guard activeSessionId != sessionId else { return }
+
+        segments.removeAll()
+        failureMessage = nil
+        activeSessionId = sessionId
+    }
+
+    func apply(event: TranscriptionEvent) {
+        switch event {
+        case let .preview(segment):
+            guard accepts(segment) else { return }
+            upsertPreview(segment)
+        case let .finalized(segment):
+            guard accepts(segment) else { return }
+            appendFinalized(segment)
+        case let .clearPreview(sessionId, sourceLabel):
+            guard activeSessionId == sessionId else { return }
+            clearPreview(forSource: sourceLabel)
+        case let .translation(sessionId, segmentID, translatedText):
+            guard activeSessionId == sessionId,
+                  let index = segments.firstIndex(where: { $0.id == segmentID }) else { return }
+            segments[index].translatedText = translatedText
+        case let .failure(sessionId, _, _, message):
+            guard activeSessionId == sessionId else { return }
+            failureMessage = message
+        }
+    }
+
+    /// 正本文字起こしの現在セッション分を、字幕を有効化した時点の初期値として取り込む。
+    func seed(_ newSegments: [TranscriptSegment], sessionId: UUID) {
+        guard activeSessionId == sessionId else { return }
+        segments = Array(
+            newSegments
+                .lazy
+                .filter { $0.sessionId == sessionId }
+                .suffix(Self.maximumRetainedSegmentCount)
+        )
+    }
+
+    func clear() {
+        segments.removeAll()
+        activeSessionId = nil
+        failureMessage = nil
+    }
+
+    private func accepts(_ segment: TranscriptSegment) -> Bool {
+        guard let activeSessionId else { return false }
+        return segment.sessionId == activeSessionId
+    }
+
+    private func upsertPreview(_ newSegment: TranscriptSegment) {
+        var preview = newSegment
+        preview.isConfirmed = false
+
+        if preview.translatedText == nil,
+           let existingPreview = segments.last(where: {
+               !$0.isConfirmed && $0.speakerLabel == preview.speakerLabel
+           }),
+           existingPreview.id == preview.id {
+            preview.translatedText = existingPreview.translatedText
+        }
+
+        clearPreview(forSource: preview.speakerLabel)
+        segments.append(preview)
+    }
+
+    private func appendFinalized(_ newSegment: TranscriptSegment) {
+        var finalized = newSegment
+        finalized.isConfirmed = true
+
+        if finalized.translatedText == nil,
+           let existingSegment = segments.first(where: { $0.id == finalized.id }) {
+            finalized.translatedText = existingSegment.translatedText
+        }
+
+        segments.removeAll {
+            $0.id == finalized.id || (!$0.isConfirmed && $0.speakerLabel == finalized.speakerLabel)
+        }
+
+        // LiveSubtitleOverlayPayload は未確定セグメントを末尾として扱うため、
+        // 確定セグメントは残っている preview より前へ追加する。
+        let insertionIndex = segments.firstIndex(where: { !$0.isConfirmed }) ?? segments.endIndex
+        segments.insert(finalized, at: insertionIndex)
+        trimOldSegmentsIfNeeded()
+    }
+
+    private func clearPreview(forSource sourceLabel: String?) {
+        segments.removeAll {
+            !$0.isConfirmed && $0.speakerLabel == sourceLabel
+        }
+    }
+
+    private func trimOldSegmentsIfNeeded() {
+        guard segments.count > Self.maximumRetainedSegmentCount else { return }
+        segments.removeFirst(segments.count - Self.maximumRetainedSegmentCount)
+    }
+}

--- a/Sources/Dahlia/Models/RecordingAudioSource.swift
+++ b/Sources/Dahlia/Models/RecordingAudioSource.swift
@@ -12,5 +12,16 @@ enum RecordingAudioSource: String, Codable, DatabaseValueConvertible {
         }
     }
 
+    init?(speakerLabel: String?) {
+        switch speakerLabel {
+        case "mic":
+            self = .microphone
+        case "system":
+            self = .system
+        default:
+            return nil
+        }
+    }
+
     var fileName: String { "\(rawValue).caf" }
 }

--- a/Sources/Dahlia/Models/TranscriptStore.swift
+++ b/Sources/Dahlia/Models/TranscriptStore.swift
@@ -36,6 +36,12 @@ final class TranscriptStore: ObservableObject {
         segments.insert(segment, at: insertIndex)
     }
 
+    /// previewを同期的に取り除いてから確定セグメントを追加し、SwiftUI上の重複IDを防ぐ。
+    func finalizeSegment(_ segment: TranscriptSegment, forSource sourceLabel: String? = nil) {
+        clearUnconfirmedSegmentsImmediately(forSource: sourceLabel)
+        addSegment(segment)
+    }
+
     /// 指定ソースの未確定セグメントを更新する。
     /// 他ソースの未確定セグメントには影響しない。
     /// 200ms 以内の連続呼び出しはスロットルし、最後の状態のみ反映する。
@@ -48,6 +54,15 @@ final class TranscriptStore: ObservableObject {
 
     func clearUnconfirmedSegments(forSource sourceLabel: String? = nil) {
         scheduleUnconfirmedMutation(.clear, forSource: sourceLabel)
+    }
+
+    private func clearUnconfirmedSegmentsImmediately(forSource sourceLabel: String?) {
+        let key = sourceLabel ?? ""
+        unconfirmedThrottleTasks[key]?.cancel()
+        unconfirmedThrottleTasks[key] = nil
+        pendingUnconfirmed[key] = nil
+        segments.removeAll { !$0.isConfirmed && $0.speakerLabel == sourceLabel }
+        lastUnconfirmedUpdate[key] = .now
     }
 
     private func scheduleUnconfirmedMutation(_ mutation: UnconfirmedMutation, forSource sourceLabel: String? = nil) {

--- a/Sources/Dahlia/Models/TranscriptionEvent.swift
+++ b/Sources/Dahlia/Models/TranscriptionEvent.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+// swiftformat:disable:next redundantSendable
+/// 逐次認識パイプラインが生成する、保存先に依存しないイベント。
+enum TranscriptionEvent: Equatable {
+    case preview(TranscriptSegment)
+    case finalized(TranscriptSegment)
+    case clearPreview(sessionId: UUID, sourceLabel: String?)
+    case translation(sessionId: UUID, segmentID: UUID, translatedText: String?)
+    case failure(sessionId: UUID, pipelineID: UUID, sourceLabel: String?, message: String)
+}

--- a/Sources/Dahlia/Models/TranscriptionSessionPlan.swift
+++ b/Sources/Dahlia/Models/TranscriptionSessionPlan.swift
@@ -1,0 +1,32 @@
+// swiftformat:disable:next redundantSendable
+/// 録音セッションで有効にする文字起こし機能の組み合わせ。
+struct TranscriptionSessionPlan: Equatable {
+    let finalMode: TranscriptionMode
+    var liveSubtitlesEnabled: Bool
+    let retainBatchAudio: Bool
+
+    /// 正本文字起こし、またはライブ字幕のために逐次認識が必要か。
+    var requiresLiveRecognition: Bool {
+        finalMode == .realtime || liveSubtitlesEnabled
+    }
+
+    /// バッチ文字起こし用の音声を録音するか。
+    var recordsBatchAudio: Bool {
+        finalMode == .batch
+    }
+
+    /// 逐次認識の結果を正本文字起こしとして永続化するか。
+    var persistsRealtimeTranscript: Bool {
+        finalMode == .realtime
+    }
+
+    /// 有効な各音源に対して生成する逐次認識器数。
+    /// realtime + live でも常に1つだけとする。
+    var liveRecognizerCountPerSource: Int {
+        requiresLiveRecognition ? 1 : 0
+    }
+
+    var batchRecorderCountPerSource: Int {
+        recordsBatchAudio ? 1 : 0
+    }
+}

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -115,6 +115,8 @@
 "Stop" = "Stop";
 "Start Recording" = "Start Recording";
 "Stop Recording" = "Stop Recording";
+"A recording session is already active." = "A recording session is already active.";
+"No recording session is active." = "No recording session is active.";
 "Stop transcribing" = "Stop transcribing";
 "Pause" = "Pause";
 "Resume" = "Resume";
@@ -143,14 +145,19 @@
 "%lld%%" = "%lld%%";
 "Show Live Subtitles" = "Show Live Subtitles";
 "Hide Live Subtitles" = "Hide Live Subtitles";
+"Subtitles" = "Subtitles";
+"Live subtitles on" = "On";
+"Live subtitles off" = "Off";
 "Live Subtitle Overlay" = "Live Subtitle Overlay";
-"Configure how the desktop live subtitle overlay is shown while recording." = "Configure how the desktop live subtitle overlay is shown while recording.";
-"Subtitles" = "Live Captions";
+"Show live subtitles when recording starts." = "Show live subtitles when recording starts.";
+"Live subtitles are available with both real-time and batch transcription." = "Live subtitles are available with both real-time and batch transcription.";
+"In batch mode, subtitles are temporary and the final transcript is created after recording stops." = "In batch mode, subtitles are temporary and the final transcript is created after recording stops.";
 "System Audio Only" = "System Audio Only";
 "Include Microphone" = "Include Microphone";
 "Choose whether live subtitles only show system audio or also include microphone input." = "Choose whether live subtitles only show system audio or also include microphone input.";
 "Overlay Segment Count" = "Overlay Segment Count";
 "Choose how many recent transcript segments the live subtitle overlay shows." = "Choose how many recent transcript segments the live subtitle overlay shows.";
+"Live subtitles stopped because the audio format could not be converted." = "Live subtitles stopped because the audio format could not be converted.";
 
 /* Detail Tabs */
 "Summary" = "Summary";
@@ -419,16 +426,23 @@
 "Keep the CAF audio files in the vault after batch transcription succeeds." = "Keep the CAF audio files in the vault after batch transcription succeeds.";
 "No transcript yet." = "No transcript yet.";
 "Recording audio for transcription after recording stops…" = "Recording audio for transcription after recording stops…";
+"Audio is ready. Confirm the language to start transcription." = "Audio is ready. Confirm the language to start transcription.";
+"Review and Start" = "Review and Start";
 "Waiting to transcribe the recording…" = "Waiting to transcribe the recording…";
 "Creating a high-accuracy transcript…" = "Creating a high-accuracy transcript…";
 "High-accuracy transcription completed." = "High-accuracy transcription completed.";
 "Batch transcription failed: %@" = "Batch transcription failed: %@";
 "Retry Batch Transcription" = "Retry Batch Transcription";
+"Start batch transcription?" = "Start batch transcription?";
+"The recording will be transcribed using the selected language. The audio is kept until transcription succeeds." = "The recording will be transcribed using the selected language. The audio is kept until transcription succeeds.";
+"Later" = "Later";
 "Discard Failed Recording" = "Discard Failed Recording";
 "Discard this failed recording?" = "Discard this failed recording?";
 "The untranscribed audio will be deleted. Existing transcript content will be kept." = "The untranscribed audio will be deleted. Existing transcript content will be kept.";
 "Cancel" = "Cancel";
 "The recorded audio format is invalid." = "The recorded audio format is invalid.";
+"The audio writer could not keep up with the recording." = "The audio writer could not keep up with the recording.";
+"The audio writer was closed before the buffer was saved." = "The audio writer was closed before the buffer was saved.";
 "Could not save the recording: %@" = "Could not save the recording: %@";
 "No compatible audio format is available." = "No compatible audio format is available.";
 "The recorded audio range is invalid or damaged." = "The recorded audio range is invalid or damaged.";

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -434,7 +434,7 @@
 "Batch transcription failed: %@" = "Batch transcription failed: %@";
 "Retry Batch Transcription" = "Retry Batch Transcription";
 "Start batch transcription?" = "Start batch transcription?";
-"The recording will be transcribed using the selected language. The audio is kept until transcription succeeds." = "The recording will be transcribed using the selected language. The audio is kept until transcription succeeds.";
+"The selected language is used for single-language recordings. Language changes made during recording are preserved. The audio is kept until transcription succeeds." = "The selected language is used for single-language recordings. Language changes made during recording are preserved. The audio is kept until transcription succeeds.";
 "Later" = "Later";
 "Discard Failed Recording" = "Discard Failed Recording";
 "Discard this failed recording?" = "Discard this failed recording?";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -115,6 +115,8 @@
 "Stop" = "停止";
 "Start Recording" = "録音を開始";
 "Stop Recording" = "録音を停止";
+"A recording session is already active." = "すでに録音セッションが実行中です。";
+"No recording session is active." = "実行中の録音セッションはありません。";
 "Stop transcribing" = "文字起こしを停止";
 "Pause" = "一時停止";
 "Resume" = "再開";
@@ -143,14 +145,19 @@
 "%lld%%" = "%lld%%";
 "Show Live Subtitles" = "ライブ字幕を表示";
 "Hide Live Subtitles" = "ライブ字幕を隠す";
+"Subtitles" = "字幕";
+"Live subtitles on" = "表示中";
+"Live subtitles off" = "非表示";
 "Live Subtitle Overlay" = "ライブ字幕オーバーレイ";
-"Configure how the desktop live subtitle overlay is shown while recording." = "録音中に表示するデスクトップのライブ字幕オーバーレイ設定を調整します。";
-"Subtitles" = "ライブ字幕";
+"Show live subtitles when recording starts." = "録音開始時にライブ字幕を表示します。";
+"Live subtitles are available with both real-time and batch transcription." = "ライブ字幕はリアルタイム文字起こしとバッチ文字起こしの両方で利用できます。";
+"In batch mode, subtitles are temporary and the final transcript is created after recording stops." = "バッチ方式では字幕は一時的な表示で、最終的な文字起こしは録音停止後に作成されます。";
 "System Audio Only" = "システムオーディオのみ";
 "Include Microphone" = "マイク入力を含める";
 "Choose whether live subtitles only show system audio or also include microphone input." = "ライブ字幕をシステムオーディオのみにするか、マイク入力も含めるかを選びます。";
 "Overlay Segment Count" = "表示セグメント数";
 "Choose how many recent transcript segments the live subtitle overlay shows." = "ライブ字幕オーバーレイに表示する最近の文字起こしセグメント数を選びます。";
+"Live subtitles stopped because the audio format could not be converted." = "音声形式を変換できなかったため、ライブ字幕を停止しました。";
 
 /* Detail Tabs */
 "Summary" = "要約";
@@ -419,16 +426,23 @@
 "Keep the CAF audio files in the vault after batch transcription succeeds." = "バッチ文字起こし成功後もCAF音声ファイルを保管庫に残します。";
 "No transcript yet." = "文字起こしはまだありません。";
 "Recording audio for transcription after recording stops…" = "録音終了後の文字起こし用に音声を保存しています…";
+"Audio is ready. Confirm the language to start transcription." = "音声の準備ができました。言語を確認して文字起こしを開始してください。";
+"Review and Start" = "確認して開始";
 "Waiting to transcribe the recording…" = "録音の文字起こしを待機しています…";
 "Creating a high-accuracy transcript…" = "高精度な文字起こしを作成しています…";
 "High-accuracy transcription completed." = "高精度な文字起こしが完了しました。";
 "Batch transcription failed: %@" = "バッチ文字起こしに失敗しました: %@";
 "Retry Batch Transcription" = "バッチ文字起こしを再試行";
+"Start batch transcription?" = "バッチ文字起こしを開始しますか？";
+"The recording will be transcribed using the selected language. The audio is kept until transcription succeeds." = "選択した言語で録音音声を文字起こしします。文字起こしが成功するまで音声データは保持されます。";
+"Later" = "あとで";
 "Discard Failed Recording" = "失敗した録音を破棄";
 "Discard this failed recording?" = "失敗した録音を破棄しますか？";
 "The untranscribed audio will be deleted. Existing transcript content will be kept." = "文字起こしできなかった音声を削除します。既存の文字起こし内容は保持されます。";
 "Cancel" = "キャンセル";
 "The recorded audio format is invalid." = "録音音声の形式が不正です。";
+"The audio writer could not keep up with the recording." = "音声ファイルへの書き込みが録音に追いつきませんでした。";
+"The audio writer was closed before the buffer was saved." = "音声バッファを保存する前に録音処理が終了しました。";
 "Could not save the recording: %@" = "録音を保存できませんでした: %@";
 "No compatible audio format is available." = "互換性のある音声形式を利用できません。";
 "The recorded audio range is invalid or damaged." = "録音音声の範囲が不正または破損しています。";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -434,7 +434,7 @@
 "Batch transcription failed: %@" = "バッチ文字起こしに失敗しました: %@";
 "Retry Batch Transcription" = "バッチ文字起こしを再試行";
 "Start batch transcription?" = "バッチ文字起こしを開始しますか？";
-"The recording will be transcribed using the selected language. The audio is kept until transcription succeeds." = "選択した言語で録音音声を文字起こしします。文字起こしが成功するまで音声データは保持されます。";
+"The selected language is used for single-language recordings. Language changes made during recording are preserved. The audio is kept until transcription succeeds." = "単一言語の録音には選択した言語を使用します。録音中に切り替えた言語区間は保持されます。文字起こしが成功するまで音声データは保持されます。";
 "Later" = "あとで";
 "Discard Failed Recording" = "失敗した録音を破棄";
 "Discard this failed recording?" = "失敗した録音を破棄しますか？";

--- a/Sources/Dahlia/Services/BatchInterruptedRecordingRecoveryService.swift
+++ b/Sources/Dahlia/Services/BatchInterruptedRecordingRecoveryService.swift
@@ -1,0 +1,41 @@
+import Foundation
+import GRDB
+
+/// クラッシュで終了時刻が未確定のバッチ録音を、確認待ちへ戻せる状態に復旧する。
+enum BatchInterruptedRecordingRecoveryService {
+    struct Failure {
+        let sessionId: UUID
+        let message: String
+    }
+
+    static func recover(
+        dbQueue: DatabaseQueue,
+        managedRootURL: URL
+    ) async -> [Failure] {
+        let sessionIds = await (try? dbQueue.read { db in
+            try RecordingSessionRecord
+                .filter(Column("transcriptionMode") == TranscriptionMode.batch.rawValue)
+                .filter(Column("endedAt") == nil)
+                .filter(Column("batchCompletedAt") == nil)
+                .filter(Column("batchDiscardedAt") == nil)
+                .order(Column("startedAt").asc)
+                .fetchAll(db)
+                .map(\.id)
+        }) ?? []
+
+        var failures: [Failure] = []
+        for sessionId in sessionIds {
+            do {
+                try BatchTranscriptionRecoveryService.recoverAudioMetadataIfNeeded(
+                    sessionId: sessionId,
+                    dbQueue: dbQueue,
+                    managedRootURL: managedRootURL
+                )
+            } catch {
+                failures.append(Failure(sessionId: sessionId, message: error.localizedDescription))
+                ErrorReportingService.capture(error, context: ["source": "batchRecordingRecovery"])
+            }
+        }
+        return failures
+    }
+}

--- a/Sources/Dahlia/Services/BatchTranscriptionConfirmationService.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionConfirmationService.swift
@@ -14,53 +14,90 @@ enum BatchTranscriptionConfirmationService {
         }
 
         return try await dbQueue.write { db in
-            guard let session = try RecordingSessionRecord.fetchOne(db, key: sessionId),
-                  session.transcriptionMode == .batch,
-                  session.endedAt != nil,
-                  session.batchCompletedAt == nil,
-                  session.batchDiscardedAt == nil,
-                  session.batchLastError == nil,
-                  session.batchAttemptCount == 0
-            else {
-                throw CocoaError(.fileNoSuchFile)
-            }
-
-            let rangeCount = try Int.fetchOne(
-                db,
-                sql: """
-                SELECT COUNT(*)
-                FROM recording_audio_ranges
-                WHERE audioFileId IN (
-                    SELECT id FROM recording_audio_files WHERE recordingSessionId = ?
-                )
-                """,
-                arguments: [sessionId]
-            ) ?? 0
-            guard rangeCount > 0 else {
-                throw CocoaError(.fileNoSuchFile)
-            }
-
+            let session = try validSession(id: sessionId, db: db)
+            try requireAudioRanges(sessionId: sessionId, db: db)
             let confirmedAt = Date.now
-            try db.execute(
-                sql: """
-                UPDATE recording_audio_ranges
-                SET localeIdentifier = ?, updatedAt = ?
-                WHERE audioFileId IN (
-                    SELECT id FROM recording_audio_files WHERE recordingSessionId = ?
-                )
-                """,
-                arguments: [normalizedLocaleIdentifier, confirmedAt, sessionId]
+            try updateSingleRecordedLocale(
+                sessionId: sessionId,
+                localeIdentifier: normalizedLocaleIdentifier,
+                updatedAt: confirmedAt,
+                db: db
             )
-            // 試行時刻を確認済みマーカーとして先に保存する。処理開始時に実際の開始時刻で上書きされる。
-            try db.execute(
-                sql: """
-                UPDATE recording_sessions
-                SET batchLastAttemptAt = ?, updatedAt = ?
-                WHERE id = ?
-                """,
-                arguments: [confirmedAt, confirmedAt, sessionId]
-            )
+            try markConfirmed(sessionId: sessionId, confirmedAt: confirmedAt, db: db)
             return session.meetingId
         }
+    }
+
+    private static func validSession(id: UUID, db: Database) throws -> RecordingSessionRecord {
+        guard let session = try RecordingSessionRecord.fetchOne(db, key: id),
+              session.transcriptionMode == .batch,
+              session.endedAt != nil,
+              session.batchCompletedAt == nil,
+              session.batchDiscardedAt == nil,
+              session.batchLastError == nil,
+              session.batchAttemptCount == 0 else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        return session
+    }
+
+    private static func requireAudioRanges(sessionId: UUID, db: Database) throws {
+        let rangeCount = try Int.fetchOne(
+            db,
+            sql: """
+            SELECT COUNT(*)
+            FROM recording_audio_ranges
+            WHERE audioFileId IN (
+                SELECT id FROM recording_audio_files WHERE recordingSessionId = ?
+            )
+            """,
+            arguments: [sessionId]
+        ) ?? 0
+        guard rangeCount > 0 else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+    }
+
+    private static func updateSingleRecordedLocale(
+        sessionId: UUID,
+        localeIdentifier: String,
+        updatedAt: Date,
+        db: Database
+    ) throws {
+        let recordedLocales = try String.fetchAll(
+            db,
+            sql: """
+            SELECT DISTINCT localeIdentifier
+            FROM recording_audio_ranges
+            WHERE audioFileId IN (
+                SELECT id FROM recording_audio_files WHERE recordingSessionId = ?
+            )
+            """,
+            arguments: [sessionId]
+        )
+        // 録音中に明示的に言語を切り替えた複数localeのrangeは保持する。
+        guard recordedLocales.count <= 1 else { return }
+        try db.execute(
+            sql: """
+            UPDATE recording_audio_ranges
+            SET localeIdentifier = ?, updatedAt = ?
+            WHERE audioFileId IN (
+                SELECT id FROM recording_audio_files WHERE recordingSessionId = ?
+            )
+            """,
+            arguments: [localeIdentifier, updatedAt, sessionId]
+        )
+    }
+
+    private static func markConfirmed(sessionId: UUID, confirmedAt: Date, db: Database) throws {
+        // 試行時刻を確認済みマーカーとして先に保存する。処理開始時に実際の開始時刻で上書きされる。
+        try db.execute(
+            sql: """
+            UPDATE recording_sessions
+            SET batchLastAttemptAt = ?, updatedAt = ?
+            WHERE id = ?
+            """,
+            arguments: [confirmedAt, confirmedAt, sessionId]
+        )
     }
 }

--- a/Sources/Dahlia/Services/BatchTranscriptionConfirmationService.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionConfirmationService.swift
@@ -1,0 +1,66 @@
+import Foundation
+import GRDB
+
+/// バッチ正本の言語を確定し、再起動後も自動復旧できる状態へ原子的に移す。
+enum BatchTranscriptionConfirmationService {
+    static func confirm(
+        sessionId: UUID,
+        localeIdentifier: String,
+        dbQueue: DatabaseQueue
+    ) async throws -> UUID {
+        let normalizedLocaleIdentifier = localeIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedLocaleIdentifier.isEmpty else {
+            throw CocoaError(.validationMissingMandatoryProperty)
+        }
+
+        return try await dbQueue.write { db in
+            guard let session = try RecordingSessionRecord.fetchOne(db, key: sessionId),
+                  session.transcriptionMode == .batch,
+                  session.endedAt != nil,
+                  session.batchCompletedAt == nil,
+                  session.batchDiscardedAt == nil,
+                  session.batchLastError == nil,
+                  session.batchAttemptCount == 0
+            else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+
+            let rangeCount = try Int.fetchOne(
+                db,
+                sql: """
+                SELECT COUNT(*)
+                FROM recording_audio_ranges
+                WHERE audioFileId IN (
+                    SELECT id FROM recording_audio_files WHERE recordingSessionId = ?
+                )
+                """,
+                arguments: [sessionId]
+            ) ?? 0
+            guard rangeCount > 0 else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+
+            let confirmedAt = Date.now
+            try db.execute(
+                sql: """
+                UPDATE recording_audio_ranges
+                SET localeIdentifier = ?, updatedAt = ?
+                WHERE audioFileId IN (
+                    SELECT id FROM recording_audio_files WHERE recordingSessionId = ?
+                )
+                """,
+                arguments: [normalizedLocaleIdentifier, confirmedAt, sessionId]
+            )
+            // 試行時刻を確認済みマーカーとして先に保存する。処理開始時に実際の開始時刻で上書きされる。
+            try db.execute(
+                sql: """
+                UPDATE recording_sessions
+                SET batchLastAttemptAt = ?, updatedAt = ?
+                WHERE id = ?
+                """,
+                arguments: [confirmedAt, confirmedAt, sessionId]
+            )
+            return session.meetingId
+        }
+    }
+}

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator+Scheduling.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator+Scheduling.swift
@@ -1,0 +1,1 @@
+extension BatchTranscriptionCoordinator: BatchTranscriptionScheduling {}

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -1,6 +1,12 @@
 import Foundation
 import GRDB
 
+private struct BatchRecordingFailure: LocalizedError {
+    let message: String
+
+    var errorDescription: String? { message }
+}
+
 /// 未完了のバッチセッションを直列実行し、成功結果だけをDBへ反映する。
 actor BatchTranscriptionCoordinator {
     typealias StateHandler = @Sendable (BatchTranscriptionUpdate) async -> Void
@@ -64,8 +70,21 @@ actor BatchTranscriptionCoordinator {
         guard session.transcriptionMode == .batch,
               session.batchCompletedAt == nil,
               session.batchDiscardedAt == nil else { return false }
+        guard session.batchLastAttemptAt != nil || session.batchLastError?.nilIfBlank != nil else {
+            return false
+        }
         guard session.batchLastError?.nilIfBlank != nil else { return true }
         return session.batchAttemptCount < maximumAutomaticAttemptCount
+    }
+
+    func confirmAndEnqueue(sessionId: UUID, localeIdentifier: String) async throws {
+        let meetingId = try await BatchTranscriptionConfirmationService.confirm(
+            sessionId: sessionId,
+            localeIdentifier: localeIdentifier,
+            dbQueue: dbQueue
+        )
+        await notify(meetingId: meetingId, state: .queued(sessionId: sessionId))
+        enqueue(sessionId: sessionId)
     }
 
     func enqueue(sessionId: UUID) {
@@ -81,8 +100,12 @@ actor BatchTranscriptionCoordinator {
         runningSessionId == sessionId
     }
 
-    func recordRecordingFailure(sessionId: UUID, error: Error) async {
-        await recordFailure(sessionId: sessionId, error: error)
+    func recordRecordingFailure(sessionId: UUID, message: String) async {
+        await persistFailure(sessionId: sessionId, message: message)
+        ErrorReportingService.capture(
+            BatchRecordingFailure(message: message),
+            context: ["source": "batchRecording"]
+        )
     }
 
     private func processQueue() async {
@@ -313,6 +336,11 @@ actor BatchTranscriptionCoordinator {
 
     private func recordFailure(sessionId: UUID, error: Error) async {
         let message = error.localizedDescription
+        await persistFailure(sessionId: sessionId, message: message)
+        ErrorReportingService.capture(error, context: ["source": "batchTranscription"])
+    }
+
+    private func persistFailure(sessionId: UUID, message: String) async {
         try? await dbQueue.write { db in
             try db.execute(
                 sql: "UPDATE recording_sessions SET batchLastError = ?, updatedAt = ? WHERE id = ?",
@@ -322,7 +350,6 @@ actor BatchTranscriptionCoordinator {
         if let meetingId = try? meetingId(for: sessionId) {
             await notify(meetingId: meetingId, state: .failed(sessionId: sessionId, message: message))
         }
-        ErrorReportingService.capture(error, context: ["source": "batchTranscription"])
     }
 
     private func notify(meetingId: UUID, state: BatchTranscriptionState) async {

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -50,6 +50,13 @@ actor BatchTranscriptionCoordinator {
             dbQueue: dbQueue,
             managedRootURL: managedRootURL
         )
+        let recoveryFailures = await BatchInterruptedRecordingRecoveryService.recover(
+            dbQueue: dbQueue,
+            managedRootURL: managedRootURL
+        )
+        for failure in recoveryFailures {
+            await persistFailure(sessionId: failure.sessionId, message: failure.message)
+        }
         let sessionIds = await (try? dbQueue.read { db in
             try RecordingSessionRecord
                 .filter(Column("transcriptionMode") == TranscriptionMode.batch.rawValue)

--- a/Sources/Dahlia/Services/LiveSubtitleOverlayCoordinator.swift
+++ b/Sources/Dahlia/Services/LiveSubtitleOverlayCoordinator.swift
@@ -5,14 +5,13 @@ import Foundation
 @MainActor
 final class LiveSubtitleOverlayCoordinator {
     private let viewModel: CaptionViewModel
-    private let liveSubtitleOverlayService: LiveSubtitleOverlayService
+    private let liveSubtitleOverlayService: any LiveSubtitlePresenting
 
     private var viewModelCancellable: AnyCancellable?
     private var storeCancellable: AnyCancellable?
     private var defaultsCancellables: [AnyCancellable] = []
-    private var activeStoreIdentifier: ObjectIdentifier?
 
-    init(viewModel: CaptionViewModel, liveSubtitleOverlayService: LiveSubtitleOverlayService) {
+    init(viewModel: CaptionViewModel, liveSubtitleOverlayService: any LiveSubtitlePresenting) {
         self.viewModel = viewModel
         self.liveSubtitleOverlayService = liveSubtitleOverlayService
         bind()
@@ -23,12 +22,14 @@ final class LiveSubtitleOverlayCoordinator {
         viewModelCancellable = viewModel.objectWillChange
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
-                guard let self else { return }
-                self.bindActiveStoreIfNeeded()
-                self.sync()
+                self?.sync()
             }
 
-        bindActiveStoreIfNeeded()
+        storeCancellable = viewModel.liveCaptionStore.objectWillChange
+            .debounce(for: .milliseconds(200), scheduler: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.sync()
+            }
 
         defaultsCancellables = [
             UserDefaults.standard.publisher(for: \.liveSubtitleOverlayEnabled).sink { [weak self] _ in self?.sync() },
@@ -40,22 +41,7 @@ final class LiveSubtitleOverlayCoordinator {
         ]
     }
 
-    private func bindActiveStoreIfNeeded() {
-        let store = viewModel.activeTranscriptStore
-        let identifier = ObjectIdentifier(store)
-        guard activeStoreIdentifier != identifier else { return }
-
-        activeStoreIdentifier = identifier
-        storeCancellable = store.objectWillChange
-            .debounce(for: .milliseconds(200), scheduler: RunLoop.main)
-            .sink { [weak self] _ in
-                self?.sync()
-            }
-    }
-
     private func sync() {
-        bindActiveStoreIfNeeded()
-
         guard viewModel.isListening,
               AppSettings.shared.liveSubtitleOverlayEnabled else {
             liveSubtitleOverlayService.hide()
@@ -63,7 +49,7 @@ final class LiveSubtitleOverlayCoordinator {
         }
 
         let payload = LiveSubtitleOverlayPayload.latest(
-            from: viewModel.activeTranscriptStore.segments,
+            from: viewModel.liveCaptionStore.segments,
             sourceMode: AppSettings.shared.liveSubtitleSourceMode,
             transcriptionLocaleIdentifier: AppSettings.shared.transcriptionLocale,
             translationEnabled: AppSettings.shared.transcriptTranslationEnabled,

--- a/Sources/Dahlia/Services/LiveSubtitleOverlayService.swift
+++ b/Sources/Dahlia/Services/LiveSubtitleOverlayService.swift
@@ -259,6 +259,8 @@ final class LiveSubtitleOverlayService: ObservableObject {
     }
 }
 
+extension LiveSubtitleOverlayService: LiveSubtitlePresenting {}
+
 private enum LiveSubtitleOverlayLayout {
     static let fixedWidth: CGFloat = 960
     static let minimumHeight: CGFloat = 72

--- a/Sources/Dahlia/Services/LiveSubtitlePresenting.swift
+++ b/Sources/Dahlia/Services/LiveSubtitlePresenting.swift
@@ -1,0 +1,5 @@
+@MainActor
+protocol LiveSubtitlePresenting: AnyObject {
+    func update(payload: LiveSubtitleOverlayPayload?)
+    func hide()
+}

--- a/Sources/Dahlia/Services/MeetingPersistenceService.swift
+++ b/Sources/Dahlia/Services/MeetingPersistenceService.swift
@@ -2,10 +2,35 @@ import Combine
 import Foundation
 import GRDB
 
+enum MeetingPersistenceStopResult {
+    case success
+    case failure(message: String)
+
+    var succeeded: Bool {
+        if case .success = self {
+            return true
+        }
+        return false
+    }
+
+    var failureMessage: String? {
+        guard case let .failure(message) = self else { return nil }
+        return message
+    }
+}
+
 /// ミーティングの文字起こし結果を GRDB/SQLite にリアルタイム保存するサービス。
 /// 確定済みセグメントを差分で INSERT する。
 @MainActor
 final class MeetingPersistenceService {
+    private enum StopError: LocalizedError {
+        case recordingSessionMissing
+
+        var errorDescription: String? {
+            L10n.recordingSessionNotActive
+        }
+    }
+
     private let store: TranscriptStore
     private let dbQueue: DatabaseQueue
     let meetingId: UUID
@@ -14,13 +39,10 @@ final class MeetingPersistenceService {
     private var persistedSegmentTranslations: [UUID: String?] = [:]
     private var recordingSession: RecordingSessionRecord
     private let createsMeeting: Bool
+    private let persistencePolicy: TranscriptPersistencePolicy
 
     var recordingSessionId: UUID {
         recordingSession.id
-    }
-
-    private var isRealtime: Bool {
-        recordingSession.transcriptionMode == .realtime
     }
 
     /// 新規ミーティングを作成して録音を開始する。
@@ -33,12 +55,14 @@ final class MeetingPersistenceService {
         calendarEvent: CalendarEvent? = nil,
         recordingSessionId: UUID = .v7(),
         transcriptionMode: TranscriptionMode = .realtime,
+        persistencePolicy: TranscriptPersistencePolicy = .streaming,
         retainAudioAfterBatch: Bool = false
     ) throws {
         self.store = store
         self.dbQueue = dbQueue
         self.meetingId = .v7()
         self.createsMeeting = true
+        self.persistencePolicy = persistencePolicy
 
         let now = store.recordingStartTime ?? Date()
         let session = Self.makeRecordingSession(
@@ -83,12 +107,14 @@ final class MeetingPersistenceService {
         recordingOffsetSeconds: TimeInterval = 0,
         recordingSessionId: UUID = .v7(),
         transcriptionMode: TranscriptionMode = .realtime,
+        persistencePolicy: TranscriptPersistencePolicy = .streaming,
         retainAudioAfterBatch: Bool = false
     ) throws {
         self.store = store
         self.dbQueue = dbQueue
         self.meetingId = existingMeetingId
         self.createsMeeting = false
+        self.persistencePolicy = persistencePolicy
         self.persistedSegmentIds = existingSegmentIds
         let session = Self.makeRecordingSession(
             id: recordingSessionId,
@@ -108,7 +134,7 @@ final class MeetingPersistenceService {
     }
 
     private func startObserving() {
-        guard isRealtime else { return }
+        guard persistencePolicy.persistsStreamingSegments else { return }
         cancellable = store.$segments
             .debounce(for: .milliseconds(500), scheduler: RunLoop.main)
             .sink { [weak self] segments in
@@ -150,11 +176,14 @@ final class MeetingPersistenceService {
     }
 
     /// 監視を停止し、最終保存とミーティング完了の記録を行う。
-    func stop() {
+    @discardableResult
+    func stop() -> MeetingPersistenceStopResult {
         cancellable = nil
-        if isRealtime {
-            persistNewConfirmedSegments(store.segments)
-        }
+        let finalSegmentRecords = persistencePolicy.persistsStreamingSegments
+            ? store.segments
+            .filter(\.isConfirmed)
+            .map { TranscriptSegmentRecord(from: $0, meetingId: meetingId, defaultSessionId: recordingSession.id) }
+            : []
 
         let now = Date.now
         let duration = max(0, now.timeIntervalSince(recordingSession.startedAt))
@@ -162,35 +191,45 @@ final class MeetingPersistenceService {
         recordingSession.duration = duration
         recordingSession.updatedAt = now
 
-        let persistedSession = try? dbQueue.write { db -> RecordingSessionRecord? in
-            // バッチ処理が先に記録したエラーや試行情報を、録音開始時点の値で上書きしない。
-            try db.execute(
-                sql: """
-                UPDATE recording_sessions
-                SET endedAt = ?, duration = ?, updatedAt = ?
-                WHERE id = ?
-                """,
-                arguments: [now, duration, now, recordingSession.id]
-            )
-            let totalDuration = try Double.fetchOne(
-                db,
-                sql: "SELECT COALESCE(SUM(duration), 0) FROM recording_sessions WHERE meetingId = ?",
-                arguments: [meetingId]
-            ) ?? duration
-            if var record = try MeetingRecord.fetchOne(db, key: meetingId) {
-                if isRealtime {
-                    record.status = .ready
+        do {
+            let persistedSession = try dbQueue.write { db -> RecordingSessionRecord in
+                // debounce中だった最終セグメントもsession終了と同じtransactionで確定する。
+                for record in finalSegmentRecords {
+                    try record.save(db)
                 }
-                record.duration = totalDuration
-                record.updatedAt = now
-                try record.update(db)
+                // バッチ処理が先に記録したエラーや試行情報を、録音開始時点の値で上書きしない。
+                try db.execute(
+                    sql: """
+                    UPDATE recording_sessions
+                    SET endedAt = ?, duration = ?, updatedAt = ?
+                    WHERE id = ?
+                    """,
+                    arguments: [now, duration, now, recordingSession.id]
+                )
+                let totalDuration = try Double.fetchOne(
+                    db,
+                    sql: "SELECT COALESCE(SUM(duration), 0) FROM recording_sessions WHERE meetingId = ?",
+                    arguments: [meetingId]
+                ) ?? duration
+                if var record = try MeetingRecord.fetchOne(db, key: meetingId) {
+                    if persistencePolicy.persistsStreamingSegments {
+                        record.status = .ready
+                    }
+                    record.duration = totalDuration
+                    record.updatedAt = now
+                    try record.update(db)
+                }
+                guard let persistedSession = try RecordingSessionRecord.fetchOne(db, key: recordingSession.id) else {
+                    throw StopError.recordingSessionMissing
+                }
+                return persistedSession
             }
-            return try RecordingSessionRecord.fetchOne(db, key: recordingSession.id)
-        }
-        if let persistedSession {
             recordingSession = persistedSession
+            store.upsertRecordingSession(RecordingSessionTimeline(from: recordingSession))
+            return .success
+        } catch {
+            return .failure(message: error.localizedDescription)
         }
-        store.upsertRecordingSession(RecordingSessionTimeline(from: recordingSession))
     }
 
     /// 保存済みセグメント追跡をリセットし、監視を再開する。

--- a/Sources/Dahlia/Services/MeetingPersistenceService.swift
+++ b/Sources/Dahlia/Services/MeetingPersistenceService.swift
@@ -195,7 +195,17 @@ final class MeetingPersistenceService {
             let persistedSession = try dbQueue.write { db -> RecordingSessionRecord in
                 // debounce中だった最終セグメントもsession終了と同じtransactionで確定する。
                 for record in finalSegmentRecords {
-                    try record.save(db)
+                    if let existing = try TranscriptSegmentRecord.fetchOne(db, key: record.id) {
+                        // 既存行のmeeting/session/timeは変更せず、この録音中に更新され得る翻訳だけを反映する。
+                        if existing.translatedText != record.translatedText {
+                            try db.execute(
+                                sql: "UPDATE transcript_segments SET translatedText = ? WHERE id = ?",
+                                arguments: [record.translatedText, record.id]
+                            )
+                        }
+                    } else {
+                        try record.insert(db)
+                    }
                 }
                 // バッチ処理が先に記録したエラーや試行情報を、録音開始時点の値で上書きしない。
                 try db.execute(

--- a/Sources/Dahlia/Services/RecordingCoordinator.swift
+++ b/Sources/Dahlia/Services/RecordingCoordinator.swift
@@ -13,10 +13,7 @@ final class RecordingCoordinator {
     }
 
     var canStartNewMeeting: Bool {
-        !viewModel.isListening
-            && !viewModel.isFinalizingRecording
-            && viewModel.analyzerReady
-            && viewModel.hasEnabledAudioSource
+        viewModel.canBeginRecording
             && sidebarViewModel.dbQueue != nil
             && sidebarViewModel.currentVault != nil
     }

--- a/Sources/Dahlia/Services/RecordingSessionController+Reconfiguration.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController+Reconfiguration.swift
@@ -1,0 +1,443 @@
+@preconcurrency import AVFoundation
+import CoreMedia
+import Foundation
+
+extension RecordingSessionController {
+    private struct LocaleRecognitionReplacement {
+        let prepared: PreparedProgressiveRecognitionSession
+        let runtimeID: UUID
+    }
+
+    private struct RetiredRecognition {
+        let source: RecordingAudioSource
+        let router: AudioFrameRouter
+        let recognition: any ProgressiveRecognitionSession
+    }
+
+    /// realtimeでは認識器を維持して投影だけ変更し、batchではlive認識をattach/detachする。
+    func setLiveSubtitlesEnabled(
+        _ isEnabled: Bool,
+        translateSegment: ProgressiveSegmentTranslationHandler?
+    ) async throws -> Snapshot {
+        guard case let .capturing(snapshot) = state else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+        guard snapshot.plan.liveSubtitlesEnabled != isEnabled else { return snapshot }
+
+        if snapshot.plan.finalMode == .batch, isEnabled {
+            try await enableBatchLiveRecognition(
+                snapshot: snapshot,
+                translateSegment: translateSegment
+            )
+        } else if snapshot.plan.finalMode == .batch {
+            await disableBatchLiveRecognition()
+        }
+
+        return try commitLiveSubtitleState(isEnabled, sessionId: snapshot.sessionId)
+    }
+
+    private func enableBatchLiveRecognition(
+        snapshot: Snapshot,
+        translateSegment: ProgressiveSegmentTranslationHandler?
+    ) async throws {
+        guard let locale = currentLocale else {
+            throw RecordingSessionControllerError.sessionNotPrepared
+        }
+        do {
+            try await recognitionFactory.prepareModel(locale: locale)
+        } catch {
+            await onRuntimeFailure?(nil, error.localizedDescription, false)
+            return
+        }
+
+        for source in Self.sortedSources(sourceRuntimes.keys) {
+            await attachBatchLiveRecognition(
+                source: source,
+                locale: locale,
+                snapshot: snapshot,
+                translateSegment: translateSegment
+            )
+        }
+    }
+
+    private func attachBatchLiveRecognition(
+        source: RecordingAudioSource,
+        locale: Locale,
+        snapshot: Snapshot,
+        translateSegment: ProgressiveSegmentTranslationHandler?
+    ) async {
+        guard let initialRuntime = sourceRuntimes[source],
+              initialRuntime.recognition == nil else { return }
+        var prepared: PreparedProgressiveRecognitionSession?
+        do {
+            let newRecognition = try await recognitionFactory.prepareSession(
+                locale: locale,
+                source: source,
+                sourceFormat: initialRuntime.pipeline.captureFormat,
+                bufferingMode: .lowLatency(maximumInputCount: 64),
+                translateSegment: translateSegment
+            )
+            prepared = newRecognition
+            try await startRecognition(newRecognition.session, source: source, snapshot: snapshot)
+            try attachStartedBatchRecognition(
+                newRecognition,
+                source: source,
+                runtimeID: initialRuntime.id,
+                sessionId: snapshot.sessionId
+            )
+        } catch {
+            if let prepared {
+                discardPendingRecognitionStart(
+                    pipelineID: prepared.session.pipelineID,
+                    source: source,
+                    sessionId: snapshot.sessionId
+                )
+                await prepared.session.cancel()
+            }
+            await onRuntimeFailure?(source, error.localizedDescription, false)
+        }
+    }
+
+    private func attachStartedBatchRecognition(
+        _ prepared: PreparedProgressiveRecognitionSession,
+        source: RecordingAudioSource,
+        runtimeID: UUID,
+        sessionId: UUID
+    ) throws {
+        try requireCurrentSourceRuntime(source: source, runtimeID: runtimeID, sessionId: sessionId)
+        try requirePendingRecognitionStartSucceeded(
+            pipelineID: prepared.session.pipelineID,
+            source: source,
+            sessionId: sessionId
+        )
+        try consumePendingRecognitionStart(
+            pipelineID: prepared.session.pipelineID,
+            source: source,
+            sessionId: sessionId
+        )
+        guard var runtime = sourceRuntimes[source], runtime.id == runtimeID else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+        runtime.recognition = prepared.session
+        sourceRuntimes[source] = runtime
+        runtime.pipeline.router.setLiveConsumer(
+            prepared.session.liveConsumer,
+            bufferingMode: .lowLatency(maximumFrameCount: 8),
+            onFailure: liveFailureHandler(
+                source: source,
+                pipelineID: prepared.session.pipelineID,
+                sessionId: sessionId
+            )
+        )
+    }
+
+    private func disableBatchLiveRecognition() async {
+        for source in Self.sortedSources(sourceRuntimes.keys) {
+            guard let runtime = sourceRuntimes[source] else { continue }
+            let runtimeID = runtime.id
+            let pipelineID = runtime.recognition?.pipelineID
+            await runtime.pipeline.router.removeLiveConsumerAndWait()
+            await runtime.recognition?.cancel()
+            guard var currentRuntime = sourceRuntimes[source],
+                  currentRuntime.id == runtimeID,
+                  currentRuntime.recognition?.pipelineID == pipelineID else { continue }
+            currentRuntime.recognition = nil
+            sourceRuntimes[source] = currentRuntime
+        }
+    }
+
+    private func commitLiveSubtitleState(_ isEnabled: Bool, sessionId: UUID) throws -> Snapshot {
+        guard case var .capturing(snapshot) = state,
+              snapshot.sessionId == sessionId else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+        snapshot.plan.liveSubtitlesEnabled = isEnabled
+        transition(to: .capturing(snapshot))
+        return snapshot
+    }
+
+    /// 新localeの認識器を先に準備・開始し、batch rangeを原子的に切り替えてからswapする。
+    func changeLocale(
+        to locale: Locale,
+        translateSegment: ProgressiveSegmentTranslationHandler?
+    ) async throws -> Snapshot {
+        guard case let .capturing(snapshot) = state else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+        guard snapshot.localeIdentifier != locale.identifier else { return snapshot }
+
+        let prepared = try await prepareLocaleReplacements(
+            locale: locale,
+            snapshot: snapshot,
+            translateSegment: translateSegment
+        )
+        do {
+            try await rotateBatchRanges(to: locale)
+        } catch {
+            await cancelLocaleReplacements(prepared, sessionId: snapshot.sessionId)
+            throw error
+        }
+
+        let replacements = try await validateLocaleReplacements(
+            prepared,
+            snapshot: snapshot
+        )
+        do {
+            try consumeLocaleReplacementStarts(replacements, sessionId: snapshot.sessionId)
+        } catch {
+            await cancelLocaleReplacements(replacements, sessionId: snapshot.sessionId)
+            throw error
+        }
+
+        let retired = installLocaleReplacements(replacements, snapshot: snapshot)
+        _ = try commitLocale(locale, sessionId: snapshot.sessionId)
+        await finishRetiredRecognitions(retired, finalMode: snapshot.plan.finalMode)
+
+        guard case let .capturing(finalSnapshot) = state,
+              finalSnapshot.sessionId == snapshot.sessionId else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+        return finalSnapshot
+    }
+
+    private func prepareLocaleReplacements(
+        locale: Locale,
+        snapshot: Snapshot,
+        translateSegment: ProgressiveSegmentTranslationHandler?
+    ) async throws -> [RecordingAudioSource: LocaleRecognitionReplacement] {
+        guard snapshot.plan.requiresLiveRecognition else { return [:] }
+        guard try await prepareLocaleRecognitionModel(locale, snapshot: snapshot) else { return [:] }
+
+        var replacements: [RecordingAudioSource: LocaleRecognitionReplacement] = [:]
+        do {
+            for source in Self.sortedSources(sourceRuntimes.keys) {
+                if let replacement = try await prepareLocaleReplacement(
+                    source: source,
+                    locale: locale,
+                    snapshot: snapshot,
+                    translateSegment: translateSegment
+                ) {
+                    replacements[source] = replacement
+                }
+            }
+            return replacements
+        } catch {
+            await cancelLocaleReplacements(replacements, sessionId: snapshot.sessionId)
+            throw error
+        }
+    }
+
+    private func prepareLocaleRecognitionModel(
+        _ locale: Locale,
+        snapshot: Snapshot
+    ) async throws -> Bool {
+        do {
+            try await recognitionFactory.prepareModel(locale: locale)
+            return true
+        } catch {
+            guard snapshot.plan.finalMode == .batch else { throw error }
+            await onRuntimeFailure?(nil, error.localizedDescription, false)
+            return false
+        }
+    }
+
+    private func prepareLocaleReplacement(
+        source: RecordingAudioSource,
+        locale: Locale,
+        snapshot: Snapshot,
+        translateSegment: ProgressiveSegmentTranslationHandler?
+    ) async throws -> LocaleRecognitionReplacement? {
+        guard let runtime = sourceRuntimes[source] else { return nil }
+        var prepared: PreparedProgressiveRecognitionSession?
+        do {
+            let replacement = try await recognitionFactory.prepareSession(
+                locale: locale,
+                source: source,
+                sourceFormat: runtime.pipeline.captureFormat,
+                bufferingMode: snapshot.plan.recordsBatchAudio
+                    ? .lowLatency(maximumInputCount: 64)
+                    : .lossless,
+                translateSegment: translateSegment
+            )
+            prepared = replacement
+            try await startRecognition(replacement.session, source: source, snapshot: snapshot)
+            try requireCurrentSourceRuntime(
+                source: source,
+                runtimeID: runtime.id,
+                sessionId: snapshot.sessionId
+            )
+            try requirePendingRecognitionStartSucceeded(
+                pipelineID: replacement.session.pipelineID,
+                source: source,
+                sessionId: snapshot.sessionId
+            )
+            return LocaleRecognitionReplacement(prepared: replacement, runtimeID: runtime.id)
+        } catch {
+            if let prepared {
+                discardPendingRecognitionStart(
+                    pipelineID: prepared.session.pipelineID,
+                    source: source,
+                    sessionId: snapshot.sessionId
+                )
+                await prepared.session.cancel()
+            }
+            guard snapshot.plan.finalMode == .batch else { throw error }
+            await onRuntimeFailure?(source, error.localizedDescription, false)
+            return nil
+        }
+    }
+
+    private func rotateBatchRanges(to locale: Locale) async throws {
+        guard let batchRecording else { return }
+        try await batchRecording.rotateRanges(
+            sourceRuntimes.values.map {
+                BatchRecordingRangeOrigin(
+                    source: $0.pipeline.source,
+                    sessionRelativeOriginSeconds: $0.pipeline.sessionRelativeOriginSeconds
+                )
+            },
+            locale: locale
+        )
+    }
+
+    private func validateLocaleReplacements(
+        _ replacements: [RecordingAudioSource: LocaleRecognitionReplacement],
+        snapshot: Snapshot
+    ) async throws -> [RecordingAudioSource: LocaleRecognitionReplacement] {
+        var valid: [RecordingAudioSource: LocaleRecognitionReplacement] = [:]
+        for source in Self.sortedSources(replacements.keys) {
+            guard let replacement = replacements[source] else { continue }
+            do {
+                try requireCurrentSourceRuntime(
+                    source: source,
+                    runtimeID: replacement.runtimeID,
+                    sessionId: snapshot.sessionId
+                )
+                try requirePendingRecognitionStartSucceeded(
+                    pipelineID: replacement.prepared.session.pipelineID,
+                    source: source,
+                    sessionId: snapshot.sessionId
+                )
+                valid[source] = replacement
+            } catch {
+                discardPendingRecognitionStart(
+                    pipelineID: replacement.prepared.session.pipelineID,
+                    source: source,
+                    sessionId: snapshot.sessionId
+                )
+                await replacement.prepared.session.cancel()
+                if snapshot.plan.finalMode == .realtime {
+                    await cancelLocaleReplacements(replacements, sessionId: snapshot.sessionId)
+                    throw error
+                }
+                await onRuntimeFailure?(source, error.localizedDescription, false)
+            }
+        }
+        return valid
+    }
+
+    private func consumeLocaleReplacementStarts(
+        _ replacements: [RecordingAudioSource: LocaleRecognitionReplacement],
+        sessionId: UUID
+    ) throws {
+        for source in Self.sortedSources(replacements.keys) {
+            guard let replacement = replacements[source] else { continue }
+            try consumePendingRecognitionStart(
+                pipelineID: replacement.prepared.session.pipelineID,
+                source: source,
+                sessionId: sessionId
+            )
+        }
+    }
+
+    private func installLocaleReplacements(
+        _ replacements: [RecordingAudioSource: LocaleRecognitionReplacement],
+        snapshot: Snapshot
+    ) -> [RetiredRecognition] {
+        let detachesMissingRecognition = snapshot.plan.finalMode == .batch
+            && snapshot.plan.liveSubtitlesEnabled
+        var retired: [RetiredRecognition] = []
+
+        for source in Self.sortedSources(sourceRuntimes.keys) {
+            guard var runtime = sourceRuntimes[source] else { continue }
+            if let replacement = replacements[source] {
+                if let previous = runtime.recognition {
+                    retired.append(RetiredRecognition(
+                        source: source,
+                        router: runtime.pipeline.router,
+                        recognition: previous
+                    ))
+                }
+                runtime.recognition = replacement.prepared.session
+                runtime.pipeline.router.setLiveConsumer(
+                    replacement.prepared.session.liveConsumer,
+                    bufferingMode: snapshot.plan.recordsBatchAudio
+                        ? .lowLatency(maximumFrameCount: 8)
+                        : .lossless,
+                    onFailure: liveFailureHandler(
+                        source: source,
+                        pipelineID: replacement.prepared.session.pipelineID,
+                        sessionId: snapshot.sessionId
+                    )
+                )
+            } else if detachesMissingRecognition {
+                if let previous = runtime.recognition {
+                    retired.append(RetiredRecognition(
+                        source: source,
+                        router: runtime.pipeline.router,
+                        recognition: previous
+                    ))
+                }
+                runtime.recognition = nil
+                runtime.pipeline.router.setLiveConsumer(nil)
+            }
+            sourceRuntimes[source] = runtime
+        }
+        return retired
+    }
+
+    private func commitLocale(_ locale: Locale, sessionId: UUID) throws -> Snapshot {
+        guard case var .capturing(snapshot) = state,
+              snapshot.sessionId == sessionId else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+        snapshot.localeIdentifier = locale.identifier
+        snapshot.enabledSources = Set(sourceRuntimes.keys)
+        currentLocale = locale
+        transition(to: .capturing(snapshot))
+        return snapshot
+    }
+
+    private func finishRetiredRecognitions(
+        _ retired: [RetiredRecognition],
+        finalMode: TranscriptionMode
+    ) async {
+        for previous in retired {
+            await previous.router.waitUntilIdle()
+            if finalMode == .realtime {
+                do {
+                    try await previous.recognition.finish()
+                } catch {
+                    await onRuntimeFailure?(previous.source, error.localizedDescription, true)
+                }
+            } else {
+                await previous.recognition.cancel()
+            }
+        }
+    }
+
+    private func cancelLocaleReplacements(
+        _ replacements: [RecordingAudioSource: LocaleRecognitionReplacement],
+        sessionId: UUID
+    ) async {
+        for (source, replacement) in replacements {
+            discardPendingRecognitionStart(
+                pipelineID: replacement.prepared.session.pipelineID,
+                source: source,
+                sessionId: sessionId
+            )
+            await replacement.prepared.session.cancel()
+        }
+    }
+
+}

--- a/Sources/Dahlia/Services/RecordingSessionController+Reconfiguration.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController+Reconfiguration.swift
@@ -47,15 +47,29 @@ extension RecordingSessionController {
             try await recognitionFactory.prepareModel(locale: locale)
         } catch {
             await onRuntimeFailure?(nil, error.localizedDescription, false)
-            return
+            throw error
         }
 
+        var attachedCount = 0
+        var firstFailureMessage: String?
         for source in Self.sortedSources(sourceRuntimes.keys) {
-            await attachBatchLiveRecognition(
-                source: source,
-                locale: locale,
-                snapshot: snapshot,
-                translateSegment: translateSegment
+            do {
+                if try await attachBatchLiveRecognition(
+                    source: source,
+                    locale: locale,
+                    snapshot: snapshot,
+                    translateSegment: translateSegment
+                ) {
+                    attachedCount += 1
+                }
+            } catch {
+                firstFailureMessage = firstFailureMessage ?? error.localizedDescription
+                await onRuntimeFailure?(source, error.localizedDescription, false)
+            }
+        }
+        guard attachedCount > 0 else {
+            throw RecordingSessionControllerError.recognitionFailed(
+                firstFailureMessage ?? L10n.speechRecognitionNotReady
             )
         }
     }
@@ -65,9 +79,9 @@ extension RecordingSessionController {
         locale: Locale,
         snapshot: Snapshot,
         translateSegment: ProgressiveSegmentTranslationHandler?
-    ) async {
-        guard let initialRuntime = sourceRuntimes[source],
-              initialRuntime.recognition == nil else { return }
+    ) async throws -> Bool {
+        guard let initialRuntime = sourceRuntimes[source] else { return false }
+        guard initialRuntime.recognition == nil else { return true }
         var prepared: PreparedProgressiveRecognitionSession?
         do {
             let newRecognition = try await recognitionFactory.prepareSession(
@@ -85,6 +99,7 @@ extension RecordingSessionController {
                 runtimeID: initialRuntime.id,
                 sessionId: snapshot.sessionId
             )
+            return true
         } catch {
             if let prepared {
                 discardPendingRecognitionStart(
@@ -94,7 +109,7 @@ extension RecordingSessionController {
                 )
                 await prepared.session.cancel()
             }
-            await onRuntimeFailure?(source, error.localizedDescription, false)
+            throw error
         }
     }
 
@@ -289,15 +304,16 @@ extension RecordingSessionController {
 
     private func rotateBatchRanges(to locale: Locale) async throws {
         guard let batchRecording else { return }
-        try await batchRecording.rotateRanges(
-            sourceRuntimes.values.map {
-                BatchRecordingRangeOrigin(
-                    source: $0.pipeline.source,
-                    sessionRelativeOriginSeconds: $0.pipeline.sessionRelativeOriginSeconds
-                )
-            },
+        let origins = sourceRuntimes.values.compactMap(\.batchRangeOrigin)
+        let rotatedOrigins = try await batchRecording.rotateRanges(
+            origins,
             locale: locale
         )
+        for (source, origin) in rotatedOrigins {
+            guard var runtime = sourceRuntimes[source] else { continue }
+            runtime.batchRangeOrigin = origin
+            sourceRuntimes[source] = runtime
+        }
     }
 
     private func validateLocaleReplacements(

--- a/Sources/Dahlia/Services/RecordingSessionController+Runtime.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController+Runtime.swift
@@ -1,0 +1,308 @@
+import Foundation
+
+extension RecordingSessionController {
+    func startRecognition(
+        _ recognition: any ProgressiveRecognitionSession,
+        source: RecordingAudioSource,
+        snapshot: Snapshot
+    ) async throws {
+        guard let onEvent else {
+            throw RecordingSessionControllerError.sessionNotPrepared
+        }
+        let pipelineID = recognition.pipelineID
+        pendingRecognitionStarts[pipelineID] = PendingRecognitionStart(
+            source: source,
+            sessionId: snapshot.sessionId,
+            failureMessage: nil
+        )
+        do {
+            try await recognition.start(
+                recordingStartTime: snapshot.startedAt,
+                recordingSessionId: snapshot.sessionId
+            ) { [weak self] event in
+                await onEvent(event)
+                guard case .failure = event else { return }
+                await self?.recognitionDidFail(
+                    event,
+                    expectedPipelineID: pipelineID,
+                    expectedSource: source,
+                    sessionId: snapshot.sessionId
+                )
+            }
+        } catch {
+            discardPendingRecognitionStart(
+                pipelineID: pipelineID,
+                source: source,
+                sessionId: snapshot.sessionId
+            )
+            throw error
+        }
+    }
+
+    /// start は成功したものの runtime へまだ attach されていない認識器を確定する。
+    /// start 中の failure event はここで同期的に失敗へ変換し、壊れた認識器の swap を防ぐ。
+    func consumePendingRecognitionStart(
+        pipelineID: UUID,
+        source: RecordingAudioSource,
+        sessionId: UUID
+    ) throws {
+        let pending = try requirePendingRecognitionStart(
+            pipelineID: pipelineID,
+            source: source,
+            sessionId: sessionId
+        )
+        pendingRecognitionStarts[pipelineID] = nil
+        try throwPendingRecognitionFailureIfNeeded(pending)
+    }
+
+    func requirePendingRecognitionStartSucceeded(
+        pipelineID: UUID,
+        source: RecordingAudioSource,
+        sessionId: UUID
+    ) throws {
+        let pending = try requirePendingRecognitionStart(
+            pipelineID: pipelineID,
+            source: source,
+            sessionId: sessionId
+        )
+        try throwPendingRecognitionFailureIfNeeded(pending)
+    }
+
+    func discardPendingRecognitionStart(
+        pipelineID: UUID,
+        source: RecordingAudioSource,
+        sessionId: UUID
+    ) {
+        guard let pending = pendingRecognitionStarts[pipelineID],
+              pending.source == source,
+              pending.sessionId == sessionId else { return }
+        pendingRecognitionStarts[pipelineID] = nil
+    }
+
+    func recognitionDidFail(
+        _ event: TranscriptionEvent,
+        expectedPipelineID: UUID,
+        expectedSource: RecordingAudioSource,
+        sessionId: UUID
+    ) async {
+        guard case let .failure(eventSessionId, pipelineID, _, message) = event,
+              eventSessionId == sessionId,
+              pipelineID == expectedPipelineID else { return }
+
+        if var pending = pendingRecognitionStarts[pipelineID],
+           pending.source == expectedSource,
+           pending.sessionId == sessionId {
+            if pending.failureMessage == nil {
+                pending.failureMessage = message
+                pendingRecognitionStarts[pipelineID] = pending
+            }
+            return
+        }
+
+        guard case let .capturing(snapshot) = state,
+              snapshot.sessionId == sessionId,
+              let runtime = sourceRuntimes[expectedSource],
+              runtime.recognition?.pipelineID == expectedPipelineID else { return }
+
+        if snapshot.plan.finalMode == .batch {
+            let runtimeID = runtime.id
+            await runtime.pipeline.router.removeLiveConsumerAndWait()
+            await runtime.recognition?.cancel()
+            guard var currentRuntime = sourceRuntimes[expectedSource],
+                  currentRuntime.id == runtimeID,
+                  currentRuntime.recognition?.pipelineID == expectedPipelineID else { return }
+            currentRuntime.recognition = nil
+            sourceRuntimes[expectedSource] = currentRuntime
+            await onRuntimeFailure?(expectedSource, message, false)
+        } else {
+            await onRuntimeFailure?(expectedSource, message, true)
+        }
+    }
+
+    func handleUnexpectedCaptureStop(
+        source: RecordingAudioSource,
+        runtimeID: UUID,
+        sessionId: UUID,
+        message: String
+    ) async {
+        guard case let .capturing(snapshot) = state,
+              snapshot.sessionId == sessionId,
+              sourceRuntimeGenerations[source] == runtimeID,
+              sourceRuntimes[source]?.id == runtimeID else { return }
+
+        await stopSource(source, expectedRuntimeID: runtimeID, finalMode: snapshot.plan.finalMode)
+        guard sourceRuntimeGenerations[source] == runtimeID,
+              sourceRuntimes[source] == nil else { return }
+        try? await batchRecording?.endRangeForReconfiguration(source: source)
+        guard case var .capturing(currentSnapshot) = state,
+              currentSnapshot.sessionId == sessionId,
+              sourceRuntimeGenerations[source] == runtimeID,
+              sourceRuntimes[source] == nil else { return }
+        currentSnapshot.enabledSources.remove(source)
+        transition(to: .capturing(currentSnapshot))
+        await onRuntimeFailure?(source, message, currentSnapshot.enabledSources.isEmpty)
+    }
+
+    func stopSource(
+        _ source: RecordingAudioSource,
+        expectedRuntimeID: UUID? = nil,
+        finalMode: TranscriptionMode
+    ) async {
+        guard let runtime = sourceRuntimes[source],
+              expectedRuntimeID == nil || runtime.id == expectedRuntimeID else { return }
+        sourceRuntimes[source] = nil
+        try? await runtime.capture.stop()
+        runtime.pipeline.router.removeAllConsumers()
+        await runtime.pipeline.router.waitUntilIdle()
+        if finalMode == .realtime {
+            try? await runtime.recognition?.finish()
+        } else {
+            await runtime.recognition?.cancel()
+        }
+    }
+
+    func cleanupActiveResources(
+        cancelRecognition: Bool,
+        deleteBatchRecording: Bool
+    ) async {
+        for source in Self.sortedSources(sourceRuntimes.keys) {
+            try? await sourceRuntimes[source]?.capture.stop()
+        }
+        for runtime in sourceRuntimes.values {
+            runtime.pipeline.router.removeAllConsumers()
+        }
+        for runtime in sourceRuntimes.values {
+            await runtime.pipeline.router.waitUntilIdle()
+            if cancelRecognition {
+                await runtime.recognition?.cancel()
+            } else {
+                try? await runtime.recognition?.finish()
+            }
+        }
+        sourceRuntimes.removeAll()
+        sourceRuntimeGenerations.removeAll()
+        pendingRecognitionStarts.removeAll()
+        if deleteBatchRecording {
+            await batchRecording?.cancelAndDelete()
+        }
+        batchRecording = nil
+    }
+
+    func liveFailureHandler(
+        source: RecordingAudioSource,
+        pipelineID: UUID,
+        sessionId: UUID
+    ) -> AudioFrameRouter.LiveFailureHandler {
+        { [weak self] in
+            Task {
+                await self?.liveConsumerDidFail(
+                    source: source,
+                    pipelineID: pipelineID,
+                    sessionId: sessionId
+                )
+            }
+        }
+    }
+
+    func liveConsumerDidFail(
+        source: RecordingAudioSource,
+        pipelineID: UUID,
+        sessionId: UUID
+    ) async {
+        guard case let .capturing(snapshot) = state,
+              snapshot.sessionId == sessionId,
+              let runtime = sourceRuntimes[source],
+              runtime.recognition?.pipelineID == pipelineID else { return }
+        if snapshot.plan.finalMode == .batch {
+            let runtimeID = runtime.id
+            await runtime.recognition?.cancel()
+            guard var currentRuntime = sourceRuntimes[source],
+                  currentRuntime.id == runtimeID,
+                  currentRuntime.recognition?.pipelineID == pipelineID else { return }
+            currentRuntime.recognition = nil
+            sourceRuntimes[source] = currentRuntime
+            await onRuntimeFailure?(source, L10n.liveSubtitleConversionFailed, false)
+        } else {
+            await onRuntimeFailure?(source, L10n.liveSubtitleConversionFailed, true)
+        }
+    }
+
+    func captureFailureHandler(
+        source: RecordingAudioSource,
+        runtimeID: UUID,
+        sessionId: UUID
+    ) -> AudioCaptureUnexpectedStopHandler {
+        { [weak self] error in
+            let message = error?.localizedDescription ?? L10n.systemAudioCaptureStopped
+            Task {
+                await self?.handleUnexpectedCaptureStop(
+                    source: source,
+                    runtimeID: runtimeID,
+                    sessionId: sessionId,
+                    message: message
+                )
+            }
+        }
+    }
+
+    func beginSourceRuntimeGeneration(
+        source: RecordingAudioSource,
+        sessionId: UUID
+    ) throws -> UUID {
+        guard case let .capturing(snapshot) = state,
+              snapshot.sessionId == sessionId else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+        let runtimeID = UUID.v7()
+        sourceRuntimeGenerations[source] = runtimeID
+        return runtimeID
+    }
+
+    func requireCurrentSourceRuntimeGeneration(
+        source: RecordingAudioSource,
+        runtimeID: UUID,
+        sessionId: UUID
+    ) throws {
+        guard case let .capturing(snapshot) = state,
+              snapshot.sessionId == sessionId,
+              sourceRuntimeGenerations[source] == runtimeID else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+    }
+
+    func requireCurrentSourceRuntime(
+        source: RecordingAudioSource,
+        runtimeID: UUID,
+        sessionId: UUID
+    ) throws {
+        try requireCurrentSourceRuntimeGeneration(
+            source: source,
+            runtimeID: runtimeID,
+            sessionId: sessionId
+        )
+        guard sourceRuntimes[source]?.id == runtimeID else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+    }
+
+    private func requirePendingRecognitionStart(
+        pipelineID: UUID,
+        source: RecordingAudioSource,
+        sessionId: UUID
+    ) throws -> PendingRecognitionStart {
+        guard let pending = pendingRecognitionStarts[pipelineID],
+              pending.source == source,
+              pending.sessionId == sessionId else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+        return pending
+    }
+
+    private func throwPendingRecognitionFailureIfNeeded(
+        _ pending: PendingRecognitionStart
+    ) throws {
+        if let failureMessage = pending.failureMessage {
+            throw RecordingSessionControllerError.recognitionFailed(failureMessage)
+        }
+    }
+}

--- a/Sources/Dahlia/Services/RecordingSessionController+Runtime.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController+Runtime.swift
@@ -20,13 +20,12 @@ extension RecordingSessionController {
                 recordingStartTime: snapshot.startedAt,
                 recordingSessionId: snapshot.sessionId
             ) { [weak self] event in
-                await onEvent(event)
-                guard case .failure = event else { return }
-                await self?.recognitionDidFail(
+                await self?.handleRecognitionEvent(
                     event,
                     expectedPipelineID: pipelineID,
                     expectedSource: source,
-                    sessionId: snapshot.sessionId
+                    sessionId: snapshot.sessionId,
+                    onEvent: onEvent
                 )
             }
         } catch {
@@ -36,6 +35,36 @@ extension RecordingSessionController {
                 sessionId: snapshot.sessionId
             )
             throw error
+        }
+    }
+
+    private func handleRecognitionEvent(
+        _ event: TranscriptionEvent,
+        expectedPipelineID: UUID,
+        expectedSource: RecordingAudioSource,
+        sessionId: UUID,
+        onEvent: @escaping EventHandler
+    ) async {
+        guard event.belongs(to: sessionId), state.belongs(to: sessionId) else { return }
+        let isPending = pendingRecognitionStarts[expectedPipelineID]?.sessionId == sessionId
+        let isCurrent = sourceRuntimes[expectedSource]?.recognition?.pipelineID == expectedPipelineID
+
+        switch event {
+        case .preview, .clearPreview:
+            guard isPending || isCurrent else { return }
+            await onEvent(event)
+        case .finalized, .translation:
+            // 引退した認識器の確定結果・翻訳は保持するが、preview世代は上のguardで分離する。
+            await onEvent(event)
+        case .failure:
+            guard isPending || isCurrent else { return }
+            await onEvent(event)
+            await recognitionDidFail(
+                event,
+                expectedPipelineID: expectedPipelineID,
+                expectedSource: expectedSource,
+                sessionId: sessionId
+            )
         }
     }
 
@@ -107,12 +136,18 @@ extension RecordingSessionController {
         if snapshot.plan.finalMode == .batch {
             let runtimeID = runtime.id
             await runtime.pipeline.router.removeLiveConsumerAndWait()
-            await runtime.recognition?.cancel()
             guard var currentRuntime = sourceRuntimes[expectedSource],
                   currentRuntime.id == runtimeID,
                   currentRuntime.recognition?.pipelineID == expectedPipelineID else { return }
+            let failedRecognition = currentRuntime.recognition
             currentRuntime.recognition = nil
             sourceRuntimes[expectedSource] = currentRuntime
+            // failureはrecognition自身のresultTaskから届くため、この場でcancel完了を待つと自己待機になる。
+            if let failedRecognition {
+                Task {
+                    await failedRecognition.cancel()
+                }
+            }
             await onRuntimeFailure?(expectedSource, message, false)
         } else {
             await onRuntimeFailure?(expectedSource, message, true)
@@ -303,6 +338,30 @@ extension RecordingSessionController {
     ) throws {
         if let failureMessage = pending.failureMessage {
             throw RecordingSessionControllerError.recognitionFailed(failureMessage)
+        }
+    }
+}
+
+private extension TranscriptionEvent {
+    func belongs(to sessionId: UUID) -> Bool {
+        switch self {
+        case let .preview(segment), let .finalized(segment):
+            segment.sessionId == sessionId
+        case let .clearPreview(eventSessionId, _),
+             let .translation(eventSessionId, _, _),
+             let .failure(eventSessionId, _, _, _):
+            eventSessionId == sessionId
+        }
+    }
+}
+
+private extension RecordingSessionController.State {
+    func belongs(to sessionId: UUID) -> Bool {
+        switch self {
+        case .idle:
+            false
+        case let .prepared(snapshot), let .capturing(snapshot), let .stopping(snapshot):
+            snapshot.sessionId == sessionId
         }
     }
 }

--- a/Sources/Dahlia/Services/RecordingSessionController+SourceReconfiguration.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController+SourceReconfiguration.swift
@@ -6,7 +6,6 @@ extension RecordingSessionController {
     private struct SourcePipelinePreparation {
         let source: RecordingAudioSource
         let pipeline: AudioSourcePipeline
-        let captureOriginDate: Date
         let preparedRecognition: PreparedProgressiveRecognitionSession?
     }
 
@@ -90,7 +89,6 @@ extension RecordingSessionController {
         guard let captureFormat = batchFormat ?? preparedRecognition?.analyzerFormat else {
             throw AudioCaptureError.converterCreationFailed
         }
-        let captureOriginDate = Date.now
         return SourcePipelinePreparation(
             source: source,
             pipeline: AudioSourcePipeline(
@@ -98,12 +96,8 @@ extension RecordingSessionController {
                 captureFormat: captureFormat,
                 captureDeviceID: configuration.captureDeviceID,
                 captureBufferSize: configuration.captureBufferSize,
-                sessionRelativeOrigin: CMTime(
-                    seconds: max(0, captureOriginDate.timeIntervalSince(snapshot.startedAt)),
-                    preferredTimescale: 1_000_000
-                )
+                sessionRelativeOrigin: .zero
             ),
-            captureOriginDate: captureOriginDate,
             preparedRecognition: preparedRecognition
         )
     }
@@ -119,11 +113,13 @@ extension RecordingSessionController {
         )
         var runtimeID: UUID?
         var capture: (any AudioCaptureSession)?
-        var didBeginBatchRange = false
+        var batchRangeOrigin: BatchRecordingRangeOrigin?
         do {
-            didBeginBatchRange = try await beginBatchRange(
+            batchRangeOrigin = try await beginBatchRange(
                 for: preparation,
-                locale: locale
+                locale: locale,
+                snapshot: snapshot,
+                continuingFromActiveRange: false
             )
             attachment = try await attachRecognition(
                 preparation.preparedRecognition,
@@ -149,7 +145,8 @@ extension RecordingSessionController {
                 id: newRuntimeID,
                 pipeline: preparation.pipeline,
                 capture: newCapture,
-                recognition: attachment.recognition
+                recognition: attachment.recognition,
+                batchRangeOrigin: batchRangeOrigin
             )
             try await newCapture.start()
             try requireCurrentSourceRuntime(
@@ -168,7 +165,7 @@ extension RecordingSessionController {
                 attachment: attachment,
                 runtimeID: runtimeID,
                 capture: capture,
-                didBeginBatchRange: didBeginBatchRange,
+                didBeginBatchRange: batchRangeOrigin != nil,
                 sessionId: snapshot.sessionId
             )
             throw error
@@ -204,16 +201,26 @@ extension RecordingSessionController {
 
     private func beginBatchRange(
         for preparation: SourcePipelinePreparation,
-        locale: Locale
-    ) async throws -> Bool {
-        guard let batchRecording else { return false }
-        let consumer = try await batchRecording.beginRangeConsumer(
+        locale: Locale,
+        snapshot: Snapshot,
+        continuingFromActiveRange: Bool
+    ) async throws -> BatchRecordingRangeOrigin? {
+        let captureOriginDate = Date.now
+        guard let batchRecording else {
+            preparation.pipeline.setSessionRelativeOrigin(
+                seconds: captureOriginDate.timeIntervalSince(snapshot.startedAt)
+            )
+            return nil
+        }
+        let attachment = try await batchRecording.beginRangeConsumer(
             source: preparation.source,
             locale: locale,
-            at: preparation.captureOriginDate
+            at: captureOriginDate,
+            continuingFromActiveRange: continuingFromActiveRange
         )
-        preparation.pipeline.router.setBatchConsumer(consumer)
-        return true
+        preparation.pipeline.setSessionRelativeOrigin(seconds: attachment.origin.sessionRelativeOriginSeconds)
+        preparation.pipeline.router.setBatchConsumer(attachment.consumer)
+        return attachment.origin
     }
 
     private func attachRecognition(
@@ -297,6 +304,7 @@ extension RecordingSessionController {
         var runtimeID: UUID?
         var capture: (any AudioCaptureSession)?
         var didAttemptPreviousCaptureStop = false
+        var batchRangeOrigin: BatchRecordingRangeOrigin?
         do {
             guard sourceRuntimes[preparation.source]?.id == previousRuntime.id else {
                 throw RecordingSessionControllerError.sessionNotActive
@@ -328,7 +336,12 @@ extension RecordingSessionController {
                 replacementRuntimeID: replacementRuntimeID,
                 sessionId: snapshot.sessionId
             )
-            _ = try await beginBatchRange(for: preparation, locale: locale)
+            batchRangeOrigin = try await beginBatchRange(
+                for: preparation,
+                locale: locale,
+                snapshot: snapshot,
+                continuingFromActiveRange: true
+            )
             attachment = try await attachRecognition(
                 preparation.preparedRecognition,
                 to: preparation.pipeline,
@@ -340,7 +353,8 @@ extension RecordingSessionController {
                 id: replacementRuntimeID,
                 pipeline: preparation.pipeline,
                 capture: replacementCapture,
-                recognition: attachment.recognition
+                recognition: attachment.recognition,
+                batchRangeOrigin: batchRangeOrigin
             )
             try await replacementCapture.start()
             try requireCurrentSourceRuntime(
@@ -399,10 +413,11 @@ extension RecordingSessionController {
             await attachment.preparedRecognition?.session.cancel()
         }
         guard didAttemptPreviousCaptureStop else { return }
-        await restoreBatchRangeIfNeeded(previousRuntime, locale: locale)
+        let restoredRangeOrigin = await restoreBatchRangeIfNeeded(previousRuntime, locale: locale)
         try await restorePreviousRuntime(
             previousRuntime,
             source: preparation.source,
+            batchRangeOrigin: restoredRangeOrigin ?? previousRuntime.batchRangeOrigin,
             sessionId: sessionId
         )
     }
@@ -410,24 +425,27 @@ extension RecordingSessionController {
     private func restoreBatchRangeIfNeeded(
         _ previousRuntime: SourceRuntime,
         locale: Locale
-    ) async {
-        guard let batchRecording else { return }
+    ) async -> BatchRecordingRangeOrigin? {
+        guard let batchRecording else { return nil }
         let source = previousRuntime.pipeline.source
         previousRuntime.pipeline.router.setBatchConsumer(nil)
         await previousRuntime.pipeline.router.waitUntilIdle()
         do {
-            let rollbackConsumer = try await batchRecording.beginRangeConsumer(
+            let attachment = try await batchRecording.beginRangeConsumer(
                 source: source,
                 locale: locale,
-                at: .now
+                at: .now,
+                continuingFromActiveRange: false
             )
-            previousRuntime.pipeline.router.setBatchConsumer(rollbackConsumer)
+            previousRuntime.pipeline.router.setBatchConsumer(attachment.consumer)
+            return attachment.origin
         } catch {
             previousRuntime.pipeline.router.setBatchConsumer(nil)
             if batchRuntimeFailureMessage == nil {
                 batchRuntimeFailureMessage = error.localizedDescription
             }
             await onRuntimeFailure?(source, error.localizedDescription, false)
+            return nil
         }
     }
 
@@ -601,6 +619,7 @@ extension RecordingSessionController {
     private func restorePreviousRuntime(
         _ previousRuntime: SourceRuntime,
         source: RecordingAudioSource,
+        batchRangeOrigin: BatchRecordingRangeOrigin?,
         sessionId: UUID
     ) async throws {
         guard case var .capturing(snapshot) = state,
@@ -609,7 +628,9 @@ extension RecordingSessionController {
             throw RecordingSessionControllerError.sessionNotActive
         }
         sourceRuntimeGenerations[source] = previousRuntime.id
-        sourceRuntimes[source] = previousRuntime
+        var restoredRuntime = previousRuntime
+        restoredRuntime.batchRangeOrigin = batchRangeOrigin
+        sourceRuntimes[source] = restoredRuntime
         do {
             try await previousRuntime.capture.start()
             try requireCurrentSourceRuntime(

--- a/Sources/Dahlia/Services/RecordingSessionController+SourceReconfiguration.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController+SourceReconfiguration.swift
@@ -1,0 +1,636 @@
+@preconcurrency import AVFoundation
+import CoreMedia
+import Foundation
+
+extension RecordingSessionController {
+    private struct SourcePipelinePreparation {
+        let source: RecordingAudioSource
+        let pipeline: AudioSourcePipeline
+        let captureOriginDate: Date
+        let preparedRecognition: PreparedProgressiveRecognitionSession?
+    }
+
+    private struct RecognitionAttachment {
+        let preparedRecognition: PreparedProgressiveRecognitionSession?
+        let recognition: (any ProgressiveRecognitionSession)?
+    }
+
+    /// 対象音源だけを追加・削除する。他音源のcaptureは継続する。
+    func setSource(
+        _ configuration: SourceConfiguration,
+        enabled: Bool,
+        translateSegment: ProgressiveSegmentTranslationHandler?
+    ) async throws -> Snapshot {
+        guard case let .capturing(snapshot) = state,
+              let locale = currentLocale else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+        let source = configuration.source
+        if enabled, let runtime = sourceRuntimes[source] {
+            let matchesConfiguration = runtime.pipeline.captureDeviceID == configuration.captureDeviceID
+                && runtime.pipeline.captureBufferSize == configuration.captureBufferSize
+            if matchesConfiguration { return snapshot }
+            return try await replaceSource(
+                runtime,
+                with: configuration,
+                locale: locale,
+                snapshot: snapshot,
+                translateSegment: translateSegment
+            )
+        } else if enabled {
+            return try await addSource(
+                configuration,
+                locale: locale,
+                snapshot: snapshot,
+                translateSegment: translateSegment
+            )
+        } else {
+            guard let runtime = sourceRuntimes[source] else { return snapshot }
+            guard sourceRuntimes.count > 1 else {
+                throw RecordingSessionControllerError.noAudioSource
+            }
+            return try await removeSource(runtime, snapshot: snapshot)
+        }
+    }
+
+    func addSource(
+        _ configuration: SourceConfiguration,
+        locale: Locale,
+        snapshot: Snapshot,
+        translateSegment: ProgressiveSegmentTranslationHandler?
+    ) async throws -> Snapshot {
+        let preparation = try await prepareSourcePipeline(
+            configuration,
+            locale: locale,
+            snapshot: snapshot,
+            translateSegment: translateSegment
+        )
+        return try await activateAddedSource(preparation, locale: locale, snapshot: snapshot)
+    }
+
+    private func prepareSourcePipeline(
+        _ configuration: SourceConfiguration,
+        locale: Locale,
+        snapshot: Snapshot,
+        translateSegment: ProgressiveSegmentTranslationHandler?
+    ) async throws -> SourcePipelinePreparation {
+        let source = configuration.source
+        guard await captureFactory.requestPermission(for: source) else {
+            throw Self.permissionError(for: source)
+        }
+        try await batchRecording?.prepare(source: source)
+        let batchFormat = await batchRecording?.targetFormat
+        let preparedRecognition = try await prepareRecognitionForNewPipeline(
+            source: source,
+            sourceFormat: batchFormat,
+            locale: locale,
+            snapshot: snapshot,
+            translateSegment: translateSegment
+        )
+        guard let captureFormat = batchFormat ?? preparedRecognition?.analyzerFormat else {
+            throw AudioCaptureError.converterCreationFailed
+        }
+        let captureOriginDate = Date.now
+        return SourcePipelinePreparation(
+            source: source,
+            pipeline: AudioSourcePipeline(
+                source: source,
+                captureFormat: captureFormat,
+                captureDeviceID: configuration.captureDeviceID,
+                captureBufferSize: configuration.captureBufferSize,
+                sessionRelativeOrigin: CMTime(
+                    seconds: max(0, captureOriginDate.timeIntervalSince(snapshot.startedAt)),
+                    preferredTimescale: 1_000_000
+                )
+            ),
+            captureOriginDate: captureOriginDate,
+            preparedRecognition: preparedRecognition
+        )
+    }
+
+    private func activateAddedSource(
+        _ preparation: SourcePipelinePreparation,
+        locale: Locale,
+        snapshot: Snapshot
+    ) async throws -> Snapshot {
+        var attachment = RecognitionAttachment(
+            preparedRecognition: preparation.preparedRecognition,
+            recognition: nil
+        )
+        var runtimeID: UUID?
+        var capture: (any AudioCaptureSession)?
+        var didBeginBatchRange = false
+        do {
+            didBeginBatchRange = try await beginBatchRange(
+                for: preparation,
+                locale: locale
+            )
+            attachment = try await attachRecognition(
+                preparation.preparedRecognition,
+                to: preparation.pipeline,
+                source: preparation.source,
+                snapshot: snapshot
+            )
+            let newRuntimeID = try beginSourceRuntimeGeneration(
+                source: preparation.source,
+                sessionId: snapshot.sessionId
+            )
+            runtimeID = newRuntimeID
+            let newCapture = captureFactory.makeSession(
+                for: preparation.pipeline,
+                onUnexpectedStop: captureFailureHandler(
+                    source: preparation.source,
+                    runtimeID: newRuntimeID,
+                    sessionId: snapshot.sessionId
+                )
+            )
+            capture = newCapture
+            sourceRuntimes[preparation.source] = SourceRuntime(
+                id: newRuntimeID,
+                pipeline: preparation.pipeline,
+                capture: newCapture,
+                recognition: attachment.recognition
+            )
+            try await newCapture.start()
+            try requireCurrentSourceRuntime(
+                source: preparation.source,
+                runtimeID: newRuntimeID,
+                sessionId: snapshot.sessionId
+            )
+            return try commitCurrentSources(
+                sessionId: snapshot.sessionId,
+                expectedSource: preparation.source,
+                runtimeID: newRuntimeID
+            )
+        } catch {
+            await rollbackAddedSource(
+                preparation,
+                attachment: attachment,
+                runtimeID: runtimeID,
+                capture: capture,
+                didBeginBatchRange: didBeginBatchRange,
+                sessionId: snapshot.sessionId
+            )
+            throw error
+        }
+    }
+
+    private func rollbackAddedSource(
+        _ preparation: SourcePipelinePreparation,
+        attachment: RecognitionAttachment,
+        runtimeID: UUID?,
+        capture: (any AudioCaptureSession)?,
+        didBeginBatchRange: Bool,
+        sessionId: UUID
+    ) async {
+        if let runtimeID,
+           sourceRuntimes[preparation.source]?.id == runtimeID {
+            sourceRuntimes[preparation.source] = nil
+        }
+        try? await capture?.stop()
+        preparation.pipeline.router.removeAllConsumers()
+        await preparation.pipeline.router.waitUntilIdle()
+        if let prepared = attachment.preparedRecognition {
+            discardPreparedRecognition(prepared, source: preparation.source, sessionId: sessionId)
+        }
+        await attachment.recognition?.cancel()
+        if attachment.recognition == nil {
+            await attachment.preparedRecognition?.session.cancel()
+        }
+        if didBeginBatchRange {
+            try? await batchRecording?.endRangeForReconfiguration(source: preparation.source)
+        }
+    }
+
+    private func beginBatchRange(
+        for preparation: SourcePipelinePreparation,
+        locale: Locale
+    ) async throws -> Bool {
+        guard let batchRecording else { return false }
+        let consumer = try await batchRecording.beginRangeConsumer(
+            source: preparation.source,
+            locale: locale,
+            at: preparation.captureOriginDate
+        )
+        preparation.pipeline.router.setBatchConsumer(consumer)
+        return true
+    }
+
+    private func attachRecognition(
+        _ prepared: PreparedProgressiveRecognitionSession?,
+        to pipeline: AudioSourcePipeline,
+        source: RecordingAudioSource,
+        snapshot: Snapshot
+    ) async throws -> RecognitionAttachment {
+        guard let prepared else {
+            return RecognitionAttachment(preparedRecognition: nil, recognition: nil)
+        }
+        let recognition = try await attachPreparedRecognition(
+            prepared,
+            to: pipeline,
+            source: source,
+            snapshot: snapshot
+        )
+        guard let recognition else {
+            return RecognitionAttachment(preparedRecognition: nil, recognition: nil)
+        }
+        return RecognitionAttachment(preparedRecognition: prepared, recognition: recognition)
+    }
+
+    private func commitCurrentSources(
+        sessionId: UUID,
+        expectedSource: RecordingAudioSource? = nil,
+        runtimeID: UUID? = nil
+    ) throws -> Snapshot {
+        guard case var .capturing(snapshot) = state,
+              snapshot.sessionId == sessionId else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+        if let expectedSource,
+           let runtimeID,
+           sourceRuntimes[expectedSource]?.id != runtimeID {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+        snapshot.enabledSources = Set(sourceRuntimes.keys)
+        transition(to: .capturing(snapshot))
+        return snapshot
+    }
+
+    private func replaceSource(
+        _ previousRuntime: SourceRuntime,
+        with configuration: SourceConfiguration,
+        locale: Locale,
+        snapshot: Snapshot,
+        translateSegment: ProgressiveSegmentTranslationHandler?
+    ) async throws -> Snapshot {
+        let preparation = try await prepareSourcePipeline(
+            configuration,
+            locale: locale,
+            snapshot: snapshot,
+            translateSegment: translateSegment
+        )
+        try await activateReplacement(
+            previousRuntime,
+            preparation: preparation,
+            locale: locale,
+            snapshot: snapshot
+        )
+        await retirePreviousRuntime(previousRuntime, finalMode: snapshot.plan.finalMode)
+
+        guard case let .capturing(finalSnapshot) = state,
+              finalSnapshot.sessionId == snapshot.sessionId else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+        return finalSnapshot
+    }
+
+    private func activateReplacement(
+        _ previousRuntime: SourceRuntime,
+        preparation: SourcePipelinePreparation,
+        locale: Locale,
+        snapshot: Snapshot
+    ) async throws {
+        var attachment = RecognitionAttachment(
+            preparedRecognition: preparation.preparedRecognition,
+            recognition: nil
+        )
+        var runtimeID: UUID?
+        var capture: (any AudioCaptureSession)?
+        var didAttemptPreviousCaptureStop = false
+        do {
+            guard sourceRuntimes[preparation.source]?.id == previousRuntime.id else {
+                throw RecordingSessionControllerError.sessionNotActive
+            }
+            let replacementRuntimeID = try beginSourceRuntimeGeneration(
+                source: preparation.source,
+                sessionId: snapshot.sessionId
+            )
+            runtimeID = replacementRuntimeID
+            let replacementCapture = captureFactory.makeSession(
+                for: preparation.pipeline,
+                onUnexpectedStop: captureFailureHandler(
+                    source: preparation.source,
+                    runtimeID: replacementRuntimeID,
+                    sessionId: snapshot.sessionId
+                )
+            )
+            capture = replacementCapture
+
+            didAttemptPreviousCaptureStop = true
+            try await previousRuntime.capture.stop()
+            if batchRecording != nil {
+                previousRuntime.pipeline.router.setBatchConsumer(nil)
+                await previousRuntime.pipeline.router.waitUntilIdle()
+            }
+            try requirePreviousRuntimeDuringReplacement(
+                previousRuntime,
+                source: preparation.source,
+                replacementRuntimeID: replacementRuntimeID,
+                sessionId: snapshot.sessionId
+            )
+            _ = try await beginBatchRange(for: preparation, locale: locale)
+            attachment = try await attachRecognition(
+                preparation.preparedRecognition,
+                to: preparation.pipeline,
+                source: preparation.source,
+                snapshot: snapshot
+            )
+
+            sourceRuntimes[preparation.source] = SourceRuntime(
+                id: replacementRuntimeID,
+                pipeline: preparation.pipeline,
+                capture: replacementCapture,
+                recognition: attachment.recognition
+            )
+            try await replacementCapture.start()
+            try requireCurrentSourceRuntime(
+                source: preparation.source,
+                runtimeID: replacementRuntimeID,
+                sessionId: snapshot.sessionId
+            )
+            _ = try commitCurrentSources(
+                sessionId: snapshot.sessionId,
+                expectedSource: preparation.source,
+                runtimeID: replacementRuntimeID
+            )
+        } catch {
+            try await rollbackReplacement(
+                previousRuntime,
+                preparation: preparation,
+                attachment: attachment,
+                runtimeID: runtimeID,
+                capture: capture,
+                didAttemptPreviousCaptureStop: didAttemptPreviousCaptureStop,
+                locale: locale,
+                sessionId: snapshot.sessionId
+            )
+            throw error
+        }
+    }
+
+    private func rollbackReplacement(
+        _ previousRuntime: SourceRuntime,
+        preparation: SourcePipelinePreparation,
+        attachment: RecognitionAttachment,
+        runtimeID: UUID?,
+        capture: (any AudioCaptureSession)?,
+        didAttemptPreviousCaptureStop: Bool,
+        locale: Locale,
+        sessionId: UUID
+    ) async throws {
+        if let runtimeID,
+           sourceRuntimes[preparation.source]?.id == runtimeID {
+            sourceRuntimes[preparation.source] = nil
+        } else if sourceRuntimes[preparation.source]?.id == previousRuntime.id {
+            if didAttemptPreviousCaptureStop {
+                sourceRuntimes[preparation.source] = nil
+            } else {
+                sourceRuntimeGenerations[preparation.source] = previousRuntime.id
+            }
+        }
+        try? await capture?.stop()
+        preparation.pipeline.router.removeAllConsumers()
+        await preparation.pipeline.router.waitUntilIdle()
+        if let prepared = attachment.preparedRecognition {
+            discardPreparedRecognition(prepared, source: preparation.source, sessionId: sessionId)
+        }
+        await attachment.recognition?.cancel()
+        if attachment.recognition == nil {
+            await attachment.preparedRecognition?.session.cancel()
+        }
+        guard didAttemptPreviousCaptureStop else { return }
+        await restoreBatchRangeIfNeeded(previousRuntime, locale: locale)
+        try await restorePreviousRuntime(
+            previousRuntime,
+            source: preparation.source,
+            sessionId: sessionId
+        )
+    }
+
+    private func restoreBatchRangeIfNeeded(
+        _ previousRuntime: SourceRuntime,
+        locale: Locale
+    ) async {
+        guard let batchRecording else { return }
+        let source = previousRuntime.pipeline.source
+        previousRuntime.pipeline.router.setBatchConsumer(nil)
+        await previousRuntime.pipeline.router.waitUntilIdle()
+        do {
+            let rollbackConsumer = try await batchRecording.beginRangeConsumer(
+                source: source,
+                locale: locale,
+                at: .now
+            )
+            previousRuntime.pipeline.router.setBatchConsumer(rollbackConsumer)
+        } catch {
+            previousRuntime.pipeline.router.setBatchConsumer(nil)
+            if batchRuntimeFailureMessage == nil {
+                batchRuntimeFailureMessage = error.localizedDescription
+            }
+            await onRuntimeFailure?(source, error.localizedDescription, false)
+        }
+    }
+
+    private func retirePreviousRuntime(
+        _ previousRuntime: SourceRuntime,
+        finalMode: TranscriptionMode
+    ) async {
+        let source = previousRuntime.pipeline.source
+        previousRuntime.pipeline.router.removeAllConsumers()
+        await previousRuntime.pipeline.router.waitUntilIdle()
+        if finalMode == .realtime {
+            do {
+                try await previousRuntime.recognition?.finish()
+            } catch {
+                await onRuntimeFailure?(source, error.localizedDescription, true)
+            }
+        } else {
+            await previousRuntime.recognition?.cancel()
+        }
+    }
+
+    private func removeSource(
+        _ runtime: SourceRuntime,
+        snapshot: Snapshot
+    ) async throws -> Snapshot {
+        let source = runtime.pipeline.source
+        guard sourceRuntimes[source]?.id == runtime.id else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+        sourceRuntimes[source] = nil
+        var currentSnapshot = snapshot
+        currentSnapshot.enabledSources = Set(sourceRuntimes.keys)
+        transition(to: .capturing(currentSnapshot))
+
+        do {
+            try await runtime.capture.stop()
+        } catch {
+            await onRuntimeFailure?(source, error.localizedDescription, false)
+        }
+        runtime.pipeline.router.removeAllConsumers()
+        await runtime.pipeline.router.waitUntilIdle()
+        if snapshot.plan.finalMode == .realtime {
+            do {
+                try await runtime.recognition?.finish()
+            } catch {
+                await onRuntimeFailure?(source, error.localizedDescription, true)
+            }
+        } else {
+            await runtime.recognition?.cancel()
+        }
+        do {
+            try await batchRecording?.endRangeForReconfiguration(source: source)
+        } catch {
+            await onRuntimeFailure?(source, error.localizedDescription, false)
+        }
+
+        guard case let .capturing(finalSnapshot) = state,
+              finalSnapshot.sessionId == snapshot.sessionId else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+        return finalSnapshot
+    }
+
+    private func prepareRecognitionForNewPipeline(
+        source: RecordingAudioSource,
+        sourceFormat: AVAudioFormat?,
+        locale: Locale,
+        snapshot: Snapshot,
+        translateSegment: ProgressiveSegmentTranslationHandler?
+    ) async throws -> PreparedProgressiveRecognitionSession? {
+        guard snapshot.plan.requiresLiveRecognition else { return nil }
+        var prepared: PreparedProgressiveRecognitionSession?
+        do {
+            try await recognitionFactory.prepareModel(locale: locale)
+            let newRecognition = try await recognitionFactory.prepareSession(
+                locale: locale,
+                source: source,
+                sourceFormat: sourceFormat,
+                bufferingMode: snapshot.plan.recordsBatchAudio
+                    ? .lowLatency(maximumInputCount: 64)
+                    : .lossless,
+                translateSegment: translateSegment
+            )
+            prepared = newRecognition
+            try await startRecognition(newRecognition.session, source: source, snapshot: snapshot)
+            try requirePendingRecognitionStartSucceeded(
+                pipelineID: newRecognition.session.pipelineID,
+                source: source,
+                sessionId: snapshot.sessionId
+            )
+            return newRecognition
+        } catch {
+            if let prepared {
+                discardPreparedRecognition(
+                    prepared,
+                    source: source,
+                    sessionId: snapshot.sessionId
+                )
+                await prepared.session.cancel()
+            }
+            guard snapshot.plan.finalMode == .batch else { throw error }
+            await onRuntimeFailure?(source, error.localizedDescription, false)
+            return nil
+        }
+    }
+
+    private func attachPreparedRecognition(
+        _ prepared: PreparedProgressiveRecognitionSession,
+        to pipeline: AudioSourcePipeline,
+        source: RecordingAudioSource,
+        snapshot: Snapshot
+    ) async throws -> (any ProgressiveRecognitionSession)? {
+        do {
+            try requirePendingRecognitionStartSucceeded(
+                pipelineID: prepared.session.pipelineID,
+                source: source,
+                sessionId: snapshot.sessionId
+            )
+            try consumePendingRecognitionStart(
+                pipelineID: prepared.session.pipelineID,
+                source: source,
+                sessionId: snapshot.sessionId
+            )
+            pipeline.router.setLiveConsumer(
+                prepared.session.liveConsumer,
+                bufferingMode: snapshot.plan.recordsBatchAudio
+                    ? .lowLatency(maximumFrameCount: 8)
+                    : .lossless,
+                onFailure: liveFailureHandler(
+                    source: source,
+                    pipelineID: prepared.session.pipelineID,
+                    sessionId: snapshot.sessionId
+                )
+            )
+            return prepared.session
+        } catch {
+            discardPreparedRecognition(prepared, source: source, sessionId: snapshot.sessionId)
+            await prepared.session.cancel()
+            guard snapshot.plan.finalMode == .batch else { throw error }
+            await onRuntimeFailure?(source, error.localizedDescription, false)
+            return nil
+        }
+    }
+
+    private func discardPreparedRecognition(
+        _ prepared: PreparedProgressiveRecognitionSession,
+        source: RecordingAudioSource,
+        sessionId: UUID
+    ) {
+        discardPendingRecognitionStart(
+            pipelineID: prepared.session.pipelineID,
+            source: source,
+            sessionId: sessionId
+        )
+    }
+
+    private func requirePreviousRuntimeDuringReplacement(
+        _ previousRuntime: SourceRuntime,
+        source: RecordingAudioSource,
+        replacementRuntimeID: UUID,
+        sessionId: UUID
+    ) throws {
+        guard case let .capturing(snapshot) = state,
+              snapshot.sessionId == sessionId,
+              sourceRuntimeGenerations[source] == replacementRuntimeID,
+              sourceRuntimes[source]?.id == previousRuntime.id else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+    }
+
+    private func restorePreviousRuntime(
+        _ previousRuntime: SourceRuntime,
+        source: RecordingAudioSource,
+        sessionId: UUID
+    ) async throws {
+        guard case var .capturing(snapshot) = state,
+              snapshot.sessionId == sessionId,
+              sourceRuntimes[source] == nil else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+        sourceRuntimeGenerations[source] = previousRuntime.id
+        sourceRuntimes[source] = previousRuntime
+        do {
+            try await previousRuntime.capture.start()
+            try requireCurrentSourceRuntime(
+                source: source,
+                runtimeID: previousRuntime.id,
+                sessionId: sessionId
+            )
+            guard case var .capturing(currentSnapshot) = state,
+                  currentSnapshot.sessionId == sessionId else {
+                throw RecordingSessionControllerError.sessionNotActive
+            }
+            currentSnapshot.enabledSources = Set(sourceRuntimes.keys)
+            transition(to: .capturing(currentSnapshot))
+        } catch {
+            if sourceRuntimes[source]?.id == previousRuntime.id {
+                sourceRuntimes[source] = nil
+            }
+            snapshot.enabledSources = Set(sourceRuntimes.keys)
+            transition(to: .capturing(snapshot))
+            await onRuntimeFailure?(source, error.localizedDescription, snapshot.enabledSources.isEmpty)
+            throw error
+        }
+    }
+}

--- a/Sources/Dahlia/Services/RecordingSessionController+Startup.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController+Startup.swift
@@ -26,14 +26,12 @@ extension RecordingSessionController {
                 preferredTimescale: 1_000_000
             )
         )
-        if let batchRecording {
-            let consumer = try await batchRecording.beginRangeConsumer(
-                source: configuration.source,
-                locale: locale,
-                at: captureOriginDate
-            )
-            pipeline.router.setBatchConsumer(consumer)
-        }
+        let batchRangeOrigin = try await attachInitialBatchRange(
+            to: pipeline,
+            source: configuration.source,
+            locale: locale,
+            captureOriginDate: captureOriginDate
+        )
         let recognition = try await startPreparedRecognition(
             preparedSource.recognition?.session,
             source: configuration.source,
@@ -58,7 +56,8 @@ extension RecordingSessionController {
             id: runtimeID,
             pipeline: pipeline,
             capture: capture,
-            recognition: recognition
+            recognition: recognition,
+            batchRangeOrigin: batchRangeOrigin
         )
         try await capture.start()
         try requireCurrentSourceRuntime(
@@ -66,6 +65,24 @@ extension RecordingSessionController {
             runtimeID: runtimeID,
             sessionId: snapshot.sessionId
         )
+    }
+
+    private func attachInitialBatchRange(
+        to pipeline: AudioSourcePipeline,
+        source: RecordingAudioSource,
+        locale: Locale,
+        captureOriginDate: Date
+    ) async throws -> BatchRecordingRangeOrigin? {
+        guard let batchRecording else { return nil }
+        let attachment = try await batchRecording.beginRangeConsumer(
+            source: source,
+            locale: locale,
+            at: captureOriginDate,
+            continuingFromActiveRange: false
+        )
+        pipeline.setSessionRelativeOrigin(seconds: attachment.origin.sessionRelativeOriginSeconds)
+        pipeline.router.setBatchConsumer(attachment.consumer)
+        return attachment.origin
     }
 
     private func preparedCaptureFormat(for source: PreparedSource) async throws -> AVAudioFormat {

--- a/Sources/Dahlia/Services/RecordingSessionController+Startup.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController+Startup.swift
@@ -1,0 +1,115 @@
+@preconcurrency import AVFoundation
+import CoreMedia
+import Foundation
+
+extension RecordingSessionController {
+    func startPreparedSource(
+        _ preparedSource: PreparedSource,
+        locale: Locale,
+        snapshot: Snapshot
+    ) async throws {
+        let configuration = preparedSource.configuration
+        let runtimeID = try beginSourceRuntimeGeneration(
+            source: configuration.source,
+            sessionId: snapshot.sessionId
+        )
+        try await batchRecording?.prepare(source: configuration.source)
+        let captureFormat = try await preparedCaptureFormat(for: preparedSource)
+        let captureOriginDate = Date.now
+        let pipeline = AudioSourcePipeline(
+            source: configuration.source,
+            captureFormat: captureFormat,
+            captureDeviceID: configuration.captureDeviceID,
+            captureBufferSize: configuration.captureBufferSize,
+            sessionRelativeOrigin: CMTime(
+                seconds: max(0, captureOriginDate.timeIntervalSince(snapshot.startedAt)),
+                preferredTimescale: 1_000_000
+            )
+        )
+        if let batchRecording {
+            let consumer = try await batchRecording.beginRangeConsumer(
+                source: configuration.source,
+                locale: locale,
+                at: captureOriginDate
+            )
+            pipeline.router.setBatchConsumer(consumer)
+        }
+        let recognition = try await startPreparedRecognition(
+            preparedSource.recognition?.session,
+            source: configuration.source,
+            pipeline: pipeline,
+            snapshot: snapshot
+        )
+
+        try requireCurrentSourceRuntimeGeneration(
+            source: configuration.source,
+            runtimeID: runtimeID,
+            sessionId: snapshot.sessionId
+        )
+        let capture = captureFactory.makeSession(
+            for: pipeline,
+            onUnexpectedStop: captureFailureHandler(
+                source: configuration.source,
+                runtimeID: runtimeID,
+                sessionId: snapshot.sessionId
+            )
+        )
+        sourceRuntimes[configuration.source] = SourceRuntime(
+            id: runtimeID,
+            pipeline: pipeline,
+            capture: capture,
+            recognition: recognition
+        )
+        try await capture.start()
+        try requireCurrentSourceRuntime(
+            source: configuration.source,
+            runtimeID: runtimeID,
+            sessionId: snapshot.sessionId
+        )
+    }
+
+    private func preparedCaptureFormat(for source: PreparedSource) async throws -> AVAudioFormat {
+        if let batchRecording {
+            return await batchRecording.targetFormat
+        }
+        guard let recognition = source.recognition else {
+            throw AudioCaptureError.converterCreationFailed
+        }
+        return recognition.analyzerFormat
+    }
+
+    private func startPreparedRecognition(
+        _ recognition: (any ProgressiveRecognitionSession)?,
+        source: RecordingAudioSource,
+        pipeline: AudioSourcePipeline,
+        snapshot: Snapshot
+    ) async throws -> (any ProgressiveRecognitionSession)? {
+        guard let recognition else { return nil }
+        do {
+            try await startRecognition(recognition, source: source, snapshot: snapshot)
+            try consumePendingRecognitionStart(
+                pipelineID: recognition.pipelineID,
+                source: source,
+                sessionId: snapshot.sessionId
+            )
+            pipeline.router.setLiveConsumer(
+                recognition.liveConsumer,
+                bufferingMode: snapshot.plan.recordsBatchAudio
+                    ? .lowLatency(maximumFrameCount: 8)
+                    : .lossless,
+                onFailure: liveFailureHandler(
+                    source: source,
+                    pipelineID: recognition.pipelineID,
+                    sessionId: snapshot.sessionId
+                )
+            )
+            return recognition
+        } catch {
+            guard snapshot.plan.finalMode == .batch else { throw error }
+            await recognition.cancel()
+            await onRuntimeFailure?(source, error.localizedDescription, false)
+            return nil
+        }
+    }
+
+}

--- a/Sources/Dahlia/Services/RecordingSessionController.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController.swift
@@ -1,0 +1,434 @@
+@preconcurrency import AVFoundation
+import CoreAudio
+import CoreMedia
+import Foundation
+import GRDB
+
+/// 物理capture、progressive認識、CAF録音をセッション単位で所有し、ライフサイクルを直列化する。
+actor RecordingSessionController {
+    typealias EventHandler = ProgressiveTranscriptionEventHandler
+    typealias RuntimeFailureHandler = @MainActor @Sendable (
+        _ source: RecordingAudioSource?,
+        _ message: String,
+        _ isFatal: Bool
+    ) -> Void
+
+    struct SourceConfiguration: Equatable {
+        let source: RecordingAudioSource
+        let captureDeviceID: AudioDeviceID?
+        let captureBufferSize: AVAudioFrameCount
+
+        init(
+            source: RecordingAudioSource,
+            captureDeviceID: AudioDeviceID? = nil,
+            captureBufferSize: AVAudioFrameCount = 4096
+        ) {
+            self.source = source
+            self.captureDeviceID = captureDeviceID
+            self.captureBufferSize = captureBufferSize
+        }
+    }
+
+    struct PreparationRequest {
+        let sessionId: UUID
+        let startedAt: Date
+        let plan: TranscriptionSessionPlan
+        let locale: Locale
+        let sources: [SourceConfiguration]
+        let dbQueue: DatabaseQueue?
+        let meetingId: UUID?
+        let batchSampleRate: Double?
+        let managedAudioRootURL: URL
+        let translateSegment: ProgressiveSegmentTranslationHandler?
+        let batchScheduler: (any BatchTranscriptionScheduling)?
+
+        init(
+            sessionId: UUID,
+            startedAt: Date,
+            plan: TranscriptionSessionPlan,
+            locale: Locale,
+            sources: [SourceConfiguration],
+            dbQueue: DatabaseQueue? = nil,
+            meetingId: UUID? = nil,
+            batchSampleRate: Double? = nil,
+            managedAudioRootURL: URL = BatchAudioStorage.managedRootURL,
+            translateSegment: ProgressiveSegmentTranslationHandler? = nil,
+            batchScheduler: (any BatchTranscriptionScheduling)? = nil
+        ) {
+            self.sessionId = sessionId
+            self.startedAt = startedAt
+            self.plan = plan
+            self.locale = locale
+            self.sources = sources
+            self.dbQueue = dbQueue
+            self.meetingId = meetingId
+            self.batchSampleRate = batchSampleRate
+            self.managedAudioRootURL = managedAudioRootURL
+            self.translateSegment = translateSegment
+            self.batchScheduler = batchScheduler
+        }
+    }
+
+    struct StopResult: Equatable {
+        let sessionId: UUID
+        let finalMode: TranscriptionMode
+        let batchRecordingSucceeded: Bool
+        let batchFailureMessage: String?
+    }
+
+    struct ResourceCounts: Equatable {
+        let captures: Int
+        let recognizers: Int
+        let batchRecorders: Int
+        let batchSchedulers: Int
+    }
+
+    struct Snapshot: Equatable {
+        let sessionId: UUID
+        let startedAt: Date
+        var plan: TranscriptionSessionPlan
+        var localeIdentifier: String
+        var enabledSources: Set<RecordingAudioSource>
+    }
+
+    enum State: Equatable {
+        case idle
+        case prepared(Snapshot)
+        case capturing(Snapshot)
+        case stopping(Snapshot)
+    }
+
+    struct PreparedSource {
+        let configuration: SourceConfiguration
+        let recognition: PreparedProgressiveRecognitionSession?
+    }
+
+    private struct Preparation {
+        let sources: [PreparedSource]
+        let locale: Locale
+    }
+
+    struct PendingRecognitionStart {
+        let source: RecordingAudioSource
+        let sessionId: UUID
+        var failureMessage: String?
+    }
+
+    struct SourceRuntime {
+        let id: UUID
+        let pipeline: AudioSourcePipeline
+        let capture: any AudioCaptureSession
+        var recognition: (any ProgressiveRecognitionSession)?
+    }
+
+    let captureFactory: any AudioCaptureSessionFactory
+    let recognitionFactory: any ProgressiveRecognitionSessionFactory
+    private let batchRecordingFactory: any BatchRecordingSessionFactory
+
+    private(set) var state: State = .idle
+    private var preparation: Preparation?
+    var sourceRuntimes: [RecordingAudioSource: SourceRuntime] = [:]
+    var sourceRuntimeGenerations: [RecordingAudioSource: UUID] = [:]
+    var pendingRecognitionStarts: [UUID: PendingRecognitionStart] = [:]
+    var batchRecording: (any BatchRecordingSession)?
+    private var batchScheduler: (any BatchTranscriptionScheduling)?
+    var onEvent: EventHandler?
+    var onRuntimeFailure: RuntimeFailureHandler?
+    var currentLocale: Locale?
+    var batchRuntimeFailureMessage: String?
+
+    init(
+        captureFactory: any AudioCaptureSessionFactory = DefaultAudioCaptureSessionFactory(),
+        recognitionFactory: any ProgressiveRecognitionSessionFactory = DefaultProgressiveRecognitionSessionFactory(),
+        batchRecordingFactory: any BatchRecordingSessionFactory = DefaultBatchRecordingSessionFactory()
+    ) {
+        self.captureFactory = captureFactory
+        self.recognitionFactory = recognitionFactory
+        self.batchRecordingFactory = batchRecordingFactory
+    }
+
+    /// permission/model/sinkを準備する。物理captureはまだ開始しない。
+    func prepare(
+        _ request: PreparationRequest,
+        onEvent: @escaping EventHandler,
+        onRuntimeFailure: @escaping RuntimeFailureHandler
+    ) async throws {
+        guard case .idle = state else {
+            throw RecordingSessionControllerError.sessionAlreadyActive
+        }
+        let configurations = Self.uniqueSortedConfigurations(request.sources)
+        guard !configurations.isEmpty else {
+            throw RecordingSessionControllerError.noAudioSource
+        }
+
+        var preparedRecognitions: [PreparedProgressiveRecognitionSession] = []
+        do {
+            for configuration in configurations {
+                guard await captureFactory.requestPermission(for: configuration.source) else {
+                    throw Self.permissionError(for: configuration.source)
+                }
+            }
+
+            var recognitionModelIsAvailable = request.plan.requiresLiveRecognition
+            if request.plan.requiresLiveRecognition {
+                do {
+                    try await recognitionFactory.prepareModel(locale: request.locale)
+                } catch {
+                    guard request.plan.finalMode == .batch else { throw error }
+                    recognitionModelIsAvailable = false
+                    await onRuntimeFailure(nil, error.localizedDescription, false)
+                }
+            }
+
+            if request.plan.recordsBatchAudio {
+                guard let dbQueue = request.dbQueue,
+                      let meetingId = request.meetingId,
+                      let sampleRate = request.batchSampleRate else {
+                    throw RecordingSessionControllerError.invalidBatchConfiguration
+                }
+                batchRecording = try await batchRecordingFactory.makeSession(
+                    dbQueue: dbQueue,
+                    managedRootURL: request.managedAudioRootURL,
+                    meetingId: meetingId,
+                    recordingSessionId: request.sessionId,
+                    recordingStartTime: request.startedAt,
+                    sampleRate: sampleRate
+                )
+            }
+
+            let batchFormat = await batchRecording?.targetFormat
+            var preparedSources: [PreparedSource] = []
+            for configuration in configurations {
+                let recognition: PreparedProgressiveRecognitionSession?
+                if recognitionModelIsAvailable {
+                    do {
+                        recognition = try await recognitionFactory.prepareSession(
+                            locale: request.locale,
+                            source: configuration.source,
+                            sourceFormat: request.plan.recordsBatchAudio ? batchFormat : nil,
+                            bufferingMode: request.plan.recordsBatchAudio
+                                ? .lowLatency(maximumInputCount: 64)
+                                : .lossless,
+                            translateSegment: request.translateSegment
+                        )
+                        if let recognition {
+                            preparedRecognitions.append(recognition)
+                        }
+                    } catch {
+                        guard request.plan.finalMode == .batch else { throw error }
+                        recognition = nil
+                        await onRuntimeFailure(configuration.source, error.localizedDescription, false)
+                    }
+                } else {
+                    recognition = nil
+                }
+                preparedSources.append(PreparedSource(
+                    configuration: configuration,
+                    recognition: recognition
+                ))
+            }
+
+            let snapshot = Snapshot(
+                sessionId: request.sessionId,
+                startedAt: request.startedAt,
+                plan: request.plan,
+                localeIdentifier: request.locale.identifier,
+                enabledSources: Set(configurations.map(\.source))
+            )
+            preparation = Preparation(
+                sources: preparedSources,
+                locale: request.locale
+            )
+            batchScheduler = request.batchScheduler
+            self.onEvent = onEvent
+            self.onRuntimeFailure = onRuntimeFailure
+            currentLocale = request.locale
+            state = .prepared(snapshot)
+        } catch {
+            for recognition in preparedRecognitions {
+                await recognition.session.cancel()
+            }
+            await cleanupPreparedResources()
+            throw error
+        }
+    }
+
+    /// persistence作成後に、consumer接続と物理capture開始を行う。
+    func startPrepared() async throws -> Snapshot {
+        guard case let .prepared(snapshot) = state,
+              let preparation else {
+            throw RecordingSessionControllerError.sessionNotPrepared
+        }
+        state = .capturing(snapshot)
+
+        do {
+            for preparedSource in preparation.sources {
+                try await startPreparedSource(
+                    preparedSource,
+                    locale: preparation.locale,
+                    snapshot: snapshot
+                )
+            }
+            guard case let .capturing(currentSnapshot) = state,
+                  currentSnapshot.sessionId == snapshot.sessionId else {
+                throw RecordingSessionControllerError.sessionNotActive
+            }
+            self.preparation = nil
+            return currentSnapshot
+        } catch {
+            if case let .capturing(currentSnapshot) = state,
+               currentSnapshot.sessionId == snapshot.sessionId {
+                await cleanupActiveResources(cancelRecognition: true, deleteBatchRecording: true)
+                await cleanupPreparedResources()
+                resetState()
+            }
+            throw error
+        }
+    }
+
+    /// capture → router drain → live finalize → CAF finalize の順で停止する。
+    func stop() async throws -> StopResult {
+        guard case let .capturing(snapshot) = state else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+        state = .stopping(snapshot)
+
+        for source in Self.sortedSources(sourceRuntimes.keys) {
+            try? await sourceRuntimes[source]?.capture.stop()
+        }
+        for runtime in sourceRuntimes.values {
+            runtime.pipeline.router.removeAllConsumers()
+        }
+        for runtime in sourceRuntimes.values {
+            await runtime.pipeline.router.waitUntilIdle()
+        }
+        var recognitionFailure: Error?
+        for source in Self.sortedSources(sourceRuntimes.keys) {
+            guard let recognition = sourceRuntimes[source]?.recognition else { continue }
+            do {
+                try await recognition.finish()
+            } catch {
+                if recognitionFailure == nil {
+                    recognitionFailure = error
+                }
+                await onRuntimeFailure?(
+                    source,
+                    error.localizedDescription,
+                    snapshot.plan.finalMode == .realtime
+                )
+            }
+        }
+
+        var batchSucceeded = batchRuntimeFailureMessage == nil
+        var batchFailureMessage = batchRuntimeFailureMessage
+        if let batchRecording {
+            do {
+                try await batchRecording.finish()
+            } catch {
+                batchSucceeded = false
+                if batchFailureMessage == nil {
+                    batchFailureMessage = error.localizedDescription
+                }
+            }
+        }
+        if let batchFailureMessage {
+            await batchScheduler?.recordRecordingFailure(
+                sessionId: snapshot.sessionId,
+                message: batchFailureMessage
+            )
+        }
+        sourceRuntimes.removeAll()
+        self.batchRecording = nil
+        if snapshot.plan.finalMode == .realtime,
+           let recognitionFailure {
+            throw recognitionFailure
+        }
+        return StopResult(
+            sessionId: snapshot.sessionId,
+            finalMode: snapshot.plan.finalMode,
+            batchRecordingSucceeded: batchSucceeded,
+            batchFailureMessage: batchFailureMessage
+        )
+    }
+
+    /// persistence終了後にセッションをidleへ戻す。batch enqueueはユーザー確認後に行う。
+    func completeStop() {
+        resetState()
+    }
+
+    func abort() async {
+        await cleanupActiveResources(cancelRecognition: true, deleteBatchRecording: true)
+        await cleanupPreparedResources()
+        resetState()
+    }
+
+    func snapshot() -> Snapshot? {
+        switch state {
+        case .idle:
+            nil
+        case let .prepared(snapshot), let .capturing(snapshot), let .stopping(snapshot):
+            snapshot
+        }
+    }
+
+    func resourceCounts() -> ResourceCounts {
+        let preparedRecognizerCount = preparation?.sources.count(where: { $0.recognition != nil }) ?? 0
+        return ResourceCounts(
+            captures: sourceRuntimes.count,
+            recognizers: sourceRuntimes.values.count(where: { $0.recognition != nil }) + preparedRecognizerCount,
+            batchRecorders: batchRecording == nil ? 0 : sourceRuntimes.count,
+            batchSchedulers: batchScheduler == nil ? 0 : 1
+        )
+    }
+
+    private func cleanupPreparedResources() async {
+        if let preparation {
+            for preparedSource in preparation.sources {
+                await preparedSource.recognition?.session.cancel()
+            }
+        }
+        preparation = nil
+        await batchRecording?.cancelAndDelete()
+        batchRecording = nil
+    }
+
+    private func resetState() {
+        preparation = nil
+        sourceRuntimes.removeAll()
+        sourceRuntimeGenerations.removeAll()
+        pendingRecognitionStarts.removeAll()
+        batchRecording = nil
+        batchScheduler = nil
+        onEvent = nil
+        onRuntimeFailure = nil
+        currentLocale = nil
+        batchRuntimeFailureMessage = nil
+        state = .idle
+    }
+
+    func transition(to newState: State) {
+        state = newState
+    }
+
+    private static func uniqueSortedConfigurations(
+        _ configurations: [SourceConfiguration]
+    ) -> [SourceConfiguration] {
+        var seen: Set<RecordingAudioSource> = []
+        return configurations
+            .sorted { $0.source.rawValue < $1.source.rawValue }
+            .filter { seen.insert($0.source).inserted }
+    }
+
+    static func sortedSources(_ sources: some Sequence<RecordingAudioSource>) -> [RecordingAudioSource] {
+        sources.sorted { $0.rawValue < $1.rawValue }
+    }
+
+    static func permissionError(for source: RecordingAudioSource) -> Error {
+        switch source {
+        case .microphone:
+            AudioCaptureError.microphonePermissionDenied
+        case .system:
+            SystemAudioCaptureError.screenRecordingPermissionDenied
+        }
+    }
+}

--- a/Sources/Dahlia/Services/RecordingSessionController.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController.swift
@@ -119,6 +119,7 @@ actor RecordingSessionController {
         let pipeline: AudioSourcePipeline
         let capture: any AudioCaptureSession
         var recognition: (any ProgressiveRecognitionSession)?
+        var batchRangeOrigin: BatchRecordingRangeOrigin?
     }
 
     let captureFactory: any AudioCaptureSessionFactory

--- a/Sources/Dahlia/Services/RecordingSessionControllerError.swift
+++ b/Sources/Dahlia/Services/RecordingSessionControllerError.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+enum RecordingSessionControllerError: LocalizedError {
+    case sessionAlreadyActive
+    case sessionNotActive
+    case sessionNotPrepared
+    case invalidBatchConfiguration
+    case noAudioSource
+    case recognitionFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .sessionAlreadyActive:
+            L10n.recordingSessionAlreadyActive
+        case .sessionNotActive:
+            L10n.recordingSessionNotActive
+        case .sessionNotPrepared:
+            L10n.speechRecognitionNotReady
+        case .invalidBatchConfiguration:
+            L10n.batchAudioFormatUnavailable
+        case .noAudioSource:
+            L10n.noAudioSourceSelected
+        case let .recognitionFailed(message):
+            message
+        }
+    }
+}

--- a/Sources/Dahlia/Services/RecordingSessionRuntimeProtocols.swift
+++ b/Sources/Dahlia/Services/RecordingSessionRuntimeProtocols.swift
@@ -1,0 +1,90 @@
+@preconcurrency import AVFoundation
+import Foundation
+import GRDB
+
+typealias AudioCaptureUnexpectedStopHandler = @Sendable (Error?) -> Void
+typealias ProgressiveTranscriptionEventHandler = @MainActor @Sendable (TranscriptionEvent) async -> Void
+typealias ProgressiveSegmentTranslationHandler = @Sendable (TranscriptSegment) async -> String?
+
+/// 1音源につき1つだけ生成される、物理 capture の実行単位。
+protocol AudioCaptureSession: Sendable {
+    func start() async throws
+    func stop() async throws
+}
+
+/// 実デバイス capture とテスト用 fake を差し替えるための生成境界。
+protocol AudioCaptureSessionFactory: Sendable {
+    func requestPermission(for source: RecordingAudioSource) async -> Bool
+
+    func makeSession(
+        for pipeline: AudioSourcePipeline,
+        onUnexpectedStop: @escaping AudioCaptureUnexpectedStopHandler
+    ) -> any AudioCaptureSession
+}
+
+/// SpeechTranscriberService と AudioBufferBridge を1つの認識処理として扱う実行単位。
+protocol ProgressiveRecognitionSession: Sendable {
+    var pipelineID: UUID { get }
+    var liveConsumer: AudioFrameRouter.LiveConsumer { get }
+
+    func start(
+        recordingStartTime: Date,
+        recordingSessionId: UUID,
+        onEvent: @escaping ProgressiveTranscriptionEventHandler
+    ) async throws
+
+    /// router を drain した後、入力を閉じて最終結果まで処理する。finalize に失敗した場合は送出する。
+    func finish() async throws
+
+    /// 一時字幕の切り離しや abort 時に、残りの入力を破棄する。
+    func cancel() async
+}
+
+/// progressive recognizer のモデル準備と session 生成を差し替える境界。
+protocol ProgressiveRecognitionSessionFactory: Sendable {
+    func prepareModel(locale: Locale) async throws
+
+    func prepareSession(
+        locale: Locale,
+        source: RecordingAudioSource,
+        sourceFormat: AVAudioFormat?,
+        bufferingMode: AudioBufferBridge.BufferingMode,
+        translateSegment: ProgressiveSegmentTranslationHandler?
+    ) async throws -> PreparedProgressiveRecognitionSession
+}
+
+/// 音源別CAFとlocale rangeを管理するバッチ録音の実行単位。
+@MainActor
+protocol BatchRecordingSession: AnyObject, Sendable {
+    var targetFormat: AVAudioFormat { get }
+
+    func prepare(source: RecordingAudioSource) async throws
+    func beginRangeConsumer(
+        source: RecordingAudioSource,
+        locale: Locale,
+        at date: Date
+    ) async throws -> AudioFrameRouter.BatchConsumer
+    func rotateRanges(_ origins: [BatchRecordingRangeOrigin], locale: Locale) async throws
+    func endRangeForReconfiguration(source: RecordingAudioSource) async throws
+    func finish() async throws
+    func cancelAndDelete() async
+}
+
+/// バッチ録音の実装を、DBや保存先を含めて生成する境界。
+protocol BatchRecordingSessionFactory: Sendable {
+    @MainActor
+    func makeSession(
+        dbQueue: DatabaseQueue,
+        managedRootURL: URL,
+        meetingId: UUID,
+        recordingSessionId: UUID,
+        recordingStartTime: Date,
+        sampleRate: Double
+    ) throws -> any BatchRecordingSession
+}
+
+/// バッチ文字起こしのqueue実装をcontrollerから注入可能にする境界。
+protocol BatchTranscriptionScheduling: Sendable {
+    func enqueue(sessionId: UUID) async
+    func recordRecordingFailure(sessionId: UUID, message: String) async
+}

--- a/Sources/Dahlia/Services/RecordingSessionRuntimeProtocols.swift
+++ b/Sources/Dahlia/Services/RecordingSessionRuntimeProtocols.swift
@@ -62,9 +62,13 @@ protocol BatchRecordingSession: AnyObject, Sendable {
     func beginRangeConsumer(
         source: RecordingAudioSource,
         locale: Locale,
-        at date: Date
-    ) async throws -> AudioFrameRouter.BatchConsumer
-    func rotateRanges(_ origins: [BatchRecordingRangeOrigin], locale: Locale) async throws
+        at date: Date,
+        continuingFromActiveRange: Bool
+    ) async throws -> BatchRecordingConsumerAttachment
+    func rotateRanges(
+        _ origins: [BatchRecordingRangeOrigin],
+        locale: Locale
+    ) async throws -> [RecordingAudioSource: BatchRecordingRangeOrigin]
     func endRangeForReconfiguration(source: RecordingAudioSource) async throws
     func finish() async throws
     func cancelAndDelete() async

--- a/Sources/Dahlia/Services/TranscriptPersistencePolicy.swift
+++ b/Sources/Dahlia/Services/TranscriptPersistencePolicy.swift
@@ -1,0 +1,9 @@
+/// 逐次認識イベントを正本 transcript として保存するかを指定する。
+enum TranscriptPersistencePolicy {
+    case streaming
+    case deferred
+
+    var persistsStreamingSegments: Bool {
+        self == .streaming
+    }
+}

--- a/Sources/Dahlia/Services/TranscriptionEventRouter.swift
+++ b/Sources/Dahlia/Services/TranscriptionEventRouter.swift
@@ -21,8 +21,7 @@ enum TranscriptionEventRouter {
         case let .preview(segment):
             store.updateUnconfirmedSegment(segment, forSource: segment.speakerLabel)
         case let .finalized(segment):
-            store.clearUnconfirmedSegments(forSource: segment.speakerLabel)
-            store.addSegment(segment)
+            store.finalizeSegment(segment, forSource: segment.speakerLabel)
         case let .clearPreview(_, sourceLabel):
             store.clearUnconfirmedSegments(forSource: sourceLabel)
         case let .translation(_, segmentID, translatedText):

--- a/Sources/Dahlia/Services/TranscriptionEventRouter.swift
+++ b/Sources/Dahlia/Services/TranscriptionEventRouter.swift
@@ -1,0 +1,34 @@
+/// 1つの逐次認識イベントを、セッションプランに応じた保存先へ分配する。
+enum TranscriptionEventRouter {
+    @MainActor
+    static func route(
+        _ event: TranscriptionEvent,
+        plan: TranscriptionSessionPlan,
+        transcriptStore: TranscriptStore,
+        liveCaptionStore: LiveCaptionStore
+    ) {
+        if plan.persistsRealtimeTranscript {
+            apply(event, to: transcriptStore)
+        }
+        if plan.liveSubtitlesEnabled {
+            liveCaptionStore.apply(event: event)
+        }
+    }
+
+    @MainActor
+    private static func apply(_ event: TranscriptionEvent, to store: TranscriptStore) {
+        switch event {
+        case let .preview(segment):
+            store.updateUnconfirmedSegment(segment, forSource: segment.speakerLabel)
+        case let .finalized(segment):
+            store.clearUnconfirmedSegments(forSource: segment.speakerLabel)
+            store.addSegment(segment)
+        case let .clearPreview(_, sourceLabel):
+            store.clearUnconfirmedSegments(forSource: sourceLabel)
+        case let .translation(_, segmentID, translatedText):
+            store.updateTranslatedText(for: segmentID, translatedText: translatedText)
+        case .failure:
+            break
+        }
+    }
+}

--- a/Sources/Dahlia/Speech/BatchSpeechTranscriberService.swift
+++ b/Sources/Dahlia/Speech/BatchSpeechTranscriberService.swift
@@ -5,15 +5,6 @@ import Speech
 
 /// CAFの指定rangeを精度優先のSpeechTranscriberで文字起こしする。
 enum BatchSpeechTranscriberService {
-    static func preferredSampleRate(locale: Locale) async throws -> Double {
-        let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
-        try await installAssetsIfNeeded(for: transcriber)
-        guard let format = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber]) else {
-            throw BatchSpeechTranscriberError.audioFormatUnavailable
-        }
-        return format.sampleRate
-    }
-
     static func transcribe(_ request: BatchSpeechTranscriptionRequest) async throws -> [TranscriptSegment] {
         guard request.startFrame >= 0, request.frameCount > 0 else { return [] }
         let rangeURL = try extractRange(

--- a/Sources/Dahlia/Speech/DefaultProgressiveRecognitionSession.swift
+++ b/Sources/Dahlia/Speech/DefaultProgressiveRecognitionSession.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// SpeechTranscriberServiceとAudioBufferBridgeを同一ライフサイクルで扱うadapter。
+actor DefaultProgressiveRecognitionSession: ProgressiveRecognitionSession {
+    nonisolated let pipelineID: UUID
+    nonisolated let liveConsumer: AudioFrameRouter.LiveConsumer
+
+    private let service: SpeechTranscriberService
+    private let bridge: AudioBufferBridge
+
+    init(service: SpeechTranscriberService, bridge: AudioBufferBridge) {
+        pipelineID = service.pipelineID
+        liveConsumer = { [bridge] chunk in
+            bridge.append(chunk)
+        }
+        self.service = service
+        self.bridge = bridge
+    }
+
+    func start(
+        recordingStartTime: Date,
+        recordingSessionId: UUID,
+        onEvent: @escaping ProgressiveTranscriptionEventHandler
+    ) async throws {
+        try await service.startStreaming(
+            bridge: bridge,
+            recordingStartTime: recordingStartTime,
+            recordingSessionId: recordingSessionId,
+            onEvent: onEvent
+        )
+    }
+
+    func finish() async throws {
+        bridge.finish()
+        try await service.stopStreaming()
+    }
+
+    func cancel() async {
+        bridge.finish()
+        await service.cancel()
+    }
+}

--- a/Sources/Dahlia/Speech/DefaultProgressiveRecognitionSessionFactory.swift
+++ b/Sources/Dahlia/Speech/DefaultProgressiveRecognitionSessionFactory.swift
@@ -1,0 +1,56 @@
+@preconcurrency import AVFoundation
+import Foundation
+
+/// Apple Speechのprogressive recognizerを生成するdefault factory。
+/// converter factoryを差し替えることで、公式AnalyzerInputConverterへ移行できる。
+struct DefaultProgressiveRecognitionSessionFactory: ProgressiveRecognitionSessionFactory {
+    private let inputConverterFactory: AnalyzerInputConverterFactory
+
+    init(inputConverterFactory: @escaping AnalyzerInputConverterFactory = { sourceFormat, analyzerFormat in
+        try AVAudioAnalyzerInputConverter(
+            sourceFormat: sourceFormat,
+            analyzerFormat: analyzerFormat
+        )
+    }) {
+        self.inputConverterFactory = inputConverterFactory
+    }
+
+    func prepareModel(locale: Locale) async throws {
+        try await SpeechTranscriberService.ensureModelInstalled(locale: locale)
+    }
+
+    func prepareSession(
+        locale: Locale,
+        source: RecordingAudioSource,
+        sourceFormat: AVAudioFormat?,
+        bufferingMode: AudioBufferBridge.BufferingMode,
+        translateSegment: ProgressiveSegmentTranslationHandler?
+    ) async throws -> PreparedProgressiveRecognitionSession {
+        let service = SpeechTranscriberService(
+            locale: locale,
+            speakerLabel: source.speakerLabel,
+            translateSegment: translateSegment
+        )
+        try await service.prepare()
+        guard let analyzerFormat = await service.targetAudioFormat() else {
+            throw AudioCaptureError.converterCreationFailed
+        }
+
+        let captureFormat = sourceFormat ?? analyzerFormat
+        let inputConverter: (any AnalyzerInputConverting)? = if captureFormat != analyzerFormat {
+            try inputConverterFactory(captureFormat, analyzerFormat)
+        } else {
+            nil
+        }
+        let bridge = try AudioBufferBridge(
+            sourceFormat: captureFormat,
+            analyzerFormat: analyzerFormat,
+            inputConverter: inputConverter,
+            bufferingMode: bufferingMode
+        )
+        return PreparedProgressiveRecognitionSession(
+            analyzerFormat: analyzerFormat,
+            session: DefaultProgressiveRecognitionSession(service: service, bridge: bridge)
+        )
+    }
+}

--- a/Sources/Dahlia/Speech/PreparedProgressiveRecognitionSession.swift
+++ b/Sources/Dahlia/Speech/PreparedProgressiveRecognitionSession.swift
@@ -1,0 +1,7 @@
+@preconcurrency import AVFoundation
+
+/// recognizer が要求する形式と、開始前のrecognition sessionをまとめたprepare結果。
+struct PreparedProgressiveRecognitionSession {
+    let analyzerFormat: AVAudioFormat
+    let session: any ProgressiveRecognitionSession
+}

--- a/Sources/Dahlia/Speech/PreviewTranslationCoordinator.swift
+++ b/Sources/Dahlia/Speech/PreviewTranslationCoordinator.swift
@@ -10,7 +10,8 @@ actor PreviewTranslationCoordinator {
     private let sleep: SleepHandler
     private let translate: TranslationHandler
 
-    private var pendingTask: Task<Void, Never>?
+    private var translationTasks: [UUID: Task<Void, Never>] = [:]
+    private var currentTaskID: UUID?
     private var generation: UInt64 = 0
     private var lastScheduledText: String?
 
@@ -35,29 +36,57 @@ actor PreviewTranslationCoordinator {
         generation += 1
         let currentGeneration = generation
 
-        pendingTask?.cancel()
-        pendingTask = nil
+        if let currentTaskID {
+            translationTasks[currentTaskID]?.cancel()
+            self.currentTaskID = nil
+        }
 
         guard shouldScheduleTranslation(for: segment.text) else { return }
 
         lastScheduledText = segment.text
-        pendingTask = Task { [debounceDuration, sleep, translate] in
+        let taskID = UUID.v7()
+        currentTaskID = taskID
+        translationTasks[taskID] = Task { [debounceDuration, sleep, translate] in
             await sleep(debounceDuration)
-            guard !Task.isCancelled else { return }
-
-            let translatedText = await translate(segment)
-            guard !Task.isCancelled else { return }
-
-            guard self.generation == currentGeneration else { return }
-            await applyTranslation(segment.id, translatedText)
+            if !Task.isCancelled {
+                let translatedText = await translate(segment)
+                if !Task.isCancelled, self.isCurrentGeneration(currentGeneration) {
+                    await applyTranslation(segment.id, translatedText)
+                }
+            }
+            self.translationTaskDidFinish(taskID)
         }
     }
 
-    func reset() {
+    func cancelPending() {
         generation += 1
-        pendingTask?.cancel()
-        pendingTask = nil
+        translationTasks.values.forEach { $0.cancel() }
+        currentTaskID = nil
         lastScheduledText = nil
+    }
+
+    func reset() async {
+        cancelPending()
+
+        while !translationTasks.isEmpty {
+            let tasks = Array(translationTasks.values)
+            translationTasks.removeAll()
+            tasks.forEach { $0.cancel() }
+            for task in tasks {
+                await task.value
+            }
+        }
+    }
+
+    private func isCurrentGeneration(_ candidate: UInt64) -> Bool {
+        generation == candidate
+    }
+
+    private func translationTaskDidFinish(_ taskID: UUID) {
+        translationTasks[taskID] = nil
+        if currentTaskID == taskID {
+            currentTaskID = nil
+        }
     }
 
     private func shouldScheduleTranslation(for newText: String) -> Bool {

--- a/Sources/Dahlia/Speech/SpeechTranscriberService.swift
+++ b/Sources/Dahlia/Speech/SpeechTranscriberService.swift
@@ -1,19 +1,36 @@
 import AVFoundation
 import CoreMedia
+import Foundation
 import Speech
 
 /// SpeechAnalyzer + SpeechTranscriber によるストリーミング文字起こしサービス。
 /// AudioBufferBridge から受け取った AsyncStream<AnalyzerInput> を SpeechAnalyzer に渡し、
-/// SpeechTranscriber の結果を TranscriptStore に反映する。
+/// SpeechTranscriber の結果を保存先に依存しないイベントとして通知する。
 actor SpeechTranscriberService {
+    typealias EventHandler = @MainActor @Sendable (TranscriptionEvent) async -> Void
     typealias SegmentTranslationHandler = @Sendable (TranscriptSegment) async -> String?
 
+    private enum ServiceError: LocalizedError {
+        case notPrepared
+
+        var errorDescription: String? {
+            L10n.speechRecognitionNotReady
+        }
+    }
+
     private nonisolated static let ignoredConfirmedTexts: Set = [".", "あ"]
+    nonisolated let pipelineID: UUID
 
     private var analyzer: SpeechAnalyzer?
     private var transcriber: SpeechTranscriber?
     private var resultTask: Task<Void, Never>?
+    private var finalTranslationTasks: [UUID: Task<Void, Never>] = [:]
     private var bestFormat: AVAudioFormat?
+    private var activeSessionId: UUID?
+    private var eventHandler: EventHandler?
+    private var previewSegmentID: UUID?
+    private var hasReportedFailure = false
+    private var streamingFailure: Error?
 
     private let locale: Locale
     private let speakerLabel: String?
@@ -21,10 +38,12 @@ actor SpeechTranscriberService {
     private let previewTranslationCoordinator: PreviewTranslationCoordinator?
 
     init(
+        pipelineID: UUID = .v7(),
         locale: Locale = Locale(identifier: "ja-JP"),
         speakerLabel: String? = nil,
         translateSegment: SegmentTranslationHandler? = nil
     ) {
+        self.pipelineID = pipelineID
         self.locale = locale
         self.speakerLabel = speakerLabel
         self.translateSegment = translateSegment
@@ -90,106 +109,247 @@ actor SpeechTranscriberService {
     }
 
     /// ストリーミング文字起こしを開始する。
-    func startStreaming(store: TranscriptStore, bridge: AudioBufferBridge, recordingStartTime: Date, recordingSessionId: UUID) async throws {
-        guard let analyzer, let transcriber else { return }
+    func startStreaming(
+        bridge: AudioBufferBridge,
+        recordingStartTime: Date,
+        recordingSessionId: UUID,
+        onEvent: @escaping EventHandler
+    ) async throws {
+        guard let analyzer, let transcriber else {
+            let error = ServiceError.notPrepared
+            await onEvent(.failure(
+                sessionId: recordingSessionId,
+                pipelineID: pipelineID,
+                sourceLabel: speakerLabel,
+                message: error.localizedDescription
+            ))
+            throw error
+        }
 
-        // SpeechAnalyzer にオーディオストリームを渡して解析開始
-        try await analyzer.start(inputSequence: bridge.stream)
+        activeSessionId = recordingSessionId
+        eventHandler = onEvent
+        previewSegmentID = nil
+        hasReportedFailure = false
+        streamingFailure = nil
 
-        // SpeechTranscriber の結果を非同期でイテレーションし、TranscriptStore に反映
+        do {
+            try await analyzer.start(inputSequence: bridge.stream)
+        } catch {
+            await reportFailure(error)
+            clearStreamingContext()
+            throw error
+        }
+
         resultTask = Task { [weak self] in
-            do {
-                for try await result in transcriber.results {
-                    guard let self else { break }
-
-                    let label = self.speakerLabel
-                    guard let text = Self.normalizedTranscriptText(String(result.text.characters)) else {
-                        if result.isFinal {
-                            await self.previewTranslationCoordinator?.reset()
-                            await MainActor.run {
-                                store.clearUnconfirmedSegments(forSource: label)
-                            }
-                        }
-                        continue
-                    }
-
-                    let startSeconds = result.range.start.seconds
-                    let endSeconds = result.range.end.seconds
-
-                    let startDate = recordingStartTime.addingTimeInterval(
-                        startSeconds.isFinite ? startSeconds : 0
-                    )
-                    let endDate = recordingStartTime.addingTimeInterval(
-                        endSeconds.isFinite ? endSeconds : 0
-                    )
-
-                    let segment = TranscriptSegment(
-                        sessionId: recordingSessionId,
-                        startTime: startDate,
-                        endTime: endDate,
-                        text: text,
-                        isConfirmed: result.isFinal,
-                        speakerLabel: label
-                    )
-
-                    if result.isFinal {
-                        await self.previewTranslationCoordinator?.reset()
-                        await MainActor.run {
-                            store.clearUnconfirmedSegments(forSource: label)
-                            store.addSegment(segment)
-                        }
-                        if let translateSegment = self.translateSegment {
-                            Task {
-                                guard let translatedText = await translateSegment(segment) else { return }
-                                await MainActor.run {
-                                    store.updateTranslatedText(for: segment.id, translatedText: translatedText)
-                                }
-                            }
-                        }
-                    } else {
-                        let unconfirmedSegment = await MainActor.run {
-                            store.updateUnconfirmedSegment(segment, forSource: label)
-                        }
-                        await self.previewTranslationCoordinator?.unconfirmedSegmentDidChange(unconfirmedSegment) { segmentID, translatedText in
-                            store.updateTranslatedText(for: segmentID, translatedText: translatedText)
-                        }
-                    }
-                }
-            } catch {
-                print("[SpeechTranscriberService] 結果イテレーションエラー: \(error)")
-            }
+            await self?.consumeResults(
+                from: transcriber,
+                recordingStartTime: recordingStartTime,
+                recordingSessionId: recordingSessionId,
+                onEvent: onEvent
+            )
         }
     }
 
     /// ストリーミング文字起こしを停止する。残りのバッファを処理してから終了。
-    func stopStreaming() async {
-        await previewTranslationCoordinator?.reset()
+    func stopStreaming() async throws {
+        await previewTranslationCoordinator?.cancelPending()
+        let runningResultTask = resultTask
+        var finalizationError: Error?
         do {
             try await analyzer?.finalizeAndFinishThroughEndOfInput()
         } catch {
-            print("[SpeechTranscriberService] 終了処理エラー: \(error)")
+            await reportFailure(error)
+            finalizationError = error
+            runningResultTask?.cancel()
+            await analyzer?.cancelAndFinishNow()
         }
 
         // 結果イテレーションタスクの完了を待機
-        await resultTask?.value
+        await runningResultTask?.value
         resultTask = nil
+        // finalize 中に届いた最後の preview が翻訳を開始している可能性がある。
+        await previewTranslationCoordinator?.reset()
+        await finishFinalTranslations(cancel: false)
+        await clearPreview()
+        let completionError = finalizationError ?? streamingFailure
+        clearStreamingContext()
+
+        if let completionError {
+            throw completionError
+        }
     }
 
     /// 即時キャンセル。残りのバッファは破棄する。
     func cancel() async {
-        await previewTranslationCoordinator?.reset()
+        await previewTranslationCoordinator?.cancelPending()
+        let runningResultTask = resultTask
+        runningResultTask?.cancel()
         await analyzer?.cancelAndFinishNow()
-        resultTask?.cancel()
+        await runningResultTask?.value
         resultTask = nil
+        // 最初の reset 後に結果タスクが登録した preview 翻訳も確実に終了させる。
+        await previewTranslationCoordinator?.reset()
+        await finishFinalTranslations(cancel: true)
+        await clearPreview()
+        clearStreamingContext()
     }
 
     /// 状態をリセットする。
     func reset() async {
-        await previewTranslationCoordinator?.reset()
-        resultTask?.cancel()
+        await previewTranslationCoordinator?.cancelPending()
+        let runningResultTask = resultTask
+        runningResultTask?.cancel()
+        await analyzer?.cancelAndFinishNow()
+        await runningResultTask?.value
         resultTask = nil
+        await previewTranslationCoordinator?.reset()
+        await finishFinalTranslations(cancel: true)
+        await clearPreview()
+        clearStreamingContext()
         analyzer = nil
         transcriber = nil
         bestFormat = nil
+    }
+
+    private func consumeResults(
+        from transcriber: SpeechTranscriber,
+        recordingStartTime: Date,
+        recordingSessionId: UUID,
+        onEvent: @escaping EventHandler
+    ) async {
+        do {
+            for try await result in transcriber.results {
+                guard !Task.isCancelled else { return }
+
+                let label = speakerLabel
+                guard let text = Self.normalizedTranscriptText(String(result.text.characters)) else {
+                    if result.isFinal {
+                        await previewTranslationCoordinator?.cancelPending()
+                        previewSegmentID = nil
+                        await onEvent(.clearPreview(sessionId: recordingSessionId, sourceLabel: label))
+                    }
+                    continue
+                }
+
+                let startSeconds = result.range.start.seconds
+                let endSeconds = result.range.end.seconds
+                let segment = TranscriptSegment(
+                    id: segmentID(forFinalResult: result.isFinal),
+                    sessionId: recordingSessionId,
+                    startTime: recordingStartTime.addingTimeInterval(startSeconds.isFinite ? startSeconds : 0),
+                    endTime: recordingStartTime.addingTimeInterval(endSeconds.isFinite ? endSeconds : 0),
+                    text: text,
+                    isConfirmed: result.isFinal,
+                    speakerLabel: label
+                )
+
+                if result.isFinal {
+                    await previewTranslationCoordinator?.cancelPending()
+                    previewSegmentID = nil
+                    await onEvent(.clearPreview(sessionId: recordingSessionId, sourceLabel: label))
+                    await onEvent(.finalized(segment))
+
+                    startFinalTranslation(
+                        for: segment,
+                        recordingSessionId: recordingSessionId,
+                        onEvent: onEvent
+                    )
+                } else {
+                    await onEvent(.preview(segment))
+                    await previewTranslationCoordinator?.unconfirmedSegmentDidChange(segment) { segmentID, translatedText in
+                        await onEvent(
+                            .translation(
+                                sessionId: recordingSessionId,
+                                segmentID: segmentID,
+                                translatedText: translatedText
+                            )
+                        )
+                    }
+                }
+            }
+        } catch {
+            guard !Task.isCancelled, !(error is CancellationError) else { return }
+            await reportFailure(error)
+        }
+    }
+
+    private func segmentID(forFinalResult isFinal: Bool) -> UUID {
+        if let previewSegmentID {
+            return previewSegmentID
+        }
+
+        let id = UUID.v7()
+        if !isFinal {
+            previewSegmentID = id
+        }
+        return id
+    }
+
+    private func reportFailure(_ error: Error) async {
+        if streamingFailure == nil {
+            streamingFailure = error
+        }
+        guard !hasReportedFailure,
+              let activeSessionId,
+              let eventHandler else { return }
+        hasReportedFailure = true
+        await eventHandler(.failure(
+            sessionId: activeSessionId,
+            pipelineID: pipelineID,
+            sourceLabel: speakerLabel,
+            message: error.localizedDescription
+        ))
+    }
+
+    private func startFinalTranslation(
+        for segment: TranscriptSegment,
+        recordingSessionId: UUID,
+        onEvent: @escaping EventHandler
+    ) {
+        guard let translateSegment else { return }
+        let taskID = UUID.v7()
+        finalTranslationTasks[taskID] = Task { [weak self] in
+            let translatedText = await translateSegment(segment)
+            if !Task.isCancelled {
+                await onEvent(.translation(
+                    sessionId: recordingSessionId,
+                    segmentID: segment.id,
+                    translatedText: translatedText
+                ))
+            }
+            await self?.finalTranslationDidFinish(taskID: taskID)
+        }
+    }
+
+    private func finalTranslationDidFinish(taskID: UUID) {
+        finalTranslationTasks[taskID] = nil
+    }
+
+    private func finishFinalTranslations(cancel: Bool) async {
+        while !finalTranslationTasks.isEmpty {
+            let tasks = Array(finalTranslationTasks.values)
+            finalTranslationTasks.removeAll()
+            if cancel {
+                tasks.forEach { $0.cancel() }
+            }
+            for task in tasks {
+                await task.value
+            }
+        }
+    }
+
+    private func clearPreview() async {
+        guard let activeSessionId,
+              let eventHandler else { return }
+        await eventHandler(.clearPreview(sessionId: activeSessionId, sourceLabel: speakerLabel))
+        previewSegmentID = nil
+    }
+
+    private func clearStreamingContext() {
+        activeSessionId = nil
+        eventHandler = nil
+        previewSegmentID = nil
+        hasReportedFailure = false
+        streamingFailure = nil
     }
 }

--- a/Sources/Dahlia/Utilities/AudioConverter.swift
+++ b/Sources/Dahlia/Utilities/AudioConverter.swift
@@ -9,7 +9,7 @@ enum AudioConverter {
         using converter: AVAudioConverter
     ) -> AVAudioPCMBuffer? {
         let ratio = targetFormat.sampleRate / inputBuffer.format.sampleRate
-        let outputFrameCount = AVAudioFrameCount(Double(inputBuffer.frameLength) * ratio)
+        let outputFrameCount = AVAudioFrameCount(ceil(Double(inputBuffer.frameLength) * ratio))
         guard outputFrameCount > 0 else { return nil }
 
         guard let outputBuffer = AVAudioPCMBuffer(

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -169,6 +169,8 @@ enum L10n {
     static var stop: String { String(localized: "Stop", bundle: bundle) }
     static var startRecording: String { String(localized: "Start Recording", bundle: bundle) }
     static var stopRecording: String { String(localized: "Stop Recording", bundle: bundle) }
+    static var recordingSessionAlreadyActive: String { String(localized: "A recording session is already active.", bundle: bundle) }
+    static var recordingSessionNotActive: String { String(localized: "No recording session is active.", bundle: bundle) }
     static var stopTranscribing: String { String(localized: "Stop transcribing", bundle: bundle) }
     static var pause: String { String(localized: "Pause", bundle: bundle) }
     static var resume: String { String(localized: "Resume", bundle: bundle) }
@@ -209,12 +211,22 @@ enum L10n {
     static func percent(_ count: Int) -> String { String(localized: "\(count)%", bundle: bundle) }
     static var showLiveSubtitles: String { String(localized: "Show Live Subtitles", bundle: bundle) }
     static var hideLiveSubtitles: String { String(localized: "Hide Live Subtitles", bundle: bundle) }
+    static var liveSubtitles: String { String(localized: "Live Subtitles", bundle: bundle) }
+    static var subtitles: String { String(localized: "Subtitles", bundle: bundle) }
+    static var liveSubtitlesOnStatus: String { String(localized: "Live subtitles on", bundle: bundle) }
+    static var liveSubtitlesOffStatus: String { String(localized: "Live subtitles off", bundle: bundle) }
     static var liveSubtitleOverlay: String { String(localized: "Live Subtitle Overlay", bundle: bundle) }
-    static var liveSubtitleOverlayDescription: String { String(
-        localized: "Configure how the desktop live subtitle overlay is shown while recording.",
+    static var liveSubtitleOverlayToggleDescription: String { String(
+        localized: "Show live subtitles when recording starts.",
         bundle: bundle
     ) }
-    static var subtitles: String { String(localized: "Subtitles", bundle: bundle) }
+    static var liveSubtitleOverlayDescription: String {
+        [
+            String(localized: "Live subtitles are available with both real-time and batch transcription.", bundle: bundle),
+            String(localized: "In batch mode, subtitles are temporary and the final transcript is created after recording stops.", bundle: bundle),
+        ].joined(separator: " ")
+    }
+
     static var systemAudioOnly: String { String(localized: "System Audio Only", bundle: bundle) }
     static var includeMicrophone: String { String(localized: "Include Microphone", bundle: bundle) }
     static var liveSubtitleSourceDescription: String { String(
@@ -224,6 +236,10 @@ enum L10n {
     static var liveSubtitleOverlaySegmentCount: String { String(localized: "Overlay Segment Count", bundle: bundle) }
     static var liveSubtitleOverlaySegmentCountDescription: String { String(
         localized: "Choose how many recent transcript segments the live subtitle overlay shows.",
+        bundle: bundle
+    ) }
+    static var liveSubtitleConversionFailed: String { String(
+        localized: "Live subtitles stopped because the audio format could not be converted.",
         bundle: bundle
     ) }
 
@@ -236,6 +252,11 @@ enum L10n {
     static var transcript: String { String(localized: "Transcript", bundle: bundle) }
     static var transcriptEmpty: String { String(localized: "No transcript yet.", bundle: bundle) }
     static var batchRecordingInProgress: String { String(localized: "Recording audio for transcription after recording stops…", bundle: bundle) }
+    static var batchTranscriptionAwaitingConfirmation: String { String(
+        localized: "Audio is ready. Confirm the language to start transcription.",
+        bundle: bundle
+    ) }
+    static var reviewBatchTranscription: String { String(localized: "Review and Start", bundle: bundle) }
     static var batchTranscriptionQueued: String { String(localized: "Waiting to transcribe the recording…", bundle: bundle) }
     static var batchTranscriptionRunning: String { String(localized: "Creating a high-accuracy transcript…", bundle: bundle) }
     static var batchTranscriptionCompleted: String { String(localized: "High-accuracy transcription completed.", bundle: bundle) }
@@ -244,6 +265,12 @@ enum L10n {
     }
 
     static var retryBatchTranscription: String { String(localized: "Retry Batch Transcription", bundle: bundle) }
+    static var batchTranscriptionConfirmationTitle: String { String(localized: "Start batch transcription?", bundle: bundle) }
+    static var batchTranscriptionConfirmationDescription: String { String(
+        localized: "The recording will be transcribed using the selected language. The audio is kept until transcription succeeds.",
+        bundle: bundle
+    ) }
+    static var later: String { String(localized: "Later", bundle: bundle) }
     static var discardFailedBatchRecording: String { String(localized: "Discard Failed Recording", bundle: bundle) }
     static var discardFailedBatchRecordingConfirmation: String { String(localized: "Discard this failed recording?", bundle: bundle) }
     static var discardFailedBatchRecordingDescription: String { String(
@@ -252,6 +279,14 @@ enum L10n {
     ) }
     static var cancel: String { String(localized: "Cancel", bundle: bundle) }
     static var batchAudioBufferInvalid: String { String(localized: "The recorded audio format is invalid.", bundle: bundle) }
+    static var batchAudioBufferOverflow: String { String(
+        localized: "The audio writer could not keep up with the recording.",
+        bundle: bundle
+    ) }
+    static var batchAudioWriterClosed: String { String(
+        localized: "The audio writer was closed before the buffer was saved.",
+        bundle: bundle
+    ) }
     static func batchAudioWriteFailed(_ reason: String) -> String {
         String(localized: "Could not save the recording: \(reason)", bundle: bundle)
     }

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -267,7 +267,8 @@ enum L10n {
     static var retryBatchTranscription: String { String(localized: "Retry Batch Transcription", bundle: bundle) }
     static var batchTranscriptionConfirmationTitle: String { String(localized: "Start batch transcription?", bundle: bundle) }
     static var batchTranscriptionConfirmationDescription: String { String(
-        localized: "The recording will be transcribed using the selected language. The audio is kept until transcription succeeds.",
+        // swiftlint:disable:next line_length
+        localized: "The selected language is used for single-language recordings. Language changes made during recording are preserved. The audio is kept until transcription succeeds.",
         bundle: bundle
     ) }
     static var later: String { String(localized: "Later", bundle: bundle) }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Combine
 import CoreAudio
+import CoreMedia
 import GRDB
 import os
 @preconcurrency import ScreenCaptureKit
@@ -48,8 +49,38 @@ private struct PersistenceStartRequest {
     let recordingStartTime: Date
     let recordingSessionId: UUID
     let transcriptionMode: TranscriptionMode
+    let persistencePolicy: TranscriptPersistencePolicy
     let retainAudioAfterBatch: Bool
     let draftMeeting: DraftMeeting?
+}
+
+private struct RecordingStartRollbackState {
+    let segments: [TranscriptSegment]
+    let recordingSessions: [RecordingSessionTimeline]
+    let recordingStartTime: Date?
+}
+
+private struct RecordingControllerStartRequest {
+    let dbQueue: DatabaseQueue
+    let meetingId: UUID?
+    let sessionId: UUID
+    let startedAt: Date
+    let plan: TranscriptionSessionPlan
+    let locale: Locale
+    let batchSampleRate: Double?
+}
+
+private enum RecordingLifecycle: Equatable {
+    case idle
+    case starting(UUID)
+    case recording(UUID)
+    case stopping(UUID)
+}
+
+private struct RecordingPipelineFailure: LocalizedError {
+    let message: String
+
+    var errorDescription: String? { message }
 }
 
 /// 音声キャプチャ → Speech フレームワーク文字起こし → UI 更新を統括するビューモデル。
@@ -64,12 +95,15 @@ final class CaptionViewModel: ObservableObject {
         }
     }
 
+    let liveCaptionStore = LiveCaptionStore()
+
     @Published var isListening = false
     @Published var isFinalizingRecording = false
     @Published var analyzerReady = false
     @Published var isPreparingAnalyzer = false
     @Published private(set) var activeTranscriptionMode: TranscriptionMode?
     @Published private(set) var batchTranscriptionState: BatchTranscriptionState?
+    @Published var pendingBatchTranscriptionConfirmation: BatchTranscriptionConfirmation?
     @Published var errorMessage: String?
     @Published var availableMicrophones: [MicrophoneDevice] = []
     @Published var microphoneSelection: MicrophoneSelection = .systemDefault
@@ -196,6 +230,23 @@ final class CaptionViewModel: ObservableObject {
     /// 少なくとも 1 つの音声ソースが有効か。
     var hasEnabledAudioSource: Bool { isMicEnabled || isSystemAudioEnabled }
 
+    var canBeginRecording: Bool {
+        recordingLifecycle == .idle
+            && !isFinalizingRecording
+            && hasEnabledAudioSource
+    }
+
+    private var enabledRecordingAudioSources: Set<RecordingAudioSource> {
+        var sources: Set<RecordingAudioSource> = []
+        if isMicEnabled {
+            sources.insert(.microphone)
+        }
+        if isSystemAudioEnabled {
+            sources.insert(.system)
+        }
+        return sources
+    }
+
     // MARK: - Recording Context (録音中のナビゲーション時に保持)
 
     /// 録音中に別トランスクリプトへナビゲーションした際の録音コンテキスト。
@@ -229,15 +280,24 @@ final class CaptionViewModel: ObservableObject {
     // MARK: - Private
 
     private var currentDbQueue: DatabaseQueue?
-    private var audioManager: AudioCaptureManager?
-    private var systemAudioManager: SystemAudioCaptureManager?
-    private var pipelines: [(service: SpeechTranscriberService, bridge: AudioBufferBridge)] = []
     private var persistenceService: MeetingPersistenceService?
-    private var batchAudioRecordingSession: BatchAudioRecordingSession?
     private var batchTranscriptionCoordinator: BatchTranscriptionCoordinator?
+    private let recordingSessionController = RecordingSessionController()
+    private var activeTranscriptionPlan: TranscriptionSessionPlan?
+    private var activeRecordingSessionId: UUID?
+    private var activeControllerSources: Set<RecordingAudioSource> = []
+    private var recordingLifecycle: RecordingLifecycle = .idle
+    private var recordingConfigurationTasks: [Int: Task<Void, Never>] = [:]
+    private var nextRecordingConfigurationID = 0
+    private var pendingRealtimeRecognitionFailure: (source: RecordingAudioSource?, message: String)?
+    private var pendingLiveSubtitleWarning: String?
+    private var startingMicrophoneSelection: MicrophoneSelection?
+    private var startingSystemAudioEnabled: Bool?
+    private var startingLocaleIdentifier: String?
     private var settingsCancellable: AnyCancellable?
     private var storeSegmentsCancellable: AnyCancellable?
     private var transcriptionLocaleCancellable: AnyCancellable?
+    private var liveSubtitleSettingsCancellable: AnyCancellable?
     private var automaticScreenshotSettingsCancellables: Set<AnyCancellable> = []
     private var automaticScreenshotTask: Task<Void, Never>?
     private var lastSavedAutomaticScreenshotFingerprint: ScreenshotFingerprint?
@@ -285,6 +345,14 @@ final class CaptionViewModel: ObservableObject {
                 self.selectedLocale = localeIdentifier
             }
 
+        liveSubtitleSettingsCancellable = UserDefaults.standard
+            .publisher(for: \.liveSubtitleOverlayEnabled)
+            .removeDuplicates()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] isEnabled in
+                self?.handleLiveSubtitleSettingChange(isEnabled: isEnabled)
+            }
+
         UserDefaults.standard
             .publisher(for: \.automaticScreenshotEnabled)
             .removeDuplicates()
@@ -324,6 +392,58 @@ final class CaptionViewModel: ObservableObject {
         }
     }
 
+    func batchTranscriptionLocaleOptions(preferredIdentifier: String) -> [Locale] {
+        var locales = filteredLocales.isEmpty ? supportedLocales : filteredLocales
+        if !locales.contains(where: { $0.identifier == preferredIdentifier }) {
+            locales.append(Locale(identifier: preferredIdentifier))
+        }
+        return locales.sortedByLocalizedName()
+    }
+
+    func presentBatchTranscriptionConfirmation() {
+        guard case let .awaitingConfirmation(sessionId) = batchTranscriptionState,
+              let meetingId = currentMeetingId else { return }
+        presentBatchTranscriptionConfirmation(
+            sessionId: sessionId,
+            meetingId: meetingId,
+            suggestedLocaleIdentifier: selectedLocale
+        )
+    }
+
+    func postponeBatchTranscription() {
+        pendingBatchTranscriptionConfirmation = nil
+    }
+
+    func confirmBatchTranscription(localeIdentifier: String) {
+        guard let confirmation = pendingBatchTranscriptionConfirmation,
+              let coordinator = batchTranscriptionCoordinator else { return }
+        let retryConfirmation = BatchTranscriptionConfirmation(
+            sessionId: confirmation.sessionId,
+            meetingId: confirmation.meetingId,
+            suggestedLocaleIdentifier: localeIdentifier
+        )
+        pendingBatchTranscriptionConfirmation = nil
+        if currentMeetingId == confirmation.meetingId {
+            batchTranscriptionState = .queued(sessionId: confirmation.sessionId)
+        }
+
+        Task {
+            do {
+                try await coordinator.confirmAndEnqueue(
+                    sessionId: confirmation.sessionId,
+                    localeIdentifier: localeIdentifier
+                )
+            } catch {
+                if currentMeetingId == confirmation.meetingId {
+                    batchTranscriptionState = .awaitingConfirmation(sessionId: confirmation.sessionId)
+                }
+                errorMessage = error.localizedDescription
+                pendingBatchTranscriptionConfirmation = retryConfirmation
+                MainWindowOpener.shared.openMainWindow()
+            }
+        }
+    }
+
     func discardFailedBatchTranscription() {
         guard case let .failed(sessionId, _) = batchTranscriptionState,
               let meetingId = currentMeetingId,
@@ -353,12 +473,17 @@ final class CaptionViewModel: ObservableObject {
             .first(where: \.blocksSummaryGeneration)
     }
 
-    private func handleBatchTranscriptionUpdate(_ update: BatchTranscriptionUpdate) async {
+    func handleBatchTranscriptionUpdate(_ update: BatchTranscriptionUpdate) async {
         guard currentMeetingId == update.meetingId,
               !(isBatchRecording && recordingMeetingId == update.meetingId) else { return }
         batchTranscriptionState = update.state
-        guard case .completed = update.state, !isListening else { return }
+        guard case .completed = update.state,
+              canReloadMeetingAfterBatchCompletion(update.meetingId) else { return }
         await reloadCurrentMeetingAfterBatchCompletion(meetingId: update.meetingId)
+    }
+
+    private func canReloadMeetingAfterBatchCompletion(_ meetingId: UUID) -> Bool {
+        !isListening || recordingMeetingId != meetingId
     }
 
     private func reloadCurrentMeetingAfterBatchCompletion(meetingId: UUID) async {
@@ -375,7 +500,8 @@ final class CaptionViewModel: ObservableObject {
                     vaultURL: vaultURL
                 )
             }.value
-            guard currentMeetingId == meetingId, !isListening else { return }
+            guard currentMeetingId == meetingId,
+                  canReloadMeetingAfterBatchCompletion(meetingId) else { return }
             store.recordingStartTime = loaded.createdAt
             store.loadRecordingSessions(loaded.recordingSessions)
             store.loadSegments(loaded.segments)
@@ -938,117 +1064,132 @@ final class CaptionViewModel: ObservableObject {
 
     func handleMicrophoneSelectionChange(from oldSelection: MicrophoneSelection, to newSelection: MicrophoneSelection) {
         guard oldSelection != newSelection else { return }
-        applyAudioSourceSelectionChange { self.microphoneSelection = oldSelection }
+        if case .starting = recordingLifecycle, let startingMicrophoneSelection {
+            if newSelection != startingMicrophoneSelection {
+                microphoneSelection = startingMicrophoneSelection
+            }
+            return
+        }
+        applyAudioSourceSelectionChange(source: .microphone) { self.microphoneSelection = oldSelection }
     }
 
     func handleSystemAudioSelectionChange(from oldValue: Bool, to newValue: Bool) {
         guard oldValue != newValue else { return }
-        applyAudioSourceSelectionChange { self.isSystemAudioEnabled = oldValue }
+        if case .starting = recordingLifecycle, let startingSystemAudioEnabled {
+            if newValue != startingSystemAudioEnabled {
+                isSystemAudioEnabled = startingSystemAudioEnabled
+            }
+            return
+        }
+        applyAudioSourceSelectionChange(source: .system) { self.isSystemAudioEnabled = oldValue }
     }
 
     private func applyLocaleChange(from oldLocale: String, to newLocale: String) {
         guard newLocale != oldLocale || !analyzerReady else { return }
+        if case .starting = recordingLifecycle, let startingLocaleIdentifier {
+            if newLocale != startingLocaleIdentifier {
+                selectedLocale = startingLocaleIdentifier
+            }
+            AppSettings.shared.transcriptionLocale = startingLocaleIdentifier
+            return
+        }
         AppSettings.shared.transcriptionLocale = newLocale
 
         if isListening {
-            Task { await rebuildPipelines(reason: .localeChange) }
+            enqueueRecordingConfiguration { [weak self] recordingSessionId in
+                _ = await self?.rebuildPipelines(
+                    reason: .localeChange,
+                    recordingSessionId: recordingSessionId
+                )
+            }
         } else {
             analyzerReady = false
-            pipelines.removeAll()
             prepareAnalyzer()
         }
     }
 
-    private func applyAudioSourceSelectionChange(restoreSelection: @escaping @MainActor () -> Void) {
+    private func applyAudioSourceSelectionChange(
+        source: RecordingAudioSource,
+        restoreSelection: @escaping @MainActor () -> Void
+    ) {
         guard isListening else { return }
 
-        Task { @MainActor in
-            let applied = await rebuildPipelines(reason: .audioSourceChange)
+        enqueueRecordingConfiguration { [weak self] recordingSessionId in
+            guard let self else { return }
+            let applied = await self.rebuildPipelines(
+                reason: .audioSourceChange(source),
+                recordingSessionId: recordingSessionId
+            )
             if !applied {
                 restoreSelection()
+                if self.activeControllerSources.isEmpty {
+                    self.stopListening()
+                }
             }
         }
     }
 
     private enum PipelineRebuildReason {
         case localeChange
-        case audioSourceChange
+        case audioSourceChange(RecordingAudioSource)
     }
 
     @discardableResult
-    private func rebuildPipelines(reason: PipelineRebuildReason) async -> Bool {
-        await stopActivePipelines()
-        stopActiveCaptures()
+    private func rebuildPipelines(
+        reason: PipelineRebuildReason,
+        recordingSessionId: UUID
+    ) async -> Bool {
+        guard recordingLifecycle == .recording(recordingSessionId) else { return false }
         do {
-            try await batchAudioRecordingSession?.endActiveRanges()
+            let snapshot: RecordingSessionController.Snapshot
+            switch reason {
+            case .localeChange:
+                let locale = resolvedSelectedLocale()
+                snapshot = try await recordingSessionController.changeLocale(
+                    to: locale,
+                    translateSegment: translationHandler(for: locale)
+                )
+            case let .audioSourceChange(source):
+                let locale = resolvedSelectedLocale()
+                snapshot = try await recordingSessionController.setSource(
+                    controllerSourceConfiguration(for: source),
+                    enabled: enabledRecordingAudioSources.contains(source),
+                    translateSegment: translationHandler(for: locale)
+                )
+            }
+            guard snapshot.sessionId == recordingSessionId else { return false }
+            activeControllerSources = snapshot.enabledSources
+            errorMessage = nil
+            return true
         } catch {
+            if let snapshot = await recordingSessionController.snapshot(),
+               snapshot.sessionId == recordingSessionId {
+                activeControllerSources = snapshot.enabledSources
+            }
             setPipelineRebuildError(error, reason: reason)
             return false
         }
-
-        let primaryLocale = resolvedSelectedLocale()
-        let sourceError: Error?
-        if activeTranscriptionMode == .batch {
-            sourceError = await firstAudioSourceError(
-                startMicrophone: { try await self.startMicrophoneBatchCapture(locale: primaryLocale) },
-                startSystemAudio: { try await self.startSystemAudioBatchCapture(locale: primaryLocale) }
-            )
-        } else {
-            do {
-                try await SpeechTranscriberService.ensureModelInstalled(locale: primaryLocale)
-            } catch {
-                setPipelineRebuildError(error, reason: reason)
-                return false
-            }
-            let recordingStartTime = Date.now
-            let recordingSessionId = persistenceService?.recordingSessionId ?? .v7()
-            sourceError = await firstAudioSourceError(
-                startMicrophone: {
-                    try await self.startMicrophonePipeline(
-                        locale: primaryLocale,
-                        recordingStartTime: recordingStartTime,
-                        recordingSessionId: recordingSessionId
-                    )
-                },
-                startSystemAudio: {
-                    try await self.startSystemAudioPipeline(
-                        locale: primaryLocale,
-                        recordingStartTime: recordingStartTime,
-                        recordingSessionId: recordingSessionId
-                    )
-                }
-            )
-            analyzerReady = true
-        }
-
-        if let sourceError {
-            setPipelineRebuildError(sourceError, reason: reason)
-            return false
-        }
-        errorMessage = nil
-        return true
     }
 
-    private func firstAudioSourceError(
-        startMicrophone: () async throws -> Void,
-        startSystemAudio: () async throws -> Void
-    ) async -> Error? {
-        var errors: [Error] = []
-        if isMicEnabled {
-            do {
-                try await startMicrophone()
-            } catch {
-                errors.append(error)
-            }
+    private func enqueueRecordingConfiguration(
+        _ operation: @escaping @MainActor (UUID) async -> Void
+    ) {
+        guard case let .recording(recordingSessionId) = recordingLifecycle else { return }
+
+        nextRecordingConfigurationID += 1
+        let operationID = nextRecordingConfigurationID
+        let previousTask = recordingConfigurationTasks
+            .max(by: { $0.key < $1.key })?
+            .value
+        let task = Task { @MainActor [weak self] in
+            await previousTask?.value
+            guard let self else { return }
+            defer { self.recordingConfigurationTasks[operationID] = nil }
+            guard !Task.isCancelled,
+                  self.recordingLifecycle == .recording(recordingSessionId) else { return }
+            await operation(recordingSessionId)
         }
-        if isSystemAudioEnabled {
-            do {
-                try await startSystemAudio()
-            } catch {
-                errors.append(error)
-            }
-        }
-        return errors.first
+        recordingConfigurationTasks[operationID] = task
     }
 
     private func setPipelineRebuildError(_ error: Error, reason: PipelineRebuildReason) {
@@ -1060,110 +1201,12 @@ final class CaptionViewModel: ObservableObject {
         }
     }
 
-    private func stopActiveCaptures() {
-        audioManager?.onAudioBuffer = nil
-        audioManager?.stopCapture()
-        audioManager = nil
-
-        systemAudioManager?.onAudioBuffer = nil
-        systemAudioManager?.onStreamStopped = nil
-        systemAudioManager?.stopCapture()
-        systemAudioManager = nil
-    }
-
-    private func stopActivePipelines() async {
-        for pipeline in pipelines {
-            pipeline.bridge.finish()
-            await pipeline.service.stopStreaming()
-        }
-        pipelines.removeAll()
-    }
-
-    private func startMicrophonePipeline(locale: Locale, recordingStartTime: Date, recordingSessionId: UUID) async throws {
-        let hasMicPermission = await AudioCaptureManager.requestMicrophonePermission()
-        guard hasMicPermission else {
-            throw AudioCaptureError.microphonePermissionDenied
-        }
-
-        let (service, bridge, format) = try await buildPipeline(
-            locale: locale,
-            speakerLabel: "mic",
-            recordingStartTime: recordingStartTime,
-            recordingSessionId: recordingSessionId
-        )
-        try startMicrophoneCapture(
-            bridge: bridge,
-            targetFormat: format,
-            selectedDeviceID: selectedMicrophoneID
-        )
-        pipelines.append((service: service, bridge: bridge))
-    }
-
-    private func startSystemAudioPipeline(locale: Locale, recordingStartTime: Date, recordingSessionId: UUID) async throws {
-        let (service, bridge, format) = try await buildPipeline(
-            locale: locale,
-            speakerLabel: "system",
-            recordingStartTime: recordingStartTime,
-            recordingSessionId: recordingSessionId
-        )
-        try await startSystemAudioCapture(bridge: bridge, targetFormat: format)
-        pipelines.append((service: service, bridge: bridge))
-    }
-
-    private func startMicrophoneBatchCapture(locale: Locale) async throws {
-        let hasMicPermission = await AudioCaptureManager.requestMicrophonePermission()
-        guard hasMicPermission else {
-            throw AudioCaptureError.microphonePermissionDenied
-        }
-        guard let batchAudioRecordingSession else {
-            throw BatchAudioFileWriterError.incompatibleBuffer
-        }
-        let writer = try await batchAudioRecordingSession.beginRange(source: .microphone, locale: locale)
-        let manager = AudioCaptureManager()
-        manager.onAudioBuffer = { [writer] buffer in
-            writer.appendBuffer(buffer)
-        }
-        try manager.startCapture(
-            targetFormat: batchAudioRecordingSession.targetFormat,
-            selectedDeviceID: selectedMicrophoneID,
-            bufferSize: 1024
-        )
-        audioManager = manager
-    }
-
-    private func startSystemAudioBatchCapture(locale: Locale) async throws {
-        let hasPermission = await SystemAudioCaptureManager.requestPermission()
-        guard hasPermission else {
-            throw SystemAudioCaptureError.screenRecordingPermissionDenied
-        }
-        guard let batchAudioRecordingSession else {
-            throw BatchAudioFileWriterError.incompatibleBuffer
-        }
-        let writer = try await batchAudioRecordingSession.beginRange(source: .system, locale: locale)
-        let manager = SystemAudioCaptureManager()
-        manager.onAudioBuffer = { [writer] buffer in
-            writer.appendBuffer(buffer)
-        }
-        manager.onStreamStopped = { [weak self] error in
-            Task { @MainActor in
-                self?.errorMessage = error?.localizedDescription ?? L10n.systemAudioCaptureStopped
-                if self?.audioManager == nil {
-                    self?.stopListening()
-                }
-            }
-        }
-        try await manager.startCapture(targetFormat: batchAudioRecordingSession.targetFormat)
-        systemAudioManager = manager
-    }
-
     private func prepareRecordingStart(
         existingMeetingId: UUID?,
         dbQueue: DatabaseQueue,
         recordingStartTime: Date
     ) -> MeetingRepository.AppendRecordingContext? {
-        pipelines.removeAll()
         persistenceService = nil
-        batchAudioRecordingSession = nil
         stopAutomaticScreenshotCapture()
 
         guard let existingMeetingId else {
@@ -1186,65 +1229,45 @@ final class CaptionViewModel: ObservableObject {
         return context
     }
 
-    private func prepareCapture(
-        mode: TranscriptionMode,
-        locale: Locale,
-        recordingStartTime: Date,
-        recordingSessionId: UUID
-    ) async throws -> Double? {
-        guard mode == .realtime else {
-            return try await BatchSpeechTranscriberService.preferredSampleRate(locale: locale)
-        }
-
-        try await SpeechTranscriberService.ensureModelInstalled(locale: locale)
-        if isMicEnabled {
-            try await startMicrophonePipeline(
-                locale: locale,
-                recordingStartTime: recordingStartTime,
-                recordingSessionId: recordingSessionId
-            )
-        }
-        if isSystemAudioEnabled {
-            try await startSystemAudioPipeline(
-                locale: locale,
-                recordingStartTime: recordingStartTime,
-                recordingSessionId: recordingSessionId
-            )
-        }
-        return nil
+    private func batchRecordingSampleRate(for plan: TranscriptionSessionPlan) -> Double? {
+        guard plan.recordsBatchAudio else { return nil }
+        return BatchAudioRecordingSession.standardSampleRate
     }
 
-    private func startBatchRecordingIfNeeded(
-        sampleRate: Double?,
-        dbQueue: DatabaseQueue,
-        meetingId: UUID?,
-        recordingSessionId: UUID,
-        recordingStartTime: Date,
-        locale: Locale
+    private func prepareAndStartRecordingController(
+        _ request: RecordingControllerStartRequest
     ) async throws {
-        guard let sampleRate, let meetingId else { return }
-        let recordingSession = try BatchAudioRecordingSession(
-            dbQueue: dbQueue,
-            meetingId: meetingId,
-            recordingSessionId: recordingSessionId,
-            recordingStartTime: recordingStartTime,
-            sampleRate: sampleRate
-        )
-        batchAudioRecordingSession = recordingSession
-        if isMicEnabled {
-            try await startMicrophoneBatchCapture(locale: locale)
+        try await recordingSessionController.prepare(
+            RecordingSessionController.PreparationRequest(
+                sessionId: request.sessionId,
+                startedAt: request.startedAt,
+                plan: request.plan,
+                locale: request.locale,
+                sources: controllerSourceConfigurations(plan: request.plan),
+                dbQueue: request.plan.recordsBatchAudio ? request.dbQueue : nil,
+                meetingId: request.plan.recordsBatchAudio ? request.meetingId : nil,
+                batchSampleRate: request.batchSampleRate,
+                translateSegment: translationHandler(for: request.locale),
+                batchScheduler: batchTranscriptionCoordinator
+            )
+        ) { [weak self] event in
+            self?.handleTranscriptionEvent(event)
+        } onRuntimeFailure: { [weak self] source, message, isFatal in
+            self?.handleControllerRuntimeFailure(
+                source: source,
+                message: message,
+                isFatal: isFatal,
+                recordingSessionId: request.sessionId
+            )
         }
-        if isSystemAudioEnabled {
-            try await startSystemAudioBatchCapture(locale: locale)
+        let snapshot = try await recordingSessionController.startPrepared()
+        activeControllerSources = snapshot.enabledSources
+        if request.plan.recordsBatchAudio {
+            batchTranscriptionState = .recording(sessionId: request.sessionId)
         }
-        batchTranscriptionState = .recording(sessionId: recordingSessionId)
     }
 
     private func canStartRecording() -> Bool {
-        guard analyzerReady else {
-            errorMessage = L10n.speechRecognitionNotReady
-            return false
-        }
         guard hasEnabledAudioSource else {
             errorMessage = L10n.noAudioSourceSelected
             return false
@@ -1252,9 +1275,15 @@ final class CaptionViewModel: ObservableObject {
         return true
     }
 
-    private func markRecordingStarted() {
+    private func markRecordingStarted(recordingSessionId: UUID) {
+        guard recordingLifecycle == .starting(recordingSessionId) else { return }
+        recordingLifecycle = .recording(recordingSessionId)
+        startingMicrophoneSelection = nil
+        startingSystemAudioEnabled = nil
+        startingLocaleIdentifier = nil
         isListening = true
-        errorMessage = nil
+        errorMessage = pendingLiveSubtitleWarning
+        pendingLiveSubtitleWarning = nil
         syncAutomaticScreenshotCaptureState()
     }
 
@@ -1269,6 +1298,7 @@ final class CaptionViewModel: ObservableObject {
                 recordingOffsetSeconds: request.appendContext?.nextOffsetSeconds ?? 0,
                 recordingSessionId: request.recordingSessionId,
                 transcriptionMode: request.transcriptionMode,
+                persistencePolicy: request.persistencePolicy,
                 retainAudioAfterBatch: request.retainAudioAfterBatch
             )
             currentMeetingId = existingMeetingId
@@ -1285,6 +1315,7 @@ final class CaptionViewModel: ObservableObject {
             calendarEvent: request.draftMeeting?.linkedCalendarEvent,
             recordingSessionId: request.recordingSessionId,
             transcriptionMode: request.transcriptionMode,
+            persistencePolicy: request.persistencePolicy,
             retainAudioAfterBatch: request.retainAudioAfterBatch
         )
         currentMeetingId = persistenceService?.meetingId
@@ -1299,19 +1330,33 @@ final class CaptionViewModel: ObservableObject {
 
     private func handleRecordingStartFailure(
         _ error: Error,
+        recordingSessionId: UUID,
+        rollbackState: RecordingStartRollbackState,
         existingMeetingId: UUID?,
         previousBatchTranscriptionState: BatchTranscriptionState?
     ) async {
+        guard recordingLifecycle == .starting(recordingSessionId) else { return }
         errorMessage = error.localizedDescription
         ErrorReportingService.capture(error, context: ["source": "startListening"])
-        await stopActivePipelines()
-        stopActiveCaptures()
+        await recordingSessionController.abort()
         stopAutomaticScreenshotCapture()
-        await batchAudioRecordingSession?.cancelAndDelete()
-        batchAudioRecordingSession = nil
         persistenceService?.cancel()
         persistenceService = nil
         activeTranscriptionMode = nil
+        activeTranscriptionPlan = nil
+        activeRecordingSessionId = nil
+        activeControllerSources.removeAll()
+        pendingRealtimeRecognitionFailure = nil
+        pendingLiveSubtitleWarning = nil
+        startingMicrophoneSelection = nil
+        startingSystemAudioEnabled = nil
+        startingLocaleIdentifier = nil
+        liveCaptionStore.clear()
+        store.clear()
+        store.loadSegments(rollbackState.segments)
+        store.loadRecordingSessions(rollbackState.recordingSessions)
+        store.recordingStartTime = rollbackState.recordingStartTime
+        recordingLifecycle = .idle
         batchTranscriptionState = previousBatchTranscriptionState
         if existingMeetingId == nil {
             currentMeetingId = nil
@@ -1330,9 +1375,10 @@ final class CaptionViewModel: ObservableObject {
     ) {
         guard !isFinalizingRecording else { return }
 
-        if isListening {
+        switch recordingLifecycle {
+        case .recording:
             stopListening()
-        } else {
+        case .idle:
             Task {
                 await startListening(
                     dbQueue: dbQueue,
@@ -1343,6 +1389,8 @@ final class CaptionViewModel: ObservableObject {
                     vaultURL: vaultURL
                 )
             }
+        case .starting, .stopping:
+            break
         }
     }
 
@@ -1356,7 +1404,7 @@ final class CaptionViewModel: ObservableObject {
         vaultURL: URL,
         appendingTo existingMeetingId: UUID? = nil
     ) async {
-        guard !isListening, !isFinalizingRecording else { return }
+        guard recordingLifecycle == .idle, !isFinalizingRecording else { return }
         let previousBatchTranscriptionState = batchTranscriptionState
 
         self.currentProjectURL = projectURL
@@ -1368,24 +1416,50 @@ final class CaptionViewModel: ObservableObject {
         let activeDraftMeeting = draftMeeting
         guard canStartRecording() else { return }
 
-        let recordingStartTime = Date()
         let recordingSessionId = UUID.v7()
-        let appendContext = prepareRecordingStart(
-            existingMeetingId: existingMeetingId,
-            dbQueue: dbQueue,
-            recordingStartTime: recordingStartTime
+        let rollbackState = RecordingStartRollbackState(
+            segments: store.segments,
+            recordingSessions: store.recordingSessions,
+            recordingStartTime: store.recordingStartTime
         )
+        startingMicrophoneSelection = microphoneSelection
+        startingSystemAudioEnabled = isSystemAudioEnabled
+        startingLocaleIdentifier = selectedLocale
+        recordingLifecycle = .starting(recordingSessionId)
+        pendingRealtimeRecognitionFailure = nil
+        pendingLiveSubtitleWarning = nil
+        let transcriptionMode = AppSettings.shared.transcriptionMode
+        let retainAudioAfterBatch = transcriptionMode == .batch
+            && AppSettings.shared.retainAudioAfterBatchTranscription
+        var transcriptionPlan = TranscriptionSessionPlan(
+            finalMode: transcriptionMode,
+            liveSubtitlesEnabled: AppSettings.shared.liveSubtitleOverlayEnabled,
+            retainBatchAudio: retainAudioAfterBatch
+        )
+        let primaryLocale = resolvedSelectedLocale()
+        activeTranscriptionMode = transcriptionMode
+        activeTranscriptionPlan = transcriptionPlan
+        activeRecordingSessionId = recordingSessionId
+        if transcriptionPlan.liveSubtitlesEnabled {
+            liveCaptionStore.start(sessionId: recordingSessionId)
+        } else {
+            liveCaptionStore.clear()
+        }
+
         do {
-            let transcriptionMode = AppSettings.shared.transcriptionMode
-            let retainAudioAfterBatch = transcriptionMode == .batch
-                && AppSettings.shared.retainAudioAfterBatchTranscription
-            activeTranscriptionMode = transcriptionMode
-            let primaryLocale = resolvedSelectedLocale()
-            let batchSampleRate = try await prepareCapture(
-                mode: transcriptionMode,
-                locale: primaryLocale,
-                recordingStartTime: recordingStartTime,
+            let batchSampleRate = batchRecordingSampleRate(for: transcriptionPlan)
+            transcriptionPlan = try await reconcileStartingPlan(
+                transcriptionPlan,
                 recordingSessionId: recordingSessionId
+            )
+            activeTranscriptionPlan = transcriptionPlan
+            try ensureSessionIsActive(recordingSessionId)
+
+            let recordingStartTime = Date.now
+            let appendContext = prepareRecordingStart(
+                existingMeetingId: existingMeetingId,
+                dbQueue: dbQueue,
+                recordingStartTime: recordingStartTime
             )
 
             try startPersistence(
@@ -1398,25 +1472,38 @@ final class CaptionViewModel: ObservableObject {
                     recordingStartTime: recordingStartTime,
                     recordingSessionId: recordingSessionId,
                     transcriptionMode: transcriptionMode,
+                    persistencePolicy: transcriptionPlan.persistsRealtimeTranscript ? .streaming : .deferred,
                     retainAudioAfterBatch: retainAudioAfterBatch,
                     draftMeeting: activeDraftMeeting
                 )
             )
-
-            try await startBatchRecordingIfNeeded(
-                sampleRate: batchSampleRate,
+            try await prepareAndStartRecordingController(RecordingControllerStartRequest(
                 dbQueue: dbQueue,
                 meetingId: currentMeetingId,
-                recordingSessionId: recordingSessionId,
-                recordingStartTime: recordingStartTime,
-                locale: primaryLocale
+                sessionId: recordingSessionId,
+                startedAt: recordingStartTime,
+                plan: transcriptionPlan,
+                locale: primaryLocale,
+                batchSampleRate: batchSampleRate
+            ))
+
+            transcriptionPlan = try await reconcileStartingLiveConfiguration(
+                transcriptionPlan,
+                recordingSessionId: recordingSessionId
             )
 
+            if let failure = pendingRealtimeRecognitionFailure {
+                throw RecordingPipelineFailure(message: failure.message)
+            }
+
             completePersistenceStart(existingMeetingId: existingMeetingId)
-            markRecordingStarted()
+            markRecordingStarted(recordingSessionId: recordingSessionId)
+            pendingRealtimeRecognitionFailure = nil
         } catch {
             await handleRecordingStartFailure(
                 error,
+                recordingSessionId: recordingSessionId,
+                rollbackState: rollbackState,
                 existingMeetingId: existingMeetingId,
                 previousBatchTranscriptionState: previousBatchTranscriptionState
             )
@@ -1424,11 +1511,16 @@ final class CaptionViewModel: ObservableObject {
     }
 
     func stopListening() {
-        guard isListening, !isFinalizingRecording else { return }
+        guard case let .recording(activeSessionId) = recordingLifecycle,
+              isListening,
+              !isFinalizingRecording else { return }
 
+        recordingLifecycle = .stopping(activeSessionId)
         isFinalizingRecording = true
         stopAutomaticScreenshotCapture()
-        stopActiveCaptures()
+        let configurationTasks = Array(recordingConfigurationTasks.values)
+        configurationTasks.forEach { $0.cancel() }
+        recordingConfigurationTasks.removeAll()
         isListening = false
 
         // ナビゲーション済みの場合、録音コンテキストからデータを取得
@@ -1441,27 +1533,46 @@ final class CaptionViewModel: ObservableObject {
         let recordingStart = activeStore.timeBase
         let transcriptionMode = activeTranscriptionMode ?? .realtime
         let recordingSessionId = persistenceService?.recordingSessionId
-        let batchRecordingSession = batchAudioRecordingSession
-        batchAudioRecordingSession = nil
         recordingContext = nil
 
         Task {
-            await stopActivePipelines()
-            await finishBatchRecording(
-                batchRecordingSession,
-                recordingSessionId: recordingSessionId,
-                meetingId: meetingId
-            )
-            persistenceService?.stop()
+            for task in configurationTasks {
+                await task.value
+            }
+            var stopResult: RecordingSessionController.StopResult?
+            do {
+                stopResult = try await recordingSessionController.stop()
+            } catch {
+                ErrorReportingService.capture(error, context: ["source": "stopRecordingSession"])
+                await recordingSessionController.abort()
+            }
+            let persistenceResult = persistenceService?.stop()
+                ?? .failure(message: L10n.recordingSessionNotActive)
             persistenceService = nil
+            if let persistenceFailureMessage = persistenceResult.failureMessage {
+                errorMessage = persistenceFailureMessage
+            }
+            await recordingSessionController.completeStop()
             activeTranscriptionMode = nil
+            activeTranscriptionPlan = nil
+            activeRecordingSessionId = nil
+            activeControllerSources.removeAll()
+            pendingRealtimeRecognitionFailure = nil
+            pendingLiveSubtitleWarning = nil
+            startingMicrophoneSelection = nil
+            startingSystemAudioEnabled = nil
+            startingLocaleIdentifier = nil
+            liveCaptionStore.clear()
+            recordingLifecycle = .idle
             var segments = activeStore.segments
             let recordingSessions = activeStore.recordingSessions
             isFinalizingRecording = false
 
             if transcriptionMode == .batch, let recordingSessionId {
-                await completeBatchRecording(
-                    sessionId: recordingSessionId,
+                await finishStoppedBatchRecording(
+                    recordingSessionId: recordingSessionId,
+                    stopResult: stopResult,
+                    persistenceResult: persistenceResult,
                     meetingId: meetingId,
                     vaultURL: vaultURL,
                     dbQueue: dbQueue
@@ -1491,40 +1602,58 @@ final class CaptionViewModel: ObservableObject {
         }
     }
 
-    private func finishBatchRecording(
-        _ recordingSession: BatchAudioRecordingSession?,
-        recordingSessionId: UUID?,
-        meetingId: UUID?
-    ) async {
-        do {
-            try await recordingSession?.finish()
-        } catch {
-            if let recordingSessionId,
-               let coordinator = batchTranscriptionCoordinator {
-                await coordinator.recordRecordingFailure(sessionId: recordingSessionId, error: error)
-            }
-            if currentMeetingId == meetingId, let recordingSessionId {
-                batchTranscriptionState = .failed(
-                    sessionId: recordingSessionId,
-                    message: error.localizedDescription
-                )
-            }
-        }
-    }
-
-    private func completeBatchRecording(
-        sessionId: UUID,
+    private func finishStoppedBatchRecording(
+        recordingSessionId: UUID,
+        stopResult: RecordingSessionController.StopResult?,
+        persistenceResult: MeetingPersistenceStopResult,
         meetingId: UUID?,
         vaultURL: URL?,
         dbQueue: DatabaseQueue?
     ) async {
-        let recordingFailed = isFailedBatchState(for: sessionId)
-        if currentMeetingId == meetingId, !recordingFailed {
-            batchTranscriptionState = .queued(sessionId: sessionId)
+        let recordingFailed = stopResult?.batchRecordingSucceeded != true || !persistenceResult.succeeded
+        if recordingFailed,
+           currentMeetingId == meetingId {
+            batchTranscriptionState = .failed(
+                sessionId: recordingSessionId,
+                message: stopResult?.batchFailureMessage
+                    ?? persistenceResult.failureMessage.map(L10n.batchAudioWriteFailed)
+                    ?? L10n.batchAudioWriteFailed("")
+            )
+        } else if let meetingId {
+            if currentMeetingId == meetingId {
+                batchTranscriptionState = .awaitingConfirmation(sessionId: recordingSessionId)
+            }
+            presentBatchTranscriptionConfirmation(
+                sessionId: recordingSessionId,
+                meetingId: meetingId,
+                suggestedLocaleIdentifier: selectedLocale
+            )
         }
-        if !recordingFailed, let coordinator = batchTranscriptionCoordinator {
-            await coordinator.enqueue(sessionId: sessionId)
-        }
+        await completeBatchRecording(
+            meetingId: meetingId,
+            vaultURL: vaultURL,
+            dbQueue: dbQueue
+        )
+    }
+
+    private func presentBatchTranscriptionConfirmation(
+        sessionId: UUID,
+        meetingId: UUID,
+        suggestedLocaleIdentifier: String
+    ) {
+        pendingBatchTranscriptionConfirmation = BatchTranscriptionConfirmation(
+            sessionId: sessionId,
+            meetingId: meetingId,
+            suggestedLocaleIdentifier: suggestedLocaleIdentifier
+        )
+        MainWindowOpener.shared.openMainWindow()
+    }
+
+    private func completeBatchRecording(
+        meetingId: UUID?,
+        vaultURL: URL?,
+        dbQueue: DatabaseQueue?
+    ) async {
         if let vaultURL, let meetingId, let dbQueue {
             await exportBatchScreenshots(
                 vaultURL: vaultURL,
@@ -1532,11 +1661,6 @@ final class CaptionViewModel: ObservableObject {
                 dbQueue: dbQueue
             )
         }
-    }
-
-    private func isFailedBatchState(for sessionId: UUID) -> Bool {
-        guard case let .failed(failedSessionId, _) = batchTranscriptionState else { return false }
-        return failedSessionId == sessionId
     }
 
     private func exportBatchScreenshots(vaultURL: URL, meetingId: UUID, dbQueue: DatabaseQueue) async {
@@ -1845,11 +1969,6 @@ final class CaptionViewModel: ObservableObject {
 
         store.clear()
         persistenceService?.reset()
-        Task {
-            for pipeline in pipelines {
-                await pipeline.service.reset()
-            }
-        }
     }
 
     // MARK: - Screenshot
@@ -2203,29 +2322,167 @@ final class CaptionViewModel: ObservableObject {
 
     // MARK: - Pipeline Construction
 
-    private func buildPipeline(
-        locale: Locale,
-        speakerLabel: String,
-        recordingStartTime: Date,
-        recordingSessionId: UUID
-    ) async throws -> (service: SpeechTranscriberService, bridge: AudioBufferBridge, format: AVAudioFormat) {
-        let service = SpeechTranscriberService(
-            locale: locale,
-            speakerLabel: speakerLabel,
-            translateSegment: translationHandler(for: locale)
+    private func handleTranscriptionEvent(_ event: TranscriptionEvent) {
+        guard let plan = activeTranscriptionPlan else { return }
+        TranscriptionEventRouter.route(
+            event,
+            plan: plan,
+            transcriptStore: activeTranscriptStore,
+            liveCaptionStore: liveCaptionStore
         )
-        try await service.prepare()
-        guard let format = await service.targetAudioFormat() else {
-            throw AudioCaptureError.converterCreationFailed
+
+        guard case let .failure(_, _, sourceLabel, message) = event else { return }
+
+        let source = RecordingAudioSource(speakerLabel: sourceLabel)
+        errorMessage = message
+        if case .starting = recordingLifecycle {
+            if plan.finalMode == .realtime {
+                pendingRealtimeRecognitionFailure = (source, message)
+            } else {
+                pendingLiveSubtitleWarning = message
+            }
         }
-        let bridge = AudioBufferBridge(sampleRate: format.sampleRate)
-        try await service.startStreaming(
-            store: store,
-            bridge: bridge,
-            recordingStartTime: recordingStartTime,
-            recordingSessionId: recordingSessionId
+    }
+
+    private func controllerSourceConfiguration(
+        for source: RecordingAudioSource,
+        plan: TranscriptionSessionPlan? = nil
+    ) -> RecordingSessionController.SourceConfiguration {
+        let effectivePlan = plan ?? activeTranscriptionPlan
+        return RecordingSessionController.SourceConfiguration(
+            source: source,
+            captureDeviceID: source == .microphone ? selectedMicrophoneID : nil,
+            captureBufferSize: effectivePlan?.recordsBatchAudio == true ? 1024 : 4096
         )
-        return (service: service, bridge: bridge, format: format)
+    }
+
+    private func controllerSourceConfigurations(
+        plan: TranscriptionSessionPlan
+    ) -> [RecordingSessionController.SourceConfiguration] {
+        enabledRecordingAudioSources.map { source in
+            controllerSourceConfiguration(for: source, plan: plan)
+        }
+    }
+
+    private func handleControllerRuntimeFailure(
+        source: RecordingAudioSource?,
+        message: String,
+        isFatal: Bool,
+        recordingSessionId: UUID
+    ) {
+        guard activeRecordingSessionId == recordingSessionId else { return }
+        errorMessage = message
+        if case .starting = recordingLifecycle {
+            if isFatal {
+                pendingRealtimeRecognitionFailure = (source, message)
+            } else {
+                pendingLiveSubtitleWarning = message
+            }
+            return
+        }
+
+        Task { @MainActor [weak self] in
+            guard let self,
+                  self.activeRecordingSessionId == recordingSessionId else { return }
+            if let snapshot = await self.recordingSessionController.snapshot(),
+               snapshot.sessionId == recordingSessionId {
+                self.activeControllerSources = snapshot.enabledSources
+            }
+            if isFatal {
+                self.stopListening()
+            }
+        }
+    }
+
+    private func handleLiveSubtitleSettingChange(isEnabled: Bool) {
+        guard var plan = activeTranscriptionPlan,
+              let recordingSessionId = activeRecordingSessionId else { return }
+
+        switch recordingLifecycle {
+        case let .starting(sessionId) where sessionId == recordingSessionId:
+            plan.liveSubtitlesEnabled = isEnabled
+            activeTranscriptionPlan = plan
+            if isEnabled {
+                liveCaptionStore.start(sessionId: recordingSessionId)
+            } else {
+                liveCaptionStore.clear()
+            }
+            return
+        case let .recording(sessionId) where sessionId == recordingSessionId:
+            break
+        default:
+            return
+        }
+
+        plan.liveSubtitlesEnabled = isEnabled
+        activeTranscriptionPlan = plan
+
+        if isEnabled {
+            liveCaptionStore.start(sessionId: recordingSessionId)
+            if plan.persistsRealtimeTranscript {
+                liveCaptionStore.seed(activeTranscriptStore.segments, sessionId: recordingSessionId)
+            }
+        } else {
+            liveCaptionStore.clear()
+        }
+
+        enqueueRecordingConfiguration { [weak self] _ in
+            guard let self,
+                  self.activeTranscriptionPlan?.liveSubtitlesEnabled == isEnabled else { return }
+            do {
+                let locale = self.resolvedSelectedLocale()
+                let snapshot = try await self.recordingSessionController.setLiveSubtitlesEnabled(
+                    isEnabled,
+                    translateSegment: self.translationHandler(for: locale)
+                )
+                self.activeControllerSources = snapshot.enabledSources
+            } catch {
+                self.errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func reconcileStartingPlan(
+        _ initialPlan: TranscriptionSessionPlan,
+        recordingSessionId: UUID
+    ) async throws -> TranscriptionSessionPlan {
+        var plan = initialPlan
+        while recordingLifecycle == .starting(recordingSessionId) {
+            let desiredValue = activeTranscriptionPlan?.liveSubtitlesEnabled
+                ?? AppSettings.shared.liveSubtitleOverlayEnabled
+            guard plan.liveSubtitlesEnabled != desiredValue else { return plan }
+
+            try ensureSessionIsActive(recordingSessionId)
+            guard activeTranscriptionPlan?.liveSubtitlesEnabled == desiredValue else { continue }
+
+            plan.liveSubtitlesEnabled = desiredValue
+            return plan
+        }
+        throw CancellationError()
+    }
+
+    private func reconcileStartingLiveConfiguration(
+        _ initialPlan: TranscriptionSessionPlan,
+        recordingSessionId: UUID
+    ) async throws -> TranscriptionSessionPlan {
+        var appliedPlan = initialPlan
+        while recordingLifecycle == .starting(recordingSessionId) {
+            guard let latestPlan = activeTranscriptionPlan else { throw CancellationError() }
+            if appliedPlan.liveSubtitlesEnabled != latestPlan.liveSubtitlesEnabled {
+                let locale = resolvedSelectedLocale()
+                let snapshot = try await recordingSessionController.setLiveSubtitlesEnabled(
+                    latestPlan.liveSubtitlesEnabled,
+                    translateSegment: translationHandler(for: locale)
+                )
+                activeControllerSources = snapshot.enabledSources
+                appliedPlan = latestPlan
+            }
+            guard activeTranscriptionPlan?.liveSubtitlesEnabled == latestPlan.liveSubtitlesEnabled else {
+                continue
+            }
+            return latestPlan
+        }
+        throw CancellationError()
     }
 
     private func translationHandler(for locale: Locale) -> SpeechTranscriberService.SegmentTranslationHandler? {
@@ -2256,38 +2513,18 @@ final class CaptionViewModel: ObservableObject {
 
     // MARK: - Private Helpers
 
-    private func startMicrophoneCapture(
-        bridge: AudioBufferBridge,
-        targetFormat: AVAudioFormat,
-        selectedDeviceID: AudioDeviceID?
-    ) throws {
-        let manager = AudioCaptureManager()
-        manager.onAudioBuffer = { [bridge] buffer in
-            bridge.appendBuffer(buffer)
+    private func ensureSessionIsActive(_ recordingSessionId: UUID) throws {
+        guard isSessionActive(recordingSessionId), !Task.isCancelled else {
+            throw CancellationError()
         }
-        try manager.startCapture(targetFormat: targetFormat, selectedDeviceID: selectedDeviceID)
-        self.audioManager = manager
     }
 
-    private func startSystemAudioCapture(bridge: AudioBufferBridge, targetFormat: AVAudioFormat) async throws {
-        let hasPermission = await SystemAudioCaptureManager.requestPermission()
-        guard hasPermission else {
-            throw SystemAudioCaptureError.screenRecordingPermissionDenied
+    private func isSessionActive(_ recordingSessionId: UUID) -> Bool {
+        switch recordingLifecycle {
+        case let .starting(sessionId), let .recording(sessionId):
+            sessionId == recordingSessionId
+        case .idle, .stopping:
+            false
         }
-
-        let manager = SystemAudioCaptureManager()
-        manager.onAudioBuffer = { [bridge] buffer in
-            bridge.appendBuffer(buffer)
-        }
-        manager.onStreamStopped = { [weak self] error in
-            Task { @MainActor in
-                self?.errorMessage = error?.localizedDescription ?? L10n.systemAudioCaptureStopped
-                if self?.audioManager == nil {
-                    self?.isListening = false
-                }
-            }
-        }
-        try await manager.startCapture(targetFormat: targetFormat)
-        self.systemAudioManager = manager
     }
 }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -681,6 +681,7 @@ final class CaptionViewModel: ObservableObject {
         vaultURL: URL
     ) {
         guard !isFinalizingRecording else { return }
+        if case .starting = recordingLifecycle { return }
 
         // 録音中に録音対象のトランスクリプトを選択した場合はライブ表示に復帰
         if isListening, meetingId == recordingMeetingId {
@@ -872,6 +873,7 @@ final class CaptionViewModel: ObservableObject {
     /// 録音中はバックグラウンド録音を維持したまま表示のみクリアする。
     func clearCurrentMeeting() {
         guard !isFinalizingRecording else { return }
+        if case .starting = recordingLifecycle { return }
 
         if isListening {
             saveRecordingContextIfNeeded()
@@ -1162,6 +1164,8 @@ final class CaptionViewModel: ObservableObject {
             errorMessage = nil
             return true
         } catch {
+            guard !Task.isCancelled,
+                  recordingLifecycle == .recording(recordingSessionId) else { return false }
             if let snapshot = await recordingSessionController.snapshot(),
                snapshot.sessionId == recordingSessionId {
                 activeControllerSources = snapshot.enabledSources
@@ -1533,12 +1537,8 @@ final class CaptionViewModel: ObservableObject {
         let recordingStart = activeStore.timeBase
         let transcriptionMode = activeTranscriptionMode ?? .realtime
         let recordingSessionId = persistenceService?.recordingSessionId
-        recordingContext = nil
 
         Task {
-            for task in configurationTasks {
-                await task.value
-            }
             var stopResult: RecordingSessionController.StopResult?
             do {
                 stopResult = try await recordingSessionController.stop()
@@ -1546,9 +1546,13 @@ final class CaptionViewModel: ObservableObject {
                 ErrorReportingService.capture(error, context: ["source": "stopRecordingSession"])
                 await recordingSessionController.abort()
             }
+            for task in configurationTasks {
+                await task.value
+            }
             let persistenceResult = persistenceService?.stop()
                 ?? .failure(message: L10n.recordingSessionNotActive)
             persistenceService = nil
+            recordingContext = nil
             if let persistenceFailureMessage = persistenceResult.failureMessage {
                 errorMessage = persistenceFailureMessage
             }
@@ -1611,14 +1615,15 @@ final class CaptionViewModel: ObservableObject {
         dbQueue: DatabaseQueue?
     ) async {
         let recordingFailed = stopResult?.batchRecordingSucceeded != true || !persistenceResult.succeeded
-        if recordingFailed,
-           currentMeetingId == meetingId {
-            batchTranscriptionState = .failed(
-                sessionId: recordingSessionId,
-                message: stopResult?.batchFailureMessage
-                    ?? persistenceResult.failureMessage.map(L10n.batchAudioWriteFailed)
-                    ?? L10n.batchAudioWriteFailed("")
-            )
+        if recordingFailed {
+            if currentMeetingId == meetingId {
+                batchTranscriptionState = .failed(
+                    sessionId: recordingSessionId,
+                    message: stopResult?.batchFailureMessage
+                        ?? persistenceResult.failureMessage.map(L10n.batchAudioWriteFailed)
+                        ?? L10n.batchAudioWriteFailed("")
+                )
+            }
         } else if let meetingId {
             if currentMeetingId == meetingId {
                 batchTranscriptionState = .awaitingConfirmation(sessionId: recordingSessionId)
@@ -2397,6 +2402,8 @@ final class CaptionViewModel: ObservableObject {
     private func handleLiveSubtitleSettingChange(isEnabled: Bool) {
         guard var plan = activeTranscriptionPlan,
               let recordingSessionId = activeRecordingSessionId else { return }
+        guard plan.liveSubtitlesEnabled != isEnabled else { return }
+        let previousValue = plan.liveSubtitlesEnabled
 
         switch recordingLifecycle {
         case let .starting(sessionId) where sessionId == recordingSessionId:
@@ -2438,7 +2445,28 @@ final class CaptionViewModel: ObservableObject {
                 self.activeControllerSources = snapshot.enabledSources
             } catch {
                 self.errorMessage = error.localizedDescription
+                self.restoreLiveSubtitleSetting(
+                    previousValue,
+                    recordingSessionId: recordingSessionId
+                )
             }
+        }
+    }
+
+    private func restoreLiveSubtitleSetting(_ isEnabled: Bool, recordingSessionId: UUID) {
+        guard activeRecordingSessionId == recordingSessionId,
+              var plan = activeTranscriptionPlan else { return }
+        plan.liveSubtitlesEnabled = isEnabled
+        activeTranscriptionPlan = plan
+        AppSettings.shared.liveSubtitleOverlayEnabled = isEnabled
+
+        if isEnabled {
+            liveCaptionStore.start(sessionId: recordingSessionId)
+            if plan.persistsRealtimeTranscript {
+                liveCaptionStore.seed(activeTranscriptStore.segments, sessionId: recordingSessionId)
+            }
+        } else {
+            liveCaptionStore.clear()
         }
     }
 

--- a/Sources/Dahlia/Views/BatchTranscriptionConfirmationView.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionConfirmationView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct BatchTranscriptionConfirmationView: View {
+    let locales: [Locale]
+    let onStart: (String) -> Void
+    let onPostpone: () -> Void
+
+    @State private var selectedLocaleIdentifier: String
+
+    init(
+        locales: [Locale],
+        initialLocaleIdentifier: String,
+        onStart: @escaping (String) -> Void,
+        onPostpone: @escaping () -> Void
+    ) {
+        self.locales = locales
+        self.onStart = onStart
+        self.onPostpone = onPostpone
+        _selectedLocaleIdentifier = State(initialValue: initialLocaleIdentifier)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(L10n.batchTranscriptionConfirmationTitle)
+                .font(.headline)
+
+            Text(L10n.batchTranscriptionConfirmationDescription)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Picker(L10n.language, selection: $selectedLocaleIdentifier) {
+                ForEach(locales, id: \.identifier) { locale in
+                    Text(displayName(for: locale)).tag(locale.identifier)
+                }
+            }
+            .pickerStyle(.menu)
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button(L10n.later, action: onPostpone)
+                    .keyboardShortcut(.cancelAction)
+                Button(L10n.startTranscription) {
+                    onStart(selectedLocaleIdentifier)
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 420)
+    }
+
+    private func displayName(for locale: Locale) -> String {
+        locale.localizedString(forIdentifier: locale.identifier)
+            ?? Locale.current.localizedString(forIdentifier: locale.identifier)
+            ?? locale.identifier
+    }
+}

--- a/Sources/Dahlia/Views/BatchTranscriptionStatusView.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionStatusView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct BatchTranscriptionStatusView: View {
     let state: BatchTranscriptionState
+    let confirm: () -> Void
     let retry: () -> Void
     let discard: () -> Void
 
@@ -14,6 +15,10 @@ struct BatchTranscriptionStatusView: View {
                 ProgressView()
                     .controlSize(.small)
                 Text(L10n.batchRecordingInProgress)
+            case .awaitingConfirmation:
+                Label(L10n.batchTranscriptionAwaitingConfirmation, systemImage: "clock")
+                Spacer()
+                Button(L10n.reviewBatchTranscription, action: confirm)
             case .queued:
                 ProgressView()
                     .controlSize(.small)

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -54,6 +54,17 @@ struct ContentView: View {
             }
         }
         .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
+        .sheet(item: $viewModel.pendingBatchTranscriptionConfirmation) { confirmation in
+            BatchTranscriptionConfirmationView(
+                locales: viewModel.batchTranscriptionLocaleOptions(
+                    preferredIdentifier: confirmation.suggestedLocaleIdentifier
+                ),
+                initialLocaleIdentifier: confirmation.suggestedLocaleIdentifier,
+                onStart: viewModel.confirmBatchTranscription,
+                onPostpone: viewModel.postponeBatchTranscription
+            )
+            .interactiveDismissDisabled()
+        }
         .onChange(of: sidebarViewModel.selectedMeetingIds) { oldValue, newValue in
             guard oldValue != newValue else { return }
             handleMeetingSelectionChange(newValue)

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -440,6 +440,7 @@ struct ControlPanelView: View {
                             && !viewModel.isViewingOtherWhileRecording,
                         showsTranslatedText: appSettings.isTranscriptTranslationEffectivelyEnabled,
                         batchTranscriptionState: viewModel.batchTranscriptionState,
+                        confirmBatchTranscription: viewModel.presentBatchTranscriptionConfirmation,
                         retryBatchTranscription: viewModel.retryBatchTranscription,
                         discardFailedBatchTranscription: viewModel.discardFailedBatchTranscription
                     )

--- a/Sources/Dahlia/Views/MeetingListSidebarView.swift
+++ b/Sources/Dahlia/Views/MeetingListSidebarView.swift
@@ -153,6 +153,8 @@ private struct RecordingStatusBar: View {
     var sidebarViewModel: SidebarViewModel
     let recordingCoordinator: RecordingCoordinator
 
+    @AppStorage("liveSubtitleOverlayEnabled") private var liveSubtitleOverlayEnabled = false
+
     private var recordingMeetingId: UUID? {
         viewModel.recordingMeetingId
     }
@@ -210,6 +212,7 @@ private struct RecordingStatusBar: View {
                 microphoneMenu
                 systemAudioMenu
                 languageMenu
+                RecordingLiveSubtitleToggle(isEnabled: $liveSubtitleOverlayEnabled)
                 screenSourceMenu
             }
         }

--- a/Sources/Dahlia/Views/MenuBarMenuView.swift
+++ b/Sources/Dahlia/Views/MenuBarMenuView.swift
@@ -26,6 +26,10 @@ struct MenuBarMenuView: View {
                 .disabled(!recordingCoordinator.canStartNewMeeting && AppSettings.shared.currentVault != nil)
             }
 
+            Toggle(isOn: $liveSubtitleOverlayEnabled) {
+                Label(L10n.menuBarShowLiveSubtitles, systemImage: "text.bubble")
+            }
+
             Divider()
 
             recordingSettingsMenus
@@ -43,10 +47,6 @@ struct MenuBarMenuView: View {
                 openWindow(id: WindowID.projectManager)
             } label: {
                 Label(L10n.manageProjects, systemImage: "folder")
-            }
-
-            Toggle(isOn: $liveSubtitleOverlayEnabled) {
-                Label(L10n.menuBarShowLiveSubtitles, systemImage: "text.bubble")
             }
 
             Divider()

--- a/Sources/Dahlia/Views/RecordingLiveSubtitleToggle.swift
+++ b/Sources/Dahlia/Views/RecordingLiveSubtitleToggle.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct RecordingLiveSubtitleToggle: View {
+    @Binding var isEnabled: Bool
+
+    var body: some View {
+        Toggle(isOn: $isEnabled) {
+            HStack(spacing: 6) {
+                Image(systemName: "text.bubble")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 14)
+                    .accessibilityHidden(true)
+
+                Text(L10n.subtitles)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .frame(width: 58, alignment: .leading)
+                    .lineLimit(1)
+
+                Text(isEnabled ? L10n.liveSubtitlesOnStatus : L10n.liveSubtitlesOffStatus)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .accessibilityHidden(true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .toggleStyle(.switch)
+        .controlSize(.small)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .frame(maxWidth: .infinity, minHeight: 32, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.primary.opacity(0.06))
+        )
+        .contentShape(RoundedRectangle(cornerRadius: 8))
+        .accessibilityLabel(L10n.liveSubtitles)
+        .accessibilityValue(isEnabled ? L10n.liveSubtitlesOnStatus : L10n.liveSubtitlesOffStatus)
+        .help(isEnabled ? L10n.hideLiveSubtitles : L10n.showLiveSubtitles)
+    }
+}

--- a/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
@@ -57,6 +57,12 @@ struct TranscriptionSettingsView: View {
             }
 
             Section {
+                Toggle(isOn: $settings.liveSubtitleOverlayEnabled) {
+                    Text(L10n.liveSubtitles)
+                    Text(L10n.liveSubtitleOverlayToggleDescription)
+                }
+                .toggleStyle(.switch)
+
                 Picker(selection: $settings.liveSubtitleSourceModeRawValue) {
                     ForEach(LiveSubtitleSourceMode.allCases) { mode in
                         Text(mode.displayName).tag(mode.rawValue)
@@ -65,6 +71,7 @@ struct TranscriptionSettingsView: View {
                     Text(L10n.source)
                     Text(L10n.liveSubtitleSourceDescription)
                 }
+                .disabled(!settings.liveSubtitleOverlayEnabled)
 
                 Picker(selection: $settings.liveSubtitleOverlaySegmentCount) {
                     ForEach(1 ..< 6, id: \.self) { count in
@@ -74,6 +81,7 @@ struct TranscriptionSettingsView: View {
                     Text(L10n.liveSubtitleOverlaySegmentCount)
                     Text(L10n.liveSubtitleOverlaySegmentCountDescription)
                 }
+                .disabled(!settings.liveSubtitleOverlayEnabled)
             } header: {
                 Text(L10n.liveSubtitleOverlay)
             } footer: {

--- a/Sources/Dahlia/Views/Toolbar/SessionControls.swift
+++ b/Sources/Dahlia/Views/Toolbar/SessionControls.swift
@@ -52,22 +52,6 @@ struct RecordToolbarButton: View {
     }
 }
 
-struct LiveSubtitleOverlayToolbarButton: View {
-    @AppStorage("liveSubtitleOverlayEnabled") private var liveSubtitleOverlayEnabled = false
-
-    var body: some View {
-        Button {
-            liveSubtitleOverlayEnabled.toggle()
-        } label: {
-            Label(
-                liveSubtitleOverlayEnabled ? L10n.hideLiveSubtitles : L10n.showLiveSubtitles,
-                systemImage: liveSubtitleOverlayEnabled ? "text.bubble.fill" : "text.bubble"
-            )
-        }
-        .help(liveSubtitleOverlayEnabled ? L10n.hideLiveSubtitles : L10n.showLiveSubtitles)
-    }
-}
-
 struct GenerateSummaryToolbarButton: View {
     @ObservedObject var viewModel: CaptionViewModel
 

--- a/Sources/Dahlia/Views/TranscriptTabView.swift
+++ b/Sources/Dahlia/Views/TranscriptTabView.swift
@@ -22,6 +22,7 @@ struct TranscriptTabView: View {
     let showsRecordingIndicator: Bool
     let showsTranslatedText: Bool
     let batchTranscriptionState: BatchTranscriptionState?
+    let confirmBatchTranscription: () -> Void
     let retryBatchTranscription: () -> Void
     let discardFailedBatchTranscription: () -> Void
 
@@ -56,6 +57,7 @@ struct TranscriptTabView: View {
             if let batchTranscriptionState {
                 BatchTranscriptionStatusView(
                     state: batchTranscriptionState,
+                    confirm: confirmBatchTranscription,
                     retry: retryBatchTranscription,
                     discard: discardFailedBatchTranscription
                 )

--- a/Tests/DahliaTests/AudioBufferBridgeTests.swift
+++ b/Tests/DahliaTests/AudioBufferBridgeTests.swift
@@ -1,0 +1,68 @@
+@preconcurrency import AVFoundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct AudioBufferBridgeTests {
+        @Test
+        func conversionIsHiddenBehindReplaceableAnalyzerInputBoundary() async throws {
+            let sourceFormat = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatInt16,
+                sampleRate: 48000,
+                channels: 1,
+                interleaved: false
+            ))
+            let analyzerFormat = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: 16000,
+                channels: 1,
+                interleaved: false
+            ))
+            let inputBuffer = try #require(AVAudioPCMBuffer(pcmFormat: sourceFormat, frameCapacity: 480))
+            inputBuffer.frameLength = 480
+            let converter = FakeAnalyzerInputConverter(outputFormat: analyzerFormat)
+            let bridge = try AudioBufferBridge(
+                sourceFormat: sourceFormat,
+                analyzerFormat: analyzerFormat,
+                inputConverter: converter
+            )
+            let chunk = CapturedAudioChunk(
+                source: .microphone,
+                buffer: inputBuffer,
+                sessionRelativeStartTime: CMTime(seconds: 12.5, preferredTimescale: 48000)
+            )
+
+            #expect(bridge.append(chunk))
+            bridge.finish()
+            var iterator = bridge.stream.makeAsyncIterator()
+            let convertedInput = await iterator.next()
+
+            #expect(converter.conversionCount == 1)
+            #expect(convertedInput?.buffer.format == analyzerFormat)
+            #expect(convertedInput?.bufferStartTime?.seconds == 12.5)
+        }
+
+        @Test
+        func appendReportsTerminatedStream() throws {
+            let format = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: 16000,
+                channels: 1,
+                interleaved: false
+            ))
+            let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 16))
+            buffer.frameLength = 16
+            let bridge = try AudioBufferBridge(sourceFormat: format, analyzerFormat: format)
+            let chunk = CapturedAudioChunk(
+                source: .system,
+                buffer: buffer,
+                sessionRelativeStartTime: .zero
+            )
+
+            bridge.finish()
+
+            #expect(!bridge.append(chunk))
+        }
+    }
+#endif

--- a/Tests/DahliaTests/AudioConverterTests.swift
+++ b/Tests/DahliaTests/AudioConverterTests.swift
@@ -1,0 +1,31 @@
+@preconcurrency import AVFoundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct AudioConverterTests {
+        @Test
+        func downsamplingCapacityRoundsUpForFractionalOutputFrames() throws {
+            let sourceFormat = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatInt16,
+                sampleRate: 48000,
+                channels: 1,
+                interleaved: false
+            ))
+            let targetFormat = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatInt16,
+                sampleRate: 16000,
+                channels: 1,
+                interleaved: false
+            ))
+            let input = try #require(AVAudioPCMBuffer(pcmFormat: sourceFormat, frameCapacity: 4096))
+            input.frameLength = 4096
+            let converter = try #require(AVAudioConverter(from: sourceFormat, to: targetFormat))
+
+            let output = try #require(AudioConverter.convert(input, to: targetFormat, using: converter))
+
+            #expect(output.frameCapacity == 1366)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/AudioFrameRouterTests.swift
+++ b/Tests/DahliaTests/AudioFrameRouterTests.swift
@@ -169,5 +169,25 @@ import os
             #expect(first.sessionRelativeStartSeconds == 3)
             #expect(second.sessionRelativeStartSeconds == 3.01)
         }
+
+        @Test
+        func sourcePipelineOriginCanBeFinalizedBeforeFirstCapture() throws {
+            let format = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatInt16,
+                sampleRate: 16000,
+                channels: 1,
+                interleaved: false
+            ))
+            let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 160))
+            buffer.frameLength = 160
+            let pipeline = AudioSourcePipeline(source: .microphone, captureFormat: format)
+
+            pipeline.setSessionRelativeOrigin(seconds: 12.5)
+            let chunk = pipeline.capture(buffer)
+            pipeline.setSessionRelativeOrigin(seconds: 99)
+
+            #expect(chunk.sessionRelativeStartSeconds == 12.5)
+            #expect(pipeline.sessionRelativeOriginSeconds == 12.5)
+        }
     }
 #endif

--- a/Tests/DahliaTests/AudioFrameRouterTests.swift
+++ b/Tests/DahliaTests/AudioFrameRouterTests.swift
@@ -1,0 +1,173 @@
+@preconcurrency import AVFoundation
+import Dispatch
+import os
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct AudioFrameRouterTests {
+        @Test
+        func routesOneCapturedBufferToBatchAndLiveConsumers() async throws {
+            let format = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatInt16,
+                sampleRate: 48000,
+                channels: 1,
+                interleaved: false
+            ))
+            let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 32))
+            buffer.frameLength = 32
+            let batchCount = OSAllocatedUnfairLock(initialState: 0)
+            let liveCount = OSAllocatedUnfairLock(initialState: 0)
+            let router = AudioFrameRouter()
+            let pipeline = AudioSourcePipeline(
+                source: .microphone,
+                router: router,
+                captureFormat: format,
+                sessionRelativeOrigin: CMTime(seconds: 2, preferredTimescale: 48000)
+            )
+            router.setBatchConsumer { chunk in
+                #expect(chunk.buffer === buffer)
+                #expect(chunk.source == .microphone)
+                #expect(chunk.sessionRelativeStartTime.seconds == 2)
+                batchCount.withLock { $0 += 1 }
+            }
+            router.setLiveConsumer { chunk in
+                #expect(chunk.buffer === buffer)
+                liveCount.withLock { $0 += 1 }
+                return true
+            }
+
+            router.route(pipeline.capture(buffer))
+            router.removeAllConsumers()
+            await router.waitUntilIdle()
+
+            #expect(batchCount.withLock { $0 } == 1)
+            #expect(liveCount.withLock { $0 } == 1)
+        }
+
+        @Test
+        func detachingLiveConsumerDoesNotStopBatchConsumer() async throws {
+            let format = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatInt16,
+                sampleRate: 48000,
+                channels: 1,
+                interleaved: false
+            ))
+            let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 1))
+            buffer.frameLength = 1
+            let batchCount = OSAllocatedUnfairLock(initialState: 0)
+            let liveCount = OSAllocatedUnfairLock(initialState: 0)
+            let router = AudioFrameRouter()
+            let pipeline = AudioSourcePipeline(source: .microphone, router: router, captureFormat: format)
+            router.setBatchConsumer { _ in batchCount.withLock { $0 += 1 } }
+            router.setLiveConsumer { _ in
+                liveCount.withLock { $0 += 1 }
+                return true
+            }
+            router.setLiveConsumer(nil)
+
+            router.route(pipeline.capture(buffer))
+            await router.waitUntilIdle()
+
+            #expect(batchCount.withLock { $0 } == 1)
+            #expect(liveCount.withLock { $0 } == 0)
+        }
+
+        @Test
+        func liveFailureDetachesConsumerAndReportsOnlyOnce() async throws {
+            let format = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatInt16,
+                sampleRate: 48000,
+                channels: 1,
+                interleaved: false
+            ))
+            let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 1))
+            buffer.frameLength = 1
+            let liveCount = OSAllocatedUnfairLock(initialState: 0)
+            let failureCount = OSAllocatedUnfairLock(initialState: 0)
+            let failureSignal = AsyncStream.makeStream(of: Void.self, bufferingPolicy: .bufferingNewest(1))
+            let router = AudioFrameRouter()
+            let pipeline = AudioSourcePipeline(source: .system, router: router, captureFormat: format)
+            router.setLiveConsumer { _ in
+                liveCount.withLock { $0 += 1 }
+                return false
+            } onFailure: {
+                failureCount.withLock { $0 += 1 }
+                failureSignal.continuation.yield()
+            }
+
+            router.route(pipeline.capture(buffer))
+            router.route(pipeline.capture(buffer))
+            var failureIterator = failureSignal.stream.makeAsyncIterator()
+            _ = await failureIterator.next()
+            await router.waitUntilIdle()
+
+            #expect(liveCount.withLock { $0 } == 1)
+            #expect(failureCount.withLock { $0 } == 1)
+        }
+
+        @Test
+        func waitUntilIdleJoinsInFlightBatchCallback() async throws {
+            let format = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatInt16,
+                sampleRate: 48000,
+                channels: 1,
+                interleaved: false
+            ))
+            let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 1))
+            buffer.frameLength = 1
+            let enteredConsumer = AsyncStream.makeStream(of: Void.self, bufferingPolicy: .bufferingNewest(1))
+            let releaseConsumer = DispatchSemaphore(value: 0)
+            let didFinishWaiting = OSAllocatedUnfairLock(initialState: false)
+            let router = AudioFrameRouter()
+            let pipeline = AudioSourcePipeline(source: .microphone, router: router, captureFormat: format)
+            router.setBatchConsumer { _ in
+                enteredConsumer.continuation.yield()
+                releaseConsumer.wait()
+            }
+
+            DispatchQueue.global(qos: .userInitiated).async {
+                router.route(pipeline.capture(buffer))
+            }
+            var enteredIterator = enteredConsumer.stream.makeAsyncIterator()
+            _ = await enteredIterator.next()
+            router.removeAllConsumers()
+            let waitTask = Task {
+                await router.waitUntilIdle()
+                didFinishWaiting.withLock { $0 = true }
+            }
+            try await Task.sleep(for: .milliseconds(20))
+            #expect(!didFinishWaiting.withLock { $0 })
+
+            releaseConsumer.signal()
+            await waitTask.value
+            #expect(didFinishWaiting.withLock { $0 })
+        }
+
+        @Test
+        func sourcePipelineKeepsSessionClockAcrossChunks() throws {
+            let format = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatInt16,
+                sampleRate: 16000,
+                channels: 1,
+                interleaved: false
+            ))
+            let firstBuffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 160))
+            firstBuffer.frameLength = 160
+            let secondBuffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 80))
+            secondBuffer.frameLength = 80
+            let pipeline = AudioSourcePipeline(
+                source: .system,
+                captureFormat: format,
+                sessionRelativeOrigin: CMTime(seconds: 3, preferredTimescale: 16000)
+            )
+
+            let first = pipeline.capture(firstBuffer)
+            let second = pipeline.capture(secondBuffer)
+
+            #expect(first.sessionRelativeStartSeconds == 3)
+            #expect(second.sessionRelativeStartSeconds == 3.01)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/BatchAudioRecordingSessionTests.swift
+++ b/Tests/DahliaTests/BatchAudioRecordingSessionTests.swift
@@ -71,6 +71,255 @@ import GRDB
             #expect(audioFile.length == 320)
         }
 
+        @Test
+        func rotatingLocaleUsesOneExactFrameBoundaryWithoutStoppingWriter() async throws {
+            let fixture = try BatchAudioTestFixture(name: "BatchRotate")
+            defer { fixture.removeFiles() }
+
+            let recorder = try BatchAudioRecordingSession(
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL,
+                meetingId: fixture.meeting.id,
+                recordingSessionId: fixture.session.id,
+                recordingStartTime: fixture.now,
+                sampleRate: 16000
+            )
+            let writer = try await recorder.beginRange(
+                source: .microphone,
+                locale: Locale(identifier: "ja_JP"),
+                at: fixture.now
+            )
+            try writer.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 80))
+
+            let rotatedWriter = try await recorder.rotateRange(
+                source: .microphone,
+                locale: Locale(identifier: "en_US"),
+                at: fixture.now.addingTimeInterval(0.005)
+            )
+            #expect(rotatedWriter === writer)
+            try writer.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 120))
+            try await recorder.finish()
+
+            let ranges = try await fixture.database.dbQueue.read { db in
+                try RecordingAudioRangeRecord.order(Column("startFrame").asc).fetchAll(db)
+            }
+            #expect(ranges.map(\.startFrame) == [0, 80])
+            #expect(ranges.map(\.frameCount) == [80, 120])
+        }
+
+        @Test
+        func rotatingMultipleSourcesIsAtomicAndUsesEachSourceFrameBoundary() async throws {
+            let fixture = try BatchAudioTestFixture(name: "BatchAtomicRotate")
+            defer { fixture.removeFiles() }
+
+            let recorder = try BatchAudioRecordingSession(
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL,
+                meetingId: fixture.meeting.id,
+                recordingSessionId: fixture.session.id,
+                recordingStartTime: fixture.now,
+                sampleRate: 16000
+            )
+            let microphoneWriter = try await recorder.beginRange(
+                source: .microphone,
+                locale: Locale(identifier: "ja_JP"),
+                at: fixture.now.addingTimeInterval(0.25)
+            )
+            let systemWriter = try await recorder.beginRange(
+                source: .system,
+                locale: Locale(identifier: "ja_JP"),
+                at: fixture.now.addingTimeInterval(0.5)
+            )
+            try microphoneWriter.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 80))
+            try systemWriter.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 120))
+
+            try await fixture.database.dbQueue.write { db in
+                try db.execute(sql: """
+                CREATE TRIGGER reject_second_english_range
+                BEFORE INSERT ON recording_audio_ranges
+                WHEN NEW.localeIdentifier = 'en_US'
+                    AND (SELECT COUNT(*) FROM recording_audio_ranges WHERE localeIdentifier = 'en_US') >= 1
+                BEGIN
+                    SELECT RAISE(ABORT, 'forced range rotation failure');
+                END
+                """)
+            }
+            await #expect(throws: (any Error).self) {
+                try await recorder.rotateRanges(
+                    [
+                        (source: .microphone, sessionRelativeOriginSeconds: 0.25),
+                        (source: .system, sessionRelativeOriginSeconds: 0.5),
+                    ],
+                    locale: Locale(identifier: "en_US")
+                )
+            }
+
+            let rangesAfterFailure = try await fixture.database.dbQueue.read { db in
+                try RecordingAudioRangeRecord.fetchAll(db)
+            }
+            #expect(rangesAfterFailure.count == 2)
+            #expect(rangesAfterFailure.allSatisfy { $0.localeIdentifier == "ja_JP" && $0.frameCount == nil })
+
+            try await fixture.database.dbQueue.write { db in
+                try db.execute(sql: "DROP TRIGGER reject_second_english_range")
+            }
+            try await recorder.rotateRanges(
+                [
+                    (source: .microphone, sessionRelativeOriginSeconds: 0.25),
+                    (source: .system, sessionRelativeOriginSeconds: 0.5),
+                ],
+                locale: Locale(identifier: "en_US")
+            )
+            try microphoneWriter.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 40))
+            try systemWriter.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 60))
+            try await recorder.finish()
+
+            let result = try await fixture.database.dbQueue.read { db in
+                let files = try RecordingAudioFileRecord
+                    .filter(Column("recordingSessionId") == fixture.session.id)
+                    .fetchAll(db)
+                let ranges = try RecordingAudioRangeRecord.order(Column("startFrame").asc).fetchAll(db)
+                return (files, ranges)
+            }
+            let fileBySource = Dictionary(uniqueKeysWithValues: result.0.map { ($0.source, $0) })
+            let microphoneFile = try #require(fileBySource[.microphone])
+            let systemFile = try #require(fileBySource[.system])
+            let microphoneRanges = result.1.filter { $0.audioFileId == microphoneFile.id }
+            let systemRanges = result.1.filter { $0.audioFileId == systemFile.id }
+
+            #expect(microphoneRanges.map(\.startFrame) == [0, 80])
+            #expect(microphoneRanges.map(\.frameCount) == [80, 40])
+            #expect(abs((microphoneRanges.last?.sessionOffsetSeconds ?? 0) - 0.255) < 0.000_001)
+            #expect(systemRanges.map(\.startFrame) == [0, 120])
+            #expect(systemRanges.map(\.frameCount) == [120, 60])
+            #expect(abs((systemRanges.last?.sessionOffsetSeconds ?? 0) - 0.5075) < 0.000_001)
+        }
+
+        @Test
+        func sealingWriterRejectsLateCallbackWithoutChangingFrameMetadata() async throws {
+            let fixture = try BatchAudioTestFixture(name: "BatchSeal")
+            defer { fixture.removeFiles() }
+
+            let recorder = try BatchAudioRecordingSession(
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL,
+                meetingId: fixture.meeting.id,
+                recordingSessionId: fixture.session.id,
+                recordingStartTime: fixture.now,
+                sampleRate: 16000
+            )
+            let writer = try await recorder.beginRange(
+                source: .microphone,
+                locale: Locale(identifier: "ja_JP")
+            )
+            try writer.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 100))
+            #expect(writer.seal() == 100)
+            try writer.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 50))
+            try await recorder.finish()
+
+            let result = try await fixture.database.dbQueue.read { db in
+                let file = try RecordingAudioFileRecord
+                    .filter(Column("recordingSessionId") == fixture.session.id)
+                    .fetchOne(db)
+                let range = try RecordingAudioRangeRecord.fetchOne(db)
+                return (file, range)
+            }
+            #expect(result.0?.totalFrameCount == 100)
+            #expect(result.1?.frameCount == 100)
+        }
+
+        @Test
+        func writerQueueOverflowIsReportedAsRecordingFailure() async throws {
+            let fixture = try BatchAudioTestFixture(name: "BatchWriterOverflow")
+            defer { fixture.removeFiles() }
+            let format = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatInt16,
+                sampleRate: 16000,
+                channels: 1,
+                interleaved: false
+            ))
+            let partialURL = fixture.managedRootURL.appending(path: "overflow.partial.caf")
+            let finalURL = fixture.managedRootURL.appending(path: "overflow.caf")
+            let writer = BatchAudioFileWriter(
+                partialURL: partialURL,
+                finalURL: finalURL,
+                format: format,
+                maximumBufferedChunkCount: 1
+            )
+
+            try writer.appendBuffer(makeBuffer(format: format, frameCount: 16))
+            try writer.appendBuffer(makeBuffer(format: format, frameCount: 16))
+            try await writer.start()
+
+            await #expect(throws: BatchAudioFileWriterError.self) {
+                try await writer.finish()
+            }
+        }
+
+        @Test
+        func failedRangeCloseRemainsActiveAndMakesFinishFailAfterRetrySucceeds() async throws {
+            let fixture = try BatchAudioTestFixture(name: "BatchRangeCloseFailure")
+            defer { fixture.removeFiles() }
+
+            let recorder = try BatchAudioRecordingSession(
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL,
+                meetingId: fixture.meeting.id,
+                recordingSessionId: fixture.session.id,
+                recordingStartTime: fixture.now,
+                sampleRate: 16000
+            )
+            let writer = try await recorder.beginRange(
+                source: .microphone,
+                locale: Locale(identifier: "ja_JP"),
+                at: fixture.now
+            )
+            try writer.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 80))
+
+            try await fixture.database.dbQueue.write { db in
+                try db.execute(sql: """
+                CREATE TRIGGER reject_range_close
+                BEFORE UPDATE ON recording_audio_ranges
+                WHEN NEW.frameCount IS NOT NULL
+                BEGIN
+                    SELECT RAISE(ABORT, 'forced range close failure');
+                END
+                """)
+            }
+            await #expect(throws: (any Error).self) {
+                try await recorder.endRangeForReconfiguration(source: .microphone)
+            }
+
+            let rangeAfterFailure = try await fixture.database.dbQueue.read { db in
+                try RecordingAudioRangeRecord.fetchOne(db)
+            }
+            #expect(rangeAfterFailure?.frameCount == nil)
+
+            try await fixture.database.dbQueue.write { db in
+                try db.execute(sql: "DROP TRIGGER reject_range_close")
+            }
+            try writer.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 40))
+            try await recorder.endRangeForReconfiguration(source: .microphone)
+
+            let rangeAfterRetry = try await fixture.database.dbQueue.read { db in
+                try RecordingAudioRangeRecord.fetchOne(db)
+            }
+            #expect(rangeAfterRetry?.frameCount == 120)
+            await #expect(throws: (any Error).self) {
+                try await recorder.finish()
+            }
+
+            let result = try await fixture.database.dbQueue.read { db in
+                let file = try RecordingAudioFileRecord
+                    .filter(Column("recordingSessionId") == fixture.session.id)
+                    .fetchOne(db)
+                let range = try RecordingAudioRangeRecord.fetchOne(db)
+                return (file, range)
+            }
+            #expect(result.0?.totalFrameCount == 120)
+            #expect(result.1?.frameCount == 120)
+        }
+
         private func makeBuffer(format: AVAudioFormat, frameCount: AVAudioFrameCount) throws -> AVAudioPCMBuffer {
             let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount))
             buffer.frameLength = frameCount

--- a/Tests/DahliaTests/BatchAudioRecordingSessionTests.swift
+++ b/Tests/DahliaTests/BatchAudioRecordingSessionTests.swift
@@ -147,8 +147,16 @@ import GRDB
             await #expect(throws: (any Error).self) {
                 try await recorder.rotateRanges(
                     [
-                        (source: .microphone, sessionRelativeOriginSeconds: 0.25),
-                        (source: .system, sessionRelativeOriginSeconds: 0.5),
+                        BatchRecordingRangeOrigin(
+                            source: .microphone,
+                            startFrame: 0,
+                            sessionRelativeOriginSeconds: 0.25
+                        ),
+                        BatchRecordingRangeOrigin(
+                            source: .system,
+                            startFrame: 0,
+                            sessionRelativeOriginSeconds: 0.5
+                        ),
                     ],
                     locale: Locale(identifier: "en_US")
                 )
@@ -165,8 +173,16 @@ import GRDB
             }
             try await recorder.rotateRanges(
                 [
-                    (source: .microphone, sessionRelativeOriginSeconds: 0.25),
-                    (source: .system, sessionRelativeOriginSeconds: 0.5),
+                    BatchRecordingRangeOrigin(
+                        source: .microphone,
+                        startFrame: 0,
+                        sessionRelativeOriginSeconds: 0.25
+                    ),
+                    BatchRecordingRangeOrigin(
+                        source: .system,
+                        startFrame: 0,
+                        sessionRelativeOriginSeconds: 0.5
+                    ),
                 ],
                 locale: Locale(identifier: "en_US")
             )
@@ -193,6 +209,49 @@ import GRDB
             #expect(systemRanges.map(\.startFrame) == [0, 120])
             #expect(systemRanges.map(\.frameCount) == [120, 60])
             #expect(abs((systemRanges.last?.sessionOffsetSeconds ?? 0) - 0.5075) < 0.000_001)
+        }
+
+        @Test
+        func replacementRangeAndLaterLocaleRotationDoNotDoubleCountElapsedFrames() async throws {
+            let fixture = try BatchAudioTestFixture(name: "BatchReplacementOrigin")
+            defer { fixture.removeFiles() }
+            let recorder = try BatchAudioRecordingSession(
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL,
+                meetingId: fixture.meeting.id,
+                recordingSessionId: fixture.session.id,
+                recordingStartTime: fixture.now,
+                sampleRate: 16000
+            )
+            let initialWriter = try await recorder.beginRange(
+                source: .microphone,
+                locale: Locale(identifier: "ja_JP"),
+                at: fixture.now
+            )
+            try initialWriter.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 16000))
+
+            let replacement = try await recorder.beginRangeWithOrigin(
+                source: .microphone,
+                locale: Locale(identifier: "ja_JP"),
+                at: fixture.now.addingTimeInterval(60),
+                continuingFromActiveRange: true
+            )
+            #expect(replacement.origin.startFrame == 16000)
+            #expect(abs(replacement.origin.sessionRelativeOriginSeconds - 1) < 0.000_001)
+            try replacement.writer.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 8000))
+
+            _ = try await recorder.rotateRanges(
+                [replacement.origin],
+                locale: Locale(identifier: "en_US")
+            )
+            try await recorder.finish()
+
+            let ranges = try await fixture.database.dbQueue.read { db in
+                try RecordingAudioRangeRecord.order(Column("startFrame").asc).fetchAll(db)
+            }
+            #expect(ranges.map(\.startFrame) == [0, 16000, 24000])
+            #expect(abs(ranges[1].sessionOffsetSeconds - 1) < 0.000_001)
+            #expect(abs(ranges[2].sessionOffsetSeconds - 1.5) < 0.000_001)
         }
 
         @Test
@@ -257,7 +316,7 @@ import GRDB
         }
 
         @Test
-        func failedRangeCloseRemainsActiveAndMakesFinishFailAfterRetrySucceeds() async throws {
+        func failedRangeCloseRemainsActiveAndFinishSucceedsAfterRetry() async throws {
             let fixture = try BatchAudioTestFixture(name: "BatchRangeCloseFailure")
             defer { fixture.removeFiles() }
 
@@ -305,9 +364,7 @@ import GRDB
                 try RecordingAudioRangeRecord.fetchOne(db)
             }
             #expect(rangeAfterRetry?.frameCount == 120)
-            await #expect(throws: (any Error).self) {
-                try await recorder.finish()
-            }
+            try await recorder.finish()
 
             let result = try await fixture.database.dbQueue.read { db in
                 let file = try RecordingAudioFileRecord

--- a/Tests/DahliaTests/BatchTranscriptionConfirmationServiceTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionConfirmationServiceTests.swift
@@ -15,7 +15,7 @@ import GRDB
         }
 
         @Test
-        func confirmationUpdatesEverySessionRangeAndMarksItForRecovery() async throws {
+        func confirmationPreservesMultilingualRangesAndMarksSessionForRecovery() async throws {
             let fixture = try BatchAudioTestFixture(
                 name: "BatchConfirmation",
                 endedAt: Date(timeIntervalSince1970: 1_776_384_060),
@@ -39,12 +39,44 @@ import GRDB
             #expect(meetingId == fixture.meeting.id)
             #expect(result.files.count == 2)
             #expect(result.ranges.count == 3)
-            #expect(result.ranges.allSatisfy { $0.localeIdentifier == "en_US" })
+            #expect(result.ranges.map(\.localeIdentifier).sorted() == ["fr_FR", "ja_JP", "ja_JP"])
             #expect(result.unrelatedRange?.localeIdentifier == "ja_JP")
             #expect(session.batchLastAttemptAt != nil)
             #expect(session.batchAttemptCount == 0)
             #expect(BatchTranscriptionState.derive(from: session) == .queued(sessionId: session.id))
             #expect(BatchTranscriptionCoordinator.shouldAutomaticallyRetry(session))
+        }
+
+        @Test
+        func confirmationReplacesSingleRecordedLocale() async throws {
+            let fixture = try BatchAudioTestFixture(
+                name: "BatchSingleLocaleConfirmation",
+                endedAt: Date(timeIntervalSince1970: 1_776_384_060),
+                duration: 60
+            )
+            defer { fixture.removeFiles() }
+            let file = fixture.makeAudioRecord(finalizedAt: fixture.now, totalFrameCount: 320)
+            let ranges = [
+                makeRange(audioFileId: file.id, startFrame: 0, localeIdentifier: "ja_JP", now: fixture.now),
+                makeRange(audioFileId: file.id, startFrame: 160, localeIdentifier: "ja_JP", now: fixture.now),
+            ]
+            try await fixture.database.dbQueue.write { db in
+                try file.insert(db)
+                for range in ranges {
+                    try range.insert(db)
+                }
+            }
+
+            _ = try await BatchTranscriptionConfirmationService.confirm(
+                sessionId: fixture.session.id,
+                localeIdentifier: "en_US",
+                dbQueue: fixture.database.dbQueue
+            )
+
+            let persisted = try await fixture.database.dbQueue.read { db in
+                try RecordingAudioRangeRecord.order(Column("startFrame").asc).fetchAll(db)
+            }
+            #expect(persisted.map(\.localeIdentifier) == ["en_US", "en_US"])
         }
 
         private func insertConfirmationScenario(in fixture: BatchAudioTestFixture) async throws -> UUID {

--- a/Tests/DahliaTests/BatchTranscriptionConfirmationServiceTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionConfirmationServiceTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct BatchTranscriptionConfirmationServiceTests {
+        private struct ConfirmationResult {
+            let session: RecordingSessionRecord?
+            let files: [RecordingAudioFileRecord]
+            let ranges: [RecordingAudioRangeRecord]
+            let unrelatedRange: RecordingAudioRangeRecord?
+        }
+
+        @Test
+        func confirmationUpdatesEverySessionRangeAndMarksItForRecovery() async throws {
+            let fixture = try BatchAudioTestFixture(
+                name: "BatchConfirmation",
+                endedAt: Date(timeIntervalSince1970: 1_776_384_060),
+                duration: 60
+            )
+            defer { fixture.removeFiles() }
+            let otherFileId = try await insertConfirmationScenario(in: fixture)
+
+            let meetingId = try await BatchTranscriptionConfirmationService.confirm(
+                sessionId: fixture.session.id,
+                localeIdentifier: "en_US",
+                dbQueue: fixture.database.dbQueue
+            )
+
+            let result = try await loadConfirmationResult(
+                sessionId: fixture.session.id,
+                otherFileId: otherFileId,
+                from: fixture.database.dbQueue
+            )
+            let session = try #require(result.session)
+            #expect(meetingId == fixture.meeting.id)
+            #expect(result.files.count == 2)
+            #expect(result.ranges.count == 3)
+            #expect(result.ranges.allSatisfy { $0.localeIdentifier == "en_US" })
+            #expect(result.unrelatedRange?.localeIdentifier == "ja_JP")
+            #expect(session.batchLastAttemptAt != nil)
+            #expect(session.batchAttemptCount == 0)
+            #expect(BatchTranscriptionState.derive(from: session) == .queued(sessionId: session.id))
+            #expect(BatchTranscriptionCoordinator.shouldAutomaticallyRetry(session))
+        }
+
+        private func insertConfirmationScenario(in fixture: BatchAudioTestFixture) async throws -> UUID {
+            let microphoneFile = fixture.makeAudioRecord(finalizedAt: fixture.now, totalFrameCount: 320)
+            let systemFile = makeAudioFile(sessionId: fixture.session.id, source: .system, name: "system.caf", now: fixture.now)
+            let otherSession = makeOtherSession(in: fixture)
+            let otherFile = makeAudioFile(sessionId: otherSession.id, source: .microphone, name: "other.caf", now: fixture.now)
+            let ranges = [
+                makeRange(audioFileId: microphoneFile.id, startFrame: 0, localeIdentifier: "ja_JP", now: fixture.now),
+                makeRange(audioFileId: microphoneFile.id, startFrame: 160, localeIdentifier: "fr_FR", now: fixture.now),
+                makeRange(audioFileId: systemFile.id, startFrame: 0, localeIdentifier: "ja_JP", now: fixture.now),
+            ]
+            let otherRange = makeRange(audioFileId: otherFile.id, startFrame: 0, localeIdentifier: "ja_JP", now: fixture.now)
+            try await fixture.database.dbQueue.write { db in
+                try otherSession.insert(db)
+                try microphoneFile.insert(db)
+                try systemFile.insert(db)
+                try otherFile.insert(db)
+                for range in ranges {
+                    try range.insert(db)
+                }
+                try otherRange.insert(db)
+            }
+            return otherFile.id
+        }
+
+        private func loadConfirmationResult(
+            sessionId: UUID,
+            otherFileId: UUID,
+            from dbQueue: DatabaseQueue
+        ) async throws -> ConfirmationResult {
+            try await dbQueue.read { db in
+                let session = try RecordingSessionRecord.fetchOne(db, key: sessionId)
+                let files = try RecordingAudioFileRecord.filter(Column("recordingSessionId") == sessionId).fetchAll(db)
+                let ranges = try RecordingAudioRangeRecord
+                    .filter(files.map(\.id).contains(Column("audioFileId")))
+                    .order(Column("startFrame").asc)
+                    .fetchAll(db)
+                let otherRange = try RecordingAudioRangeRecord.filter(Column("audioFileId") == otherFileId).fetchOne(db)
+                return ConfirmationResult(session: session, files: files, ranges: ranges, unrelatedRange: otherRange)
+            }
+        }
+
+        private func makeOtherSession(in fixture: BatchAudioTestFixture) -> RecordingSessionRecord {
+            RecordingSessionRecord(
+                id: .v7(),
+                meetingId: fixture.meeting.id,
+                startedAt: fixture.now.addingTimeInterval(-120),
+                endedAt: fixture.now.addingTimeInterval(-60),
+                duration: 60,
+                offsetSeconds: 0,
+                createdAt: fixture.now,
+                updatedAt: fixture.now,
+                transcriptionMode: .batch
+            )
+        }
+
+        private func makeAudioFile(
+            sessionId: UUID,
+            source: RecordingAudioSource,
+            name: String,
+            now: Date
+        ) -> RecordingAudioFileRecord {
+            RecordingAudioFileRecord(
+                id: .v7(),
+                recordingSessionId: sessionId,
+                source: source,
+                relativePath: name,
+                sampleRate: 16000,
+                channelCount: 1,
+                finalizedAt: now,
+                totalFrameCount: 160,
+                createdAt: now,
+                updatedAt: now
+            )
+        }
+
+        private func makeRange(
+            audioFileId: UUID,
+            startFrame: Int64,
+            localeIdentifier: String,
+            now: Date
+        ) -> RecordingAudioRangeRecord {
+            RecordingAudioRangeRecord(
+                id: .v7(),
+                audioFileId: audioFileId,
+                startFrame: startFrame,
+                frameCount: 160,
+                sessionOffsetSeconds: Double(startFrame) / 16000,
+                localeIdentifier: localeIdentifier,
+                createdAt: now,
+                updatedAt: now
+            )
+        }
+    }
+#endif

--- a/Tests/DahliaTests/BatchTranscriptionRecoveryServiceTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionRecoveryServiceTests.swift
@@ -8,7 +8,7 @@ import GRDB
     @MainActor
     struct BatchTranscriptionRecoveryServiceTests {
         @Test
-        func recoversPartialCAFAndOpenRangeAfterCrash() throws {
+        func recoversPartialCAFAndOpenRangeAfterCrash() async throws {
             let fixture = try BatchAudioTestFixture(name: "Recovery")
             defer { fixture.removeFiles() }
             let audioRecord = fixture.makeAudioRecord(finalizedAt: nil, totalFrameCount: nil)
@@ -22,7 +22,7 @@ import GRDB
                 createdAt: fixture.now,
                 updatedAt: fixture.now
             )
-            try fixture.database.dbQueue.write { db in
+            try await fixture.database.dbQueue.write { db in
                 try audioRecord.insert(db)
                 try range.insert(db)
             }
@@ -38,7 +38,7 @@ import GRDB
                 managedRootURL: fixture.managedRootURL
             )
 
-            let result = try fixture.database.dbQueue.read { db in
+            let result = try await fixture.database.dbQueue.read { db in
                 let recoveredSession = try RecordingSessionRecord.fetchOne(db, key: fixture.session.id)
                 let recoveredMeeting = try MeetingRecord.fetchOne(db, key: fixture.meeting.id)
                 let recoveredFile = try RecordingAudioFileRecord.fetchOne(db, key: audioRecord.id)
@@ -61,6 +61,47 @@ import GRDB
                 relativePath: fixture.managedRelativePath
             )
             #expect(FileManager.default.fileExists(atPath: finalURL.path))
+        }
+
+        @Test
+        func coordinatorRecoversInterruptedRecordingIntoConfirmationState() async throws {
+            let fixture = try BatchAudioTestFixture(name: "CoordinatorRecovery")
+            defer { fixture.removeFiles() }
+            let audioRecord = fixture.makeAudioRecord(finalizedAt: nil, totalFrameCount: nil)
+            let range = RecordingAudioRangeRecord(
+                id: .v7(),
+                audioFileId: audioRecord.id,
+                startFrame: 0,
+                frameCount: nil,
+                sessionOffsetSeconds: 0,
+                localeIdentifier: "ja_JP",
+                createdAt: fixture.now,
+                updatedAt: fixture.now
+            )
+            try await fixture.database.dbQueue.write { db in
+                try audioRecord.insert(db)
+                try range.insert(db)
+            }
+            let partialURL = BatchAudioStorage.partialURL(
+                baseURL: fixture.managedRootURL,
+                relativePath: fixture.managedRelativePath
+            )
+            try BatchAudioTestFixture.writeCAF(url: partialURL, frameCount: 320)
+            let coordinator = BatchTranscriptionCoordinator(
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL,
+                onStateChange: { _ in }
+            )
+
+            await coordinator.recoverAndEnqueue()
+
+            let session = try await fixture.database.dbQueue.read { db in
+                let record = try RecordingSessionRecord.fetchOne(db, key: fixture.session.id)
+                return try #require(record)
+            }
+            #expect(session.endedAt != nil)
+            #expect(session.batchLastAttemptAt == nil)
+            #expect(BatchTranscriptionState.derive(from: session) == .awaitingConfirmation(sessionId: session.id))
         }
     }
 #endif

--- a/Tests/DahliaTests/BatchTranscriptionStateTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionStateTests.swift
@@ -23,8 +23,11 @@ import Foundation
             #expect(BatchTranscriptionState.derive(from: session) == .recording(sessionId: session.id))
 
             session.endedAt = now.addingTimeInterval(10)
-            #expect(BatchTranscriptionState.derive(from: session) == .queued(sessionId: session.id))
+            #expect(BatchTranscriptionState.derive(from: session) == .awaitingConfirmation(sessionId: session.id))
             #expect(BatchTranscriptionState.derive(from: session, isRunning: true) == .running(sessionId: session.id))
+
+            session.batchLastAttemptAt = now.addingTimeInterval(11)
+            #expect(BatchTranscriptionState.derive(from: session) == .queued(sessionId: session.id))
 
             session.batchLastError = "damaged"
             #expect(BatchTranscriptionState.derive(from: session) == .failed(sessionId: session.id, message: "damaged"))
@@ -77,7 +80,13 @@ import Foundation
 
             // 実行中クラッシュでエラーが記録されなかったセッションは、回数にかかわらず復旧対象にする。
             session.batchLastError = nil
+            session.batchLastAttemptAt = now.addingTimeInterval(11)
             #expect(BatchTranscriptionCoordinator.shouldAutomaticallyRetry(session))
+
+            // 停止後にまだ確認されていないセッションは、再起動しても自動実行しない。
+            session.batchLastAttemptAt = nil
+            session.batchAttemptCount = 0
+            #expect(!BatchTranscriptionCoordinator.shouldAutomaticallyRetry(session))
         }
     }
 #endif

--- a/Tests/DahliaTests/CaptionViewModelBatchUpdateTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelBatchUpdateTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct CaptionViewModelBatchUpdateTests {
+        private struct Fixture {
+            let batch: BatchAudioTestFixture
+            let recordingMeeting: MeetingRecord
+            let recordingSegment: TranscriptSegmentRecord
+            let visibleSegment: TranscriptSegmentRecord
+        }
+
+        @Test
+        func completedBatchUpdateReplacesAwaitingConfirmationState() async throws {
+            let prepared = try makeFixture(name: "completed-replaces-queued")
+            let batch = prepared.batch
+            defer { batch.removeFiles() }
+
+            let viewModel = CaptionViewModel()
+            viewModel.loadMeeting(
+                batch.meeting.id,
+                dbQueue: batch.database.dbQueue,
+                projectURL: nil,
+                projectId: nil,
+                vaultURL: batch.vaultURL
+            )
+
+            #expect(await waitUntil {
+                viewModel.batchTranscriptionState == .awaitingConfirmation(sessionId: batch.session.id)
+            })
+
+            _ = try completeBatchSessionAndInsertSegment(batch: batch)
+            await viewModel.handleBatchTranscriptionUpdate(
+                BatchTranscriptionUpdate(
+                    meetingId: batch.meeting.id,
+                    state: .completed(sessionId: batch.session.id)
+                )
+            )
+
+            #expect(viewModel.batchTranscriptionState == nil)
+        }
+
+        @Test
+        func completedBatchReloadsVisibleMeetingWhileAnotherMeetingIsRecording() async throws {
+            let prepared = try makeFixture(name: "visible-batch")
+            let batch = prepared.batch
+            defer { batch.removeFiles() }
+
+            let viewModel = CaptionViewModel()
+            viewModel.loadMeeting(
+                prepared.recordingMeeting.id,
+                dbQueue: batch.database.dbQueue,
+                projectURL: nil,
+                projectId: nil,
+                vaultURL: batch.vaultURL
+            )
+            #expect(await waitUntil {
+                viewModel.store.segments.contains(where: { $0.id == prepared.recordingSegment.id })
+            })
+
+            viewModel.isListening = true
+            viewModel.loadMeeting(
+                batch.meeting.id,
+                dbQueue: batch.database.dbQueue,
+                projectURL: nil,
+                projectId: nil,
+                vaultURL: batch.vaultURL
+            )
+            #expect(await waitUntil {
+                viewModel.store.segments.contains(where: { $0.id == prepared.visibleSegment.id })
+            })
+            #expect(viewModel.recordingMeetingId == prepared.recordingMeeting.id)
+            #expect(viewModel.isViewingOtherWhileRecording)
+
+            let completedSegment = try completeBatchSessionAndInsertSegment(batch: batch)
+            await viewModel.handleBatchTranscriptionUpdate(
+                BatchTranscriptionUpdate(
+                    meetingId: batch.meeting.id,
+                    state: .completed(sessionId: batch.session.id)
+                )
+            )
+
+            #expect(viewModel.store.segments.contains(where: { $0.id == completedSegment.id }))
+            #expect(viewModel.currentMeetingId == batch.meeting.id)
+            #expect(viewModel.recordingMeetingId == prepared.recordingMeeting.id)
+        }
+
+        private func makeFixture(name: String) throws -> Fixture {
+            let batch = try BatchAudioTestFixture(
+                name: name,
+                endedAt: Date(timeIntervalSince1970: 1_776_384_001),
+                duration: 1
+            )
+            let recordingMeeting = MeetingRecord(
+                id: .v7(),
+                vaultId: batch.meeting.vaultId,
+                projectId: nil,
+                name: "active-recording",
+                createdAt: batch.now.addingTimeInterval(-60),
+                updatedAt: batch.now.addingTimeInterval(-60)
+            )
+            let recordingSegment = TranscriptSegmentRecord(
+                id: .v7(),
+                meetingId: recordingMeeting.id,
+                startTime: recordingMeeting.createdAt,
+                endTime: nil,
+                text: "active recording transcript",
+                translatedText: nil,
+                isConfirmed: true,
+                speakerLabel: "mic"
+            )
+            let visibleSegment = TranscriptSegmentRecord(
+                id: .v7(),
+                meetingId: batch.meeting.id,
+                startTime: batch.now,
+                endTime: nil,
+                text: "visible transcript before completion",
+                translatedText: nil,
+                isConfirmed: true,
+                speakerLabel: "mic"
+            )
+            try batch.database.dbQueue.write { db in
+                try recordingMeeting.insert(db)
+                try recordingSegment.insert(db)
+                try visibleSegment.insert(db)
+            }
+            return Fixture(
+                batch: batch,
+                recordingMeeting: recordingMeeting,
+                recordingSegment: recordingSegment,
+                visibleSegment: visibleSegment
+            )
+        }
+
+        private func completeBatchSessionAndInsertSegment(
+            batch: BatchAudioTestFixture
+        ) throws -> TranscriptSegmentRecord {
+            let completedAt = batch.now.addingTimeInterval(2)
+            let segment = TranscriptSegmentRecord(
+                id: .v7(),
+                meetingId: batch.meeting.id,
+                startTime: completedAt,
+                endTime: nil,
+                text: "loaded after batch completion",
+                translatedText: nil,
+                isConfirmed: true,
+                speakerLabel: "mic"
+            )
+            try batch.database.dbQueue.write { db in
+                try db.execute(
+                    sql: "UPDATE recording_sessions SET batchCompletedAt = ?, updatedAt = ? WHERE id = ?",
+                    arguments: [completedAt, completedAt, batch.session.id]
+                )
+                try segment.insert(db)
+            }
+            return segment
+        }
+
+        private func waitUntil(
+            timeout: Duration = .seconds(1),
+            condition: () -> Bool
+        ) async -> Bool {
+            let clock = ContinuousClock()
+            let deadline = clock.now + timeout
+
+            while clock.now < deadline {
+                if condition() {
+                    return true
+                }
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+
+            return condition()
+        }
+    }
+#endif

--- a/Tests/DahliaTests/FakeAnalyzerInputConverter.swift
+++ b/Tests/DahliaTests/FakeAnalyzerInputConverter.swift
@@ -1,0 +1,31 @@
+@preconcurrency import AVFoundation
+import CoreMedia
+import os
+import Speech
+@testable import Dahlia
+
+final class FakeAnalyzerInputConverter: AnalyzerInputConverting {
+    private let outputFormat: AVAudioFormat
+    private let count = OSAllocatedUnfairLock(initialState: 0)
+
+    var conversionCount: Int {
+        count.withLock { $0 }
+    }
+
+    init(outputFormat: AVAudioFormat) {
+        self.outputFormat = outputFormat
+    }
+
+    func convert(_: AVAudioPCMBuffer, at startTime: CMTime) throws -> [AnalyzerInput] {
+        count.withLock { $0 += 1 }
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: 1) else {
+            return []
+        }
+        buffer.frameLength = 1
+        return [AnalyzerInput(buffer: buffer, bufferStartTime: startTime)]
+    }
+
+    func finish() throws -> [AnalyzerInput] {
+        []
+    }
+}

--- a/Tests/DahliaTests/FakeLiveSubtitlePresenter.swift
+++ b/Tests/DahliaTests/FakeLiveSubtitlePresenter.swift
@@ -1,0 +1,16 @@
+@testable import Dahlia
+
+@MainActor
+final class FakeLiveSubtitlePresenter: LiveSubtitlePresenting {
+    private(set) var lastPayload: LiveSubtitleOverlayPayload?
+    private(set) var hideCount = 0
+
+    func update(payload: LiveSubtitleOverlayPayload?) {
+        lastPayload = payload
+    }
+
+    func hide() {
+        hideCount += 1
+        lastPayload = nil
+    }
+}

--- a/Tests/DahliaTests/LiveCaptionStoreTests.swift
+++ b/Tests/DahliaTests/LiveCaptionStoreTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+
+#if canImport(Testing)
+    import Testing
+    @testable import Dahlia
+
+    @MainActor
+    struct LiveCaptionStoreTests {
+        @Test
+        func previewUpsertIsIndependentForEachSource() {
+            let sessionID = UUID.v7()
+            let store = LiveCaptionStore()
+            store.start(sessionId: sessionID)
+
+            store.apply(event: .preview(makeSegment(sessionID: sessionID, text: "Mic first", source: "mic")))
+            store.apply(event: .preview(makeSegment(sessionID: sessionID, text: "System", source: "system")))
+            store.apply(event: .preview(makeSegment(sessionID: sessionID, text: "Mic latest", source: "mic")))
+
+            #expect(store.segments.count == 2)
+            #expect(store.segments.first(where: { $0.speakerLabel == "mic" })?.text == "Mic latest")
+            #expect(store.segments.first(where: { $0.speakerLabel == "system" })?.text == "System")
+            #expect(store.segments.allSatisfy { !$0.isConfirmed })
+        }
+
+        @Test
+        func finalizedEventClearsOnlyItsSourcePreviewAndAcceptsTranslation() throws {
+            let sessionID = UUID.v7()
+            let finalizedID = UUID.v7()
+            let store = LiveCaptionStore()
+            store.start(sessionId: sessionID)
+            store.apply(event: .preview(makeSegment(sessionID: sessionID, text: "Mic preview", source: "mic")))
+            store.apply(event: .preview(makeSegment(sessionID: sessionID, text: "System preview", source: "system")))
+
+            store.apply(event: .finalized(makeSegment(
+                id: finalizedID,
+                sessionID: sessionID,
+                text: "Mic final",
+                source: "mic"
+            )))
+            store.apply(event: .translation(
+                sessionId: sessionID,
+                segmentID: finalizedID,
+                translatedText: "マイク確定"
+            ))
+
+            let finalized = try #require(store.segments.first(where: { $0.id == finalizedID }))
+            #expect(finalized.isConfirmed)
+            #expect(finalized.translatedText == "マイク確定")
+            #expect(!store.segments.contains(where: { $0.text == "Mic preview" }))
+            #expect(store.segments.contains(where: { $0.text == "System preview" && !$0.isConfirmed }))
+
+            store.apply(event: .clearPreview(sessionId: sessionID, sourceLabel: "system"))
+            #expect(store.segments == [finalized])
+        }
+
+        @Test
+        func eventsFromInactiveSessionAreIgnored() {
+            let activeSessionID = UUID.v7()
+            let inactiveSessionID = UUID.v7()
+            let segment = makeSegment(sessionID: activeSessionID, text: "Active", source: "mic")
+            let store = LiveCaptionStore()
+            store.start(sessionId: activeSessionID)
+            store.apply(event: .finalized(segment))
+
+            store.apply(event: .preview(makeSegment(
+                sessionID: inactiveSessionID,
+                text: "Stale preview",
+                source: "system"
+            )))
+            store.apply(event: .clearPreview(sessionId: inactiveSessionID, sourceLabel: "mic"))
+            store.apply(event: .translation(
+                sessionId: inactiveSessionID,
+                segmentID: segment.id,
+                translatedText: "古い翻訳"
+            ))
+            store.apply(event: .failure(
+                sessionId: inactiveSessionID,
+                pipelineID: .v7(),
+                sourceLabel: "system",
+                message: "Stale failure"
+            ))
+
+            #expect(store.segments == [segmentWithConfirmation(segment)])
+            #expect(store.failureMessage == nil)
+        }
+
+        @Test
+        func seedFiltersSegmentsAndCannotReactivateAnOldSession() {
+            let activeSessionID = UUID.v7()
+            let oldSessionID = UUID.v7()
+            let activeSegment = makeSegment(
+                sessionID: activeSessionID,
+                text: "Active",
+                source: "mic",
+                isConfirmed: true
+            )
+            let oldSegment = makeSegment(
+                sessionID: oldSessionID,
+                text: "Old",
+                source: "system",
+                isConfirmed: true
+            )
+            let store = LiveCaptionStore()
+            store.start(sessionId: activeSessionID)
+
+            store.seed([oldSegment, activeSegment], sessionId: activeSessionID)
+            #expect(store.segments == [activeSegment])
+
+            store.seed([oldSegment], sessionId: oldSessionID)
+            #expect(store.activeSessionId == activeSessionID)
+            #expect(store.segments == [activeSegment])
+        }
+
+        @Test
+        func startingNewSessionAndClearingResetTransientState() {
+            let firstSessionID = UUID.v7()
+            let secondSessionID = UUID.v7()
+            let store = LiveCaptionStore()
+            store.start(sessionId: firstSessionID)
+            store.apply(event: .preview(makeSegment(sessionID: firstSessionID, text: "Preview", source: "mic")))
+            store.apply(event: .failure(
+                sessionId: firstSessionID,
+                pipelineID: .v7(),
+                sourceLabel: "mic",
+                message: "Recognition unavailable"
+            ))
+
+            store.start(sessionId: firstSessionID)
+            #expect(store.segments.count == 1)
+            #expect(store.failureMessage == "Recognition unavailable")
+
+            store.start(sessionId: secondSessionID)
+            #expect(store.activeSessionId == secondSessionID)
+            #expect(store.segments.isEmpty)
+            #expect(store.failureMessage == nil)
+
+            store.clear()
+            #expect(store.activeSessionId == nil)
+            #expect(store.segments.isEmpty)
+            #expect(store.failureMessage == nil)
+        }
+
+        private func makeSegment(
+            id: UUID = .v7(),
+            sessionID: UUID,
+            text: String,
+            source: String?,
+            isConfirmed: Bool = false
+        ) -> TranscriptSegment {
+            TranscriptSegment(
+                id: id,
+                sessionId: sessionID,
+                startTime: Date(timeIntervalSince1970: 1_776_384_000),
+                text: text,
+                isConfirmed: isConfirmed,
+                speakerLabel: source
+            )
+        }
+
+        private func segmentWithConfirmation(_ segment: TranscriptSegment) -> TranscriptSegment {
+            TranscriptSegment(
+                id: segment.id,
+                sessionId: segment.sessionId,
+                startTime: segment.startTime,
+                endTime: segment.endTime,
+                text: segment.text,
+                translatedText: segment.translatedText,
+                isConfirmed: true,
+                speakerLabel: segment.speakerLabel
+            )
+        }
+    }
+#endif

--- a/Tests/DahliaTests/LiveSubtitleOverlayCoordinatorTests.swift
+++ b/Tests/DahliaTests/LiveSubtitleOverlayCoordinatorTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+#if canImport(Testing)
+    import Testing
+    @testable import Dahlia
+
+    @MainActor
+    @Suite(.serialized)
+    struct LiveSubtitleOverlayCoordinatorTests {
+        @Test
+        func overlayReadsEphemeralCaptionStoreInsteadOfAuthoritativeTranscript() throws {
+            let previousSetting = AppSettings.shared.liveSubtitleOverlayEnabled
+            AppSettings.shared.liveSubtitleOverlayEnabled = true
+            defer { AppSettings.shared.liveSubtitleOverlayEnabled = previousSetting }
+
+            let viewModel = CaptionViewModel(
+                availableInputDevicesProvider: { [] },
+                defaultInputDeviceIDProvider: { nil }
+            )
+            let sessionID = UUID.v7()
+            viewModel.isListening = true
+            viewModel.store.addSegment(
+                TranscriptSegment(
+                    sessionId: sessionID,
+                    startTime: .now,
+                    text: "Historical transcript",
+                    isConfirmed: true,
+                    speakerLabel: "system"
+                )
+            )
+            viewModel.liveCaptionStore.start(sessionId: sessionID)
+            viewModel.liveCaptionStore.apply(event: .finalized(
+                TranscriptSegment(
+                    sessionId: sessionID,
+                    startTime: .now,
+                    text: "Ephemeral live caption",
+                    isConfirmed: true,
+                    speakerLabel: "system"
+                )
+            ))
+            let presenter = FakeLiveSubtitlePresenter()
+
+            _ = LiveSubtitleOverlayCoordinator(
+                viewModel: viewModel,
+                liveSubtitleOverlayService: presenter
+            )
+
+            let payload = try #require(presenter.lastPayload)
+            #expect(payload.entries.map(\.primaryText) == ["Ephemeral live caption"])
+        }
+    }
+#endif

--- a/Tests/DahliaTests/MeetingPersistenceServiceTests.swift
+++ b/Tests/DahliaTests/MeetingPersistenceServiceTests.swift
@@ -6,6 +6,7 @@ import GRDB
     import Testing
 
     @MainActor
+    // swiftlint:disable:next type_body_length
     struct MeetingPersistenceServiceTests {
         @Test
         func newMeetingStartsPersistedAsReady() throws {
@@ -44,6 +45,7 @@ import GRDB
                 projectId: nil,
                 initialName: "Batch meeting",
                 transcriptionMode: .batch,
+                persistencePolicy: .deferred,
                 retainAudioAfterBatch: true
             )
             store.addSegment(
@@ -82,7 +84,8 @@ import GRDB
                 vaultId: testVault.id,
                 projectId: nil,
                 initialName: "Failed batch meeting",
-                transcriptionMode: .batch
+                transcriptionMode: .batch,
+                persistencePolicy: .deferred
             )
             let attemptDate = Date(timeIntervalSince1970: 1_776_384_030)
             try database.dbQueue.write { db in

--- a/Tests/DahliaTests/MeetingPersistenceStopTests.swift
+++ b/Tests/DahliaTests/MeetingPersistenceStopTests.swift
@@ -72,6 +72,57 @@ import GRDB
             #expect(session.duration == nil)
         }
 
+        @Test
+        func appendStopDoesNotAssignLegacySegmentsToNewSession() throws {
+            let fixture = try makeDatabase()
+            let meetingId = UUID.v7()
+            let legacySegment = TranscriptSegment(
+                id: .v7(),
+                sessionId: nil,
+                startTime: fixture.vault.createdAt,
+                text: "Legacy transcript",
+                isConfirmed: true,
+                speakerLabel: "mic"
+            )
+            try fixture.database.dbQueue.write { db in
+                try MeetingRecord(
+                    id: meetingId,
+                    vaultId: fixture.vault.id,
+                    projectId: nil,
+                    name: "Legacy meeting",
+                    status: .ready,
+                    createdAt: fixture.vault.createdAt,
+                    updatedAt: fixture.vault.createdAt
+                ).insert(db)
+                try TranscriptSegmentRecord(from: legacySegment, meetingId: meetingId).insert(db)
+            }
+            let store = TranscriptStore()
+            store.loadSegments([legacySegment])
+            let service = try MeetingPersistenceService(
+                store: store,
+                dbQueue: fixture.database.dbQueue,
+                existingMeetingId: meetingId,
+                existingSegmentIds: [legacySegment.id],
+                recordingStartDate: .now
+            )
+            let newSegment = TranscriptSegment(
+                startTime: .now,
+                text: "New transcript",
+                isConfirmed: true,
+                speakerLabel: "mic"
+            )
+            store.addSegment(newSegment)
+
+            let result = service.stop()
+
+            let records = try fixture.database.dbQueue.read { db in
+                try TranscriptSegmentRecord.order(Column("startTime").asc).fetchAll(db)
+            }
+            #expect(result.succeeded)
+            #expect(records.first(where: { $0.id == legacySegment.id })?.sessionId == nil)
+            #expect(records.first(where: { $0.id == newSegment.id })?.sessionId == service.recordingSessionId)
+        }
+
         private func makeDatabase() throws -> (database: AppDatabaseManager, vault: VaultRecord) {
             let database = try AppDatabaseManager(path: ":memory:")
             let createdAt = Date(timeIntervalSince1970: 1_776_380_000)

--- a/Tests/DahliaTests/MeetingPersistenceStopTests.swift
+++ b/Tests/DahliaTests/MeetingPersistenceStopTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct MeetingPersistenceStopTests {
+        @Test
+        func stopPersistsFinalConfirmedSegmentsBeforeReportingSuccess() throws {
+            let fixture = try makeDatabase()
+            let store = TranscriptStore()
+            let startDate = Date(timeIntervalSince1970: 1_776_384_000)
+            store.recordingStartTime = startDate
+            let service = try MeetingPersistenceService(
+                store: store,
+                dbQueue: fixture.database.dbQueue,
+                vaultId: fixture.vault.id,
+                projectId: nil,
+                initialName: "Final segment"
+            )
+            let segment = TranscriptSegment(
+                startTime: startDate,
+                text: "Persisted at stop",
+                isConfirmed: true,
+                speakerLabel: "mic"
+            )
+            store.addSegment(segment)
+
+            let result = service.stop()
+
+            let persisted = try fixture.database.dbQueue.read { db in
+                try TranscriptSegmentRecord.fetchOne(db, key: segment.id)
+            }
+            #expect(result.succeeded)
+            #expect(persisted?.sessionId == service.recordingSessionId)
+            #expect(persisted?.text == segment.text)
+        }
+
+        @Test
+        func stopReportsSessionPersistenceFailure() throws {
+            let fixture = try makeDatabase()
+            let store = TranscriptStore()
+            store.recordingStartTime = Date(timeIntervalSince1970: 1_776_384_000)
+            let service = try MeetingPersistenceService(
+                store: store,
+                dbQueue: fixture.database.dbQueue,
+                vaultId: fixture.vault.id,
+                projectId: nil,
+                initialName: "Persistence failure"
+            )
+            try fixture.database.dbQueue.write { db in
+                try db.execute(sql: """
+                CREATE TRIGGER fail_recording_session_stop
+                BEFORE UPDATE OF endedAt ON recording_sessions
+                BEGIN
+                    SELECT RAISE(ABORT, 'forced stop failure');
+                END
+                """)
+            }
+
+            let result = service.stop()
+
+            let session = try fixture.database.dbQueue.read { db in
+                let record = try RecordingSessionRecord.fetchOne(db, key: service.recordingSessionId)
+                return try #require(record)
+            }
+            #expect(!result.succeeded)
+            #expect(result.failureMessage != nil)
+            #expect(session.endedAt == nil)
+            #expect(session.duration == nil)
+        }
+
+        private func makeDatabase() throws -> (database: AppDatabaseManager, vault: VaultRecord) {
+            let database = try AppDatabaseManager(path: ":memory:")
+            let createdAt = Date(timeIntervalSince1970: 1_776_380_000)
+            let vault = VaultRecord(
+                id: .v7(),
+                path: URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).path,
+                name: "Persistence Stop Test Vault",
+                createdAt: createdAt,
+                lastOpenedAt: createdAt
+            )
+            try database.dbQueue.write { db in
+                try vault.insert(db)
+            }
+            return (database, vault)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/PreviewTranslationCoordinatorTests.swift
+++ b/Tests/DahliaTests/PreviewTranslationCoordinatorTests.swift
@@ -128,6 +128,51 @@ struct PreviewTranslationCoordinatorTests {
         #expect(await recorder.appliedTexts() == ["新しい訳"])
         #expect(await recorder.appliedSegmentIDs() == [thirdSegmentID])
     }
+
+    @Test
+    func resetWaitsForAllInFlightTranslationsAndSuppressesTheirResults() async {
+        let translator = BlockingTranslator()
+        let recorder = PreviewTranslationRecorder()
+        let resetState = AsyncCompletionState()
+        let coordinator = PreviewTranslationCoordinator(
+            sleep: { _ in },
+            translate: { segment in
+                await recorder.recordTranslate(text: segment.text)
+                return await translator.translate(text: segment.text)
+            }
+        )
+
+        await coordinator.unconfirmedSegmentDidChange(
+            TranscriptSegment(startTime: .now, text: "Hello", isConfirmed: false)
+        ) { segmentID, translatedText in
+            await recorder.recordApply(segmentID: segmentID, translatedText: translatedText)
+        }
+        await translator.waitUntilStarted()
+
+        await coordinator.unconfirmedSegmentDidChange(
+            TranscriptSegment(startTime: .now, text: "Hello world", isConfirmed: false)
+        ) { segmentID, translatedText in
+            await recorder.recordApply(segmentID: segmentID, translatedText: translatedText)
+        }
+        await translator.waitUntilStarted(count: 2)
+
+        let resetTask = Task {
+            await coordinator.reset()
+            await resetState.markFinished()
+        }
+        try? await Task.sleep(for: .milliseconds(20))
+        #expect(await !(resetState.isFinished()))
+
+        await translator.resume(with: "古い訳")
+        try? await Task.sleep(for: .milliseconds(20))
+        #expect(await !(resetState.isFinished()))
+
+        await translator.resume(with: "新しい訳")
+        await resetTask.value
+
+        #expect(await resetState.isFinished())
+        #expect(await recorder.appliedTexts().isEmpty)
+    }
 }
 
 #elseif canImport(XCTest)
@@ -349,6 +394,18 @@ private actor BlockingTranslator {
         guard !continuations.isEmpty else { return }
         let continuation = continuations.removeFirst()
         continuation.resume(returning: text)
+    }
+}
+
+private actor AsyncCompletionState {
+    private var finished = false
+
+    func markFinished() {
+        finished = true
+    }
+
+    func isFinished() -> Bool {
+        finished
     }
 }
 

--- a/Tests/DahliaTests/RecordingSessionControllerTests.swift
+++ b/Tests/DahliaTests/RecordingSessionControllerTests.swift
@@ -115,6 +115,114 @@
         }
 
         @Test
+        func failedBatchLiveToggleDoesNotCommitEnabledPlan() async throws {
+            let runtime = try await makeRuntime(
+                mode: .batch,
+                liveSubtitlesEnabled: false,
+                recognitionFailureMode: .modelPreparation
+            )
+
+            await #expect(throws: FakeRuntimeError.self) {
+                try await runtime.controller.setLiveSubtitlesEnabled(true, translateSegment: nil)
+            }
+
+            let snapshot = try #require(await runtime.controller.snapshot())
+            #expect(!snapshot.plan.liveSubtitlesEnabled)
+            #expect(await runtime.controller.resourceCounts().recognizers == 0)
+            _ = try await runtime.controller.stop()
+            await runtime.controller.completeStop()
+        }
+
+        @Test
+        func batchRecognitionFailureDoesNotWaitForItsOwnEventDelivery() async throws {
+            let probe = RecordingRuntimeProbe()
+            let control = SelfWaitingRecognitionControl()
+            let failures = RuntimeFailureRecorder()
+            let controller = RecordingSessionController(
+                captureFactory: FakeAudioCaptureFactory(probe: probe),
+                recognitionFactory: SelfWaitingRecognitionFactory(probe: probe, control: control),
+                batchRecordingFactory: FakeBatchFactory(probe: probe)
+            )
+            let sessionID = UUID.v7()
+            try await controller.prepare(
+                RecordingSessionController.PreparationRequest(
+                    sessionId: sessionID,
+                    startedAt: .now,
+                    plan: TranscriptionSessionPlan(
+                        finalMode: .batch,
+                        liveSubtitlesEnabled: true,
+                        retainBatchAudio: false
+                    ),
+                    locale: Locale(identifier: "ja_JP"),
+                    sources: [.init(source: .microphone)],
+                    dbQueue: DatabaseQueue(),
+                    meetingId: .v7(),
+                    batchSampleRate: 16000
+                ),
+                onEvent: { _ in },
+                onRuntimeFailure: { source, message, isFatal in
+                    failures.append(source: source, message: message, isFatal: isFatal)
+                }
+            )
+            _ = try await controller.startPrepared()
+
+            await control.emitFailure()
+
+            #expect(await controller.resourceCounts().recognizers == 0)
+            let entries = await failures.entries
+            #expect(entries.contains { $0.source == .microphone && !$0.isFatal })
+            let result = try await controller.stop()
+            #expect(result.batchRecordingSucceeded)
+            await controller.completeStop()
+        }
+
+        @Test
+        func retiredRecognitionCannotClearReplacementPreview() async throws {
+            let probe = RecordingRuntimeProbe()
+            let control = SelfWaitingRecognitionControl()
+            let events = TranscriptionEventRecorder()
+            let controller = RecordingSessionController(
+                captureFactory: FakeAudioCaptureFactory(probe: probe),
+                recognitionFactory: SelfWaitingRecognitionFactory(probe: probe, control: control),
+                batchRecordingFactory: FakeBatchFactory(probe: probe)
+            )
+            let sessionID = UUID.v7()
+            try await controller.prepare(
+                RecordingSessionController.PreparationRequest(
+                    sessionId: sessionID,
+                    startedAt: .now,
+                    plan: TranscriptionSessionPlan(
+                        finalMode: .realtime,
+                        liveSubtitlesEnabled: true,
+                        retainBatchAudio: false
+                    ),
+                    locale: Locale(identifier: "ja_JP"),
+                    sources: [.init(source: .microphone)]
+                ),
+                onEvent: { event in events.append(event) },
+                onRuntimeFailure: { _, _, _ in }
+            )
+            _ = try await controller.startPrepared()
+
+            _ = try await controller.changeLocale(
+                to: Locale(identifier: "en_US"),
+                translateSegment: nil
+            )
+
+            let deliveredEvents = await events.events
+            #expect(deliveredEvents.contains { event in
+                guard case let .preview(segment) = event else { return false }
+                return segment.text == "replacement preview"
+            })
+            #expect(!deliveredEvents.contains { event in
+                if case .clearPreview = event { return true }
+                return false
+            })
+            _ = try await controller.stop()
+            await controller.completeStop()
+        }
+
+        @Test
         func stopOrdersCaptureBeforeRecognitionBeforeBatchAndWaitsForConfirmation() async throws {
             let runtime = try await makeRuntime(mode: .batch, liveSubtitlesEnabled: true)
             await runtime.probe.clear()
@@ -430,6 +538,15 @@
         }
     }
 
+    @MainActor
+    private final class TranscriptionEventRecorder {
+        private(set) var events: [TranscriptionEvent] = []
+
+        func append(_ event: TranscriptionEvent) {
+            events.append(event)
+        }
+    }
+
     private struct FakeAudioCaptureFactory: AudioCaptureSessionFactory {
         let probe: RecordingRuntimeProbe
         let failingSource: RecordingAudioSource?
@@ -588,6 +705,134 @@
         }
     }
 
+    private struct SelfWaitingRecognitionFactory: ProgressiveRecognitionSessionFactory {
+        let probe: RecordingRuntimeProbe
+        let control: SelfWaitingRecognitionControl
+
+        func prepareModel(locale _: Locale) async throws {}
+
+        func prepareSession(
+            locale _: Locale,
+            source: RecordingAudioSource,
+            sourceFormat _: AVAudioFormat?,
+            bufferingMode _: AudioBufferBridge.BufferingMode,
+            translateSegment _: ProgressiveSegmentTranslationHandler?
+        ) async throws -> PreparedProgressiveRecognitionSession {
+            let format = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: 16000,
+                channels: 1,
+                interleaved: false
+            ))
+            return PreparedProgressiveRecognitionSession(
+                analyzerFormat: format,
+                session: SelfWaitingRecognitionSession(source: source, probe: probe, control: control)
+            )
+        }
+    }
+
+    private actor SelfWaitingRecognitionSession: ProgressiveRecognitionSession {
+        nonisolated let pipelineID = UUID.v7()
+        nonisolated let liveConsumer: AudioFrameRouter.LiveConsumer = { _ in true }
+
+        private let source: RecordingAudioSource
+        private let probe: RecordingRuntimeProbe
+        private let control: SelfWaitingRecognitionControl
+
+        init(source: RecordingAudioSource, probe: RecordingRuntimeProbe, control: SelfWaitingRecognitionControl) {
+            self.source = source
+            self.probe = probe
+            self.control = control
+        }
+
+        func start(
+            recordingStartTime _: Date,
+            recordingSessionId: UUID,
+            onEvent: @escaping ProgressiveTranscriptionEventHandler
+        ) async throws {
+            await probe.append(.recognitionStart(source))
+            await control.register(
+                sessionID: recordingSessionId,
+                pipelineID: pipelineID,
+                source: source,
+                handler: onEvent
+            )
+        }
+
+        func finish() async throws {
+            await control.finish(pipelineID: pipelineID)
+            await probe.append(.recognitionFinish(source))
+        }
+
+        func cancel() async {
+            await control.waitForActiveDelivery()
+            await probe.append(.recognitionCancel(source))
+        }
+    }
+
+    private actor SelfWaitingRecognitionControl {
+        private struct Registration {
+            let sessionID: UUID
+            let pipelineID: UUID
+            let source: RecordingAudioSource
+            let handler: ProgressiveTranscriptionEventHandler
+        }
+
+        private var registrations: [Registration] = []
+        private var activeDelivery: Task<Void, Never>?
+
+        func register(
+            sessionID: UUID,
+            pipelineID: UUID,
+            source: RecordingAudioSource,
+            handler: @escaping ProgressiveTranscriptionEventHandler
+        ) {
+            registrations.append(Registration(
+                sessionID: sessionID,
+                pipelineID: pipelineID,
+                source: source,
+                handler: handler
+            ))
+        }
+
+        func emitFailure() async {
+            guard let registration = registrations.last else { return }
+            let delivery = Task {
+                await registration.handler(.failure(
+                    sessionId: registration.sessionID,
+                    pipelineID: registration.pipelineID,
+                    sourceLabel: registration.source.speakerLabel,
+                    message: "runtime recognition failure"
+                ))
+            }
+            activeDelivery = delivery
+            await delivery.value
+            activeDelivery = nil
+        }
+
+        func waitForActiveDelivery() async {
+            await activeDelivery?.value
+        }
+
+        func finish(pipelineID: UUID) async {
+            guard let retiring = registrations.first(where: { $0.pipelineID == pipelineID }),
+                  let latest = registrations.last,
+                  latest.pipelineID != retiring.pipelineID else { return }
+            let preview = TranscriptSegment(
+                sessionId: latest.sessionID,
+                startTime: .now,
+                text: "replacement preview",
+                isConfirmed: false,
+                speakerLabel: latest.source.speakerLabel
+            )
+            await latest.handler(.preview(preview))
+            await retiring.handler(.clearPreview(
+                sessionId: retiring.sessionID,
+                sourceLabel: retiring.source.speakerLabel
+            ))
+        }
+    }
+
     private struct FakeBatchFactory: BatchRecordingSessionFactory {
         let probe: RecordingRuntimeProbe
 
@@ -622,14 +867,28 @@
         func prepare(source _: RecordingAudioSource) async throws {}
 
         func beginRangeConsumer(
-            source _: RecordingAudioSource,
+            source: RecordingAudioSource,
             locale _: Locale,
-            at _: Date
-        ) async throws -> AudioFrameRouter.BatchConsumer {
-            { _ in }
+            at _: Date,
+            continuingFromActiveRange _: Bool
+        ) async throws -> BatchRecordingConsumerAttachment {
+            BatchRecordingConsumerAttachment(
+                consumer: { _ in },
+                origin: BatchRecordingRangeOrigin(
+                    source: source,
+                    startFrame: 0,
+                    sessionRelativeOriginSeconds: 0
+                )
+            )
         }
 
-        func rotateRanges(_: [BatchRecordingRangeOrigin], locale _: Locale) async throws {}
+        func rotateRanges(
+            _ origins: [BatchRecordingRangeOrigin],
+            locale _: Locale
+        ) async throws -> [RecordingAudioSource: BatchRecordingRangeOrigin] {
+            Dictionary(uniqueKeysWithValues: origins.map { ($0.source, $0) })
+        }
+
         func endRangeForReconfiguration(source _: RecordingAudioSource) async throws {}
 
         func finish() async throws {

--- a/Tests/DahliaTests/RecordingSessionControllerTests.swift
+++ b/Tests/DahliaTests/RecordingSessionControllerTests.swift
@@ -1,0 +1,676 @@
+#if canImport(Testing)
+    @preconcurrency import AVFoundation
+    import Foundation
+    import GRDB
+    import Testing
+    @testable import Dahlia
+
+    struct RecordingSessionControllerTests {
+        private struct PlanExpectation {
+            let mode: TranscriptionMode
+            let liveSubtitlesEnabled: Bool
+            let recognizerCount: Int
+            let recorderCount: Int
+        }
+
+        @Test
+        func lifecycleKeepsFinalModeWhileLiveSubtitlesChange() async throws {
+            let runtime = try await makeRuntime(mode: .batch, liveSubtitlesEnabled: false)
+            let sessionID = try #require(await runtime.controller.snapshot()?.sessionId)
+
+            let updated = try await runtime.controller.setLiveSubtitlesEnabled(
+                true,
+                translateSegment: nil
+            )
+            #expect(updated.sessionId == sessionID)
+            #expect(updated.plan.finalMode == .batch)
+            #expect(updated.plan.liveSubtitlesEnabled)
+
+            let reconfigured = try await runtime.controller.changeLocale(
+                to: Locale(identifier: "en_US"),
+                translateSegment: nil
+            )
+            #expect(reconfigured.localeIdentifier == "en_US")
+
+            _ = try await runtime.controller.stop()
+            await runtime.controller.completeStop()
+            #expect(await runtime.controller.snapshot() == nil)
+        }
+
+        @Test
+        func overlappingSessionsAreRejectedAndAbortReturnsToIdle() async throws {
+            let runtime = try await makeRuntime(mode: .realtime, liveSubtitlesEnabled: true)
+            let plan = TranscriptionSessionPlan(
+                finalMode: .realtime,
+                liveSubtitlesEnabled: true,
+                retainBatchAudio: false
+            )
+
+            await #expect(throws: RecordingSessionControllerError.self) {
+                try await runtime.controller.prepare(
+                    RecordingSessionController.PreparationRequest(
+                        sessionId: .v7(),
+                        startedAt: .now,
+                        plan: plan,
+                        locale: Locale(identifier: "ja_JP"),
+                        sources: [.init(source: .microphone)]
+                    ),
+                    onEvent: { _ in },
+                    onRuntimeFailure: { _, _, _ in }
+                )
+            }
+
+            await runtime.controller.abort()
+            #expect(await runtime.controller.snapshot() == nil)
+        }
+
+        @Test
+        func fourPlansCreateExactlyOneCaptureAndAtMostOneRecognizerPerSource() async throws {
+            let cases = [
+                PlanExpectation(mode: .realtime, liveSubtitlesEnabled: false, recognizerCount: 2, recorderCount: 0),
+                PlanExpectation(mode: .realtime, liveSubtitlesEnabled: true, recognizerCount: 2, recorderCount: 0),
+                PlanExpectation(mode: .batch, liveSubtitlesEnabled: false, recognizerCount: 0, recorderCount: 2),
+                PlanExpectation(mode: .batch, liveSubtitlesEnabled: true, recognizerCount: 2, recorderCount: 2),
+            ]
+
+            for testCase in cases {
+                let runtime = try await makeRuntime(
+                    mode: testCase.mode,
+                    liveSubtitlesEnabled: testCase.liveSubtitlesEnabled
+                )
+                let counts = await runtime.controller.resourceCounts()
+
+                #expect(counts.captures == 2)
+                #expect(counts.recognizers == testCase.recognizerCount)
+                #expect(counts.batchRecorders == testCase.recorderCount)
+                #expect(counts.batchSchedulers == (testCase.mode == .batch ? 1 : 0))
+
+                _ = try await runtime.controller.stop()
+                await runtime.controller.completeStop()
+            }
+        }
+
+        @Test
+        func liveToggleAttachesOnlyBatchRecognizerAndNeverDuplicatesRealtimeRecognizer() async throws {
+            let batch = try await makeRuntime(mode: .batch, liveSubtitlesEnabled: false)
+            var counts = await batch.controller.resourceCounts()
+            #expect(counts.recognizers == 0)
+
+            _ = try await batch.controller.setLiveSubtitlesEnabled(true, translateSegment: nil)
+            counts = await batch.controller.resourceCounts()
+            #expect(counts.recognizers == 2)
+
+            _ = try await batch.controller.setLiveSubtitlesEnabled(false, translateSegment: nil)
+            counts = await batch.controller.resourceCounts()
+            #expect(counts.recognizers == 0)
+            _ = try await batch.controller.stop()
+            await batch.controller.completeStop()
+
+            let realtime = try await makeRuntime(mode: .realtime, liveSubtitlesEnabled: false)
+            #expect(await realtime.controller.resourceCounts().recognizers == 2)
+            _ = try await realtime.controller.setLiveSubtitlesEnabled(true, translateSegment: nil)
+            #expect(await realtime.controller.resourceCounts().recognizers == 2)
+            _ = try await realtime.controller.stop()
+            await realtime.controller.completeStop()
+        }
+
+        @Test
+        func stopOrdersCaptureBeforeRecognitionBeforeBatchAndWaitsForConfirmation() async throws {
+            let runtime = try await makeRuntime(mode: .batch, liveSubtitlesEnabled: true)
+            await runtime.probe.clear()
+
+            let result = try await runtime.controller.stop()
+            #expect(result.batchRecordingSucceeded)
+            var actions = await runtime.probe.actions
+            let lastCaptureStop = try #require(actions.lastIndex(where: { $0.isCaptureStop }))
+            let firstRecognitionFinish = try #require(actions.firstIndex(where: { $0.isRecognitionFinish }))
+            let batchFinish = try #require(actions.firstIndex(of: .batchFinish))
+            #expect(lastCaptureStop < firstRecognitionFinish)
+            #expect(firstRecognitionFinish < batchFinish)
+            #expect(!actions.contains(.batchEnqueue))
+
+            await runtime.controller.completeStop()
+            actions = await runtime.probe.actions
+            #expect(!actions.contains(.batchEnqueue))
+        }
+
+        @Test
+        func localeChangeKeepsCaptureAndSourceChangeTouchesOnlyRequestedSource() async throws {
+            let runtime = try await makeRuntime(mode: .realtime, liveSubtitlesEnabled: true)
+            await runtime.probe.clear()
+
+            let removed = try await runtime.controller.setSource(
+                .init(source: .microphone),
+                enabled: false,
+                translateSegment: nil
+            )
+            #expect(removed.enabledSources == [.system])
+            #expect(await runtime.controller.resourceCounts().captures == 1)
+            #expect(await runtime.controller.resourceCounts().recognizers == 1)
+
+            await runtime.probe.clear()
+            _ = try await runtime.controller.changeLocale(
+                to: Locale(identifier: "en_US"),
+                translateSegment: nil
+            )
+            let localeActions = await runtime.probe.actions
+            let restartedCapture = localeActions.contains(where: \.isCaptureStartOrStop)
+            #expect(!restartedCapture)
+
+            let restored = try await runtime.controller.setSource(
+                .init(source: .microphone),
+                enabled: true,
+                translateSegment: nil
+            )
+            #expect(restored.enabledSources == [.microphone, .system])
+            #expect(await runtime.controller.resourceCounts().captures == 2)
+            _ = try await runtime.controller.stop()
+            await runtime.controller.completeStop()
+        }
+
+        @Test
+        func startFailureRollsBackAllPreparedResourcesAndBatchAudio() async throws {
+            let probe = RecordingRuntimeProbe()
+            let controller = RecordingSessionController(
+                captureFactory: FakeAudioCaptureFactory(probe: probe, failingSource: .system),
+                recognitionFactory: FakeRecognitionFactory(probe: probe),
+                batchRecordingFactory: FakeBatchFactory(probe: probe)
+            )
+            try await controller.prepare(
+                RecordingSessionController.PreparationRequest(
+                    sessionId: .v7(),
+                    startedAt: .now,
+                    plan: TranscriptionSessionPlan(
+                        finalMode: .batch,
+                        liveSubtitlesEnabled: true,
+                        retainBatchAudio: true
+                    ),
+                    locale: Locale(identifier: "ja_JP"),
+                    sources: [.init(source: .microphone), .init(source: .system)],
+                    dbQueue: DatabaseQueue(),
+                    meetingId: .v7(),
+                    batchSampleRate: 16000
+                ),
+                onEvent: { _ in },
+                onRuntimeFailure: { _, _, _ in }
+            )
+
+            await #expect(throws: FakeRuntimeError.self) {
+                try await controller.startPrepared()
+            }
+            #expect(await controller.snapshot() == nil)
+            #expect(await controller.resourceCounts().captures == 0)
+            #expect(await probe.actions.contains(.batchCancel))
+        }
+
+        @Test
+        func batchLiveRecognitionFailuresKeepCaptureAndBatchRecordingRunning() async throws {
+            let failureModes: [FakeRecognitionFailureMode] = [
+                .modelPreparation,
+                .sessionPreparation,
+                .start,
+                .eventDuringStart,
+            ]
+
+            for failureMode in failureModes {
+                let failures = RuntimeFailureRecorder()
+                let runtime = try await makeRuntime(
+                    mode: .batch,
+                    liveSubtitlesEnabled: true,
+                    recognitionFailureMode: failureMode,
+                    failureRecorder: failures
+                )
+
+                let counts = await runtime.controller.resourceCounts()
+                #expect(counts.captures == 2)
+                #expect(counts.recognizers == 0)
+                #expect(counts.batchRecorders == 2)
+
+                let warnings = await failures.entries
+                #expect(!warnings.isEmpty)
+                #expect(warnings.allSatisfy { !$0.isFatal })
+
+                let actionsBeforeStop = await runtime.probe.actions
+                #expect(!actionsBeforeStop.contains(.batchCancel))
+                let result = try await runtime.controller.stop()
+                #expect(result.batchRecordingSucceeded)
+                await runtime.controller.completeStop()
+
+                let finalActions = await runtime.probe.actions
+                #expect(finalActions.contains(.batchFinish))
+                #expect(!finalActions.contains(.batchEnqueue))
+            }
+        }
+
+        @Test
+        func recognitionFinishFailureIsFatalOnlyForRealtime() async throws {
+            let realtimeFailures = RuntimeFailureRecorder()
+            let realtime = try await makeRuntime(
+                mode: .realtime,
+                liveSubtitlesEnabled: true,
+                failingRecognitionFinishSource: .microphone,
+                failureRecorder: realtimeFailures
+            )
+
+            await #expect(throws: FakeRuntimeError.self) {
+                try await realtime.controller.stop()
+            }
+            let realtimeEntries = await realtimeFailures.entries
+            #expect(realtimeEntries.contains { $0.source == .microphone && $0.isFatal })
+            await realtime.controller.completeStop()
+
+            let batchFailures = RuntimeFailureRecorder()
+            let batch = try await makeRuntime(
+                mode: .batch,
+                liveSubtitlesEnabled: true,
+                failingRecognitionFinishSource: .microphone,
+                failureRecorder: batchFailures
+            )
+
+            let batchResult = try await batch.controller.stop()
+            #expect(batchResult.batchRecordingSucceeded)
+            await batch.controller.completeStop()
+
+            let batchEntries = await batchFailures.entries
+            #expect(batchEntries.contains { $0.source == .microphone && !$0.isFatal })
+            let batchActions = await batch.probe.actions
+            #expect(batchActions.contains(.batchFinish))
+            #expect(!batchActions.contains(.batchEnqueue))
+        }
+
+        @Test
+        func sourceReplacementCaptureStartFailureRestoresPreviousRuntimeOnly() async throws {
+            let replacementDeviceID = AudioDeviceID(42)
+            let runtime = try await makeRuntime(
+                mode: .realtime,
+                liveSubtitlesEnabled: true,
+                failingCaptureDeviceID: replacementDeviceID
+            )
+            await runtime.probe.clear()
+
+            await #expect(throws: FakeRuntimeError.self) {
+                try await runtime.controller.setSource(
+                    .init(source: .microphone, captureDeviceID: replacementDeviceID),
+                    enabled: true,
+                    translateSegment: nil
+                )
+            }
+
+            let snapshot = try #require(await runtime.controller.snapshot())
+            let counts = await runtime.controller.resourceCounts()
+            #expect(snapshot.enabledSources == [.microphone, .system])
+            #expect(counts.captures == 2)
+            #expect(counts.recognizers == 2)
+
+            let replacementActions = await runtime.probe.actions
+            let microphoneStarts = replacementActions.count(where: { $0 == .captureStart(.microphone) })
+            #expect(microphoneStarts == 2)
+            #expect(!replacementActions.contains(.captureStart(.system)))
+            #expect(!replacementActions.contains(.captureStop(.system)))
+
+            await runtime.probe.clear()
+            _ = try await runtime.controller.setSource(
+                .init(source: .microphone),
+                enabled: true,
+                translateSegment: nil
+            )
+            let unchangedActions = await runtime.probe.actions
+            #expect(unchangedActions.isEmpty)
+
+            _ = try await runtime.controller.stop()
+            await runtime.controller.completeStop()
+        }
+
+        private func makeRuntime(
+            mode: TranscriptionMode,
+            liveSubtitlesEnabled: Bool,
+            recognitionFailureMode: FakeRecognitionFailureMode = .none,
+            failingRecognitionFinishSource: RecordingAudioSource? = nil,
+            failingCaptureDeviceID: AudioDeviceID? = nil,
+            failureRecorder: RuntimeFailureRecorder? = nil
+        ) async throws -> (controller: RecordingSessionController, probe: RecordingRuntimeProbe) {
+            let probe = RecordingRuntimeProbe()
+            let scheduler = FakeBatchScheduler(probe: probe)
+            let controller = RecordingSessionController(
+                captureFactory: FakeAudioCaptureFactory(
+                    probe: probe,
+                    failingDeviceID: failingCaptureDeviceID
+                ),
+                recognitionFactory: FakeRecognitionFactory(
+                    probe: probe,
+                    failureMode: recognitionFailureMode,
+                    failingFinishSource: failingRecognitionFinishSource
+                ),
+                batchRecordingFactory: FakeBatchFactory(probe: probe)
+            )
+            let plan = TranscriptionSessionPlan(
+                finalMode: mode,
+                liveSubtitlesEnabled: liveSubtitlesEnabled,
+                retainBatchAudio: mode == .batch
+            )
+            try await controller.prepare(
+                RecordingSessionController.PreparationRequest(
+                    sessionId: .v7(),
+                    startedAt: .now,
+                    plan: plan,
+                    locale: Locale(identifier: "ja_JP"),
+                    sources: [
+                        .init(source: .microphone),
+                        .init(source: .system),
+                    ],
+                    dbQueue: mode == .batch ? DatabaseQueue() : nil,
+                    meetingId: mode == .batch ? .v7() : nil,
+                    batchSampleRate: mode == .batch ? 16000 : nil,
+                    batchScheduler: mode == .batch ? scheduler : nil
+                ),
+                onEvent: { _ in },
+                onRuntimeFailure: { source, message, isFatal in
+                    failureRecorder?.append(source: source, message: message, isFatal: isFatal)
+                }
+            )
+            _ = try await controller.startPrepared()
+            return (controller, probe)
+        }
+    }
+
+    private actor RecordingRuntimeProbe {
+        enum Action: Equatable {
+            case captureStart(RecordingAudioSource)
+            case captureStop(RecordingAudioSource)
+            case recognitionStart(RecordingAudioSource)
+            case recognitionFinish(RecordingAudioSource)
+            case recognitionCancel(RecordingAudioSource)
+            case batchFinish
+            case batchCancel
+            case batchEnqueue
+
+            var isCaptureStop: Bool {
+                if case .captureStop = self { return true }
+                return false
+            }
+
+            var isRecognitionFinish: Bool {
+                if case .recognitionFinish = self { return true }
+                return false
+            }
+
+            var isCaptureStartOrStop: Bool {
+                switch self {
+                case .captureStart, .captureStop:
+                    true
+                default:
+                    false
+                }
+            }
+        }
+
+        private(set) var actions: [Action] = []
+
+        func append(_ action: Action) {
+            actions.append(action)
+        }
+
+        func clear() {
+            actions.removeAll()
+        }
+    }
+
+    @MainActor
+    private final class RuntimeFailureRecorder {
+        struct Entry: Equatable {
+            let source: RecordingAudioSource?
+            let message: String
+            let isFatal: Bool
+        }
+
+        private(set) var entries: [Entry] = []
+
+        func append(source: RecordingAudioSource?, message: String, isFatal: Bool) {
+            entries.append(Entry(source: source, message: message, isFatal: isFatal))
+        }
+    }
+
+    private struct FakeAudioCaptureFactory: AudioCaptureSessionFactory {
+        let probe: RecordingRuntimeProbe
+        let failingSource: RecordingAudioSource?
+        let failingDeviceID: AudioDeviceID?
+
+        init(
+            probe: RecordingRuntimeProbe,
+            failingSource: RecordingAudioSource? = nil,
+            failingDeviceID: AudioDeviceID? = nil
+        ) {
+            self.probe = probe
+            self.failingSource = failingSource
+            self.failingDeviceID = failingDeviceID
+        }
+
+        func requestPermission(for _: RecordingAudioSource) async -> Bool { true }
+
+        func makeSession(
+            for pipeline: AudioSourcePipeline,
+            onUnexpectedStop _: @escaping AudioCaptureUnexpectedStopHandler
+        ) -> any AudioCaptureSession {
+            let deviceShouldFail = failingDeviceID.map { pipeline.captureDeviceID == $0 } ?? false
+            return FakeAudioCaptureSession(
+                source: pipeline.source,
+                probe: probe,
+                shouldFail: pipeline.source == failingSource || deviceShouldFail
+            )
+        }
+    }
+
+    private actor FakeAudioCaptureSession: AudioCaptureSession {
+        let source: RecordingAudioSource
+        let probe: RecordingRuntimeProbe
+        let shouldFail: Bool
+
+        init(source: RecordingAudioSource, probe: RecordingRuntimeProbe, shouldFail: Bool) {
+            self.source = source
+            self.probe = probe
+            self.shouldFail = shouldFail
+        }
+
+        func start() async throws {
+            await probe.append(.captureStart(source))
+            if shouldFail {
+                throw FakeRuntimeError.captureStart
+            }
+        }
+
+        func stop() async throws {
+            await probe.append(.captureStop(source))
+        }
+    }
+
+    private struct FakeRecognitionFactory: ProgressiveRecognitionSessionFactory {
+        let probe: RecordingRuntimeProbe
+        let failureMode: FakeRecognitionFailureMode
+        let failingFinishSource: RecordingAudioSource?
+
+        init(
+            probe: RecordingRuntimeProbe,
+            failureMode: FakeRecognitionFailureMode = .none,
+            failingFinishSource: RecordingAudioSource? = nil
+        ) {
+            self.probe = probe
+            self.failureMode = failureMode
+            self.failingFinishSource = failingFinishSource
+        }
+
+        func prepareModel(locale _: Locale) async throws {
+            if failureMode == .modelPreparation {
+                throw FakeRuntimeError.recognitionModelPreparation
+            }
+        }
+
+        func prepareSession(
+            locale _: Locale,
+            source: RecordingAudioSource,
+            sourceFormat _: AVAudioFormat?,
+            bufferingMode _: AudioBufferBridge.BufferingMode,
+            translateSegment _: ProgressiveSegmentTranslationHandler?
+        ) async throws -> PreparedProgressiveRecognitionSession {
+            if failureMode == .sessionPreparation {
+                throw FakeRuntimeError.recognitionSessionPreparation
+            }
+            let format = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: 16000,
+                channels: 1,
+                interleaved: false
+            ))
+            return PreparedProgressiveRecognitionSession(
+                analyzerFormat: format,
+                session: FakeRecognitionSession(
+                    source: source,
+                    probe: probe,
+                    shouldFailStart: failureMode == .start,
+                    shouldEmitFailureDuringStart: failureMode == .eventDuringStart,
+                    shouldFailFinish: source == failingFinishSource
+                )
+            )
+        }
+    }
+
+    private actor FakeRecognitionSession: ProgressiveRecognitionSession {
+        nonisolated let pipelineID = UUID.v7()
+        nonisolated let liveConsumer: AudioFrameRouter.LiveConsumer = { _ in true }
+
+        private let source: RecordingAudioSource
+        private let probe: RecordingRuntimeProbe
+        private let shouldFailStart: Bool
+        private let shouldEmitFailureDuringStart: Bool
+        private let shouldFailFinish: Bool
+
+        init(
+            source: RecordingAudioSource,
+            probe: RecordingRuntimeProbe,
+            shouldFailStart: Bool,
+            shouldEmitFailureDuringStart: Bool,
+            shouldFailFinish: Bool
+        ) {
+            self.source = source
+            self.probe = probe
+            self.shouldFailStart = shouldFailStart
+            self.shouldEmitFailureDuringStart = shouldEmitFailureDuringStart
+            self.shouldFailFinish = shouldFailFinish
+        }
+
+        func start(
+            recordingStartTime _: Date,
+            recordingSessionId: UUID,
+            onEvent: @escaping ProgressiveTranscriptionEventHandler
+        ) async throws {
+            await probe.append(.recognitionStart(source))
+            if shouldFailStart {
+                throw FakeRuntimeError.recognitionStart
+            }
+            if shouldEmitFailureDuringStart {
+                await onEvent(.failure(
+                    sessionId: recordingSessionId,
+                    pipelineID: pipelineID,
+                    sourceLabel: source.speakerLabel,
+                    message: "recognition failed during start"
+                ))
+            }
+        }
+
+        func finish() async throws {
+            await probe.append(.recognitionFinish(source))
+            if shouldFailFinish {
+                throw FakeRuntimeError.recognitionFinish
+            }
+        }
+
+        func cancel() async {
+            await probe.append(.recognitionCancel(source))
+        }
+    }
+
+    private struct FakeBatchFactory: BatchRecordingSessionFactory {
+        let probe: RecordingRuntimeProbe
+
+        @MainActor
+        func makeSession(
+            dbQueue _: DatabaseQueue,
+            managedRootURL _: URL,
+            meetingId _: UUID,
+            recordingSessionId _: UUID,
+            recordingStartTime _: Date,
+            sampleRate _: Double
+        ) throws -> any BatchRecordingSession {
+            try FakeBatchSession(probe: probe)
+        }
+    }
+
+    @MainActor
+    private final class FakeBatchSession: BatchRecordingSession {
+        let targetFormat: AVAudioFormat
+        private let probe: RecordingRuntimeProbe
+
+        init(probe: RecordingRuntimeProbe) throws {
+            self.probe = probe
+            targetFormat = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatInt16,
+                sampleRate: 16000,
+                channels: 1,
+                interleaved: false
+            ))
+        }
+
+        func prepare(source _: RecordingAudioSource) async throws {}
+
+        func beginRangeConsumer(
+            source _: RecordingAudioSource,
+            locale _: Locale,
+            at _: Date
+        ) async throws -> AudioFrameRouter.BatchConsumer {
+            { _ in }
+        }
+
+        func rotateRanges(_: [BatchRecordingRangeOrigin], locale _: Locale) async throws {}
+        func endRangeForReconfiguration(source _: RecordingAudioSource) async throws {}
+
+        func finish() async throws {
+            await probe.append(.batchFinish)
+        }
+
+        func cancelAndDelete() async {
+            await probe.append(.batchCancel)
+        }
+    }
+
+    private actor FakeBatchScheduler: BatchTranscriptionScheduling {
+        let probe: RecordingRuntimeProbe
+
+        init(probe: RecordingRuntimeProbe) {
+            self.probe = probe
+        }
+
+        func recoverAndEnqueue() async {}
+
+        func enqueue(sessionId _: UUID) async {
+            await probe.append(.batchEnqueue)
+        }
+
+        func isRunning(sessionId _: UUID) async -> Bool { false }
+        func recordRecordingFailure(sessionId _: UUID, message _: String) async {}
+    }
+
+    private enum FakeRecognitionFailureMode: Equatable {
+        case none
+        case modelPreparation
+        case sessionPreparation
+        case start
+        case eventDuringStart
+    }
+
+    private enum FakeRuntimeError: Error {
+        case captureStart
+        case recognitionModelPreparation
+        case recognitionSessionPreparation
+        case recognitionStart
+        case recognitionFinish
+    }
+#endif

--- a/Tests/DahliaTests/TranscriptionEventRouterTests.swift
+++ b/Tests/DahliaTests/TranscriptionEventRouterTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+#if canImport(Testing)
+    import Testing
+    @testable import Dahlia
+
+    @MainActor
+    struct TranscriptionEventRouterTests {
+        @Test
+        func realtimeAndLiveShareOneEventWithoutDuplicatingEitherStore() {
+            let sessionID = UUID.v7()
+            let segment = makeSegment(sessionID: sessionID)
+            let transcriptStore = TranscriptStore()
+            let liveStore = LiveCaptionStore()
+            liveStore.start(sessionId: sessionID)
+            let plan = TranscriptionSessionPlan(
+                finalMode: .realtime,
+                liveSubtitlesEnabled: true,
+                retainBatchAudio: false
+            )
+
+            TranscriptionEventRouter.route(
+                .finalized(segment),
+                plan: plan,
+                transcriptStore: transcriptStore,
+                liveCaptionStore: liveStore
+            )
+
+            #expect(transcriptStore.segments == [segment])
+            #expect(liveStore.segments == [segment])
+        }
+
+        @Test
+        func batchAndLiveKeepsPreviewOutOfAuthoritativeTranscript() {
+            let sessionID = UUID.v7()
+            let segment = makeSegment(sessionID: sessionID)
+            let transcriptStore = TranscriptStore()
+            let liveStore = LiveCaptionStore()
+            liveStore.start(sessionId: sessionID)
+            let plan = TranscriptionSessionPlan(
+                finalMode: .batch,
+                liveSubtitlesEnabled: true,
+                retainBatchAudio: false
+            )
+
+            TranscriptionEventRouter.route(
+                .finalized(segment),
+                plan: plan,
+                transcriptStore: transcriptStore,
+                liveCaptionStore: liveStore
+            )
+
+            #expect(transcriptStore.segments.isEmpty)
+            #expect(liveStore.segments == [segment])
+        }
+
+        @Test
+        func batchWithoutLiveIgnoresStreamingEvents() {
+            let sessionID = UUID.v7()
+            let transcriptStore = TranscriptStore()
+            let liveStore = LiveCaptionStore()
+            liveStore.start(sessionId: sessionID)
+            let plan = TranscriptionSessionPlan(
+                finalMode: .batch,
+                liveSubtitlesEnabled: false,
+                retainBatchAudio: false
+            )
+
+            TranscriptionEventRouter.route(
+                .finalized(makeSegment(sessionID: sessionID)),
+                plan: plan,
+                transcriptStore: transcriptStore,
+                liveCaptionStore: liveStore
+            )
+
+            #expect(transcriptStore.segments.isEmpty)
+            #expect(liveStore.segments.isEmpty)
+        }
+
+        private func makeSegment(sessionID: UUID) -> TranscriptSegment {
+            TranscriptSegment(
+                sessionId: sessionID,
+                startTime: Date(timeIntervalSince1970: 1_776_384_000),
+                text: "Shared recognition",
+                isConfirmed: true,
+                speakerLabel: "system"
+            )
+        }
+    }
+#endif

--- a/Tests/DahliaTests/TranscriptionEventRouterTests.swift
+++ b/Tests/DahliaTests/TranscriptionEventRouterTests.swift
@@ -77,6 +77,45 @@ import Foundation
             #expect(liveStore.segments.isEmpty)
         }
 
+        @Test
+        func finalizationRemovesMatchingPreviewSynchronously() {
+            let sessionID = UUID.v7()
+            let segmentID = UUID.v7()
+            let transcriptStore = TranscriptStore()
+            let liveStore = LiveCaptionStore()
+            let plan = TranscriptionSessionPlan(
+                finalMode: .realtime,
+                liveSubtitlesEnabled: false,
+                retainBatchAudio: false
+            )
+            let preview = TranscriptSegment(
+                id: segmentID,
+                sessionId: sessionID,
+                startTime: Date(timeIntervalSince1970: 1_776_384_000),
+                text: "Preview",
+                isConfirmed: false,
+                speakerLabel: "mic"
+            )
+            var final = preview
+            final.text = "Final"
+            final.isConfirmed = true
+
+            TranscriptionEventRouter.route(
+                .preview(preview),
+                plan: plan,
+                transcriptStore: transcriptStore,
+                liveCaptionStore: liveStore
+            )
+            TranscriptionEventRouter.route(
+                .finalized(final),
+                plan: plan,
+                transcriptStore: transcriptStore,
+                liveCaptionStore: liveStore
+            )
+
+            #expect(transcriptStore.segments == [final])
+        }
+
         private func makeSegment(sessionID: UUID) -> TranscriptSegment {
             TranscriptSegment(
                 sessionId: sessionID,

--- a/Tests/DahliaTests/TranscriptionSessionPlanTests.swift
+++ b/Tests/DahliaTests/TranscriptionSessionPlanTests.swift
@@ -1,0 +1,70 @@
+#if canImport(Testing)
+    import Testing
+    @testable import Dahlia
+
+    struct TranscriptionSessionPlanTests {
+        @Test
+        func capabilitiesCoverAllModeAndSubtitleCombinations() {
+            let realtimeWithoutSubtitles = TranscriptionSessionPlan(
+                finalMode: .realtime,
+                liveSubtitlesEnabled: false,
+                retainBatchAudio: false
+            )
+            let realtimeWithSubtitles = TranscriptionSessionPlan(
+                finalMode: .realtime,
+                liveSubtitlesEnabled: true,
+                retainBatchAudio: false
+            )
+            let batchWithoutSubtitles = TranscriptionSessionPlan(
+                finalMode: .batch,
+                liveSubtitlesEnabled: false,
+                retainBatchAudio: true
+            )
+            let batchWithSubtitles = TranscriptionSessionPlan(
+                finalMode: .batch,
+                liveSubtitlesEnabled: true,
+                retainBatchAudio: true
+            )
+
+            #expect(realtimeWithoutSubtitles.requiresLiveRecognition)
+            #expect(realtimeWithoutSubtitles.liveRecognizerCountPerSource == 1)
+            #expect(realtimeWithoutSubtitles.batchRecorderCountPerSource == 0)
+            #expect(!realtimeWithoutSubtitles.recordsBatchAudio)
+            #expect(realtimeWithoutSubtitles.persistsRealtimeTranscript)
+
+            #expect(realtimeWithSubtitles.requiresLiveRecognition)
+            #expect(realtimeWithSubtitles.liveRecognizerCountPerSource == 1)
+            #expect(realtimeWithSubtitles.batchRecorderCountPerSource == 0)
+            #expect(!realtimeWithSubtitles.recordsBatchAudio)
+            #expect(realtimeWithSubtitles.persistsRealtimeTranscript)
+
+            #expect(!batchWithoutSubtitles.requiresLiveRecognition)
+            #expect(batchWithoutSubtitles.liveRecognizerCountPerSource == 0)
+            #expect(batchWithoutSubtitles.batchRecorderCountPerSource == 1)
+            #expect(batchWithoutSubtitles.recordsBatchAudio)
+            #expect(!batchWithoutSubtitles.persistsRealtimeTranscript)
+
+            #expect(batchWithSubtitles.requiresLiveRecognition)
+            #expect(batchWithSubtitles.liveRecognizerCountPerSource == 1)
+            #expect(batchWithSubtitles.batchRecorderCountPerSource == 1)
+            #expect(batchWithSubtitles.recordsBatchAudio)
+            #expect(!batchWithSubtitles.persistsRealtimeTranscript)
+        }
+
+        @Test
+        func liveSubtitleCapabilityCanChangeWithoutChangingFinalMode() {
+            var plan = TranscriptionSessionPlan(
+                finalMode: .batch,
+                liveSubtitlesEnabled: false,
+                retainBatchAudio: true
+            )
+
+            plan.liveSubtitlesEnabled = true
+
+            #expect(plan.finalMode == .batch)
+            #expect(plan.requiresLiveRecognition)
+            #expect(plan.recordsBatchAudio)
+            #expect(plan.retainBatchAudio)
+        }
+    }
+#endif


### PR DESCRIPTION
## 概要

最終文字起こし方式とライブ字幕を独立した設定として扱い、バッチ文字起こし中でもライブ字幕を利用できるようにしました。

- 音源ごとの物理キャプチャを1回に統合し、batch recorderとprogressive recognitionへfan-out
- realtime＋ライブ字幕では同一の認識・翻訳イベントを共有し、認識器の二重起動を防止
- batch＋ライブ字幕ではライブ結果を一時字幕だけに投影し、正本や要約へ混入させない
- ライブ字幕の切替を録音中パネルとメニューバーの録音操作直下へ配置
- バッチ録音停止後、言語選択付き確認画面を表示してから文字起こしを開始
- アプリバージョンを0.3.0へ更新

## 背景・原因

従来は最終transcriptの生成方式とライブ字幕の実行状態が密結合しており、バッチ方式では録音用CAF writerしか起動しないためライブ字幕を併用できませんでした。またバッチ録音停止時に現在の言語設定で即時enqueueされ、言語を確認する機会がないまま処理成功後に音声が削除されていました。

## 主な変更

- `TranscriptionSessionPlan` と `RecordingSessionController` を導入
- `AudioSourcePipeline` / `AudioFrameRouter` でconsumerごとのキューと失敗分離を実装
- 後からAnalyzerInputConverterへ置換できる変換境界を追加
- `TranscriptionEvent` を正本storeと `LiveCaptionStore` へpolicyに応じて投影
- batch結果だけが対象sessionの正本を置換する永続化policyを明示
- 録音中の字幕切替、ロケール変更、音源変更をcontrollerで再構成
- batch停止後に確認待ち状態を追加し、選択言語を対象rangeへ原子的に反映してからenqueue
- 「あとで」を選んだ場合や未確認のまま再起動した場合は音声を保持し、自動処理しない
- 日英ローカライズとアーキテクチャ文書を更新

DB migrationおよび新規外部依存の追加はありません。

## 影響

以下の4構成をサポートします。

- realtime / 字幕OFF
- realtime / 字幕ON
- batch / 字幕OFF
- batch / 字幕ON

batchのライブ字幕は一時表示のみで、正本・DB・要約・exportには昇格しません。batch音声は文字起こし成功まで保持されます。

## 検証

- `swift build`
- `swift test`（Swift Testing 225件、XCTest 3件成功）
- batch確認サービスの対象テスト
- 新規ファイルのstrict SwiftLint（0 violations）
- SwiftFormat、ローカライズplist、差分整合性チェック
