### PR TITLE
プロジェクト管理画面に新規作成ボタンを追加

### DIFF
--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -32,6 +32,8 @@
 "Me" = "Me";
 "Ask" = "Ask";
 "New Project" = "New Project";
+"Could Not Create Project" = "Could Not Create Project";
+"The project folder could not be created." = "The project folder could not be created.";
 "New meeting" = "New meeting";
 "Project Name" = "Project Name";
 "Location" = "Location";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -32,6 +32,8 @@
 "Me" = "自分";
 "Ask" = "Ask";
 "New Project" = "新規プロジェクト";
+"Could Not Create Project" = "プロジェクトを作成できませんでした";
+"The project folder could not be created." = "プロジェクトフォルダを作成できませんでした。";
 "New meeting" = "New meeting";
 "Project Name" = "プロジェクト名";
 "Location" = "場所";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -62,6 +62,8 @@ enum L10n {
     static var me: String { String(localized: "Me", bundle: bundle) }
     static var ask: String { String(localized: "Ask", bundle: bundle) }
     static var newProject: String { String(localized: "New Project", bundle: bundle) }
+    static var projectCreationFailed: String { String(localized: "Could Not Create Project", bundle: bundle) }
+    static var projectCreationFailedDescription: String { String(localized: "The project folder could not be created.", bundle: bundle) }
     static var newMeeting: String { String(localized: "New meeting", bundle: bundle) }
     static var projectName: String { String(localized: "Project Name", bundle: bundle) }
     static var location: String { String(localized: "Location", bundle: bundle) }

--- a/Sources/Dahlia/Views/ProjectManagementView.swift
+++ b/Sources/Dahlia/Views/ProjectManagementView.swift
@@ -285,15 +285,25 @@ struct ProjectManagementView: View {
     }
 
     private func createProject() {
-        guard !trimmedNewProjectName.isEmpty else { return }
-        guard let project = sidebarViewModel.fetchOrCreateProject(name: trimmedNewProjectName) else {
-            projectCreationErrorMessage = sidebarViewModel.lastError ?? L10n.projectCreationFailedDescription
-            isShowingProjectCreationError = true
-            return
+        let projectName = trimmedNewProjectName
+        guard !projectName.isEmpty else { return }
+
+        let projectId: UUID
+        if let existingProject = sidebarViewModel.allProjectItems.first(where: {
+            $0.projectName.caseInsensitiveCompare(projectName) == .orderedSame
+        }) {
+            projectId = existingProject.projectId
+        } else {
+            guard let project = sidebarViewModel.fetchOrCreateProject(name: projectName) else {
+                projectCreationErrorMessage = sidebarViewModel.lastError ?? L10n.projectCreationFailedDescription
+                isShowingProjectCreationError = true
+                return
+            }
+            projectId = project.record.id
         }
 
         projectSearchText = ""
-        selectedProjectId = project.record.id
+        selectedProjectId = projectId
     }
 
     private func reconcileSelection(with projects: [ProjectOverviewItem]) {

--- a/Sources/Dahlia/Views/ProjectManagementView.swift
+++ b/Sources/Dahlia/Views/ProjectManagementView.swift
@@ -7,6 +7,10 @@ struct ProjectManagementView: View {
     @ObservedObject private var driveStore = GoogleDriveStore.shared
     @State private var selectedProjectId: UUID?
     @State private var projectSearchText = ""
+    @State private var isShowingProjectCreation = false
+    @State private var newProjectName = ""
+    @State private var isShowingProjectCreationError = false
+    @State private var projectCreationErrorMessage = ""
     @State private var pickingProjectId: UUID?
     @State private var contextText = ""
     @State private var contextFileURL: URL?
@@ -71,6 +75,10 @@ struct ProjectManagementView: View {
         return sidebarViewModel.allProjectItems.first(where: { $0.projectId == selectedProjectId })
     }
 
+    private var trimmedNewProjectName: String {
+        newProjectName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     private var projectSidebar: some View {
         List(selection: $selectedProjectId) {
             if filteredProjectNodes.isEmpty {
@@ -91,6 +99,22 @@ struct ProjectManagementView: View {
         .listStyle(.sidebar)
         .navigationTitle(L10n.projects)
         .searchable(text: $projectSearchText, prompt: L10n.searchProjects)
+        .toolbar {
+            ToolbarItem {
+                Button(L10n.newProject, systemImage: "plus", action: presentProjectCreation)
+                    .disabled(AppSettings.shared.currentVault == nil)
+                    .help(L10n.newProject)
+            }
+        }
+        .alert(L10n.newProject, isPresented: $isShowingProjectCreation) {
+            TextField(L10n.projectName, text: $newProjectName)
+            Button(L10n.cancel, role: .cancel) {}
+            Button(L10n.create, action: createProject)
+                .disabled(trimmedNewProjectName.isEmpty)
+        }
+        .alert(L10n.projectCreationFailed, isPresented: $isShowingProjectCreationError) {} message: {
+            Text(projectCreationErrorMessage)
+        }
     }
 
     @ViewBuilder
@@ -253,6 +277,23 @@ struct ProjectManagementView: View {
     private func selectInitialProjectIfNeeded() {
         guard selectedProjectId == nil else { return }
         selectedProjectId = sidebarViewModel.allProjectItems.first?.projectId
+    }
+
+    private func presentProjectCreation() {
+        newProjectName = ""
+        isShowingProjectCreation = true
+    }
+
+    private func createProject() {
+        guard !trimmedNewProjectName.isEmpty else { return }
+        guard let project = sidebarViewModel.fetchOrCreateProject(name: trimmedNewProjectName) else {
+            projectCreationErrorMessage = sidebarViewModel.lastError ?? L10n.projectCreationFailedDescription
+            isShowingProjectCreationError = true
+            return
+        }
+
+        projectSearchText = ""
+        selectedProjectId = project.record.id
     }
 
     private func reconcileSelection(with projects: [ProjectOverviewItem]) {


### PR DESCRIPTION
## 概要

- プロジェクト管理サイドバーに新規プロジェクト作成ボタンを追加
- プロジェクト名の入力ダイアログから、既存のフォルダ作成処理を実行
- 作成後に検索を解除し、作成したプロジェクトを自動選択
- 保管庫未選択時の無効化と、作成失敗時の日本語・英語エラー表示を追加

## 背景

これまではプロジェクト管理画面からプロジェクトフォルダを新規作成できず、別の画面または Finder での作成が必要でした。管理画面内で作成から設定まで完結できるようにします。

## ユーザーへの影響

プロジェクト管理画面のツールバーにある `+` ボタンから、現在の保管庫へプロジェクトフォルダを追加できます。

## 動作確認

- `swift build`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test`（238テスト成功）
- SwiftFormat（変更なし）
- SwiftLint は既存のリポジトリ全体の違反により非クリーン