### PR TITLE
バッチ文字起こしを既定化して録音状態を明確化

### DIFF
--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -110,7 +110,7 @@ final class AppSettings: ObservableObject {
     // MARK: - 音声認識設定
 
     @AppStorage("transcriptionLocale") var transcriptionLocale: String = Locale.current.identifier
-    @AppStorage(TranscriptionMode.userDefaultsKey) var transcriptionModeRawValue = TranscriptionMode.realtime.rawValue
+    @AppStorage(TranscriptionMode.userDefaultsKey) var transcriptionModeRawValue = TranscriptionMode.defaultMode.rawValue
     @AppStorage("retainAudioAfterBatchTranscription") var retainAudioAfterBatchTranscription = false
     @AppStorage("transcriptTranslationEnabled") var transcriptTranslationEnabled = true
     @AppStorage("transcriptTranslationTargetLanguage") var transcriptTranslationTargetLanguage = TranscriptTranslationLanguage.defaultIdentifier
@@ -124,8 +124,13 @@ final class AppSettings: ObservableObject {
         AppSettings.defaultAutomaticScreenshotChangeThresholdPercent
 
     var transcriptionMode: TranscriptionMode {
-        get { TranscriptionMode(rawValue: transcriptionModeRawValue) ?? .realtime }
+        get { TranscriptionMode(rawValue: transcriptionModeRawValue) ?? .defaultMode }
         set { transcriptionModeRawValue = newValue.rawValue }
+    }
+
+    var isRealtimeTranscriptionEnabled: Bool {
+        get { transcriptionMode == .realtime }
+        set { transcriptionMode = newValue ? .realtime : .batch }
     }
 
     var automaticScreenshotIntervalSeconds: Int {

--- a/Sources/Dahlia/Models/TranscriptionMode.swift
+++ b/Sources/Dahlia/Models/TranscriptionMode.swift
@@ -2,29 +2,10 @@ import Foundation
 import GRDB
 
 /// 録音セッションで使用する文字起こし方式。
-enum TranscriptionMode: String, CaseIterable, Codable, DatabaseValueConvertible, Identifiable {
+enum TranscriptionMode: String, Codable, DatabaseValueConvertible {
     case realtime
     case batch
 
     nonisolated static let userDefaultsKey = "transcriptionMode"
-
-    var id: String { rawValue }
-
-    var displayName: String {
-        switch self {
-        case .realtime:
-            L10n.realtimeTranscription
-        case .batch:
-            L10n.batchTranscription
-        }
-    }
-
-    var description: String {
-        switch self {
-        case .realtime:
-            L10n.realtimeTranscriptionDescription
-        case .batch:
-            L10n.batchTranscriptionDescription
-        }
-    }
+    nonisolated static let defaultMode: TranscriptionMode = .batch
 }

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Action items extracted from summaries will appear here." = "Action items extracted from summaries will appear here.";
 "We couldn't detect any conversation in this meeting." = "We couldn't detect any conversation in this meeting.";
 "Recording now" = "Recording now";
-"Transcribing now" = "Transcribing";
+"Transcribing now" = "Live transcription";
 "Return to recording meeting" = "Return to recording meeting";
 "Return to transcribing meeting" = "Return to transcribing meeting";
 "Yesterday" = "Yesterday";
@@ -435,9 +435,8 @@
 
 /* Batch Transcription */
 "Transcription Method" = "Transcription Method";
-"Real-time" = "Real-time";
-"After Recording" = "After Recording";
-"Show the transcript while recording. Audio files are not saved." = "Show the transcript while recording. Audio files are not saved.";
+"Enable Real-time Transcription" = "Enable Real-time Transcription";
+"Show the transcript while recording. Accuracy may be lower than transcription after recording, and audio files are not saved." = "Show the transcript while recording. Accuracy may be lower than transcription after recording, and audio files are not saved.";
 "Record audio first, then create a higher-accuracy transcript after recording stops." = "Record audio first, then create a higher-accuracy transcript after recording stops.";
 "Keep Audio After Transcription" = "Keep Audio After Transcription";
 "Keep the CAF audio files in the vault after batch transcription succeeds." = "Keep the CAF audio files in the vault after batch transcription succeeds.";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Action items extracted from summaries will appear here." = "要約から抽出された Action Items がここに表示されます。";
 "We couldn't detect any conversation in this meeting." = "この meeting では会話を検出できませんでした。";
 "Recording now" = "録音中";
-"Transcribing now" = "文字起こし中";
+"Transcribing now" = "ライブ文字起こし中";
 "Return to recording meeting" = "録音中のミーティングに戻る";
 "Return to transcribing meeting" = "文字起こし中のミーティングに戻る";
 "Yesterday" = "昨日";
@@ -435,9 +435,8 @@
 
 /* Batch Transcription */
 "Transcription Method" = "文字起こし方式";
-"Real-time" = "リアルタイム";
-"After Recording" = "録音後に処理";
-"Show the transcript while recording. Audio files are not saved." = "録音中に文字起こしを表示します。音声ファイルは保存しません。";
+"Enable Real-time Transcription" = "リアルタイム文字起こしを有効にする";
+"Show the transcript while recording. Accuracy may be lower than transcription after recording, and audio files are not saved." = "録音中に文字起こしを表示します。録音後の文字起こしより精度が低下する場合があり、音声ファイルは保存されません。";
 "Record audio first, then create a higher-accuracy transcript after recording stops." = "先に音声を録音し、録音終了後に高精度な文字起こしを作成します。";
 "Keep Audio After Transcription" = "文字起こし後も音声を残す";
 "Keep the CAF audio files in the vault after batch transcription succeeds." = "バッチ文字起こし成功後もCAF音声ファイルを保管庫に残します。";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -341,10 +341,9 @@ enum L10n {
         bundle: bundle
     ) }
     static var transcriptionMethod: String { String(localized: "Transcription Method", bundle: bundle) }
-    static var realtimeTranscription: String { String(localized: "Real-time", bundle: bundle) }
-    static var batchTranscription: String { String(localized: "After Recording", bundle: bundle) }
+    static var enableRealtimeTranscription: String { String(localized: "Enable Real-time Transcription", bundle: bundle) }
     static var realtimeTranscriptionDescription: String { String(
-        localized: "Show the transcript while recording. Audio files are not saved.",
+        localized: "Show the transcript while recording. Accuracy may be lower than transcription after recording, and audio files are not saved.",
         bundle: bundle
     ) }
     static var batchTranscriptionDescription: String { String(

--- a/Sources/Dahlia/Views/MeetingListSidebarView.swift
+++ b/Sources/Dahlia/Views/MeetingListSidebarView.swift
@@ -182,6 +182,19 @@ private struct RecordingStatusBar: View {
             ?? Date()
     }
 
+    private var transcriptionMode: TranscriptionMode {
+        viewModel.activeTranscriptionMode ?? .defaultMode
+    }
+
+    private var recordingLabels: (activity: String, returnToMeeting: String, stop: String) {
+        switch transcriptionMode {
+        case .realtime:
+            (L10n.transcribingNow, L10n.returnToTranscribingMeeting, L10n.stopTranscribing)
+        case .batch:
+            (L10n.recordingNow, L10n.returnToRecordingMeeting, L10n.stopRecording)
+        }
+    }
+
     var body: some View {
         VStack(spacing: 10) {
             HStack(spacing: 8) {
@@ -192,18 +205,18 @@ private struct RecordingStatusBar: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(recordingMeetingId == nil)
-                .help(L10n.returnToTranscribingMeeting)
-                .accessibilityLabel("\(L10n.transcribingNow), \(recordingTitle)")
+                .help(recordingLabels.returnToMeeting)
+                .accessibilityLabel("\(recordingLabels.activity), \(recordingTitle)")
 
                 Button {
                     recordingCoordinator.stopRecording()
                 } label: {
-                    Label(L10n.stopTranscribing, systemImage: "stop.fill")
+                    Label(recordingLabels.stop, systemImage: "stop.fill")
                 }
                 .labelStyle(.iconOnly)
                 .buttonStyle(.bordered)
                 .controlSize(.small)
-                .help(L10n.stopTranscribing)
+                .help(recordingLabels.stop)
             }
 
             Divider()
@@ -229,12 +242,10 @@ private struct RecordingStatusBar: View {
 
     private var panelContent: some View {
         HStack(spacing: 8) {
-            Circle()
-                .fill(.red)
-                .frame(width: 8, height: 8)
+            RecordingActivityIcon(mode: transcriptionMode)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(L10n.transcribingNow)
+                Text(recordingLabels.activity)
                     .font(.caption2.weight(.semibold))
                     .foregroundStyle(.red)
 

--- a/Sources/Dahlia/Views/RecordingActivityIcon.swift
+++ b/Sources/Dahlia/Views/RecordingActivityIcon.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct RecordingActivityIcon: View {
+    let mode: TranscriptionMode
+
+    @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+
+    var body: some View {
+        Image(systemName: systemImage)
+            .font(.body)
+            .symbolRenderingMode(.hierarchical)
+            .foregroundStyle(.red)
+            .symbolEffect(
+                .breathe.pulse,
+                options: .repeat(.periodic(delay: 0.8)).speed(0.7),
+                isActive: !accessibilityReduceMotion
+            )
+            .frame(width: 18)
+            .accessibilityHidden(true)
+    }
+
+    private var systemImage: String {
+        mode == .realtime ? "waveform.badge.microphone" : "record.circle.fill"
+    }
+}

--- a/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
@@ -11,17 +11,13 @@ struct TranscriptionSettingsView: View {
     var body: some View {
         Form {
             Section {
-                Picker(selection: $settings.transcriptionModeRawValue) {
-                    ForEach(TranscriptionMode.allCases) { mode in
-                        Text(mode.displayName).tag(mode.rawValue)
-                    }
-                } label: {
-                    Text(L10n.transcriptionMethod)
-                    Text(settings.transcriptionMode.description)
+                Toggle(isOn: $settings.isRealtimeTranscriptionEnabled) {
+                    Text(L10n.enableRealtimeTranscription)
+                    Text(L10n.realtimeTranscriptionDescription)
                 }
-                .pickerStyle(.radioGroup)
+                .toggleStyle(.switch)
 
-                if settings.transcriptionMode == .batch {
+                if !settings.isRealtimeTranscriptionEnabled {
                     Toggle(isOn: $settings.retainAudioAfterBatchTranscription) {
                         Text(L10n.retainBatchAudio)
                         Text(L10n.retainBatchAudioDescription)
@@ -30,6 +26,10 @@ struct TranscriptionSettingsView: View {
                 }
             } header: {
                 Text(L10n.transcriptionMethod)
+            } footer: {
+                if !settings.isRealtimeTranscriptionEnabled {
+                    Text(L10n.batchTranscriptionDescription)
+                }
             }
 
             Section {

--- a/Tests/DahliaTests/TranscriptionSessionPlanTests.swift
+++ b/Tests/DahliaTests/TranscriptionSessionPlanTests.swift
@@ -4,6 +4,11 @@
 
     struct TranscriptionSessionPlanTests {
         @Test
+        func batchIsTheDefaultTranscriptionMode() {
+            #expect(TranscriptionMode.defaultMode == .batch)
+        }
+
+        @Test
         func capabilitiesCoverAllModeAndSubtitleCombinations() {
             let realtimeWithoutSubtitles = TranscriptionSessionPlan(
                 finalMode: .realtime,


### PR DESCRIPTION
## 概要

- 録音後のバッチ文字起こしを既定に変更
- リアルタイム文字起こしを、精度低下の注意を伴う設定スイッチとして整理
- サイドバー下部の録音パネルをセッションモード別の SF Symbol と文言に変更
- 録音中アイコンへ軽い呼吸アニメーションを追加し、Reduce Motion に対応
- 日本語・英語ローカライズを更新

## 変更理由

高精度な録音後文字起こしを標準フローとしつつ、低遅延が必要な場合だけリアルタイム文字起こしを明示的に選べるようにするためです。また、現在実行中の処理が録音かライブ文字起こしかを録音パネルで判別できるようにしました。

## 確認

- `swift test` — ビルド成功（この環境ではテスト集計行が出ず、テスト本体は未実行）
- SwiftFormat — 成功
- Localizable.strings の `plutil -lint` — 成功
- `git diff --check` — 成功
- SwiftLint — SourceKitten が `sourcekitdInProc` を読み込めない環境エラーのため未実行