### PR TITLE
バッチ文字起こし前に録音ファイル削除を確認

### DIFF
--- a/Sources/Dahlia/Models/BatchTranscriptionConfirmation.swift
+++ b/Sources/Dahlia/Models/BatchTranscriptionConfirmation.swift
@@ -4,6 +4,7 @@ struct BatchTranscriptionConfirmation: Identifiable, Equatable {
     let sessionId: UUID
     let meetingId: UUID
     let suggestedLocaleIdentifier: String
+    let retainAudioAfterBatch: Bool
 
     var id: UUID { sessionId }
 }

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -454,6 +454,8 @@
 "Retry Batch Transcription" = "Retry Batch Transcription";
 "Start batch transcription?" = "Start batch transcription?";
 "The selected language is used for single-language recordings. Language changes made during recording are preserved. The audio is kept until transcription succeeds." = "The selected language is used for single-language recordings. Language changes made during recording are preserved. The audio is kept until transcription succeeds.";
+"Delete Recording Files After Transcription" = "Delete Recording Files After Transcription";
+"Delete the recording files after batch transcription succeeds. They are kept if transcription fails." = "Delete the recording files after batch transcription succeeds. They are kept if transcription fails.";
 "Later" = "Later";
 "Discard Failed Recording" = "Discard Failed Recording";
 "Discard this failed recording?" = "Discard this failed recording?";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -454,6 +454,8 @@
 "Retry Batch Transcription" = "バッチ文字起こしを再試行";
 "Start batch transcription?" = "バッチ文字起こしを開始しますか？";
 "The selected language is used for single-language recordings. Language changes made during recording are preserved. The audio is kept until transcription succeeds." = "単一言語の録音には選択した言語を使用します。録音中に切り替えた言語区間は保持されます。文字起こしが成功するまで音声データは保持されます。";
+"Delete Recording Files After Transcription" = "文字起こし後に録音ファイルを削除";
+"Delete the recording files after batch transcription succeeds. They are kept if transcription fails." = "バッチ文字起こしが成功したら録音ファイルを削除します。失敗した場合は再試行のため保持されます。";
 "Later" = "あとで";
 "Discard Failed Recording" = "失敗した録音を破棄";
 "Discard this failed recording?" = "失敗した録音を破棄しますか？";

--- a/Sources/Dahlia/Services/BatchTranscriptionConfirmationService.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionConfirmationService.swift
@@ -6,6 +6,7 @@ enum BatchTranscriptionConfirmationService {
     static func confirm(
         sessionId: UUID,
         localeIdentifier: String,
+        retainAudioAfterBatch: Bool,
         dbQueue: DatabaseQueue
     ) async throws -> UUID {
         let normalizedLocaleIdentifier = localeIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -23,7 +24,12 @@ enum BatchTranscriptionConfirmationService {
                 updatedAt: confirmedAt,
                 db: db
             )
-            try markConfirmed(sessionId: sessionId, confirmedAt: confirmedAt, db: db)
+            try markConfirmed(
+                sessionId: sessionId,
+                retainAudioAfterBatch: retainAudioAfterBatch,
+                confirmedAt: confirmedAt,
+                db: db
+            )
             return session.meetingId
         }
     }
@@ -89,15 +95,20 @@ enum BatchTranscriptionConfirmationService {
         )
     }
 
-    private static func markConfirmed(sessionId: UUID, confirmedAt: Date, db: Database) throws {
+    private static func markConfirmed(
+        sessionId: UUID,
+        retainAudioAfterBatch: Bool,
+        confirmedAt: Date,
+        db: Database
+    ) throws {
         // 試行時刻を確認済みマーカーとして先に保存する。処理開始時に実際の開始時刻で上書きされる。
         try db.execute(
             sql: """
             UPDATE recording_sessions
-            SET batchLastAttemptAt = ?, updatedAt = ?
+            SET retainAudioAfterBatch = ?, batchLastAttemptAt = ?, updatedAt = ?
             WHERE id = ?
             """,
-            arguments: [confirmedAt, confirmedAt, sessionId]
+            arguments: [retainAudioAfterBatch, confirmedAt, confirmedAt, sessionId]
         )
     }
 }

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -84,10 +84,15 @@ actor BatchTranscriptionCoordinator {
         return session.batchAttemptCount < maximumAutomaticAttemptCount
     }
 
-    func confirmAndEnqueue(sessionId: UUID, localeIdentifier: String) async throws {
+    func confirmAndEnqueue(
+        sessionId: UUID,
+        localeIdentifier: String,
+        retainAudioAfterBatch: Bool
+    ) async throws {
         let meetingId = try await BatchTranscriptionConfirmationService.confirm(
             sessionId: sessionId,
             localeIdentifier: localeIdentifier,
+            retainAudioAfterBatch: retainAudioAfterBatch,
             dbQueue: dbQueue
         )
         await notify(meetingId: meetingId, state: .queued(sessionId: sessionId))

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -274,6 +274,14 @@ enum L10n {
         localized: "The selected language is used for single-language recordings. Language changes made during recording are preserved. The audio is kept until transcription succeeds.",
         bundle: bundle
     ) }
+    static var deleteBatchAudioAfterTranscription: String { String(
+        localized: "Delete Recording Files After Transcription",
+        bundle: bundle
+    ) }
+    static var deleteBatchAudioAfterTranscriptionDescription: String { String(
+        localized: "Delete the recording files after batch transcription succeeds. They are kept if transcription fails.",
+        bundle: bundle
+    ) }
     static var later: String { String(localized: "Later", bundle: bundle) }
     static var discardFailedBatchRecording: String { String(localized: "Discard Failed Recording", bundle: bundle) }
     static var discardFailedBatchRecordingConfirmation: String { String(localized: "Discard this failed recording?", bundle: bundle) }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -406,7 +406,8 @@ final class CaptionViewModel: ObservableObject {
         presentBatchTranscriptionConfirmation(
             sessionId: sessionId,
             meetingId: meetingId,
-            suggestedLocaleIdentifier: selectedLocale
+            suggestedLocaleIdentifier: selectedLocale,
+            dbQueue: currentDbQueue
         )
     }
 
@@ -414,13 +415,14 @@ final class CaptionViewModel: ObservableObject {
         pendingBatchTranscriptionConfirmation = nil
     }
 
-    func confirmBatchTranscription(localeIdentifier: String) {
+    func confirmBatchTranscription(localeIdentifier: String, retainAudioAfterBatch: Bool) {
         guard let confirmation = pendingBatchTranscriptionConfirmation,
               let coordinator = batchTranscriptionCoordinator else { return }
         let retryConfirmation = BatchTranscriptionConfirmation(
             sessionId: confirmation.sessionId,
             meetingId: confirmation.meetingId,
-            suggestedLocaleIdentifier: localeIdentifier
+            suggestedLocaleIdentifier: localeIdentifier,
+            retainAudioAfterBatch: retainAudioAfterBatch
         )
         pendingBatchTranscriptionConfirmation = nil
         if currentMeetingId == confirmation.meetingId {
@@ -431,7 +433,8 @@ final class CaptionViewModel: ObservableObject {
             do {
                 try await coordinator.confirmAndEnqueue(
                     sessionId: confirmation.sessionId,
-                    localeIdentifier: localeIdentifier
+                    localeIdentifier: localeIdentifier,
+                    retainAudioAfterBatch: retainAudioAfterBatch
                 )
             } catch {
                 if currentMeetingId == confirmation.meetingId {
@@ -1631,7 +1634,8 @@ final class CaptionViewModel: ObservableObject {
             presentBatchTranscriptionConfirmation(
                 sessionId: recordingSessionId,
                 meetingId: meetingId,
-                suggestedLocaleIdentifier: selectedLocale
+                suggestedLocaleIdentifier: selectedLocale,
+                dbQueue: dbQueue
             )
         }
         await completeBatchRecording(
@@ -1644,14 +1648,27 @@ final class CaptionViewModel: ObservableObject {
     private func presentBatchTranscriptionConfirmation(
         sessionId: UUID,
         meetingId: UUID,
-        suggestedLocaleIdentifier: String
+        suggestedLocaleIdentifier: String,
+        dbQueue: DatabaseQueue?
     ) {
         pendingBatchTranscriptionConfirmation = BatchTranscriptionConfirmation(
             sessionId: sessionId,
             meetingId: meetingId,
-            suggestedLocaleIdentifier: suggestedLocaleIdentifier
+            suggestedLocaleIdentifier: suggestedLocaleIdentifier,
+            retainAudioAfterBatch: batchAudioRetentionPreference(
+                sessionId: sessionId,
+                dbQueue: dbQueue
+            )
         )
         MainWindowOpener.shared.openMainWindow()
+    }
+
+    private func batchAudioRetentionPreference(sessionId: UUID, dbQueue: DatabaseQueue?) -> Bool {
+        let fallback = AppSettings.shared.retainAudioAfterBatchTranscription
+        guard let dbQueue else { return fallback }
+        return (try? dbQueue.read { db in
+            try RecordingSessionRecord.fetchOne(db, key: sessionId)
+        })?.retainAudioAfterBatch ?? fallback
     }
 
     private func completeBatchRecording(

--- a/Sources/Dahlia/Views/BatchTranscriptionConfirmationView.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionConfirmationView.swift
@@ -2,21 +2,24 @@ import SwiftUI
 
 struct BatchTranscriptionConfirmationView: View {
     let locales: [Locale]
-    let onStart: (String) -> Void
+    let onStart: (String, Bool) -> Void
     let onPostpone: () -> Void
 
     @State private var selectedLocaleIdentifier: String
+    @State private var deleteAudioAfterTranscription: Bool
 
     init(
         locales: [Locale],
         initialLocaleIdentifier: String,
-        onStart: @escaping (String) -> Void,
+        initiallyRetainsAudioAfterBatch: Bool,
+        onStart: @escaping (String, Bool) -> Void,
         onPostpone: @escaping () -> Void
     ) {
         self.locales = locales
         self.onStart = onStart
         self.onPostpone = onPostpone
         _selectedLocaleIdentifier = State(initialValue: initialLocaleIdentifier)
+        _deleteAudioAfterTranscription = State(initialValue: !initiallyRetainsAudioAfterBatch)
     }
 
     var body: some View {
@@ -35,16 +38,24 @@ struct BatchTranscriptionConfirmationView: View {
             }
             .pickerStyle(.menu)
 
+            Toggle(isOn: $deleteAudioAfterTranscription) {
+                VStack(alignment: .leading) {
+                    Text(L10n.deleteBatchAudioAfterTranscription)
+                    Text(L10n.deleteBatchAudioAfterTranscriptionDescription)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .toggleStyle(.checkbox)
+
             Divider()
 
             HStack {
                 Spacer()
                 Button(L10n.later, action: onPostpone)
                     .keyboardShortcut(.cancelAction)
-                Button(L10n.startTranscription) {
-                    onStart(selectedLocaleIdentifier)
-                }
-                .keyboardShortcut(.defaultAction)
+                Button(L10n.startTranscription, action: startTranscription)
+                    .keyboardShortcut(.defaultAction)
             }
         }
         .padding(20)
@@ -55,5 +66,9 @@ struct BatchTranscriptionConfirmationView: View {
         locale.localizedString(forIdentifier: locale.identifier)
             ?? Locale.current.localizedString(forIdentifier: locale.identifier)
             ?? locale.identifier
+    }
+
+    private func startTranscription() {
+        onStart(selectedLocaleIdentifier, !deleteAudioAfterTranscription)
     }
 }

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -60,6 +60,7 @@ struct ContentView: View {
                     preferredIdentifier: confirmation.suggestedLocaleIdentifier
                 ),
                 initialLocaleIdentifier: confirmation.suggestedLocaleIdentifier,
+                initiallyRetainsAudioAfterBatch: confirmation.retainAudioAfterBatch,
                 onStart: viewModel.confirmBatchTranscription,
                 onPostpone: viewModel.postponeBatchTranscription
             )

--- a/Tests/DahliaTests/BatchTranscriptionConfirmationServiceTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionConfirmationServiceTests.swift
@@ -27,6 +27,7 @@ import GRDB
             let meetingId = try await BatchTranscriptionConfirmationService.confirm(
                 sessionId: fixture.session.id,
                 localeIdentifier: "en_US",
+                retainAudioAfterBatch: true,
                 dbQueue: fixture.database.dbQueue
             )
 
@@ -43,6 +44,7 @@ import GRDB
             #expect(result.unrelatedRange?.localeIdentifier == "ja_JP")
             #expect(session.batchLastAttemptAt != nil)
             #expect(session.batchAttemptCount == 0)
+            #expect(session.retainAudioAfterBatch)
             #expect(BatchTranscriptionState.derive(from: session) == .queued(sessionId: session.id))
             #expect(BatchTranscriptionCoordinator.shouldAutomaticallyRetry(session))
         }
@@ -52,7 +54,8 @@ import GRDB
             let fixture = try BatchAudioTestFixture(
                 name: "BatchSingleLocaleConfirmation",
                 endedAt: Date(timeIntervalSince1970: 1_776_384_060),
-                duration: 60
+                duration: 60,
+                retainAudioAfterBatch: true
             )
             defer { fixture.removeFiles() }
             let file = fixture.makeAudioRecord(finalizedAt: fixture.now, totalFrameCount: 320)
@@ -70,13 +73,17 @@ import GRDB
             _ = try await BatchTranscriptionConfirmationService.confirm(
                 sessionId: fixture.session.id,
                 localeIdentifier: "en_US",
+                retainAudioAfterBatch: false,
                 dbQueue: fixture.database.dbQueue
             )
 
-            let persisted = try await fixture.database.dbQueue.read { db in
-                try RecordingAudioRangeRecord.order(Column("startFrame").asc).fetchAll(db)
+            let result = try await fixture.database.dbQueue.read { db in
+                let ranges = try RecordingAudioRangeRecord.order(Column("startFrame").asc).fetchAll(db)
+                let session = try RecordingSessionRecord.fetchOne(db, key: fixture.session.id)
+                return (ranges, session)
             }
-            #expect(persisted.map(\.localeIdentifier) == ["en_US", "en_US"])
+            #expect(result.0.map(\.localeIdentifier) == ["en_US", "en_US"])
+            #expect(result.1?.retainAudioAfterBatch == false)
         }
 
         private func insertConfirmationScenario(in fixture: BatchAudioTestFixture) async throws -> UUID {


### PR DESCRIPTION
## 概要

- バッチ文字起こし開始ポップアップに「文字起こし後に録音ファイルを削除」のチェック項目を追加
- 録音開始時の保存設定を初期値として表示し、開始確定時の選択を録音セッションへ保存
- 開始ボタンをデフォルトアクションとして、Enter / Return で即座に確定できるように設定
- 日本語・英語の表示文言を追加

## 背景

これまでは録音ファイルを保持するかどうかが録音開始前の設定だけで決まり、録音停止後のバッチ文字起こし開始確認では言語しか確認できませんでした。そのため、実際に文字起こしを開始する時点で録音ファイルの削除方針を確認・変更できませんでした。

## 影響

選択した保存方針は言語確定と同じDBトランザクションで保存されます。文字起こし成功後は選択に従って録音ファイルを削除または保管し、失敗時は再試行用に保持します。

## 検証

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test`
  - Swift Testing 235件、XCTest 3件の合計238件が成功
- SwiftFormat: 変更不要
- 日英の `Localizable.strings`: `plutil -lint` 成功
- SwiftLint: リポジトリ既存の違反を検出（今回の変更行に新規違反なし）