### PR TITLE
Vault書き出しパスを永続化して移動を追従

### DIFF
--- a/Sources/Dahlia/Database/AppDatabaseManager.swift
+++ b/Sources/Dahlia/Database/AppDatabaseManager.swift
@@ -77,6 +77,10 @@ final class AppDatabaseManager: Sendable {
             try addBatchDiscardedAtColumnIfNeeded(in: db)
         }
 
+        migrator.registerMigration("v13_summaryVaultRelativePath") { db in
+            try addSummaryVaultRelativePathColumnIfNeeded(in: db)
+        }
+
         return migrator
     }()
 
@@ -364,6 +368,10 @@ final class AppDatabaseManager: Sendable {
 
     private static func addSummaryDocumentColumnIfNeeded(in db: Database) throws {
         try addColumnIfNeeded(in: db, table: "summaries", column: "document", type: .text)
+    }
+
+    private static func addSummaryVaultRelativePathColumnIfNeeded(in db: Database) throws {
+        try addColumnIfNeeded(in: db, table: "summaries", column: "vaultRelativePath", type: .text)
     }
 
     private static func addBatchTranscriptionSchemaIfNeeded(in db: Database) throws {

--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -343,6 +343,7 @@ final class MeetingRepository {
                 title: trimmedTitle.isEmpty ? (existingSummary?.title ?? "") : trimmedTitle,
                 summary: renderedBody,
                 document: document.databaseJSONString(),
+                vaultRelativePath: existingSummary?.vaultRelativePath,
                 googleFileId: existingSummary?.googleFileId,
                 createdAt: existingSummary?.createdAt ?? Date()
             )
@@ -521,6 +522,15 @@ final class MeetingRepository {
             try db.execute(
                 sql: "UPDATE summaries SET googleFileId = ? WHERE meetingId = ?",
                 arguments: [googleFileId?.nilIfBlank, meetingId]
+            )
+        }
+    }
+
+    nonisolated func updateSummaryVaultRelativePath(forMeetingId meetingId: UUID, relativePath: String?) throws {
+        try dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE summaries SET vaultRelativePath = ? WHERE meetingId = ?",
+                arguments: [relativePath?.nilIfBlank, meetingId]
             )
         }
     }

--- a/Sources/Dahlia/Database/SummaryRecord.swift
+++ b/Sources/Dahlia/Database/SummaryRecord.swift
@@ -43,9 +43,9 @@ struct SummaryRecord: Codable, FetchableRecord, PersistableRecord {
         }
     }
 
-    static func updateVaultRelativePath(
-        _ relativePath: String,
-        meetingId: UUID,
+    static func renameVaultRelativePath(
+        from oldPath: String,
+        to newPath: String,
         vaultId: UUID,
         in db: Database
     ) throws {
@@ -53,10 +53,10 @@ struct SummaryRecord: Codable, FetchableRecord, PersistableRecord {
             sql: """
             UPDATE summaries
             SET vaultRelativePath = ?
-            WHERE meetingId = ?
+            WHERE vaultRelativePath = ?
               AND meetingId IN (SELECT id FROM meetings WHERE vaultId = ?)
             """,
-            arguments: [relativePath, meetingId, vaultId]
+            arguments: [newPath, oldPath, vaultId]
         )
     }
 

--- a/Sources/Dahlia/Database/SummaryRecord.swift
+++ b/Sources/Dahlia/Database/SummaryRecord.swift
@@ -9,8 +9,68 @@ struct SummaryRecord: Codable, FetchableRecord, PersistableRecord {
     var title: String
     var summary: String
     var document: String? = nil
+    var vaultRelativePath: String?
     var googleFileId: String?
     var createdAt: Date
+
+    static func fetchAll(vaultId: UUID, in db: Database) throws -> [Self] {
+        try fetchAll(
+            db,
+            sql: """
+            SELECT summaries.*
+            FROM summaries
+            JOIN meetings ON meetings.id = summaries.meetingId
+            WHERE meetings.vaultId = ?
+            """,
+            arguments: [vaultId]
+        )
+    }
+
+    static func renameVaultRelativePathsByPrefix(
+        oldPrefix: String,
+        newPrefix: String,
+        vaultId: UUID,
+        in db: Database
+    ) throws {
+        let summaries = try fetchAll(vaultId: vaultId, in: db)
+
+        for var summary in summaries {
+            guard let relativePath = summary.vaultRelativePath,
+                  relativePath == oldPrefix || relativePath.hasPrefix(oldPrefix + "/")
+            else { continue }
+            summary.vaultRelativePath = newPrefix + relativePath.dropFirst(oldPrefix.count)
+            try summary.update(db)
+        }
+    }
+
+    static func updateVaultRelativePath(
+        _ relativePath: String,
+        meetingId: UUID,
+        vaultId: UUID,
+        in db: Database
+    ) throws {
+        try db.execute(
+            sql: """
+            UPDATE summaries
+            SET vaultRelativePath = ?
+            WHERE meetingId = ?
+              AND meetingId IN (SELECT id FROM meetings WHERE vaultId = ?)
+            """,
+            arguments: [relativePath, meetingId, vaultId]
+        )
+    }
+
+    static func clearVaultRelativePath(_ relativePath: String, vaultId: UUID, in db: Database) throws {
+        try db.execute(
+            sql: """
+            UPDATE summaries
+            SET vaultRelativePath = NULL
+            WHERE vaultRelativePath = ?
+              AND meetingId IN (SELECT id FROM meetings WHERE vaultId = ?)
+            """,
+            arguments: [relativePath, vaultId]
+        )
+    }
 
     func loadDocument() -> SummaryDocument {
         if let document = document?.nilIfBlank,

--- a/Sources/Dahlia/Services/SummaryService.swift
+++ b/Sources/Dahlia/Services/SummaryService.swift
@@ -133,32 +133,19 @@ enum SummaryService {
         return "<time>\(time)</time> <image_id>\(screenshot.id.uuidString)</image_id> <image_filename>\(imageFilename)</image_filename>"
     }
 
-    /// 要約保存先ディレクトリ内の `.md` ファイルを走査し、frontmatter の `meeting_id` が一致するファイルを返す。
-    static func findSummaryFile(projectURL: URL?, vaultURL: URL, meetingId: UUID) -> URL? {
-        let fm = FileManager.default
-        let targetId = meetingId.uuidString.lowercased()
-        let directoryURL = projectURL ?? vaultURL
-
-        guard let enumerator = fm.enumerator(
-            at: directoryURL,
-            includingPropertiesForKeys: [.isRegularFileKey],
-            options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
-        ) else { return nil }
-
-        for case let fileURL as URL in enumerator {
-            guard fileURL.pathExtension == "md" else { continue }
-            guard let handle = try? FileHandle(forReadingFrom: fileURL) else { continue }
-            defer { try? handle.close() }
-            guard let data = try? handle.read(upToCount: 512),
-                  let head = String(data: data, encoding: .utf8) else { continue }
-            // frontmatter 内の meeting_id を case-insensitive で照合
-            let lowered = head.lowercased()
-            if lowered.contains("meeting_id:"),
-               lowered.contains(targetId) {
-                return fileURL
-            }
-        }
-        return nil
+    /// DB の Vault 相対パスを優先し、旧データや外部移動時だけ frontmatter を走査する。
+    static func findSummaryFile(
+        storedRelativePath: String? = nil,
+        projectURL: URL?,
+        vaultURL: URL,
+        meetingId: UUID
+    ) -> URL? {
+        VaultSummaryFileLocator.findSummaryFile(
+            storedRelativePath: storedRelativePath,
+            projectURL: projectURL,
+            vaultURL: vaultURL,
+            meetingId: meetingId
+        )
     }
 
     static func resolvedTags(resultTags: [String], contextContent: String?) -> [String] {

--- a/Sources/Dahlia/Services/SummaryService.swift
+++ b/Sources/Dahlia/Services/SummaryService.swift
@@ -133,18 +133,14 @@ enum SummaryService {
         return "<time>\(time)</time> <image_id>\(screenshot.id.uuidString)</image_id> <image_filename>\(imageFilename)</image_filename>"
     }
 
-    /// DB の Vault 相対パスを優先し、旧データや外部移動時だけ frontmatter を走査する。
+    /// DB に保存した Vault 相対パスから要約ファイルを解決する。
     static func findSummaryFile(
-        storedRelativePath: String? = nil,
-        projectURL: URL?,
-        vaultURL: URL,
-        meetingId: UUID
+        storedRelativePath: String?,
+        vaultURL: URL
     ) -> URL? {
         VaultSummaryFileLocator.findSummaryFile(
             storedRelativePath: storedRelativePath,
-            projectURL: projectURL,
-            vaultURL: vaultURL,
-            meetingId: meetingId
+            vaultURL: vaultURL
         )
     }
 

--- a/Sources/Dahlia/Services/VaultFileSystemEventBatch.swift
+++ b/Sources/Dahlia/Services/VaultFileSystemEventBatch.swift
@@ -1,0 +1,154 @@
+import CoreServices
+import Foundation
+
+struct VaultFileSystemEventBatch {
+    let directoryRenames: [(oldPath: String, newPath: String)]
+    let newDirectories: [String]
+    let removedDirectories: [String]
+    let changedSummaryPaths: [String]
+    let removedSummaryPaths: [String]
+
+    init(paths: [String], flags: [UInt32], vaultURL: URL, fileManager: FileManager = .default) {
+        let vaultPath = vaultURL.path + "/"
+        var pendingRenames: [(path: String, exists: Bool)] = []
+        var newDirectories: [String] = []
+        var removedDirectories: [String] = []
+        var changedSummaryPaths: [String] = []
+        var removedSummaryPaths: [String] = []
+
+        for (path, flag) in zip(paths, flags) {
+            guard let event = Self.classify(path: path, flag: flag, vaultPath: vaultPath, fileManager: fileManager) else { continue }
+            switch event {
+            case let .directoryRename(path, exists):
+                pendingRenames.append((path, exists))
+            case let .directoryCreated(path):
+                newDirectories.append(path)
+            case let .directoryRemoved(path):
+                removedDirectories.append(path)
+            case let .summaryChanged(path):
+                changedSummaryPaths.append(path)
+            case let .summaryRemoved(path):
+                removedSummaryPaths.append(path)
+            }
+        }
+
+        let resolvedRenames = Self.resolveDirectoryRenames(pendingRenames)
+        directoryRenames = resolvedRenames.renames
+        self.newDirectories = newDirectories + resolvedRenames.created
+        self.removedDirectories = removedDirectories + resolvedRenames.removed
+        self.changedSummaryPaths = changedSummaryPaths
+        self.removedSummaryPaths = removedSummaryPaths
+    }
+
+    private static func classify(
+        path: String,
+        flag: UInt32,
+        vaultPath: String,
+        fileManager: FileManager
+    ) -> Event? {
+        guard path.hasPrefix(vaultPath) else { return nil }
+        let relativePath = String(path.dropFirst(vaultPath.count))
+        guard !relativePath.isEmpty else { return nil }
+
+        let isDirectory = flag & UInt32(kFSEventStreamEventFlagItemIsDir) != 0
+        if isDirectory {
+            return classifyDirectory(path: path, relativePath: relativePath, flag: flag, fileManager: fileManager)
+        }
+        return classifyFile(path: path, relativePath: relativePath, flag: flag, fileManager: fileManager)
+    }
+
+    private static func classifyDirectory(
+        path: String,
+        relativePath: String,
+        flag: UInt32,
+        fileManager: FileManager
+    ) -> Event? {
+        let components = relativePath.split(separator: "/")
+        guard !components.contains(where: { $0.hasPrefix(".") || $0.hasPrefix("_") }) else { return nil }
+
+        let exists = fileManager.fileExists(atPath: path)
+        if flag & UInt32(kFSEventStreamEventFlagItemRenamed) != 0 {
+            return .directoryRename(relativePath, exists: exists)
+        }
+        if flag & UInt32(kFSEventStreamEventFlagItemRemoved) != 0, !exists {
+            return .directoryRemoved(relativePath)
+        }
+        if flag & UInt32(kFSEventStreamEventFlagItemCreated) != 0, exists {
+            return .directoryCreated(relativePath)
+        }
+        return nil
+    }
+
+    private static func classifyFile(
+        path: String,
+        relativePath: String,
+        flag: UInt32,
+        fileManager: FileManager
+    ) -> Event? {
+        let components = relativePath.split(separator: "/")
+        guard !components.contains(where: { $0.hasPrefix(".") }),
+              !components.contains("_dahlia"),
+              URL(fileURLWithPath: relativePath).pathExtension.lowercased() == "md"
+        else { return nil }
+
+        let exists = fileManager.fileExists(atPath: path)
+        let isRenamed = flag & UInt32(kFSEventStreamEventFlagItemRenamed) != 0
+        let isCreated = flag & UInt32(kFSEventStreamEventFlagItemCreated) != 0
+        let isRemoved = flag & UInt32(kFSEventStreamEventFlagItemRemoved) != 0
+        if exists, isRenamed || isCreated {
+            return .summaryChanged(relativePath)
+        }
+        if !exists, isRenamed || isRemoved {
+            return .summaryRemoved(relativePath)
+        }
+        return nil
+    }
+
+    private static func resolveDirectoryRenames(
+        _ pendingRenames: [(path: String, exists: Bool)]
+    ) -> (renames: [(oldPath: String, newPath: String)], created: [String], removed: [String]) {
+        var renames: [(oldPath: String, newPath: String)] = []
+        var created: [String] = []
+        var removed: [String] = []
+        var index = 0
+
+        while index + 1 < pendingRenames.count {
+            let first = pendingRenames[index]
+            let second = pendingRenames[index + 1]
+            if first.exists != second.exists {
+                let oldPath = first.exists ? second.path : first.path
+                let newPath = first.exists ? first.path : second.path
+                renames.append((oldPath, newPath))
+                index += 2
+            } else {
+                appendUnpairedRename(first, created: &created, removed: &removed)
+                index += 1
+            }
+        }
+
+        if index < pendingRenames.count {
+            appendUnpairedRename(pendingRenames[index], created: &created, removed: &removed)
+        }
+        return (renames, created, removed)
+    }
+
+    private static func appendUnpairedRename(
+        _ rename: (path: String, exists: Bool),
+        created: inout [String],
+        removed: inout [String]
+    ) {
+        if rename.exists {
+            created.append(rename.path)
+        } else {
+            removed.append(rename.path)
+        }
+    }
+
+    private enum Event {
+        case directoryRename(String, exists: Bool)
+        case directoryCreated(String)
+        case directoryRemoved(String)
+        case summaryChanged(String)
+        case summaryRemoved(String)
+    }
+}

--- a/Sources/Dahlia/Services/VaultFileSystemEventBatch.swift
+++ b/Sources/Dahlia/Services/VaultFileSystemEventBatch.swift
@@ -5,39 +5,40 @@ struct VaultFileSystemEventBatch {
     let directoryRenames: [(oldPath: String, newPath: String)]
     let newDirectories: [String]
     let removedDirectories: [String]
-    let changedSummaryPaths: [String]
+    let summaryRenames: [(oldPath: String, newPath: String)]
     let removedSummaryPaths: [String]
 
     init(paths: [String], flags: [UInt32], vaultURL: URL, fileManager: FileManager = .default) {
         let vaultPath = vaultURL.path + "/"
-        var pendingRenames: [(path: String, exists: Bool)] = []
+        var pendingDirectoryRenames: [(path: String, exists: Bool)] = []
+        var pendingSummaryRenames: [(path: String, exists: Bool)] = []
         var newDirectories: [String] = []
         var removedDirectories: [String] = []
-        var changedSummaryPaths: [String] = []
         var removedSummaryPaths: [String] = []
 
         for (path, flag) in zip(paths, flags) {
             guard let event = Self.classify(path: path, flag: flag, vaultPath: vaultPath, fileManager: fileManager) else { continue }
             switch event {
             case let .directoryRename(path, exists):
-                pendingRenames.append((path, exists))
+                pendingDirectoryRenames.append((path, exists))
             case let .directoryCreated(path):
                 newDirectories.append(path)
             case let .directoryRemoved(path):
                 removedDirectories.append(path)
-            case let .summaryChanged(path):
-                changedSummaryPaths.append(path)
+            case let .summaryRename(path, exists):
+                pendingSummaryRenames.append((path, exists))
             case let .summaryRemoved(path):
                 removedSummaryPaths.append(path)
             }
         }
 
-        let resolvedRenames = Self.resolveDirectoryRenames(pendingRenames)
-        directoryRenames = resolvedRenames.renames
-        self.newDirectories = newDirectories + resolvedRenames.created
-        self.removedDirectories = removedDirectories + resolvedRenames.removed
-        self.changedSummaryPaths = changedSummaryPaths
-        self.removedSummaryPaths = removedSummaryPaths
+        let resolvedDirectoryRenames = Self.resolveRenames(pendingDirectoryRenames)
+        let resolvedSummaryRenames = Self.resolveRenames(pendingSummaryRenames)
+        directoryRenames = resolvedDirectoryRenames.renames
+        self.newDirectories = newDirectories + resolvedDirectoryRenames.created
+        self.removedDirectories = removedDirectories + resolvedDirectoryRenames.removed
+        summaryRenames = resolvedSummaryRenames.renames
+        self.removedSummaryPaths = removedSummaryPaths + resolvedSummaryRenames.removed
     }
 
     private static func classify(
@@ -93,18 +94,17 @@ struct VaultFileSystemEventBatch {
 
         let exists = fileManager.fileExists(atPath: path)
         let isRenamed = flag & UInt32(kFSEventStreamEventFlagItemRenamed) != 0
-        let isCreated = flag & UInt32(kFSEventStreamEventFlagItemCreated) != 0
         let isRemoved = flag & UInt32(kFSEventStreamEventFlagItemRemoved) != 0
-        if exists, isRenamed || isCreated {
-            return .summaryChanged(relativePath)
+        if isRenamed {
+            return .summaryRename(relativePath, exists: exists)
         }
-        if !exists, isRenamed || isRemoved {
+        if !exists, isRemoved {
             return .summaryRemoved(relativePath)
         }
         return nil
     }
 
-    private static func resolveDirectoryRenames(
+    private static func resolveRenames(
         _ pendingRenames: [(path: String, exists: Bool)]
     ) -> (renames: [(oldPath: String, newPath: String)], created: [String], removed: [String]) {
         var renames: [(oldPath: String, newPath: String)] = []
@@ -148,7 +148,7 @@ struct VaultFileSystemEventBatch {
         case directoryRename(String, exists: Bool)
         case directoryCreated(String)
         case directoryRemoved(String)
-        case summaryChanged(String)
+        case summaryRename(String, exists: Bool)
         case summaryRemoved(String)
     }
 }

--- a/Sources/Dahlia/Services/VaultSummaryExportService.swift
+++ b/Sources/Dahlia/Services/VaultSummaryExportService.swift
@@ -9,6 +9,7 @@ enum VaultSummaryExportService {
     static func exportSummaryBundle(
         projectURL: URL?,
         vaultURL: URL,
+        storedSummaryRelativePath: String? = nil,
         meetingId: UUID,
         createdAt: Date,
         projectName: String,
@@ -21,6 +22,7 @@ enum VaultSummaryExportService {
         try await exportSummaryBundle(
             projectURL: projectURL,
             vaultURL: vaultURL,
+            storedSummaryRelativePath: storedSummaryRelativePath,
             meetingId: meetingId,
             createdAt: createdAt,
             projectName: projectName,
@@ -38,6 +40,7 @@ enum VaultSummaryExportService {
     static func exportSummaryBundle(
         projectURL: URL?,
         vaultURL: URL,
+        storedSummaryRelativePath: String? = nil,
         meetingId: UUID,
         createdAt: Date,
         projectName: String,
@@ -53,7 +56,7 @@ enum VaultSummaryExportService {
         let summaryFileURL = try resolveSummaryFileURL(
             projectURL: projectURL,
             vaultURL: vaultURL,
-            meetingId: meetingId,
+            storedSummaryRelativePath: storedSummaryRelativePath,
             summaryFileName: summaryFileName
         )
 
@@ -86,13 +89,12 @@ enum VaultSummaryExportService {
     static func resolveSummaryFileURL(
         projectURL: URL?,
         vaultURL: URL,
-        meetingId: UUID,
+        storedSummaryRelativePath: String?,
         summaryFileName: String
     ) throws -> URL {
         if let existing = SummaryService.findSummaryFile(
-            projectURL: projectURL,
-            vaultURL: vaultURL,
-            meetingId: meetingId
+            storedRelativePath: storedSummaryRelativePath,
+            vaultURL: vaultURL
         ) {
             return existing
         }

--- a/Sources/Dahlia/Services/VaultSummaryFileLocator.swift
+++ b/Sources/Dahlia/Services/VaultSummaryFileLocator.swift
@@ -16,8 +16,9 @@ enum VaultSummaryFileLocator {
     ) -> URL? {
         if let storedRelativePath,
            let storedURL = fileURL(for: storedRelativePath, vaultURL: vaultURL),
-           FileManager.default.fileExists(atPath: storedURL.path) {
-            return storedURL
+           let storedSummary = locatedSummaryFile(at: storedURL, vaultURL: vaultURL),
+           storedSummary.meetingId == meetingId {
+            return storedSummary.url
         }
 
         if let projectURL,

--- a/Sources/Dahlia/Services/VaultSummaryFileLocator.swift
+++ b/Sources/Dahlia/Services/VaultSummaryFileLocator.swift
@@ -1,48 +1,17 @@
 import Foundation
 
-struct LocatedVaultSummaryFile: Equatable {
-    let meetingId: UUID
-    let relativePath: String
-    let url: URL
-}
-
 /// Vault 内の要約 Markdown と、DB に保存する Vault 相対パスを相互変換する。
 enum VaultSummaryFileLocator {
     static func findSummaryFile(
         storedRelativePath: String?,
-        projectURL: URL?,
-        vaultURL: URL,
-        meetingId: UUID
+        vaultURL: URL
     ) -> URL? {
-        if let storedRelativePath,
-           let storedURL = fileURL(for: storedRelativePath, vaultURL: vaultURL),
-           let storedSummary = locatedSummaryFile(at: storedURL, vaultURL: vaultURL),
-           storedSummary.meetingId == meetingId {
-            return storedSummary.url
-        }
-
-        if let projectURL,
-           let projectMatch = locatedSummaryFiles(in: projectURL, recursively: false)
-           .first(where: { $0.meetingId == meetingId }) {
-            return projectMatch.url
-        }
-
-        return locatedSummaryFiles(in: vaultURL, recursively: true)
-            .first(where: { $0.meetingId == meetingId })?
-            .url
-    }
-
-    static func locatedSummaryFiles(in vaultURL: URL) -> [LocatedVaultSummaryFile] {
-        locatedSummaryFiles(in: vaultURL, recursively: true)
-    }
-
-    static func locatedSummaryFile(at fileURL: URL, vaultURL: URL) -> LocatedVaultSummaryFile? {
-        guard fileURL.pathExtension.lowercased() == "md",
-              let meetingId = meetingId(in: fileURL),
-              let relativePath = relativePath(for: fileURL, vaultURL: vaultURL)
+        guard let storedRelativePath,
+              let storedURL = fileURL(for: storedRelativePath, vaultURL: vaultURL),
+              storedURL.pathExtension.lowercased() == "md",
+              (try? storedURL.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true
         else { return nil }
-
-        return LocatedVaultSummaryFile(meetingId: meetingId, relativePath: relativePath, url: fileURL)
+        return storedURL
     }
 
     static func relativePath(for fileURL: URL, vaultURL: URL) -> String? {
@@ -63,59 +32,5 @@ enum VaultSummaryFileLocator {
 
         guard candidate.path.hasPrefix(prefix) else { return nil }
         return candidate
-    }
-
-    private static func locatedSummaryFiles(in directoryURL: URL, recursively: Bool) -> [LocatedVaultSummaryFile] {
-        let options: FileManager.DirectoryEnumerationOptions = recursively
-            ? [.skipsHiddenFiles]
-            : [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
-
-        guard let enumerator = FileManager.default.enumerator(
-            at: directoryURL,
-            includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey],
-            options: options
-        ) else { return [] }
-
-        var locations: [LocatedVaultSummaryFile] = []
-        while let url = enumerator.nextObject() as? URL {
-            guard let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isRegularFileKey]) else { continue }
-
-            if values.isDirectory == true {
-                if url.lastPathComponent == "_dahlia" {
-                    enumerator.skipDescendants()
-                }
-                continue
-            }
-
-            guard values.isRegularFile == true,
-                  let location = locatedSummaryFile(at: url, vaultURL: directoryURL)
-            else { continue }
-            locations.append(location)
-        }
-
-        return locations.sorted { $0.relativePath.localizedStandardCompare($1.relativePath) == .orderedAscending }
-    }
-
-    private static func meetingId(in fileURL: URL) -> UUID? {
-        guard let handle = try? FileHandle(forReadingFrom: fileURL) else { return nil }
-        defer { try? handle.close() }
-
-        guard let data = try? handle.read(upToCount: 4096),
-              let head = String(data: data, encoding: .utf8)
-        else { return nil }
-
-        for line in head.split(whereSeparator: \Character.isNewline) {
-            let fields = line.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
-            guard fields.count == 2,
-                  fields[0].trimmingCharacters(in: .whitespaces).lowercased() == "meeting_id"
-            else { continue }
-
-            let value = fields[1]
-                .trimmingCharacters(in: .whitespaces)
-                .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
-            return UUID(uuidString: value)
-        }
-
-        return nil
     }
 }

--- a/Sources/Dahlia/Services/VaultSummaryFileLocator.swift
+++ b/Sources/Dahlia/Services/VaultSummaryFileLocator.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+struct LocatedVaultSummaryFile: Equatable {
+    let meetingId: UUID
+    let relativePath: String
+    let url: URL
+}
+
+/// Vault 内の要約 Markdown と、DB に保存する Vault 相対パスを相互変換する。
+enum VaultSummaryFileLocator {
+    static func findSummaryFile(
+        storedRelativePath: String?,
+        projectURL: URL?,
+        vaultURL: URL,
+        meetingId: UUID
+    ) -> URL? {
+        if let storedRelativePath,
+           let storedURL = fileURL(for: storedRelativePath, vaultURL: vaultURL),
+           FileManager.default.fileExists(atPath: storedURL.path) {
+            return storedURL
+        }
+
+        if let projectURL,
+           let projectMatch = locatedSummaryFiles(in: projectURL, recursively: false)
+           .first(where: { $0.meetingId == meetingId }) {
+            return projectMatch.url
+        }
+
+        return locatedSummaryFiles(in: vaultURL, recursively: true)
+            .first(where: { $0.meetingId == meetingId })?
+            .url
+    }
+
+    static func locatedSummaryFiles(in vaultURL: URL) -> [LocatedVaultSummaryFile] {
+        locatedSummaryFiles(in: vaultURL, recursively: true)
+    }
+
+    static func locatedSummaryFile(at fileURL: URL, vaultURL: URL) -> LocatedVaultSummaryFile? {
+        guard fileURL.pathExtension.lowercased() == "md",
+              let meetingId = meetingId(in: fileURL),
+              let relativePath = relativePath(for: fileURL, vaultURL: vaultURL)
+        else { return nil }
+
+        return LocatedVaultSummaryFile(meetingId: meetingId, relativePath: relativePath, url: fileURL)
+    }
+
+    static func relativePath(for fileURL: URL, vaultURL: URL) -> String? {
+        let vaultPath = vaultURL.standardizedFileURL.path
+        let filePath = fileURL.standardizedFileURL.path
+        let prefix = vaultPath.hasSuffix("/") ? vaultPath : vaultPath + "/"
+
+        guard filePath.hasPrefix(prefix) else { return nil }
+        return String(filePath.dropFirst(prefix.count))
+    }
+
+    static func fileURL(for relativePath: String, vaultURL: URL) -> URL? {
+        guard !relativePath.isEmpty, !relativePath.hasPrefix("/") else { return nil }
+
+        let vaultPath = vaultURL.standardizedFileURL.path
+        let candidate = vaultURL.appending(path: relativePath).standardizedFileURL
+        let prefix = vaultPath.hasSuffix("/") ? vaultPath : vaultPath + "/"
+
+        guard candidate.path.hasPrefix(prefix) else { return nil }
+        return candidate
+    }
+
+    private static func locatedSummaryFiles(in directoryURL: URL, recursively: Bool) -> [LocatedVaultSummaryFile] {
+        let options: FileManager.DirectoryEnumerationOptions = recursively
+            ? [.skipsHiddenFiles]
+            : [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
+
+        guard let enumerator = FileManager.default.enumerator(
+            at: directoryURL,
+            includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey],
+            options: options
+        ) else { return [] }
+
+        var locations: [LocatedVaultSummaryFile] = []
+        while let url = enumerator.nextObject() as? URL {
+            guard let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isRegularFileKey]) else { continue }
+
+            if values.isDirectory == true {
+                if url.lastPathComponent == "_dahlia" {
+                    enumerator.skipDescendants()
+                }
+                continue
+            }
+
+            guard values.isRegularFile == true,
+                  let location = locatedSummaryFile(at: url, vaultURL: directoryURL)
+            else { continue }
+            locations.append(location)
+        }
+
+        return locations.sorted { $0.relativePath.localizedStandardCompare($1.relativePath) == .orderedAscending }
+    }
+
+    private static func meetingId(in fileURL: URL) -> UUID? {
+        guard let handle = try? FileHandle(forReadingFrom: fileURL) else { return nil }
+        defer { try? handle.close() }
+
+        guard let data = try? handle.read(upToCount: 4096),
+              let head = String(data: data, encoding: .utf8)
+        else { return nil }
+
+        for line in head.split(whereSeparator: \Character.isNewline) {
+            let fields = line.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+            guard fields.count == 2,
+                  fields[0].trimmingCharacters(in: .whitespaces).lowercased() == "meeting_id"
+            else { continue }
+
+            let value = fields[1]
+                .trimmingCharacters(in: .whitespaces)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+            return UUID(uuidString: value)
+        }
+
+        return nil
+    }
+}

--- a/Sources/Dahlia/Services/VaultSummaryPathSynchronizer.swift
+++ b/Sources/Dahlia/Services/VaultSummaryPathSynchronizer.swift
@@ -2,30 +2,17 @@ import Foundation
 import GRDB
 
 struct VaultSummaryPathSynchronizer {
-    let vaultURL: URL
     let dbQueue: DatabaseQueue
     let vaultId: UUID
 
-    func filesForInitialReconciliation() -> [LocatedVaultSummaryFile] {
-        guard pathsNeedReconciliation() else { return [] }
-        return VaultSummaryFileLocator.locatedSummaryFiles(in: vaultURL)
-    }
-
-    func reconcile(_ summaryFiles: [LocatedVaultSummaryFile], in db: Database) throws {
-        let pathsByMeetingId = Dictionary(grouping: summaryFiles, by: \LocatedVaultSummaryFile.meetingId)
-            .mapValues { $0.map(\.relativePath) }
-        let summaries = try SummaryRecord.fetchAll(vaultId: vaultId, in: db)
-
-        for var summary in summaries {
-            guard let candidates = pathsByMeetingId[summary.meetingId],
-                  let relativePath = candidates.first
-            else { continue }
-            if let storedRelativePath = summary.vaultRelativePath,
-               candidates.contains(storedRelativePath) {
-                continue
-            }
-            summary.vaultRelativePath = relativePath
-            try summary.update(db)
+    func renamePath(from oldPath: String, to newPath: String) {
+        try? dbQueue.write { db in
+            try SummaryRecord.renameVaultRelativePath(
+                from: oldPath,
+                to: newPath,
+                vaultId: vaultId,
+                in: db
+            )
         }
     }
 
@@ -38,28 +25,6 @@ struct VaultSummaryPathSynchronizer {
         )
     }
 
-    func syncFiles(at relativePaths: [String]) {
-        let summaryFiles = relativePaths.compactMap { relativePath -> LocatedVaultSummaryFile? in
-            guard let fileURL = VaultSummaryFileLocator.fileURL(for: relativePath, vaultURL: vaultURL) else { return nil }
-            return VaultSummaryFileLocator.locatedSummaryFile(at: fileURL, vaultURL: vaultURL)
-        }
-        guard !summaryFiles.isEmpty else { return }
-
-        try? dbQueue.write { db in
-            for summaryFile in summaryFiles {
-                if storedSummaryFileExists(for: summaryFile.meetingId, in: db) {
-                    continue
-                }
-                try SummaryRecord.updateVaultRelativePath(
-                    summaryFile.relativePath,
-                    meetingId: summaryFile.meetingId,
-                    vaultId: vaultId,
-                    in: db
-                )
-            }
-        }
-    }
-
     func clearRemovedPaths(_ relativePaths: [String]) {
         guard !relativePaths.isEmpty else { return }
         try? dbQueue.write { db in
@@ -67,25 +32,5 @@ struct VaultSummaryPathSynchronizer {
                 try SummaryRecord.clearVaultRelativePath(relativePath, vaultId: vaultId, in: db)
             }
         }
-    }
-
-    private func pathsNeedReconciliation() -> Bool {
-        (try? dbQueue.read { db in
-            let summaries = try SummaryRecord.fetchAll(vaultId: vaultId, in: db)
-            return summaries.contains { summary in
-                guard let relativePath = summary.vaultRelativePath,
-                      let fileURL = VaultSummaryFileLocator.fileURL(for: relativePath, vaultURL: vaultURL)
-                else { return true }
-                return !FileManager.default.fileExists(atPath: fileURL.path)
-            }
-        }) ?? false
-    }
-
-    private func storedSummaryFileExists(for meetingId: UUID, in db: Database) -> Bool {
-        guard let summary = try? SummaryRecord.fetchOne(db, key: meetingId),
-              let storedRelativePath = summary.vaultRelativePath,
-              let storedURL = VaultSummaryFileLocator.fileURL(for: storedRelativePath, vaultURL: vaultURL)
-        else { return false }
-        return FileManager.default.fileExists(atPath: storedURL.path)
     }
 }

--- a/Sources/Dahlia/Services/VaultSummaryPathSynchronizer.swift
+++ b/Sources/Dahlia/Services/VaultSummaryPathSynchronizer.swift
@@ -1,0 +1,91 @@
+import Foundation
+import GRDB
+
+struct VaultSummaryPathSynchronizer {
+    let vaultURL: URL
+    let dbQueue: DatabaseQueue
+    let vaultId: UUID
+
+    func filesForInitialReconciliation() -> [LocatedVaultSummaryFile] {
+        guard pathsNeedReconciliation() else { return [] }
+        return VaultSummaryFileLocator.locatedSummaryFiles(in: vaultURL)
+    }
+
+    func reconcile(_ summaryFiles: [LocatedVaultSummaryFile], in db: Database) throws {
+        let pathsByMeetingId = Dictionary(grouping: summaryFiles, by: \LocatedVaultSummaryFile.meetingId)
+            .mapValues { $0.map(\.relativePath) }
+        let summaries = try SummaryRecord.fetchAll(vaultId: vaultId, in: db)
+
+        for var summary in summaries {
+            guard let candidates = pathsByMeetingId[summary.meetingId],
+                  let relativePath = candidates.first
+            else { continue }
+            if let storedRelativePath = summary.vaultRelativePath,
+               candidates.contains(storedRelativePath) {
+                continue
+            }
+            summary.vaultRelativePath = relativePath
+            try summary.update(db)
+        }
+    }
+
+    func renamePathsByPrefix(oldPrefix: String, newPrefix: String, in db: Database) throws {
+        try SummaryRecord.renameVaultRelativePathsByPrefix(
+            oldPrefix: oldPrefix,
+            newPrefix: newPrefix,
+            vaultId: vaultId,
+            in: db
+        )
+    }
+
+    func syncFiles(at relativePaths: [String]) {
+        let summaryFiles = relativePaths.compactMap { relativePath -> LocatedVaultSummaryFile? in
+            guard let fileURL = VaultSummaryFileLocator.fileURL(for: relativePath, vaultURL: vaultURL) else { return nil }
+            return VaultSummaryFileLocator.locatedSummaryFile(at: fileURL, vaultURL: vaultURL)
+        }
+        guard !summaryFiles.isEmpty else { return }
+
+        try? dbQueue.write { db in
+            for summaryFile in summaryFiles {
+                if storedSummaryFileExists(for: summaryFile.meetingId, in: db) {
+                    continue
+                }
+                try SummaryRecord.updateVaultRelativePath(
+                    summaryFile.relativePath,
+                    meetingId: summaryFile.meetingId,
+                    vaultId: vaultId,
+                    in: db
+                )
+            }
+        }
+    }
+
+    func clearRemovedPaths(_ relativePaths: [String]) {
+        guard !relativePaths.isEmpty else { return }
+        try? dbQueue.write { db in
+            for relativePath in relativePaths {
+                try SummaryRecord.clearVaultRelativePath(relativePath, vaultId: vaultId, in: db)
+            }
+        }
+    }
+
+    private func pathsNeedReconciliation() -> Bool {
+        (try? dbQueue.read { db in
+            let summaries = try SummaryRecord.fetchAll(vaultId: vaultId, in: db)
+            return summaries.contains { summary in
+                guard let relativePath = summary.vaultRelativePath,
+                      let fileURL = VaultSummaryFileLocator.fileURL(for: relativePath, vaultURL: vaultURL)
+                else { return true }
+                return !FileManager.default.fileExists(atPath: fileURL.path)
+            }
+        }) ?? false
+    }
+
+    private func storedSummaryFileExists(for meetingId: UUID, in db: Database) -> Bool {
+        guard let summary = try? SummaryRecord.fetchOne(db, key: meetingId),
+              let storedRelativePath = summary.vaultRelativePath,
+              let storedURL = VaultSummaryFileLocator.fileURL(for: storedRelativePath, vaultURL: vaultURL)
+        else { return false }
+        return FileManager.default.fileExists(atPath: storedURL.path)
+    }
+}

--- a/Sources/Dahlia/Services/VaultSyncService.swift
+++ b/Sources/Dahlia/Services/VaultSyncService.swift
@@ -17,7 +17,7 @@ final class VaultSyncService: @unchecked Sendable {
         self.vaultURL = vaultURL
         self.dbQueue = dbQueue
         self.vaultId = vaultId
-        summaryPathSynchronizer = VaultSummaryPathSynchronizer(vaultURL: vaultURL, dbQueue: dbQueue, vaultId: vaultId)
+        summaryPathSynchronizer = VaultSummaryPathSynchronizer(dbQueue: dbQueue, vaultId: vaultId)
     }
 
     deinit {
@@ -29,13 +29,9 @@ final class VaultSyncService: @unchecked Sendable {
     /// vault 内の全ディレクトリをスキャンし、projects テーブルと同期する。
     func performInitialSync() {
         let diskNames = Set(scanAllDirectoryNames())
-        let summaryFiles = summaryPathSynchronizer.filesForInitialReconciliation()
         try? dbQueue.write { db in
             try ProjectRecord.upsertAll(names: Array(diskNames), vaultId: self.vaultId, in: db)
             try self.reconcileMissingProjects(diskNames: diskNames, in: db)
-            if !summaryFiles.isEmpty {
-                try self.summaryPathSynchronizer.reconcile(summaryFiles, in: db)
-            }
         }
     }
 
@@ -204,6 +200,9 @@ final class VaultSyncService: @unchecked Sendable {
         for rename in events.directoryRenames {
             renameProjectsByPrefix(oldPrefix: rename.oldPath, newPrefix: rename.newPath)
         }
+        for rename in events.summaryRenames {
+            summaryPathSynchronizer.renamePath(from: rename.oldPath, to: rename.newPath)
+        }
 
         if !events.removedDirectories.isEmpty {
             try? dbQueue.write { db in
@@ -221,7 +220,6 @@ final class VaultSyncService: @unchecked Sendable {
             upsertProjects(names: Array(allNames))
         }
 
-        summaryPathSynchronizer.syncFiles(at: events.changedSummaryPaths)
         summaryPathSynchronizer.clearRemovedPaths(events.removedSummaryPaths)
     }
 }

--- a/Sources/Dahlia/Services/VaultSyncService.swift
+++ b/Sources/Dahlia/Services/VaultSyncService.swift
@@ -8,6 +8,7 @@ final class VaultSyncService: @unchecked Sendable {
     private let vaultURL: URL
     private let dbQueue: DatabaseQueue
     private let vaultId: UUID
+    private let summaryPathSynchronizer: VaultSummaryPathSynchronizer
     private var stream: FSEventStreamRef?
     private let fileManager = FileManager.default
     private let callbackQueue = DispatchQueue(label: "com.dahlia.vault-sync", qos: .utility)
@@ -16,6 +17,7 @@ final class VaultSyncService: @unchecked Sendable {
         self.vaultURL = vaultURL
         self.dbQueue = dbQueue
         self.vaultId = vaultId
+        summaryPathSynchronizer = VaultSummaryPathSynchronizer(vaultURL: vaultURL, dbQueue: dbQueue, vaultId: vaultId)
     }
 
     deinit {
@@ -27,9 +29,13 @@ final class VaultSyncService: @unchecked Sendable {
     /// vault 内の全ディレクトリをスキャンし、projects テーブルと同期する。
     func performInitialSync() {
         let diskNames = Set(scanAllDirectoryNames())
+        let summaryFiles = summaryPathSynchronizer.filesForInitialReconciliation()
         try? dbQueue.write { db in
             try ProjectRecord.upsertAll(names: Array(diskNames), vaultId: self.vaultId, in: db)
             try self.reconcileMissingProjects(diskNames: diskNames, in: db)
+            if !summaryFiles.isEmpty {
+                try self.summaryPathSynchronizer.reconcile(summaryFiles, in: db)
+            }
         }
     }
 
@@ -159,6 +165,7 @@ final class VaultSyncService: @unchecked Sendable {
     private func renameProjectsByPrefix(oldPrefix: String, newPrefix: String) {
         try? dbQueue.write { db in
             try ProjectRecord.renameByPrefix(oldPrefix: oldPrefix, newPrefix: newPrefix, vaultId: self.vaultId, in: db)
+            try summaryPathSynchronizer.renamePathsByPrefix(oldPrefix: oldPrefix, newPrefix: newPrefix, in: db)
         }
     }
 
@@ -193,87 +200,29 @@ final class VaultSyncService: @unchecked Sendable {
     // MARK: - FSEvents Handler
 
     func handleEvents(paths: [String], flags: [UInt32]) {
-        let vaultPath = vaultURL.path + "/"
-
-        var pendingRenames: [(path: String, exists: Bool)] = []
-        var newDirs: [String] = []
-        var removedDirs: [String] = []
-
-        for (i, path) in paths.enumerated() {
-            let flag = flags[i]
-            let isDir = (flag & UInt32(kFSEventStreamEventFlagItemIsDir)) != 0
-            guard isDir else { continue }
-
-            guard path.hasPrefix(vaultPath) else { continue }
-            let relativePath = String(path.dropFirst(vaultPath.count))
-            guard !relativePath.isEmpty else { continue }
-
-            let components = relativePath.split(separator: "/")
-            let shouldSkip = components.contains { $0.hasPrefix(".") || $0.hasPrefix("_") }
-            if shouldSkip { continue }
-
-            let isRenamed = (flag & UInt32(kFSEventStreamEventFlagItemRenamed)) != 0
-            let isCreated = (flag & UInt32(kFSEventStreamEventFlagItemCreated)) != 0
-            let isRemoved = (flag & UInt32(kFSEventStreamEventFlagItemRemoved)) != 0
-
-            if isRenamed {
-                let exists = fileManager.fileExists(atPath: path)
-                pendingRenames.append((path: relativePath, exists: exists))
-            } else if isRemoved {
-                if !fileManager.fileExists(atPath: path) {
-                    removedDirs.append(relativePath)
-                }
-            } else if isCreated {
-                if fileManager.fileExists(atPath: path) {
-                    newDirs.append(relativePath)
-                }
-            }
+        let events = VaultFileSystemEventBatch(paths: paths, flags: flags, vaultURL: vaultURL, fileManager: fileManager)
+        for rename in events.directoryRenames {
+            renameProjectsByPrefix(oldPrefix: rename.oldPath, newPrefix: rename.newPath)
         }
 
-        // リネームペアの処理
-        var i = 0
-        while i < pendingRenames.count - 1 {
-            let first = pendingRenames[i]
-            let second = pendingRenames[i + 1]
-
-            if !first.exists, second.exists {
-                renameProjectsByPrefix(oldPrefix: first.path, newPrefix: second.path)
-                i += 2
-            } else if first.exists, !second.exists {
-                renameProjectsByPrefix(oldPrefix: second.path, newPrefix: first.path)
-                i += 2
-            } else {
-                if first.exists {
-                    newDirs.append(first.path)
-                } else {
-                    removedDirs.append(first.path)
-                }
-                i += 1
-            }
-        }
-        if i < pendingRenames.count {
-            if pendingRenames[i].exists {
-                newDirs.append(pendingRenames[i].path)
-            } else {
-                removedDirs.append(pendingRenames[i].path)
-            }
-        }
-
-        if !removedDirs.isEmpty {
+        if !events.removedDirectories.isEmpty {
             try? dbQueue.write { db in
-                try self.handleDirectoryRemovals(removedDirs, in: db)
+                try self.handleDirectoryRemovals(events.removedDirectories, in: db)
             }
         }
 
-        if !newDirs.isEmpty {
+        if !events.newDirectories.isEmpty {
             var allNames: Set<String> = []
-            for dir in newDirs {
-                for path in ProjectRecord.allIntermediatePaths(for: dir) {
+            for directory in events.newDirectories {
+                for path in ProjectRecord.allIntermediatePaths(for: directory) {
                     allNames.insert(path)
                 }
             }
             upsertProjects(names: Array(allNames))
         }
+
+        summaryPathSynchronizer.syncFiles(at: events.changedSummaryPaths)
+        summaryPathSynchronizer.clearRemovedPaths(events.removedSummaryPaths)
     }
 }
 

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -649,11 +649,22 @@ final class CaptionViewModel: ObservableObject {
         let recordingSessions = detail.recordingSessions.map(RecordingSessionTimeline.init)
         let segments = detail.segments.map(TranscriptSegment.init(from:))
 
-        let lastSummaryURL = SummaryService.findSummaryFile(
-            projectURL: projectURL,
-            vaultURL: vaultURL,
-            meetingId: meetingId
-        )
+        let lastSummaryURL: URL? = if let summary = detail.summary {
+            SummaryService.findSummaryFile(
+                storedRelativePath: summary.vaultRelativePath,
+                projectURL: projectURL,
+                vaultURL: vaultURL,
+                meetingId: meetingId
+            )
+        } else {
+            nil
+        }
+
+        if let lastSummaryURL,
+           let relativePath = VaultSummaryFileLocator.relativePath(for: lastSummaryURL, vaultURL: vaultURL),
+           relativePath != detail.summary?.vaultRelativePath {
+            try repo.updateSummaryVaultRelativePath(forMeetingId: meetingId, relativePath: relativePath)
+        }
 
         return LoadedMeetingData(
             createdAt: detail.meeting?.createdAt,
@@ -1856,6 +1867,9 @@ final class CaptionViewModel: ObservableObject {
 
             do {
                 let fileURL = try await vaultExport
+                if let relativePath = VaultSummaryFileLocator.relativePath(for: fileURL, vaultURL: vaultURL) {
+                    try repo?.updateSummaryVaultRelativePath(forMeetingId: meetingId, relativePath: relativePath)
+                }
                 summaryProgress.vaultExport = .completed
                 if currentMeetingId == meetingId {
                     lastSummaryURL = fileURL

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -490,13 +490,11 @@ final class CaptionViewModel: ObservableObject {
         guard let dbQueue = currentDbQueue,
               let vaultURL = currentVaultURL,
               currentMeetingId == meetingId else { return }
-        let projectURL = currentProjectURL
         do {
             let loaded = try await Task.detached(priority: .userInitiated) {
                 try Self.fetchLoadedMeetingData(
                     meetingId: meetingId,
                     dbQueue: dbQueue,
-                    projectURL: projectURL,
                     vaultURL: vaultURL
                 )
             }.value
@@ -641,7 +639,6 @@ final class CaptionViewModel: ObservableObject {
     private nonisolated static func fetchLoadedMeetingData(
         meetingId: UUID,
         dbQueue: DatabaseQueue,
-        projectURL: URL?,
         vaultURL: URL
     ) throws -> LoadedMeetingData {
         let repo = MeetingRepository(dbQueue: dbQueue)
@@ -652,18 +649,10 @@ final class CaptionViewModel: ObservableObject {
         let lastSummaryURL: URL? = if let summary = detail.summary {
             SummaryService.findSummaryFile(
                 storedRelativePath: summary.vaultRelativePath,
-                projectURL: projectURL,
-                vaultURL: vaultURL,
-                meetingId: meetingId
+                vaultURL: vaultURL
             )
         } else {
             nil
-        }
-
-        if let lastSummaryURL,
-           let relativePath = VaultSummaryFileLocator.relativePath(for: lastSummaryURL, vaultURL: vaultURL),
-           relativePath != detail.summary?.vaultRelativePath {
-            try repo.updateSummaryVaultRelativePath(forMeetingId: meetingId, relativePath: relativePath)
         }
 
         return LoadedMeetingData(
@@ -720,7 +709,7 @@ final class CaptionViewModel: ObservableObject {
             vaultURL: vaultURL
         )
 
-        meetingLoadTask = Task { [weak self, meetingId, dbQueue, projectURL, vaultURL] in
+        meetingLoadTask = Task { [weak self, meetingId, dbQueue, vaultURL] in
             guard let self else { return }
 
             let loaded: LoadedMeetingData
@@ -729,7 +718,6 @@ final class CaptionViewModel: ObservableObject {
                     try Self.fetchLoadedMeetingData(
                         meetingId: meetingId,
                         dbQueue: dbQueue,
-                        projectURL: projectURL,
                         vaultURL: vaultURL
                     )
                 }.value
@@ -932,8 +920,7 @@ final class CaptionViewModel: ObservableObject {
         guard let meetingId = currentMeetingId,
               let dbQueue = currentDbQueue,
               let vaultURL = currentVaultURL else { return }
-        let projectURL = currentProjectURL
-        meetingLoadTask = Task { [weak self, meetingId, dbQueue, projectURL, vaultURL] in
+        meetingLoadTask = Task { [weak self, meetingId, dbQueue, vaultURL] in
             guard let self else { return }
             let loaded: LoadedMeetingData
             do {
@@ -941,7 +928,6 @@ final class CaptionViewModel: ObservableObject {
                     try Self.fetchLoadedMeetingData(
                         meetingId: meetingId,
                         dbQueue: dbQueue,
-                        projectURL: projectURL,
                         vaultURL: vaultURL
                     )
                 }.value
@@ -1833,6 +1819,7 @@ final class CaptionViewModel: ObservableObject {
             if currentMeetingId == meetingId {
                 currentSummaryDocument = generatedSummary.document
             }
+            let storedSummaryRelativePath = try repo?.fetchSummary(forMeetingId: meetingId)?.vaultRelativePath
 
             summaryProgress.vaultExport = .running
             if googleDriveFolderId != nil {
@@ -1842,6 +1829,7 @@ final class CaptionViewModel: ObservableObject {
             async let vaultExport: URL = VaultSummaryExportService.exportSummaryBundle(
                 projectURL: projectURL,
                 vaultURL: vaultURL,
+                storedSummaryRelativePath: storedSummaryRelativePath,
                 meetingId: meetingId,
                 createdAt: createdAt,
                 projectName: projectName,

--- a/Tests/DahliaTests/MeetingRepositorySummaryTests.swift
+++ b/Tests/DahliaTests/MeetingRepositorySummaryTests.swift
@@ -56,12 +56,13 @@ import GRDB
         }
 
         @Test
-        func legacySummaryRecordLoadsDocumentFromMarkdownFallback() throws {
+        func legacySummaryRecordLoadsDocumentFromMarkdownFallback() {
             let record = SummaryRecord(
                 meetingId: UUID.v7(),
                 title: "Legacy",
                 summary: "## Summary\n\n- Decide [[meeting#00:10:00|00:10:00]]",
                 document: nil,
+                vaultRelativePath: nil,
                 googleFileId: nil,
                 createdAt: Date()
             )
@@ -75,6 +76,37 @@ import GRDB
                     items: [SummaryText("Decide", transcriptRef: TranscriptReference(time: "00:10:00"))]
                 ),
             ])
+        }
+
+        @Test
+        func regeneratingSummaryPreservesStoredVaultRelativePath() throws {
+            let context = try makeRepositoryContext()
+            try context.repo.upsertSummary(
+                SummaryRecord(
+                    meetingId: context.meeting.id,
+                    title: "Old",
+                    summary: "Old body",
+                    vaultRelativePath: "Acme/Existing.md",
+                    googleFileId: nil,
+                    createdAt: .now
+                )
+            )
+            let document = SummaryDocument(
+                title: "Updated",
+                sections: [SummarySection(id: .v7(), heading: "Summary", blocks: [.paragraph("New body")])],
+                tags: []
+            )
+
+            try context.repo.applyGeneratedSummary(
+                toMeetingId: context.meeting.id,
+                document: document,
+                renderedBody: "New body",
+                tags: []
+            )
+
+            let fetchedSummary = try context.repo.fetchSummary(forMeetingId: context.meeting.id)
+            let summary = try #require(fetchedSummary)
+            #expect(summary.vaultRelativePath == "Acme/Existing.md")
         }
 
         private func makeRepositoryContext() throws -> RepositoryContext {

--- a/Tests/DahliaTests/SummaryVaultPathMigrationTests.swift
+++ b/Tests/DahliaTests/SummaryVaultPathMigrationTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct SummaryVaultPathMigrationTests {
+        @Test
+        func initializesDatabaseWithSummaryVaultRelativePathColumn() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
+
+            let columns = try database.dbQueue.read { db in
+                try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
+            }
+
+            #expect(columns.contains("vaultRelativePath"))
+        }
+
+        @Test
+        func existingV12DatabaseAddsColumnWithoutDataLoss() throws {
+            let databaseURL = FileManager.default.temporaryDirectory
+                .appending(path: UUID().uuidString)
+                .appendingPathExtension("sqlite")
+            let meetingId = UUID.v7()
+            let createdAt = Date.now
+            defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+            let legacyQueue = try DatabaseQueue(path: databaseURL.path)
+            try createV12SummaryDatabase(
+                in: legacyQueue,
+                meetingId: meetingId,
+                createdAt: createdAt
+            )
+
+            let migrated = try AppDatabaseManager(path: databaseURL.path)
+            let result = try migrated.dbQueue.read { db in
+                let columns = try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
+                let row = try Row.fetchOne(db, sql: "SELECT * FROM summaries WHERE meetingId = ?", arguments: [meetingId])
+                return try (columns, #require(row))
+            }
+            let vaultRelativePath: String? = result.1["vaultRelativePath"]
+
+            #expect(result.0.contains("vaultRelativePath"))
+            #expect(result.1["title"] == "Legacy")
+            #expect(result.1["summary"] == "Body")
+            #expect(result.1["googleFileId"] == "drive-id")
+            #expect(vaultRelativePath == nil)
+        }
+
+        private func createV12SummaryDatabase(
+            in dbQueue: DatabaseQueue,
+            meetingId: UUID,
+            createdAt: Date
+        ) throws {
+            try dbQueue.write { db in
+                try db.execute(
+                    sql: """
+                    CREATE TABLE summaries (
+                        meetingId BLOB PRIMARY KEY,
+                        title TEXT NOT NULL DEFAULT '',
+                        summary TEXT NOT NULL,
+                        document TEXT,
+                        googleFileId TEXT,
+                        createdAt DATETIME NOT NULL
+                    )
+                    """
+                )
+                try db.create(table: "grdb_migrations") { table in
+                    table.column("identifier", .text).primaryKey()
+                }
+                for migration in Self.v12MigrationIdentifiers {
+                    try db.execute(sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)", arguments: [migration])
+                }
+                try db.execute(
+                    sql: """
+                    INSERT INTO summaries (meetingId, title, summary, document, googleFileId, createdAt)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    arguments: [meetingId, "Legacy", "Body", "{\"title\":\"Legacy\"}", "drive-id", createdAt]
+                )
+            }
+        }
+
+        private static let v12MigrationIdentifiers = [
+            "v3_googleDriveFolderSchema",
+            "v4_instructionsSchema",
+            "v5_summaryGoogleFileId",
+            "v6_transcriptSegmentTranslation",
+            "v7_normalizeLegacyMeetingStatus",
+            "v8_recordingSessions",
+            "v9_summaryDocument",
+            "v10_batchTranscription",
+            "v11_batchAudioStorageLocation",
+            "v12_batchTranscriptionDiscard",
+        ]
+    }
+#endif

--- a/Tests/DahliaTests/VaultSummaryExportServiceTests.swift
+++ b/Tests/DahliaTests/VaultSummaryExportServiceTests.swift
@@ -2,147 +2,148 @@ import Foundation
 @testable import Dahlia
 
 #if canImport(Testing)
-import Testing
+    import Testing
 
-struct VaultSummaryExportServiceTests {
-    @Test
-    func exportSummaryBundleWritesSummaryTranscriptAndScreenshots() async throws {
-        let vaultURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let projectURL = vaultURL.appendingPathComponent("Project", isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: vaultURL) }
+    struct VaultSummaryExportServiceTests {
+        @Test
+        func exportSummaryBundleWritesSummaryTranscriptAndScreenshots() async throws {
+            let vaultURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            let projectURL = vaultURL.appendingPathComponent("Project", isDirectory: true)
+            defer { try? FileManager.default.removeItem(at: vaultURL) }
 
-        try FileManager.default.createDirectory(at: projectURL, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: projectURL, withIntermediateDirectories: true)
 
-        let meetingId = UUID()
-        let screenshot = MeetingScreenshotRecord(
-            id: UUID(),
-            meetingId: meetingId,
-            capturedAt: Date(timeIntervalSince1970: 0),
-            imageData: Data([0x89, 0x50, 0x4E, 0x47]),
-            mimeType: "image/png"
-        )
-        let summaryMarkdown = """
-        ---
-        meeting_id: "\(meetingId.uuidString)"
-        ---
-
-        Summary body
-        """
-
-        let summaryURL = try await VaultSummaryExportService.exportSummaryBundle(
-            projectURL: projectURL,
-            vaultURL: vaultURL,
-            meetingId: meetingId,
-            createdAt: Date(timeIntervalSince1970: 0),
-            projectName: "Test Project",
-            segments: [
-                TranscriptSegment(
-                    startTime: Date(timeIntervalSince1970: 0),
-                    text: "hello"
-                ),
-            ],
-            screenshots: [screenshot],
-            summaryFileName: "summary.md",
-            summaryMarkdown: summaryMarkdown
-        )
-
-        #expect(summaryURL == projectURL.appendingPathComponent("summary.md"))
-        #expect(try String(contentsOf: summaryURL, encoding: .utf8) == summaryMarkdown)
-        #expect(FileManager.default.fileExists(atPath: vaultURL.appendingPathComponent("_dahlia/transcripts/\(meetingId.uuidString).md").path))
-        #expect(
-            FileManager.default.fileExists(
-                atPath: vaultURL.appendingPathComponent("_dahlia/screenshots/\(screenshot.id.uuidString).png").path
+            let meetingId = UUID()
+            let screenshot = MeetingScreenshotRecord(
+                id: UUID(),
+                meetingId: meetingId,
+                capturedAt: Date(timeIntervalSince1970: 0),
+                imageData: Data([0x89, 0x50, 0x4E, 0x47]),
+                mimeType: "image/png"
             )
-        )
-    }
-
-    @Test
-    func exportSummaryBundleReusesExistingSummaryFileForMeetingID() async throws {
-        let vaultURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let projectURL = vaultURL.appendingPathComponent("Project", isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: vaultURL) }
-
-        try FileManager.default.createDirectory(at: projectURL, withIntermediateDirectories: true)
-
-        let meetingId = UUID()
-        let existingSummaryURL = projectURL.appendingPathComponent("existing-summary.md")
-        try Data(
-            """
+            let summaryMarkdown = """
             ---
             meeting_id: "\(meetingId.uuidString)"
             ---
 
-            Old body
-            """.utf8
-        ).write(to: existingSummaryURL, options: .atomic)
+            Summary body
+            """
 
-        let summaryMarkdown = """
-        ---
-        meeting_id: "\(meetingId.uuidString)"
-        ---
-
-        New body
-        """
-
-        let summaryURL = try await VaultSummaryExportService.exportSummaryBundle(
-            projectURL: projectURL,
-            vaultURL: vaultURL,
-            meetingId: meetingId,
-            createdAt: Date(timeIntervalSince1970: 0),
-            projectName: "Test Project",
-            segments: [],
-            screenshots: [],
-            summaryFileName: "new-summary.md",
-            summaryMarkdown: summaryMarkdown
-        )
-
-        #expect(summaryURL.resolvingSymlinksInPath() == existingSummaryURL.resolvingSymlinksInPath())
-        #expect(try String(contentsOf: existingSummaryURL, encoding: .utf8) == summaryMarkdown)
-        #expect(!FileManager.default.fileExists(atPath: projectURL.appendingPathComponent("new-summary.md").path))
-    }
-
-    @Test
-    func exportSummaryBundleFailsWhenAnyArtifactExportFails() async throws {
-        enum ExpectedError: Error {
-            case transcriptFailed
-        }
-
-        let vaultURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let projectURL = vaultURL.appendingPathComponent("Project", isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: vaultURL) }
-
-        try FileManager.default.createDirectory(at: projectURL, withIntermediateDirectories: true)
-
-        var didThrowExpectedError = false
-
-        do {
-            _ = try await VaultSummaryExportService.exportSummaryBundle(
+            let summaryURL = try await VaultSummaryExportService.exportSummaryBundle(
                 projectURL: projectURL,
                 vaultURL: vaultURL,
-                meetingId: UUID(),
+                meetingId: meetingId,
+                createdAt: Date(timeIntervalSince1970: 0),
+                projectName: "Test Project",
+                segments: [
+                    TranscriptSegment(
+                        startTime: Date(timeIntervalSince1970: 0),
+                        text: "hello"
+                    ),
+                ],
+                screenshots: [screenshot],
+                summaryFileName: "summary.md",
+                summaryMarkdown: summaryMarkdown
+            )
+
+            #expect(summaryURL == projectURL.appendingPathComponent("summary.md"))
+            #expect(try String(contentsOf: summaryURL, encoding: .utf8) == summaryMarkdown)
+            #expect(FileManager.default.fileExists(atPath: vaultURL.appendingPathComponent("_dahlia/transcripts/\(meetingId.uuidString).md").path))
+            #expect(
+                FileManager.default.fileExists(
+                    atPath: vaultURL.appendingPathComponent("_dahlia/screenshots/\(screenshot.id.uuidString).png").path
+                )
+            )
+        }
+
+        @Test
+        func exportSummaryBundleReusesStoredSummaryPath() async throws {
+            let vaultURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            let projectURL = vaultURL.appendingPathComponent("Project", isDirectory: true)
+            defer { try? FileManager.default.removeItem(at: vaultURL) }
+
+            try FileManager.default.createDirectory(at: projectURL, withIntermediateDirectories: true)
+
+            let meetingId = UUID()
+            let existingSummaryURL = projectURL.appendingPathComponent("existing-summary.md")
+            try Data(
+                """
+                ---
+                meeting_id: "\(meetingId.uuidString)"
+                ---
+
+                Old body
+                """.utf8
+            ).write(to: existingSummaryURL, options: .atomic)
+
+            let summaryMarkdown = """
+            ---
+            meeting_id: "\(meetingId.uuidString)"
+            ---
+
+            New body
+            """
+
+            let summaryURL = try await VaultSummaryExportService.exportSummaryBundle(
+                projectURL: projectURL,
+                vaultURL: vaultURL,
+                storedSummaryRelativePath: "Project/existing-summary.md",
+                meetingId: meetingId,
                 createdAt: Date(timeIntervalSince1970: 0),
                 projectName: "Test Project",
                 segments: [],
                 screenshots: [],
-                summaryFileName: "summary.md",
-                summaryMarkdown: "summary",
-                exportTranscript: { _, _, _, _, _, _ in
-                    throw ExpectedError.transcriptFailed
-                },
-                exportScreenshots: { _, _ in [] },
-                writeSummary: { fileURL, markdown in
-                    try Data(markdown.utf8).write(to: fileURL, options: .atomic)
-                    return fileURL
-                }
+                summaryFileName: "new-summary.md",
+                summaryMarkdown: summaryMarkdown
             )
-        } catch is ExpectedError {
-            didThrowExpectedError = true
+
+            #expect(summaryURL.resolvingSymlinksInPath() == existingSummaryURL.resolvingSymlinksInPath())
+            #expect(try String(contentsOf: existingSummaryURL, encoding: .utf8) == summaryMarkdown)
+            #expect(!FileManager.default.fileExists(atPath: projectURL.appendingPathComponent("new-summary.md").path))
         }
 
-        #expect(didThrowExpectedError)
+        @Test
+        func exportSummaryBundleFailsWhenAnyArtifactExportFails() async throws {
+            enum ExpectedError: Error {
+                case transcriptFailed
+            }
+
+            let vaultURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            let projectURL = vaultURL.appendingPathComponent("Project", isDirectory: true)
+            defer { try? FileManager.default.removeItem(at: vaultURL) }
+
+            try FileManager.default.createDirectory(at: projectURL, withIntermediateDirectories: true)
+
+            var didThrowExpectedError = false
+
+            do {
+                _ = try await VaultSummaryExportService.exportSummaryBundle(
+                    projectURL: projectURL,
+                    vaultURL: vaultURL,
+                    meetingId: UUID(),
+                    createdAt: Date(timeIntervalSince1970: 0),
+                    projectName: "Test Project",
+                    segments: [],
+                    screenshots: [],
+                    summaryFileName: "summary.md",
+                    summaryMarkdown: "summary",
+                    exportTranscript: { _, _, _, _, _, _ in
+                        throw ExpectedError.transcriptFailed
+                    },
+                    exportScreenshots: { _, _ in [] },
+                    writeSummary: { fileURL, markdown in
+                        try Data(markdown.utf8).write(to: fileURL, options: .atomic)
+                        return fileURL
+                    }
+                )
+            } catch is ExpectedError {
+                didThrowExpectedError = true
+            }
+
+            #expect(didThrowExpectedError)
+        }
     }
-}
 #endif

--- a/Tests/DahliaTests/VaultSummaryFileLocatorTests.swift
+++ b/Tests/DahliaTests/VaultSummaryFileLocatorTests.swift
@@ -47,6 +47,30 @@ import Foundation
             #expect(resolved?.resolvingSymlinksInPath() == movedURL.resolvingSymlinksInPath())
         }
 
+        @Test
+        func storedPathForAnotherMeetingFallsBackToMatchingSummary() throws {
+            let vaultURL = FileManager.default.temporaryDirectory
+                .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+            let storedURL = vaultURL.appending(path: "Project/Stored.md")
+            let matchingURL = vaultURL.appending(path: "Archive/Matching.md")
+            let meetingId = UUID.v7()
+            defer { try? FileManager.default.removeItem(at: vaultURL) }
+
+            try FileManager.default.createDirectory(at: storedURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: matchingURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try writeSummary(meetingId: .v7(), to: storedURL)
+            try writeSummary(meetingId: meetingId, to: matchingURL)
+
+            let resolved = SummaryService.findSummaryFile(
+                storedRelativePath: "Project/Stored.md",
+                projectURL: storedURL.deletingLastPathComponent(),
+                vaultURL: vaultURL,
+                meetingId: meetingId
+            )
+
+            #expect(resolved?.resolvingSymlinksInPath() == matchingURL.resolvingSymlinksInPath())
+        }
+
         private func writeSummary(meetingId: UUID, to url: URL) throws {
             try Data(
                 """

--- a/Tests/DahliaTests/VaultSummaryFileLocatorTests.swift
+++ b/Tests/DahliaTests/VaultSummaryFileLocatorTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct VaultSummaryFileLocatorTests {
+        @Test
+        func storedPathResolvesWithoutCurrentProjectContext() throws {
+            let vaultURL = FileManager.default.temporaryDirectory
+                .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+            let summaryURL = vaultURL.appending(path: "Projects/Alpha/summary.md")
+            let meetingId = UUID.v7()
+            defer { try? FileManager.default.removeItem(at: vaultURL) }
+
+            try FileManager.default.createDirectory(at: summaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try writeSummary(meetingId: meetingId, to: summaryURL)
+
+            let resolved = SummaryService.findSummaryFile(
+                storedRelativePath: "Projects/Alpha/summary.md",
+                projectURL: nil,
+                vaultURL: vaultURL,
+                meetingId: meetingId
+            )
+
+            #expect(resolved == summaryURL.standardizedFileURL)
+        }
+
+        @Test
+        func staleStoredPathFallsBackToMovedSummaryFrontmatter() throws {
+            let vaultURL = FileManager.default.temporaryDirectory
+                .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+            let movedURL = vaultURL.appending(path: "Archive/Renamed.md")
+            let meetingId = UUID.v7()
+            defer { try? FileManager.default.removeItem(at: vaultURL) }
+
+            try FileManager.default.createDirectory(at: movedURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try writeSummary(meetingId: meetingId, to: movedURL)
+
+            let resolved = SummaryService.findSummaryFile(
+                storedRelativePath: "Projects/Alpha/Old.md",
+                projectURL: vaultURL.appending(path: "Projects/Alpha", directoryHint: .isDirectory),
+                vaultURL: vaultURL,
+                meetingId: meetingId
+            )
+
+            #expect(resolved?.resolvingSymlinksInPath() == movedURL.resolvingSymlinksInPath())
+        }
+
+        private func writeSummary(meetingId: UUID, to url: URL) throws {
+            try Data(
+                """
+                ---
+                meeting_id: "\(meetingId.uuidString)"
+                ---
+
+                Summary
+                """.utf8
+            ).write(to: url, options: .atomic)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/VaultSummaryFileLocatorTests.swift
+++ b/Tests/DahliaTests/VaultSummaryFileLocatorTests.swift
@@ -6,28 +6,25 @@ import Foundation
 
     struct VaultSummaryFileLocatorTests {
         @Test
-        func storedPathResolvesWithoutCurrentProjectContext() throws {
+        func storedPathResolvesWithoutReadingFrontmatter() throws {
             let vaultURL = FileManager.default.temporaryDirectory
                 .appending(path: UUID().uuidString, directoryHint: .isDirectory)
             let summaryURL = vaultURL.appending(path: "Projects/Alpha/summary.md")
-            let meetingId = UUID.v7()
             defer { try? FileManager.default.removeItem(at: vaultURL) }
 
             try FileManager.default.createDirectory(at: summaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try writeSummary(meetingId: meetingId, to: summaryURL)
+            try Data("Summary".utf8).write(to: summaryURL, options: .atomic)
 
             let resolved = SummaryService.findSummaryFile(
                 storedRelativePath: "Projects/Alpha/summary.md",
-                projectURL: nil,
-                vaultURL: vaultURL,
-                meetingId: meetingId
+                vaultURL: vaultURL
             )
 
             #expect(resolved == summaryURL.standardizedFileURL)
         }
 
         @Test
-        func staleStoredPathFallsBackToMovedSummaryFrontmatter() throws {
+        func staleStoredPathDoesNotSearchFrontmatter() throws {
             let vaultURL = FileManager.default.temporaryDirectory
                 .appending(path: UUID().uuidString, directoryHint: .isDirectory)
             let movedURL = vaultURL.appending(path: "Archive/Renamed.md")
@@ -35,43 +32,6 @@ import Foundation
             defer { try? FileManager.default.removeItem(at: vaultURL) }
 
             try FileManager.default.createDirectory(at: movedURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try writeSummary(meetingId: meetingId, to: movedURL)
-
-            let resolved = SummaryService.findSummaryFile(
-                storedRelativePath: "Projects/Alpha/Old.md",
-                projectURL: vaultURL.appending(path: "Projects/Alpha", directoryHint: .isDirectory),
-                vaultURL: vaultURL,
-                meetingId: meetingId
-            )
-
-            #expect(resolved?.resolvingSymlinksInPath() == movedURL.resolvingSymlinksInPath())
-        }
-
-        @Test
-        func storedPathForAnotherMeetingFallsBackToMatchingSummary() throws {
-            let vaultURL = FileManager.default.temporaryDirectory
-                .appending(path: UUID().uuidString, directoryHint: .isDirectory)
-            let storedURL = vaultURL.appending(path: "Project/Stored.md")
-            let matchingURL = vaultURL.appending(path: "Archive/Matching.md")
-            let meetingId = UUID.v7()
-            defer { try? FileManager.default.removeItem(at: vaultURL) }
-
-            try FileManager.default.createDirectory(at: storedURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try FileManager.default.createDirectory(at: matchingURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try writeSummary(meetingId: .v7(), to: storedURL)
-            try writeSummary(meetingId: meetingId, to: matchingURL)
-
-            let resolved = SummaryService.findSummaryFile(
-                storedRelativePath: "Project/Stored.md",
-                projectURL: storedURL.deletingLastPathComponent(),
-                vaultURL: vaultURL,
-                meetingId: meetingId
-            )
-
-            #expect(resolved?.resolvingSymlinksInPath() == matchingURL.resolvingSymlinksInPath())
-        }
-
-        private func writeSummary(meetingId: UUID, to url: URL) throws {
             try Data(
                 """
                 ---
@@ -80,7 +40,32 @@ import Foundation
 
                 Summary
                 """.utf8
-            ).write(to: url, options: .atomic)
+            ).write(to: movedURL, options: .atomic)
+
+            let resolved = SummaryService.findSummaryFile(
+                storedRelativePath: "Projects/Alpha/Old.md",
+                vaultURL: vaultURL
+            )
+
+            #expect(resolved == nil)
+        }
+
+        @Test
+        func missingStoredPathDoesNotSearchVault() throws {
+            let vaultURL = FileManager.default.temporaryDirectory
+                .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+            let summaryURL = vaultURL.appending(path: "Project/Summary.md")
+            defer { try? FileManager.default.removeItem(at: vaultURL) }
+
+            try FileManager.default.createDirectory(at: summaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try Data("Summary".utf8).write(to: summaryURL, options: .atomic)
+
+            let resolved = SummaryService.findSummaryFile(
+                storedRelativePath: nil,
+                vaultURL: vaultURL
+            )
+
+            #expect(resolved == nil)
         }
     }
 #endif

--- a/Tests/DahliaTests/VaultSyncSummaryPathTests.swift
+++ b/Tests/DahliaTests/VaultSyncSummaryPathTests.swift
@@ -1,0 +1,143 @@
+import CoreServices
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct VaultSyncSummaryPathTests {
+        @Test
+        func markdownRenameUpdatesStoredSummaryPath() throws {
+            let context = try makeContext(projectName: "Project", summaryRelativePath: "Project/Original.md")
+            defer { try? FileManager.default.removeItem(at: context.vaultURL) }
+
+            let originalURL = context.vaultURL.appending(path: "Project/Original.md")
+            let renamedURL = context.vaultURL.appending(path: "Project/Renamed.md")
+            try writeSummary(meetingId: context.meeting.id, to: originalURL)
+            try FileManager.default.moveItem(at: originalURL, to: renamedURL)
+
+            let renameFlag = UInt32(kFSEventStreamEventFlagItemRenamed)
+                | UInt32(kFSEventStreamEventFlagItemIsFile)
+            context.syncService.handleEvents(
+                paths: [originalURL.path, renamedURL.path],
+                flags: [renameFlag, renameFlag]
+            )
+
+            let fetchedSummary = try context.repository.fetchSummary(forMeetingId: context.meeting.id)
+            let summary = try #require(fetchedSummary)
+            #expect(summary.vaultRelativePath == "Project/Renamed.md")
+        }
+
+        @Test
+        func projectFolderRenameUpdatesStoredSummaryPathByPrefix() throws {
+            let context = try makeContext(projectName: "Original", summaryRelativePath: "Original/Summary.md")
+            defer { try? FileManager.default.removeItem(at: context.vaultURL) }
+
+            let originalURL = context.vaultURL.appending(path: "Original", directoryHint: .isDirectory)
+            let renamedURL = context.vaultURL.appending(path: "Renamed", directoryHint: .isDirectory)
+            try FileManager.default.moveItem(at: originalURL, to: renamedURL)
+
+            let renameFlag = UInt32(kFSEventStreamEventFlagItemRenamed)
+                | UInt32(kFSEventStreamEventFlagItemIsDir)
+            context.syncService.handleEvents(
+                paths: [originalURL.path, renamedURL.path],
+                flags: [renameFlag, renameFlag]
+            )
+
+            let fetchedProject = try context.repository.fetchProject(id: context.project.id)
+            let fetchedSummary = try context.repository.fetchSummary(forMeetingId: context.meeting.id)
+            let project = try #require(fetchedProject)
+            let summary = try #require(fetchedSummary)
+            #expect(project.name == "Renamed")
+            #expect(summary.vaultRelativePath == "Renamed/Summary.md")
+        }
+
+        @Test
+        func initialSyncRepairsPathMovedWhileAppWasNotMonitoring() throws {
+            let context = try makeContext(projectName: "Project", summaryRelativePath: "Project/Original.md")
+            defer { try? FileManager.default.removeItem(at: context.vaultURL) }
+
+            let originalURL = context.vaultURL.appending(path: "Project/Original.md")
+            let archiveURL = context.vaultURL.appending(path: "Archive/Moved.md")
+            try writeSummary(meetingId: context.meeting.id, to: originalURL)
+            try FileManager.default.createDirectory(at: archiveURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try FileManager.default.moveItem(at: originalURL, to: archiveURL)
+
+            context.syncService.performInitialSync()
+
+            let fetchedSummary = try context.repository.fetchSummary(forMeetingId: context.meeting.id)
+            let summary = try #require(fetchedSummary)
+            #expect(summary.vaultRelativePath == "Archive/Moved.md")
+        }
+
+        private func makeContext(projectName: String, summaryRelativePath: String) throws -> TestContext {
+            let vaultURL = FileManager.default.temporaryDirectory
+                .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+            try FileManager.default.createDirectory(
+                at: vaultURL.appending(path: projectName, directoryHint: .isDirectory),
+                withIntermediateDirectories: true
+            )
+
+            let manager = try AppDatabaseManager(path: ":memory:")
+            let repository = MeetingRepository(dbQueue: manager.dbQueue)
+            let vault = VaultRecord(
+                id: .v7(),
+                path: vaultURL.path,
+                name: "Test Vault",
+                createdAt: .now,
+                lastOpenedAt: .now
+            )
+            try repository.insertVault(vault)
+            let project = try repository.fetchOrCreateProject(name: projectName, vaultId: vault.id)
+            let meeting = MeetingRecord(
+                id: .v7(),
+                vaultId: vault.id,
+                projectId: project.id,
+                name: "Meeting",
+                createdAt: .now,
+                updatedAt: .now
+            )
+            try manager.dbQueue.write { db in
+                try meeting.insert(db)
+                try SummaryRecord(
+                    meetingId: meeting.id,
+                    title: "Summary",
+                    summary: "Body",
+                    vaultRelativePath: summaryRelativePath,
+                    googleFileId: nil,
+                    createdAt: .now
+                ).insert(db)
+            }
+
+            return TestContext(
+                vaultURL: vaultURL,
+                repository: repository,
+                project: project,
+                meeting: meeting,
+                syncService: VaultSyncService(vaultURL: vaultURL, dbQueue: manager.dbQueue, vaultId: vault.id)
+            )
+        }
+
+        private func writeSummary(meetingId: UUID, to url: URL) throws {
+            try Data(
+                """
+                ---
+                meeting_id: "\(meetingId.uuidString)"
+                ---
+
+                Summary
+                """.utf8
+            ).write(to: url, options: .atomic)
+        }
+
+        private struct TestContext {
+            let vaultURL: URL
+            let repository: MeetingRepository
+            let project: ProjectRecord
+            let meeting: MeetingRecord
+            let syncService: VaultSyncService
+        }
+    }
+#endif

--- a/Tests/DahliaTests/VaultSyncSummaryPathTests.swift
+++ b/Tests/DahliaTests/VaultSyncSummaryPathTests.swift
@@ -9,13 +9,13 @@ import GRDB
     @MainActor
     struct VaultSyncSummaryPathTests {
         @Test
-        func markdownRenameUpdatesStoredSummaryPath() throws {
+        func markdownRenameUpdatesStoredSummaryPathWithoutReadingFrontmatter() throws {
             let context = try makeContext(projectName: "Project", summaryRelativePath: "Project/Original.md")
             defer { try? FileManager.default.removeItem(at: context.vaultURL) }
 
             let originalURL = context.vaultURL.appending(path: "Project/Original.md")
             let renamedURL = context.vaultURL.appending(path: "Project/Renamed.md")
-            try writeSummary(meetingId: context.meeting.id, to: originalURL)
+            try Data("Summary".utf8).write(to: originalURL, options: .atomic)
             try FileManager.default.moveItem(at: originalURL, to: renamedURL)
 
             let renameFlag = UInt32(kFSEventStreamEventFlagItemRenamed)
@@ -55,7 +55,7 @@ import GRDB
         }
 
         @Test
-        func initialSyncRepairsPathMovedWhileAppWasNotMonitoring() throws {
+        func initialSyncDoesNotGuessSummaryPathFromFrontmatter() throws {
             let context = try makeContext(projectName: "Project", summaryRelativePath: "Project/Original.md")
             defer { try? FileManager.default.removeItem(at: context.vaultURL) }
 
@@ -69,7 +69,7 @@ import GRDB
 
             let fetchedSummary = try context.repository.fetchSummary(forMeetingId: context.meeting.id)
             let summary = try #require(fetchedSummary)
-            #expect(summary.vaultRelativePath == "Archive/Moved.md")
+            #expect(summary.vaultRelativePath == "Project/Original.md")
         }
 
         private func makeContext(projectName: String, summaryRelativePath: String) throws -> TestContext {


### PR DESCRIPTION
## 概要

Vault に書き出した Obsidian 向け Markdown を、ページ遷移後も「Obsidianで開く」から参照できるようにします。

## 原因

書き出し直後は ViewModel が保持する一時 URL を利用していましたが、ページ再表示時には現在のプロジェクト直下を再走査していました。そのため、プロジェクトコンテキストが変わった場合やファイルが移動・rename された場合に書き出し先を復元できませんでした。

## 変更内容

- `summaries.vaultRelativePath` を追加する非破壊マイグレーション `v13_summaryVaultRelativePath` を追加
- Vault 書き出し成功時に Markdown の Vault 相対パスを DB へ保存
- ページ再表示時は保存済みパスを優先して「Obsidianで開く」の URL を復元
- Markdown 単体の rename/move を FSEvents と frontmatter の `meeting_id` で追従
- 親プロジェクトフォルダの rename 時に保存済みパスの prefix も同一トランザクションで更新
- アプリ停止中に移動された既存ファイルや旧データは Vault 初期同期・読み込み時に再探索してパスを修復
- 通常起動では保存済みパスが有効なら Vault 全体の Markdown 走査を省略

## ユーザーへの影響

要約を書き出した後に別ページへ移動して戻った場合や、Obsidian 側でファイル・フォルダを移動または rename した場合でも、保存先を再解決できます。

## 検証

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test`
  - Swift Testing: 243件成功
  - XCTest: 3件成功
- 変更13ファイルの SwiftFormat チェック成功
- 追加したイベント分類・パス探索・同期ファイルに SwiftLint の新規違反なし
  - リポジトリ全体の SwiftLint には既存違反あり
