### PR TITLE
Avoid duplicate Action Items sections

### DIFF
--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -403,7 +403,7 @@ final class AppSettings: ObservableObject {
     - Inline text fields may use Markdown for emphasis and links.
     - Keep the summary easy to scan.
       - Prefer headings and bullet points over long paragraphs.
-      - Use checkboxes only for concrete action items.
+      - Keep concrete action items out of summary sections; return them only in the top-level `action_items` array.
       - Do not invent facts.
     - Preserve uncertainty where the transcript is ambiguous.
     - Write in a casual yet professional tone.
@@ -411,7 +411,7 @@ final class AppSettings: ObservableObject {
 
     <citation_policy>
     - Support important claims with transcript references when possible.
-    - Add transcript references to each relevant `content.transcript_ref` or `items[].transcript_ref` for key decisions, action items, risks, dates, and open questions.
+    - Add transcript references to each relevant `content.transcript_ref` or `items[].transcript_ref` for key decisions, risks, dates, and open questions.
     - Do not over-cite to the point that readability suffers.
     </citation_policy>
 
@@ -441,7 +441,7 @@ final class AppSettings: ObservableObject {
 
     <summary_template>
     - Treat each major heading as one section.
-    - List action items if there are any.
+    - Do not add an Action Items section; return action items only in the top-level `action_items` array.
     - Add any other sections you think are necessary.
     </summary_template>
     """

--- a/Sources/Dahlia/Models/SummaryDocumentResponse.swift
+++ b/Sources/Dahlia/Models/SummaryDocumentResponse.swift
@@ -114,6 +114,7 @@ struct SummaryDocumentResponse: Decodable {
                 "title": ["type": "string"],
                 "sections": [
                     "type": "array",
+                    "description": "Summary body sections only. Do not include an Action Items section or repeat action items here.",
                     "items": [
                         "type": "object",
                         "properties": [
@@ -133,6 +134,7 @@ struct SummaryDocumentResponse: Decodable {
                 ],
                 "action_items": [
                     "type": "array",
+                    "description": "The only location for concrete action items.",
                     "items": actionItemSchema,
                 ],
             ],

--- a/Sources/Dahlia/Services/SummaryRendering/ObsidianMarkdownSummaryRenderer.swift
+++ b/Sources/Dahlia/Services/SummaryRendering/ObsidianMarkdownSummaryRenderer.swift
@@ -64,7 +64,22 @@ enum ObsidianMarkdownSummaryRenderer {
             }
         }
 
+        if let actionItems = renderActionItems(document.actionItems) {
+            chunks.append(actionItems)
+        }
+
         return chunks.joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func renderActionItems(_ actionItems: [SummaryActionItem]) -> String? {
+        let lines = actionItems.compactMap { item -> String? in
+            guard let title = item.title.nilIfBlank else { return nil }
+            let assignee = item.assignee.nilIfBlank.map { " (\($0))" } ?? ""
+            return "- [ ] \(title)\(assignee)"
+        }
+        guard !lines.isEmpty else { return nil }
+
+        return (["## \(L10n.actionItems)"] + lines).joined(separator: "\n")
     }
 
     private static func renderBlock(_ block: SummaryBlock, context: SummaryRenderContext) -> String? {

--- a/Sources/Dahlia/Services/SummaryService.swift
+++ b/Sources/Dahlia/Services/SummaryService.swift
@@ -36,7 +36,7 @@ enum SummaryService {
         # Response Format
         Your response MUST be a JSON object with exactly four keys:
         - "title": a concise title for this meeting/transcript (one line, no quotes)
-        - "sections": an array of sections. Each section has:
+        - "sections": an array of summary body sections that exclude action items. Each section has:
           - "heading": the section heading, or an empty string for an intro section
           - "blocks": an array of content blocks in reading order
         - "tags": an array of relevant short Obsidian-compatible tags for categorization (empty array if none)
@@ -45,7 +45,7 @@ enum SummaryService {
           - Tags MUST use only letters, numbers, "_" and "-".
           - Use "_" or "-" to join words instead of spaces or punctuation.
           - Do not include "#", slashes, emojis, quotes, brackets, commas, or other symbols.
-        - "action_items": an array of objects with exactly two keys:
+        - "action_items": the only location for action items; an array of objects with exactly two keys:
           - "title": the concrete action item
           - "assignee": who owns it, or an empty string if unclear
 

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -169,7 +169,7 @@ final class CaptionViewModel: ObservableObject {
 
     var hasCurrentMeetingSummary: Bool {
         guard let currentSummaryDocument else { return false }
-        return !currentSummaryDocument.sections.isEmpty
+        return !currentSummaryDocument.sections.isEmpty || !currentSummaryDocument.actionItems.isEmpty
     }
 
     var canShareCurrentSummary: Bool {

--- a/Sources/Dahlia/Views/SummaryActionItemsView.swift
+++ b/Sources/Dahlia/Views/SummaryActionItemsView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct SummaryActionItemsView: View {
+    let actionItems: [SummaryActionItem]
+
+    var body: some View {
+        let displayableItems = actionItems.filter { $0.title.nilIfBlank != nil }
+
+        if !displayableItems.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(L10n.actionItems)
+                    .font(.title3.bold())
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 4)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(Array(displayableItems.enumerated()), id: \.offset) { _, item in
+                        HStack(alignment: .firstTextBaseline, spacing: 6) {
+                            Image(systemName: "square")
+                                .foregroundStyle(.tertiary)
+                                .accessibilityHidden(true)
+
+                            Text(inlineMarkdown(item.title))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .fixedSize(horizontal: false, vertical: true)
+
+                            if let assignee = item.assignee.nilIfBlank {
+                                Text("(\(assignee))")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .font(.body)
+                        .accessibilityElement(children: .combine)
+                    }
+                }
+                .padding(.leading, 8)
+            }
+        }
+    }
+
+    private func inlineMarkdown(_ text: String) -> AttributedString {
+        (try? AttributedString(
+            markdown: text,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )) ?? AttributedString(text)
+    }
+}

--- a/Sources/Dahlia/Views/SummaryDocumentView.swift
+++ b/Sources/Dahlia/Views/SummaryDocumentView.swift
@@ -28,6 +28,8 @@ struct SummaryDocumentView: View {
             ForEach(document.sections) { section in
                 sectionView(section)
             }
+
+            SummaryActionItemsView(actionItems: document.actionItems)
         }
         .textSelection(.enabled)
     }

--- a/Tests/DahliaTests/CaptionViewModelBatchUpdateTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelBatchUpdateTests.swift
@@ -161,7 +161,7 @@ import GRDB
         }
 
         private func waitUntil(
-            timeout: Duration = .seconds(1),
+            timeout: Duration = .seconds(5),
             condition: () -> Bool
         ) async -> Bool {
             let clock = ContinuousClock()

--- a/Tests/DahliaTests/CaptionViewModelTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelTests.swift
@@ -137,6 +137,18 @@ import GRDB
         }
 
         @Test
+        func structuredActionItemsCountAsDisplayableSummaryContent() {
+            let viewModel = CaptionViewModel()
+            viewModel.currentSummaryDocument = SummaryDocument(
+                title: "",
+                sections: [],
+                actionItems: [SummaryActionItem(title: "Send notes", assignee: "Aki")]
+            )
+
+            #expect(viewModel.hasCurrentMeetingSummary)
+        }
+
+        @Test
         func canGenerateSummaryIsDisabledWhileListening() {
             let viewModel = summaryReadyViewModel()
 

--- a/Tests/DahliaTests/ObsidianMarkdownSummaryRendererTests.swift
+++ b/Tests/DahliaTests/ObsidianMarkdownSummaryRendererTests.swift
@@ -34,7 +34,10 @@ import Foundation
                         ]
                     ),
                 ],
-                tags: ["team"]
+                tags: ["team"],
+                actionItems: [
+                    SummaryActionItem(title: "Send **notes**", assignee: "Aki"),
+                ]
             )
             let context = SummaryRenderContext(meetingId: meetingId, createdAt: createdAt, screenshots: [screenshot])
 
@@ -48,6 +51,7 @@ import Foundation
             #expect(rendered.body.contains("![[\(screenshotId.uuidString).jpeg]]"))
             #expect(rendered.body.contains("![[\(screenshotId.uuidString).jpeg]]\n\nScreen"))
             #expect(rendered.body.contains("[[\(meetingId.uuidString)#00:11:00|00:11:00]]"))
+            #expect(rendered.body.contains("## Action Items\n- [ ] Send **notes** (Aki)"))
             #expect(!rendered.body.contains("SQL(elements:"))
         }
 

--- a/Tests/DahliaTests/SummaryServiceTests.swift
+++ b/Tests/DahliaTests/SummaryServiceTests.swift
@@ -66,6 +66,8 @@ struct SummaryServiceTests {
         #expect((content["additionalProperties"] as? Bool) == false)
         #expect((blockListItem["additionalProperties"] as? Bool) == false)
         #expect((items["additionalProperties"] as? Bool) == false)
+        #expect((sections["description"] as? String)?.contains("Do not include an Action Items section") == true)
+        #expect((actionItems["description"] as? String)?.contains("only location") == true)
     }
 
     @Test
@@ -376,6 +378,12 @@ struct SummaryServiceTests {
         #expect(AppSettings.defaultSummaryPrompt.contains("create an `image` block"))
         #expect(AppSettings.defaultSummaryPrompt.contains("content.transcript_ref"))
         #expect(AppSettings.defaultSummaryPrompt.contains("items[].transcript_ref"))
+    }
+
+    @Test
+    func summaryPromptsKeepActionItemsOutOfBodySections() {
+        #expect(AppSettings.defaultSummaryPrompt.contains("Do not add an Action Items section"))
+        #expect(!AppSettings.defaultSummaryPrompt.contains("List action items if there are any"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- make the structured `action_items` field the canonical source for action items
- instruct summary body sections to exclude action items
- render structured action items in the summary UI and Markdown exports
- keep Google Docs and Slack sharing backed by the structured action items

## Why

The summary prompt asked the model to include Action Items in the body while the structured response also returned `action_items`. Rendering both produced duplicate Action Items sections.

## Impact

New summaries render Action Items exactly once from the structured field across the app UI and export paths, without post-generation duplicate detection.

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` — 252 tests passed
- `swiftformat --lint Sources/ --config .swiftformat`
- targeted SwiftLint for the new Action Items view and Markdown renderer