### PR TITLE
Improve calendar event identity and project assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ AudioSourcePipeline → CapturedAudioChunk
 MeetingPersistenceService → SQLite (GRDB)
 ```
 
+See [Calendar event persistence schema](docs/calendar-event-schema.md) for the UID/RECURRENCE-ID key, source mapping, and Meeting cardinality contract.
+
 ### Project Structure
 
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -98,6 +98,8 @@ AudioSourcePipeline → CapturedAudioChunk
 MeetingPersistenceService → SQLite (GRDB)
 ```
 
+UID／RECURRENCE-IDのキー形式、source対応、Meetingとのカーディナリティは[カレンダー予定の永続化スキーマ](docs/calendar-event-schema.md)を参照してください。
+
 ### プロジェクト構成
 
 ```

--- a/Sources/Dahlia/DahliaApp.swift
+++ b/Sources/Dahlia/DahliaApp.swift
@@ -167,7 +167,7 @@ struct DahliaApp: App {
 
         if let event = meeting.calendarEvent {
             let repository = MeetingRepository(dbQueue: db.dbQueue)
-            if let existingMeetingId = try? repository.fetchMeetingIdForCalendarEvent(event) {
+            if let existingMeetingId = try? repository.fetchMeetingIdForCalendarEvent(event, vaultId: vault.id) {
                 sidebarViewModel.selectMeeting(existingMeetingId)
                 if startTranscription {
                     startTranscriptionForMeeting(existingMeetingId, in: db, vault: vault)

--- a/Sources/Dahlia/DahliaApp.swift
+++ b/Sources/Dahlia/DahliaApp.swift
@@ -167,11 +167,17 @@ struct DahliaApp: App {
 
         if let event = meeting.calendarEvent {
             let repository = MeetingRepository(dbQueue: db.dbQueue)
-            if let existingMeetingId = try? repository.fetchMeetingIdForCalendarEvent(event, vaultId: vault.id) {
-                sidebarViewModel.selectMeeting(existingMeetingId)
-                if startTranscription {
-                    startTranscriptionForMeeting(existingMeetingId, in: db, vault: vault)
+            do {
+                if let existingMeetingId = try repository.resolveMeetingIdForCalendarEvent(event, vaultId: vault.id) {
+                    sidebarViewModel.selectMeeting(existingMeetingId)
+                    if startTranscription {
+                        startTranscriptionForMeeting(existingMeetingId, in: db, vault: vault)
+                    }
+                    return
                 }
+            } catch {
+                viewModel.errorMessage = error.localizedDescription
+                ErrorReportingService.capture(error, context: ["source": "calendarMeetingResolution"])
                 return
             }
 
@@ -206,7 +212,14 @@ struct DahliaApp: App {
     }
 
     private func startTranscriptionForMeeting(_ meetingId: UUID, in db: AppDatabaseManager, vault: VaultRecord) {
-        let ctx = meetingContext(for: meetingId)
+        let ctx: (projectURL: URL?, projectId: UUID?, projectName: String?)
+        do {
+            ctx = try meetingContext(for: meetingId, in: db, vault: vault)
+        } catch {
+            viewModel.errorMessage = error.localizedDescription
+            ErrorReportingService.capture(error, context: ["source": "meetingContext"])
+            return
+        }
         Task { @MainActor in
             await viewModel.startListening(
                 dbQueue: db.dbQueue,
@@ -220,13 +233,18 @@ struct DahliaApp: App {
         }
     }
 
-    private func meetingContext(for meetingId: UUID) -> (projectURL: URL?, projectId: UUID?, projectName: String?) {
-        guard let meetingItem = sidebarViewModel.allMeetings.first(where: { $0.meetingId == meetingId }) else {
+    private func meetingContext(
+        for meetingId: UUID,
+        in db: AppDatabaseManager,
+        vault: VaultRecord
+    ) throws -> (projectURL: URL?, projectId: UUID?, projectName: String?) {
+        let repository = MeetingRepository(dbQueue: db.dbQueue)
+        guard let meeting = try repository.fetchMeeting(id: meetingId) else {
             return (nil, nil, nil)
         }
-
-        let projectURL = meetingItem.projectName.map { sidebarViewModel.projectURL(for: $0) }
-        return (projectURL, meetingItem.projectId, meetingItem.projectName)
+        let project = try meeting.projectId.flatMap { try repository.fetchProject(id: $0) }
+        let projectURL = project.map { vault.url.appending(path: $0.name, directoryHint: .isDirectory) }
+        return (projectURL, project?.id, project?.name)
     }
 }
 

--- a/Sources/Dahlia/DahliaApp.swift
+++ b/Sources/Dahlia/DahliaApp.swift
@@ -152,8 +152,8 @@ struct DahliaApp: App {
 
     private func joinAndStartRecording(_ meeting: DetectedMeeting, in db: AppDatabaseManager) {
         handleDetectedMeeting(meeting, in: db, startTranscription: true)
-        if let meetingURL = meeting.calendarEvent?.meetingURL {
-            NSWorkspace.shared.open(meetingURL)
+        if let conferenceURI = meeting.calendarEvent?.conferenceURI {
+            NSWorkspace.shared.open(conferenceURI)
         }
     }
 
@@ -167,10 +167,7 @@ struct DahliaApp: App {
 
         if let event = meeting.calendarEvent {
             let repository = MeetingRepository(dbQueue: db.dbQueue)
-            if let existingMeetingId = try? repository.fetchMeetingIdForCalendarEvent(
-                platform: event.platform,
-                platformId: event.platformId
-            ) {
+            if let existingMeetingId = try? repository.fetchMeetingIdForCalendarEvent(event) {
                 sidebarViewModel.selectMeeting(existingMeetingId)
                 if startTranscription {
                     startTranscriptionForMeeting(existingMeetingId, in: db, vault: vault)

--- a/Sources/Dahlia/Database/AppDatabaseManager.swift
+++ b/Sources/Dahlia/Database/AppDatabaseManager.swift
@@ -85,6 +85,14 @@ final class AppDatabaseManager: Sendable {
             try addProjectDescriptionColumnIfNeeded(in: db)
         }
 
+        migrator.registerMigration("v15_calendarEventIdentity") { db in
+            try replaceCalendarEventSchema(in: db)
+        }
+
+        migrator.registerMigration("v16_calendarEventURL") { db in
+            try moveCalendarEventURLToCanonicalTable(in: db)
+        }
+
         return migrator
     }()
 
@@ -396,6 +404,203 @@ final class AppDatabaseManager: Sendable {
                     .defaults(to: false)
             }
         }
+    }
+
+    private static func replaceCalendarEventSchema(in db: Database) throws {
+        if try db.tableExists("calendar_event_sources") {
+            try db.drop(table: "calendar_event_sources")
+        }
+        if try db.tableExists("calendar_events") {
+            // Calendar event rows are a cache. Meetings and all other user-authored data are retained.
+            try db.drop(table: "calendar_events")
+        }
+
+        try createCanonicalCalendarEventTables(in: db)
+        try addCalendarEventReferenceColumns(in: db)
+    }
+
+    private static func moveCalendarEventURLToCanonicalTable(in db: Database) throws {
+        guard try db.tableExists("calendar_events") else { return }
+        try addColumnIfNeeded(in: db, table: "calendar_events", column: "url", type: .text)
+
+        guard try db.tableExists("calendar_event_sources") else { return }
+        let sourceColumns = try String.fetchAll(
+            db,
+            sql: "SELECT name FROM pragma_table_info('calendar_event_sources')"
+        )
+        guard sourceColumns.contains("source_event_url") else { return }
+
+        try db.execute(
+            sql: """
+            UPDATE calendar_events
+            SET url = (
+                SELECT source_event_url
+                FROM calendar_event_sources
+                WHERE calendar_event_sources.ical_uid = calendar_events.ical_uid
+                  AND calendar_event_sources.recurrence_id = calendar_events.recurrence_id
+                  AND source_event_url IS NOT NULL
+                  AND trim(source_event_url) <> ''
+                ORDER BY
+                    CASE WHEN platform = ? THEN 0 ELSE 1 END,
+                    updated_at DESC,
+                    calendar_id,
+                    platform_id
+                LIMIT 1
+            )
+            WHERE url IS NULL
+            """,
+            arguments: [CalendarEventPlatform.googleCalendar]
+        )
+        try db.execute(sql: "ALTER TABLE calendar_event_sources DROP COLUMN source_event_url")
+    }
+
+    private static func createCanonicalCalendarEventTables(in db: Database) throws {
+        try db.execute(
+            sql: """
+            CREATE TABLE calendar_events (
+                ical_uid TEXT NOT NULL,
+                recurrence_id TEXT NOT NULL DEFAULT '',
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                title TEXT NOT NULL DEFAULT '',
+                description TEXT NOT NULL DEFAULT '',
+                start DATETIME NOT NULL,
+                "end" DATETIME NOT NULL,
+                is_all_day BOOLEAN NOT NULL DEFAULT 0,
+                conference_uri TEXT CHECK (conference_uri IS NULL OR trim(conference_uri) <> ''),
+                PRIMARY KEY (ical_uid, recurrence_id)
+            ) WITHOUT ROWID
+            """
+        )
+        try db.execute(
+            sql: """
+            CREATE TABLE calendar_event_sources (
+                platform TEXT NOT NULL,
+                calendar_id TEXT NOT NULL,
+                platform_id TEXT NOT NULL,
+                ical_uid TEXT NOT NULL,
+                recurrence_id TEXT NOT NULL,
+                source_event_url TEXT,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                PRIMARY KEY (platform, calendar_id, platform_id),
+                FOREIGN KEY (ical_uid, recurrence_id)
+                    REFERENCES calendar_events (ical_uid, recurrence_id)
+                    ON UPDATE CASCADE
+                    ON DELETE CASCADE
+            ) WITHOUT ROWID
+            """
+        )
+        try db.execute(
+            sql: """
+            CREATE INDEX calendar_event_sources_on_event
+            ON calendar_event_sources (ical_uid, recurrence_id)
+            """
+        )
+    }
+
+    private static func addCalendarEventReferenceColumns(in db: Database) throws {
+        guard try db.tableExists("meetings") else { return }
+        try addColumnIfNeeded(
+            in: db,
+            table: "meetings",
+            column: "calendar_event_ical_uid",
+            type: .text
+        )
+        try addColumnIfNeeded(
+            in: db,
+            table: "meetings",
+            column: "calendar_event_recurrence_id",
+            type: .text
+        )
+        try db.execute(
+            sql: """
+            CREATE INDEX meetings_on_calendar_event
+            ON meetings (calendar_event_ical_uid, calendar_event_recurrence_id, createdAt)
+            """
+        )
+        // SQLite は ALTER TABLE で複合外部キーを追加できない。meetings を再作成せず
+        // ユーザーデータを保持するため、同等の参照制約をトリガーで適用する。
+        try createCalendarEventReferenceTriggers(in: db)
+    }
+
+    private static func createCalendarEventReferenceTriggers(in db: Database) throws {
+        try createMeetingCalendarEventReferenceTriggers(in: db)
+        try createCalendarEventMutationTriggers(in: db)
+    }
+
+    private static func createMeetingCalendarEventReferenceTriggers(in db: Database) throws {
+        try db.execute(
+            sql: """
+            CREATE TRIGGER meetings_calendar_event_reference_insert
+            BEFORE INSERT ON meetings
+            WHEN
+                (NEW.calendar_event_ical_uid IS NULL) <> (NEW.calendar_event_recurrence_id IS NULL)
+                OR (
+                    NEW.calendar_event_ical_uid IS NOT NULL
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM calendar_events
+                        WHERE ical_uid = NEW.calendar_event_ical_uid
+                          AND recurrence_id = NEW.calendar_event_recurrence_id
+                    )
+                )
+            BEGIN
+                SELECT RAISE(ABORT, 'invalid calendar event reference');
+            END
+            """
+        )
+        try db.execute(
+            sql: """
+            CREATE TRIGGER meetings_calendar_event_reference_update
+            BEFORE UPDATE OF calendar_event_ical_uid, calendar_event_recurrence_id ON meetings
+            WHEN
+                (NEW.calendar_event_ical_uid IS NULL) <> (NEW.calendar_event_recurrence_id IS NULL)
+                OR (
+                    NEW.calendar_event_ical_uid IS NOT NULL
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM calendar_events
+                        WHERE ical_uid = NEW.calendar_event_ical_uid
+                          AND recurrence_id = NEW.calendar_event_recurrence_id
+                    )
+                )
+            BEGIN
+                SELECT RAISE(ABORT, 'invalid calendar event reference');
+            END
+            """
+        )
+    }
+
+    private static func createCalendarEventMutationTriggers(in db: Database) throws {
+        try db.execute(
+            sql: """
+            CREATE TRIGGER calendar_events_reference_delete
+            BEFORE DELETE ON calendar_events
+            WHEN EXISTS (
+                SELECT 1
+                FROM meetings
+                WHERE calendar_event_ical_uid = OLD.ical_uid
+                  AND calendar_event_recurrence_id = OLD.recurrence_id
+            )
+            BEGIN
+                SELECT RAISE(ABORT, 'calendar event is referenced by a meeting');
+            END
+            """
+        )
+        try db.execute(
+            sql: """
+            CREATE TRIGGER calendar_events_reference_update
+            AFTER UPDATE OF ical_uid, recurrence_id ON calendar_events
+            BEGIN
+                UPDATE meetings
+                SET calendar_event_ical_uid = NEW.ical_uid,
+                    calendar_event_recurrence_id = NEW.recurrence_id
+                WHERE calendar_event_ical_uid = OLD.ical_uid
+                  AND calendar_event_recurrence_id = OLD.recurrence_id;
+            END
+            """
+        )
     }
 
     private static func addBatchTranscriptionSchemaIfNeeded(in db: Database) throws {

--- a/Sources/Dahlia/Database/AppDatabaseManager.swift
+++ b/Sources/Dahlia/Database/AppDatabaseManager.swift
@@ -93,6 +93,10 @@ final class AppDatabaseManager: Sendable {
             try moveCalendarEventURLToCanonicalTable(in: db)
         }
 
+        migrator.registerMigration("v17_calendarEventIntegrity") { db in
+            try strengthenCalendarEventIntegrity(in: db)
+        }
+
         return migrator
     }()
 
@@ -452,6 +456,148 @@ final class AppDatabaseManager: Sendable {
             arguments: [CalendarEventPlatform.googleCalendar]
         )
         try db.execute(sql: "ALTER TABLE calendar_event_sources DROP COLUMN source_event_url")
+    }
+
+    private static func strengthenCalendarEventIntegrity(in db: Database) throws {
+        guard try db.tableExists("calendar_events") else { return }
+        try normalizeLegacyDateRecurrenceIDs(in: db)
+
+        guard try db.tableExists("meetings") else { return }
+        try replaceCalendarEventMeetingIndex(in: db)
+        try deleteUnreferencedCalendarEvents(in: db)
+        try createCalendarEventCleanupTriggers(in: db)
+    }
+
+    private static func normalizeLegacyDateRecurrenceIDs(in db: Database) throws {
+        try db.execute(
+            sql: """
+            INSERT OR IGNORE INTO calendar_events (
+                ical_uid,
+                recurrence_id,
+                created_at,
+                updated_at,
+                title,
+                description,
+                start,
+                "end",
+                is_all_day,
+                conference_uri,
+                url
+            )
+            SELECT
+                ical_uid,
+                substr(recurrence_id, 12),
+                created_at,
+                updated_at,
+                title,
+                description,
+                start,
+                "end",
+                is_all_day,
+                conference_uri,
+                url
+            FROM calendar_events
+            WHERE recurrence_id GLOB 'VALUE=DATE:[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]'
+            """
+        )
+        if try db.tableExists("calendar_event_sources") {
+            try db.execute(
+                sql: """
+                UPDATE calendar_event_sources
+                SET recurrence_id = substr(recurrence_id, 12)
+                WHERE recurrence_id GLOB 'VALUE=DATE:[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]'
+                """
+            )
+        }
+        if try db.tableExists("meetings") {
+            try db.execute(
+                sql: """
+                UPDATE meetings
+                SET calendar_event_recurrence_id = substr(calendar_event_recurrence_id, 12)
+                WHERE calendar_event_recurrence_id
+                    GLOB 'VALUE=DATE:[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]'
+                """
+            )
+        }
+        try db.execute(
+            sql: """
+            DELETE FROM calendar_events
+            WHERE recurrence_id GLOB 'VALUE=DATE:[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]'
+            """
+        )
+    }
+
+    private static func replaceCalendarEventMeetingIndex(in db: Database) throws {
+        try db.execute(sql: "DROP INDEX IF EXISTS meetings_on_calendar_event")
+        try db.execute(
+            sql: """
+            CREATE INDEX meetings_on_calendar_event
+            ON meetings (
+                vaultId,
+                calendar_event_ical_uid,
+                calendar_event_recurrence_id,
+                createdAt,
+                id
+            )
+            """
+        )
+    }
+
+    private static func deleteUnreferencedCalendarEvents(in db: Database) throws {
+        try db.execute(
+            sql: """
+            DELETE FROM calendar_events
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM meetings
+                WHERE meetings.calendar_event_ical_uid = calendar_events.ical_uid
+                  AND meetings.calendar_event_recurrence_id = calendar_events.recurrence_id
+            )
+            """
+        )
+    }
+
+    private static func createCalendarEventCleanupTriggers(in db: Database) throws {
+        try db.execute(
+            sql: """
+            CREATE TRIGGER meetings_calendar_event_cleanup_delete
+            AFTER DELETE ON meetings
+            WHEN OLD.calendar_event_ical_uid IS NOT NULL
+            BEGIN
+                DELETE FROM calendar_events
+                WHERE ical_uid = OLD.calendar_event_ical_uid
+                  AND recurrence_id = OLD.calendar_event_recurrence_id
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM meetings
+                      WHERE calendar_event_ical_uid = OLD.calendar_event_ical_uid
+                        AND calendar_event_recurrence_id = OLD.calendar_event_recurrence_id
+                  );
+            END
+            """
+        )
+        try db.execute(
+            sql: """
+            CREATE TRIGGER meetings_calendar_event_cleanup_update
+            AFTER UPDATE OF calendar_event_ical_uid, calendar_event_recurrence_id ON meetings
+            WHEN OLD.calendar_event_ical_uid IS NOT NULL
+              AND (
+                  OLD.calendar_event_ical_uid IS NOT NEW.calendar_event_ical_uid
+                  OR OLD.calendar_event_recurrence_id IS NOT NEW.calendar_event_recurrence_id
+              )
+            BEGIN
+                DELETE FROM calendar_events
+                WHERE ical_uid = OLD.calendar_event_ical_uid
+                  AND recurrence_id = OLD.calendar_event_recurrence_id
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM meetings
+                      WHERE calendar_event_ical_uid = OLD.calendar_event_ical_uid
+                        AND calendar_event_recurrence_id = OLD.calendar_event_recurrence_id
+                  );
+            END
+            """
+        )
     }
 
     private static func createCanonicalCalendarEventTables(in db: Database) throws {

--- a/Sources/Dahlia/Database/CalendarEventRecord.swift
+++ b/Sources/Dahlia/Database/CalendarEventRecord.swift
@@ -50,6 +50,9 @@ struct CalendarEventRecord: Codable, FetchableRecord, PersistableRecord, Equatab
         var record = Self(now: now, event: event, key: key)
         if let existing = try fetch(key: key, in: db) {
             record.createdAt = existing.createdAt
+            record.title = record.title.nilIfBlank ?? existing.title
+            record.description = record.description.nilIfBlank ?? existing.description
+            record.conferenceURI = record.conferenceURI ?? existing.conferenceURI
             record.url = record.url ?? existing.url
         }
         try record.save(db)

--- a/Sources/Dahlia/Database/CalendarEventRecord.swift
+++ b/Sources/Dahlia/Database/CalendarEventRecord.swift
@@ -3,59 +3,62 @@ import GRDB
 
 struct CalendarEventRecord: Codable, FetchableRecord, PersistableRecord, Equatable {
     static let databaseTableName = "calendar_events"
-    static let googleCalendarPlatform = CalendarEventPlatform.googleCalendar
-    static let macOSCalendarPlatform = CalendarEventPlatform.macOSCalendar
 
-    var id: Int64? = nil
-    var meetingId: UUID
+    var icalUid: String
+    var recurrenceId: String
     var createdAt: Date
     var updatedAt: Date
-    var platform: String
-    var platformId: String
+    var title: String
     var description: String
-    var icalUid: String?
     var start: Date
     var end: Date
-    var meetingUrl: String?
+    var isAllDay: Bool
+    var conferenceURI: String?
+    var url: String?
 
-    init(
-        id: Int64? = nil,
-        meetingId: UUID,
-        createdAt: Date,
-        updatedAt: Date,
-        platform: String,
-        platformId: String,
-        description: String,
-        icalUid: String?,
-        start: Date,
-        end: Date,
-        meetingUrl: String?
-    ) {
-        self.id = id
-        self.meetingId = meetingId
-        self.createdAt = createdAt
-        self.updatedAt = updatedAt
-        self.platform = platform
-        self.platformId = platformId
-        self.description = description
-        self.icalUid = icalUid
-        self.start = start
-        self.end = end
-        self.meetingUrl = meetingUrl
+    enum CodingKeys: String, CodingKey {
+        case icalUid = "ical_uid"
+        case recurrenceId = "recurrence_id"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case title
+        case description
+        case start
+        case end
+        case isAllDay = "is_all_day"
+        case conferenceURI = "conference_uri"
+        case url
     }
 
-    init(meetingId: UUID, now: Date, event: CalendarEvent) {
-        self.init(
-            meetingId: meetingId,
-            createdAt: now,
-            updatedAt: now,
-            platform: event.platform,
-            platformId: event.platformId,
-            description: event.description,
-            icalUid: event.icalUid,
-            start: event.startDate,
-            end: event.endDate,
-            meetingUrl: event.meetingURL?.absoluteString
-        )
+    init(now: Date, event: CalendarEvent, key: CalendarEventKey) {
+        icalUid = key.icalUid
+        recurrenceId = key.recurrenceId
+        createdAt = now
+        updatedAt = now
+        title = event.title
+        description = event.description
+        start = event.startDate
+        end = event.endDate
+        isAllDay = event.isAllDay
+        conferenceURI = event.conferenceURI?.absoluteString.nilIfBlank
+        url = event.url?.absoluteString.nilIfBlank
+    }
+
+    static func upsert(event: CalendarEvent, now: Date, in db: Database) throws {
+        guard let key = event.key else { return }
+
+        var record = Self(now: now, event: event, key: key)
+        if let existing = try fetch(key: key, in: db) {
+            record.createdAt = existing.createdAt
+            record.url = record.url ?? existing.url
+        }
+        try record.save(db)
+        try CalendarEventSourceRecord.upsert(event: event, key: key, now: now, in: db)
+    }
+
+    static func fetch(key: CalendarEventKey, in db: Database) throws -> Self? {
+        try filter(Column("ical_uid") == key.icalUid)
+            .filter(Column("recurrence_id") == key.recurrenceId)
+            .fetchOne(db)
     }
 }

--- a/Sources/Dahlia/Database/CalendarEventSourceRecord.swift
+++ b/Sources/Dahlia/Database/CalendarEventSourceRecord.swift
@@ -1,0 +1,45 @@
+import Foundation
+import GRDB
+
+struct CalendarEventSourceRecord: Codable, FetchableRecord, PersistableRecord, Equatable {
+    static let databaseTableName = "calendar_event_sources"
+
+    var platform: String
+    var calendarId: String
+    var platformId: String
+    var icalUid: String
+    var recurrenceId: String
+    var createdAt: Date
+    var updatedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case platform
+        case calendarId = "calendar_id"
+        case platformId = "platform_id"
+        case icalUid = "ical_uid"
+        case recurrenceId = "recurrence_id"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+
+    init(now: Date, event: CalendarEvent, key: CalendarEventKey) {
+        platform = event.platform
+        calendarId = event.calendarID
+        platformId = event.platformId
+        icalUid = key.icalUid
+        recurrenceId = key.recurrenceId
+        createdAt = now
+        updatedAt = now
+    }
+
+    static func upsert(event: CalendarEvent, key: CalendarEventKey, now: Date, in db: Database) throws {
+        var record = Self(now: now, event: event, key: key)
+        if let existing = try filter(Column("platform") == record.platform)
+            .filter(Column("calendar_id") == record.calendarId)
+            .filter(Column("platform_id") == record.platformId)
+            .fetchOne(db) {
+            record.createdAt = existing.createdAt
+        }
+        try record.save(db)
+    }
+}

--- a/Sources/Dahlia/Database/MeetingRecord.swift
+++ b/Sources/Dahlia/Database/MeetingRecord.swift
@@ -69,11 +69,13 @@ extension MeetingRecord {
         requestedProjectId: UUID?,
         calendarEvent: CalendarEvent?,
         vaultId: UUID,
+        allowsCalendarSeriesProjectInheritance: Bool = true,
         in db: Database
     ) throws -> UUID? {
         if let requestedProjectId {
             return requestedProjectId
         }
+        guard allowsCalendarSeriesProjectInheritance else { return nil }
         guard let calendarEvent,
               let icalUid = calendarEvent.key?.icalUid else { return nil }
 
@@ -88,6 +90,7 @@ extension MeetingRecord {
             JOIN projects ON projects.id = meetings.projectId
             WHERE meetings.vaultId = ?
               AND projects.vaultId = ?
+              AND projects.missingOnDisk = 0
               AND meetings.calendar_event_ical_uid = ?
               AND calendar_events.start <= ?
             ORDER BY calendar_events.start DESC, meetings.createdAt DESC, meetings.id DESC

--- a/Sources/Dahlia/Database/MeetingRecord.swift
+++ b/Sources/Dahlia/Database/MeetingRecord.swift
@@ -46,4 +46,54 @@ struct MeetingRecord: Codable, FetchableRecord, PersistableRecord, Equatable {
     var duration: TimeInterval?
     var createdAt: Date
     var updatedAt: Date
+    var calendarEventIcalUid: String? = nil
+    var calendarEventRecurrenceId: String? = nil
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case vaultId
+        case projectId
+        case name
+        case status
+        case duration
+        case createdAt
+        case updatedAt
+        case calendarEventIcalUid = "calendar_event_ical_uid"
+        case calendarEventRecurrenceId = "calendar_event_recurrence_id"
+    }
+}
+
+extension MeetingRecord {
+    /// 明示指定がなければ、同じ iCalendar 系列の現在以前の予定から直近の project を引き継ぐ。
+    static func resolvedProjectIdForNewMeeting(
+        requestedProjectId: UUID?,
+        calendarEvent: CalendarEvent?,
+        vaultId: UUID,
+        in db: Database
+    ) throws -> UUID? {
+        if let requestedProjectId {
+            return requestedProjectId
+        }
+        guard let calendarEvent,
+              let icalUid = calendarEvent.key?.icalUid else { return nil }
+
+        return try UUID.fetchOne(
+            db,
+            sql: """
+            SELECT projects.id
+            FROM meetings
+            JOIN calendar_events
+              ON calendar_events.ical_uid = meetings.calendar_event_ical_uid
+             AND calendar_events.recurrence_id = meetings.calendar_event_recurrence_id
+            JOIN projects ON projects.id = meetings.projectId
+            WHERE meetings.vaultId = ?
+              AND projects.vaultId = ?
+              AND meetings.calendar_event_ical_uid = ?
+              AND calendar_events.start <= ?
+            ORDER BY calendar_events.start DESC, meetings.createdAt DESC, meetings.id DESC
+            LIMIT 1
+            """,
+            arguments: [vaultId, vaultId, icalUid, calendarEvent.startDate]
+        )
+    }
 }

--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -254,11 +254,12 @@ final class MeetingRepository {
         }
     }
 
-    func fetchMeetingIdForCalendarEvent(_ event: CalendarEvent) throws -> UUID? {
+    func fetchMeetingIdForCalendarEvent(_ event: CalendarEvent, vaultId: UUID) throws -> UUID? {
         guard let key = event.key else { return nil }
         return try dbQueue.read { db in
             try MeetingRecord
                 .select(Column("id"))
+                .filter(Column("vaultId") == vaultId)
                 .filter(Column("calendar_event_ical_uid") == key.icalUid)
                 .filter(Column("calendar_event_recurrence_id") == key.recurrenceId)
                 .order(Column("createdAt").desc)

--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -254,12 +254,14 @@ final class MeetingRepository {
         }
     }
 
-    func fetchMeetingIdForCalendarEvent(platform: String, platformId: String) throws -> UUID? {
-        try dbQueue.read { db in
-            try CalendarEventRecord
-                .select(Column("meetingId"))
-                .filter(Column("platform") == platform)
-                .filter(Column("platformId") == platformId)
+    func fetchMeetingIdForCalendarEvent(_ event: CalendarEvent) throws -> UUID? {
+        guard let key = event.key else { return nil }
+        return try dbQueue.read { db in
+            try MeetingRecord
+                .select(Column("id"))
+                .filter(Column("calendar_event_ical_uid") == key.icalUid)
+                .filter(Column("calendar_event_recurrence_id") == key.recurrenceId)
+                .order(Column("createdAt").desc)
                 .asRequest(of: UUID.self)
                 .fetchOne(db)
         }
@@ -534,9 +536,8 @@ final class MeetingRepository {
 
     func fetchCalendarEvent(forMeetingId meetingId: UUID) throws -> CalendarEventRecord? {
         try dbQueue.read { db in
-            try CalendarEventRecord
-                .filter(Column("meetingId") == meetingId)
-                .fetchOne(db)
+            let meeting = try MeetingRecord.fetchOne(db, key: meetingId)
+            return try Self.fetchCalendarEvent(for: meeting, in: db)
         }
     }
 
@@ -563,9 +564,7 @@ final class MeetingRepository {
     nonisolated func fetchMeetingDetail(id meetingId: UUID) throws -> MeetingDetail {
         try dbQueue.read { db in
             let meeting = try MeetingRecord.fetchOne(db, key: meetingId)
-            let calendarEvent = try CalendarEventRecord
-                .filter(Column("meetingId") == meetingId)
-                .fetchOne(db)
+            let calendarEvent = try Self.fetchCalendarEvent(for: meeting, in: db)
             let segments = try TranscriptSegmentRecord
                 .filter(Column("meetingId") == meetingId)
                 .order(Column("startTime").asc)
@@ -590,6 +589,19 @@ final class MeetingRepository {
                 summary: summary
             )
         }
+    }
+
+    private nonisolated static func fetchCalendarEvent(
+        for meeting: MeetingRecord?,
+        in db: Database
+    ) throws -> CalendarEventRecord? {
+        guard let icalUid = meeting?.calendarEventIcalUid,
+              let recurrenceId = meeting?.calendarEventRecurrenceId
+        else { return nil }
+        return try CalendarEventRecord.fetch(
+            key: CalendarEventKey(icalUid: icalUid, recurrenceId: recurrenceId),
+            in: db
+        )
     }
 
 }

--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -254,20 +254,6 @@ final class MeetingRepository {
         }
     }
 
-    func fetchMeetingIdForCalendarEvent(_ event: CalendarEvent, vaultId: UUID) throws -> UUID? {
-        guard let key = event.key else { return nil }
-        return try dbQueue.read { db in
-            try MeetingRecord
-                .select(Column("id"))
-                .filter(Column("vaultId") == vaultId)
-                .filter(Column("calendar_event_ical_uid") == key.icalUid)
-                .filter(Column("calendar_event_recurrence_id") == key.recurrenceId)
-                .order(Column("createdAt").desc)
-                .asRequest(of: UUID.self)
-                .fetchOne(db)
-        }
-    }
-
     func renameMeeting(id: UUID, newName: String) throws {
         try dbQueue.write { db in
             if var record = try MeetingRecord.fetchOne(db, key: id) {
@@ -604,5 +590,29 @@ final class MeetingRepository {
             in: db
         )
     }
+}
 
+extension MeetingRepository {
+    /// 現在の Vault にある同一予定の最新 Meeting を返し、観測した予定情報も更新する。
+    func resolveMeetingIdForCalendarEvent(
+        _ event: CalendarEvent,
+        vaultId: UUID,
+        observedAt: Date = .now
+    ) throws -> UUID? {
+        guard let key = event.key else { return nil }
+        return try dbQueue.write { db in
+            let meetingId = try MeetingRecord
+                .select(Column("id"))
+                .filter(Column("vaultId") == vaultId)
+                .filter(Column("calendar_event_ical_uid") == key.icalUid)
+                .filter(Column("calendar_event_recurrence_id") == key.recurrenceId)
+                .order(Column("createdAt").desc, Column("id").desc)
+                .asRequest(of: UUID.self)
+                .fetchOne(db)
+            if meetingId != nil {
+                try CalendarEventRecord.upsert(event: event, now: observedAt, in: db)
+            }
+            return meetingId
+        }
+    }
 }

--- a/Sources/Dahlia/Models/CalendarEvent.swift
+++ b/Sources/Dahlia/Models/CalendarEvent.swift
@@ -92,12 +92,35 @@ extension [CalendarEvent] {
             let existing = result[existingIndex]
             if existing.platform == event.platform {
                 result.append(event)
-            } else if existing.platform != CalendarEventPlatform.googleCalendar,
-                      event.platform == CalendarEventPlatform.googleCalendar {
-                result[existingIndex] = event
+            } else {
+                let preferred = event.platform == CalendarEventPlatform.googleCalendar ? event : existing
+                let fallback = event.platform == CalendarEventPlatform.googleCalendar ? existing : event
+                result[existingIndex] = preferred.mergingMissingMetadata(from: fallback)
             }
         }
         return result
+    }
+}
+
+private extension CalendarEvent {
+    func mergingMissingMetadata(from fallback: CalendarEvent) -> CalendarEvent {
+        CalendarEvent(
+            id: id,
+            calendarID: calendarID,
+            calendarName: calendarName,
+            calendarColorHex: calendarColorHex,
+            platform: platform,
+            platformId: platformId,
+            title: title,
+            description: description.nilIfBlank ?? fallback.description,
+            icalUid: icalUid,
+            recurrenceId: recurrenceId,
+            startDate: startDate,
+            endDate: endDate,
+            isAllDay: isAllDay,
+            conferenceURI: conferenceURI ?? fallback.conferenceURI,
+            url: url ?? fallback.url
+        )
     }
 }
 

--- a/Sources/Dahlia/Models/CalendarEvent.swift
+++ b/Sources/Dahlia/Models/CalendarEvent.swift
@@ -15,10 +15,12 @@ struct CalendarEvent: Identifiable, Equatable, Codable {
     let title: String
     let description: String
     let icalUid: String?
+    let recurrenceId: String
     let startDate: Date
     let endDate: Date
     let isAllDay: Bool
-    let meetingURL: URL?
+    let conferenceURI: URL?
+    let url: URL?
 
     init(
         id: String,
@@ -30,10 +32,12 @@ struct CalendarEvent: Identifiable, Equatable, Codable {
         title: String,
         description: String,
         icalUid: String?,
+        recurrenceId: String = ICalendarRecurrenceID.singleEvent,
         startDate: Date,
         endDate: Date,
         isAllDay: Bool,
-        meetingURL: URL?
+        conferenceURI: URL?,
+        url: URL? = nil
     ) {
         self.id = id
         self.calendarID = calendarID
@@ -44,41 +48,41 @@ struct CalendarEvent: Identifiable, Equatable, Codable {
         self.title = title
         self.description = description
         self.icalUid = icalUid
+        self.recurrenceId = recurrenceId
         self.startDate = startDate
         self.endDate = endDate
         self.isAllDay = isAllDay
-        self.meetingURL = meetingURL
+        self.conferenceURI = conferenceURI
+        self.url = url
     }
 }
 
 extension CalendarEvent {
+    var key: CalendarEventKey? {
+        CalendarEventKey(icalUid: icalUid, recurrenceId: recurrenceId)
+    }
+
     var resolvedMeetingTitle: String {
         let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmedTitle.isEmpty ? L10n.newMeeting : trimmedTitle
     }
 }
 
-private struct CalendarEventOccurrenceKey: Hashable {
-    let icalUid: String
-    let startDate: Date
-}
-
 extension [CalendarEvent] {
     /// Google と macOS の両ソースが同じ物理イベントを返した場合に 1 件へ畳み込む。
-    /// iCalUID は繰り返しイベントでは系列単位のため開始時刻と組で照合し、
-    /// 会議 URL などの情報が揃っている Google 側を優先する。同一ソース内の重複
+    /// iCalendar の UID と RECURRENCE-ID で照合し、会議 URI などの情報が揃っている
+    /// Google 側を優先する。同一ソース内の重複
     /// （複数カレンダーに同じ予定がある場合）は従来どおり残す。
     func deduplicatedAcrossSources() -> [CalendarEvent] {
-        var indexByKey: [CalendarEventOccurrenceKey: Int] = [:]
+        var indexByKey: [CalendarEventKey: Int] = [:]
         var result: [CalendarEvent] = []
 
         for event in self {
-            guard let icalUid = event.icalUid, !icalUid.isEmpty else {
+            guard let key = event.key else {
                 result.append(event)
                 continue
             }
 
-            let key = CalendarEventOccurrenceKey(icalUid: icalUid, startDate: event.startDate)
             guard let existingIndex = indexByKey[key] else {
                 indexByKey[key] = result.count
                 result.append(event)
@@ -94,5 +98,52 @@ extension [CalendarEvent] {
             }
         }
         return result
+    }
+}
+
+extension CalendarEvent {
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case calendarID
+        case calendarName
+        case calendarColorHex
+        case platform
+        case platformId
+        case title
+        case description
+        case icalUid
+        case recurrenceId
+        case startDate
+        case endDate
+        case isAllDay
+        case conferenceURI
+        case url
+    }
+
+    private enum LegacyCodingKeys: String, CodingKey {
+        case meetingURL
+        case sourceEventURL
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let legacyContainer = try decoder.container(keyedBy: LegacyCodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        calendarID = try container.decode(String.self, forKey: .calendarID)
+        calendarName = try container.decode(String.self, forKey: .calendarName)
+        calendarColorHex = try container.decodeIfPresent(String.self, forKey: .calendarColorHex)
+        platform = try container.decode(String.self, forKey: .platform)
+        platformId = try container.decode(String.self, forKey: .platformId)
+        title = try container.decode(String.self, forKey: .title)
+        description = try container.decode(String.self, forKey: .description)
+        icalUid = try container.decodeIfPresent(String.self, forKey: .icalUid)
+        recurrenceId = try container.decodeIfPresent(String.self, forKey: .recurrenceId) ?? ICalendarRecurrenceID.singleEvent
+        startDate = try container.decode(Date.self, forKey: .startDate)
+        endDate = try container.decode(Date.self, forKey: .endDate)
+        isAllDay = try container.decode(Bool.self, forKey: .isAllDay)
+        conferenceURI = try container.decodeIfPresent(URL.self, forKey: .conferenceURI)
+            ?? legacyContainer.decodeIfPresent(URL.self, forKey: .meetingURL)
+        url = try container.decodeIfPresent(URL.self, forKey: .url)
+            ?? legacyContainer.decodeIfPresent(URL.self, forKey: .sourceEventURL)
     }
 }

--- a/Sources/Dahlia/Models/CalendarEventKey.swift
+++ b/Sources/Dahlia/Models/CalendarEventKey.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// iCalendar の UID と RECURRENCE-ID で特定される予定の論理キー。
+struct CalendarEventKey: Hashable, Codable {
+    let icalUid: String
+    let recurrenceId: String
+
+    init(icalUid: String, recurrenceId: String) {
+        self.icalUid = icalUid
+        self.recurrenceId = recurrenceId
+    }
+
+    init?(icalUid: String?, recurrenceId: String) {
+        guard let icalUid = icalUid?.nilIfBlank else { return nil }
+        self.init(icalUid: icalUid, recurrenceId: recurrenceId)
+    }
+}

--- a/Sources/Dahlia/Models/DraftMeeting.swift
+++ b/Sources/Dahlia/Models/DraftMeeting.swift
@@ -7,4 +7,5 @@ struct DraftMeeting: Equatable {
     var projectURL: URL?
     var projectId: UUID?
     var projectName: String?
+    var allowsCalendarSeriesProjectInheritance = true
 }

--- a/Sources/Dahlia/Services/GoogleCalendarAPIClient.swift
+++ b/Sources/Dahlia/Services/GoogleCalendarAPIClient.swift
@@ -120,6 +120,8 @@ final class GoogleCalendarAPIClient: GoogleCalendarAPIClientProviding {
         guard let start = try item.start.resolvedDate(calendar: calendar),
               let end = try item.end.resolvedDate(calendar: calendar)
         else { return nil }
+        let recurrenceId = try item.originalStartTime?.resolvedRecurrenceId(calendar: calendar)
+            ?? ICalendarRecurrenceID.singleEvent
 
         return CalendarEvent(
             id: "\(calendarItem.id)::\(item.id)",
@@ -131,25 +133,25 @@ final class GoogleCalendarAPIClient: GoogleCalendarAPIClientProviding {
             title: item.summary?.nilIfBlank ?? L10n.googleCalendarUntitledEvent,
             description: item.description?.nilIfBlank ?? "",
             icalUid: item.iCalUID?.nilIfBlank,
+            recurrenceId: recurrenceId,
             startDate: start,
             endDate: max(end, start),
             isAllDay: item.start.date != nil,
-            meetingURL: conferenceURL(for: item)
+            conferenceURI: conferenceURI(for: item),
+            url: absoluteURL(from: item.htmlLink)
         )
     }
 
-    static func conferenceURL(for item: EventItem) -> URL? {
-        if let hangoutLink = item.hangoutLink,
-           let url = URL(string: hangoutLink) {
-            return url
+    static func conferenceURI(for item: EventItem) -> URL? {
+        let entryPointURIs = item.conferenceData?.entryPoints.compactMap { absoluteURL(from: $0.uri) } ?? []
+        let candidates: [URL] = if !entryPointURIs.isEmpty {
+            entryPointURIs
+        } else if let hangoutURI = absoluteURL(from: item.hangoutLink) {
+            [hangoutURI]
+        } else {
+            []
         }
-
-        let entryPoint = item.conferenceData?.entryPoints.first { entry in
-            guard let uri = entry.uri else { return false }
-            return URL(string: uri) != nil
-        }
-        guard let uri = entryPoint?.uri else { return nil }
-        return URL(string: uri)
+        return candidates.first { $0.scheme?.lowercased() == "https" } ?? candidates.first
     }
 
     static func sortAndFilter(
@@ -232,6 +234,15 @@ final class GoogleCalendarAPIClient: GoogleCalendarAPIClientProviding {
         }
         return url
     }
+
+    private static func absoluteURL(from value: String?) -> URL? {
+        guard let value = value?.nilIfBlank,
+              let url = URL(string: value),
+              let scheme = url.scheme?.lowercased().nilIfBlank,
+              !(["http", "https"].contains(scheme) && url.host?.nilIfBlank == nil)
+        else { return nil }
+        return url
+    }
 }
 
 extension GoogleCalendarAPIClient {
@@ -306,6 +317,19 @@ extension GoogleCalendarAPIClient {
                 return nil
             }
 
+            func resolvedRecurrenceId(calendar: Calendar) throws -> String? {
+                if let date {
+                    _ = try calendar.googleCalendarDate(from: date)
+                    guard let recurrenceId = ICalendarRecurrenceID.date(date) else {
+                        throw GoogleCalendarAPIError.invalidCalendarDate(date)
+                    }
+                    return recurrenceId
+                }
+
+                guard let resolvedDate = try resolvedDate(calendar: calendar) else { return nil }
+                return ICalendarRecurrenceID.dateTime(resolvedDate)
+            }
+
             private nonisolated(unsafe) static let googleCalendarWithFractionalSeconds: ISO8601DateFormatter = {
                 let formatter = ISO8601DateFormatter()
                 formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -331,9 +355,11 @@ extension GoogleCalendarAPIClient {
         let summary: String?
         let description: String?
         let iCalUID: String?
+        let htmlLink: String?
         let hangoutLink: String?
         let start: EventDateTime
         let end: EventDateTime
+        let originalStartTime: EventDateTime?
         let conferenceData: ConferenceData?
         let eventType: String?
 

--- a/Sources/Dahlia/Services/GoogleCalendarAPIClient.swift
+++ b/Sources/Dahlia/Services/GoogleCalendarAPIClient.swift
@@ -120,8 +120,18 @@ final class GoogleCalendarAPIClient: GoogleCalendarAPIClientProviding {
         guard let start = try item.start.resolvedDate(calendar: calendar),
               let end = try item.end.resolvedDate(calendar: calendar)
         else { return nil }
-        let recurrenceId = try item.originalStartTime?.resolvedRecurrenceId(calendar: calendar)
-            ?? ICalendarRecurrenceID.singleEvent
+        let recurrenceId: String
+        if let originalStartTime = item.originalStartTime {
+            guard let resolvedRecurrenceId = try originalStartTime.resolvedRecurrenceId(calendar: calendar) else {
+                throw GoogleCalendarAPIError.invalidResponse
+            }
+            recurrenceId = resolvedRecurrenceId
+        } else {
+            guard item.recurringEventId?.nilIfBlank == nil else {
+                throw GoogleCalendarAPIError.invalidResponse
+            }
+            recurrenceId = ICalendarRecurrenceID.singleEvent
+        }
 
         return CalendarEvent(
             id: "\(calendarItem.id)::\(item.id)",
@@ -143,15 +153,21 @@ final class GoogleCalendarAPIClient: GoogleCalendarAPIClientProviding {
     }
 
     static func conferenceURI(for item: EventItem) -> URL? {
-        let entryPointURIs = item.conferenceData?.entryPoints.compactMap { absoluteURL(from: $0.uri) } ?? []
-        let candidates: [URL] = if !entryPointURIs.isEmpty {
-            entryPointURIs
-        } else if let hangoutURI = absoluteURL(from: item.hangoutLink) {
-            [hangoutURI]
-        } else {
-            []
-        }
-        return candidates.first { $0.scheme?.lowercased() == "https" } ?? candidates.first
+        let entryPoints = item.conferenceData?.entryPoints.compactMap { entryPoint -> (type: String?, uri: URL)? in
+            guard let uri = absoluteURL(from: entryPoint.uri) else { return nil }
+            return (entryPoint.entryPointType?.lowercased(), uri)
+        } ?? []
+        let entryPointURIs = entryPoints.map(\.uri)
+        let videoURIs = entryPoints.filter { $0.type == "video" }.map(\.uri)
+        let hangoutURI = absoluteURL(from: item.hangoutLink)
+        let httpsHangoutURI = hangoutURI.flatMap { $0.isHTTPS ? $0 : nil }
+
+        return videoURIs.first(where: \.isHTTPS)
+            ?? httpsHangoutURI
+            ?? entryPointURIs.first(where: \.isHTTPS)
+            ?? videoURIs.first
+            ?? hangoutURI
+            ?? entryPointURIs.first
     }
 
     static func sortAndFilter(
@@ -301,13 +317,23 @@ extension GoogleCalendarAPIClient {
         struct EventDateTime: Decodable {
             let date: String?
             let dateTime: String?
+            let timeZone: String?
+
+            init(date: String?, dateTime: String?, timeZone: String? = nil) {
+                self.date = date
+                self.dateTime = dateTime
+                self.timeZone = timeZone
+            }
 
             func resolvedDate(calendar: Calendar) throws -> Date? {
                 if let dateTime {
                     if let parsed = Self.googleCalendarWithFractionalSeconds.date(from: dateTime) {
                         return parsed
                     }
-                    return Self.googleCalendar.date(from: dateTime)
+                    if let parsed = Self.googleCalendar.date(from: dateTime) {
+                        return parsed
+                    }
+                    return localDate(from: dateTime)
                 }
 
                 if let date {
@@ -326,8 +352,25 @@ extension GoogleCalendarAPIClient {
                     return recurrenceId
                 }
 
-                guard let resolvedDate = try resolvedDate(calendar: calendar) else { return nil }
+                guard let resolvedDate = try resolvedDate(calendar: calendar) else {
+                    throw GoogleCalendarAPIError.invalidCalendarDate(dateTime ?? "")
+                }
                 return ICalendarRecurrenceID.dateTime(resolvedDate)
+            }
+
+            private func localDate(from value: String) -> Date? {
+                guard let timeZone = timeZone.flatMap(TimeZone.init(identifier:)) else { return nil }
+                for includesFractionalSeconds in [true, false] {
+                    let formatter = ISO8601DateFormatter()
+                    formatter.timeZone = timeZone
+                    formatter.formatOptions = includesFractionalSeconds
+                        ? [.withFullDate, .withTime, .withColonSeparatorInTime, .withFractionalSeconds]
+                        : [.withFullDate, .withTime, .withColonSeparatorInTime]
+                    if let date = formatter.date(from: value) {
+                        return date
+                    }
+                }
+                return nil
             }
 
             private nonisolated(unsafe) static let googleCalendarWithFractionalSeconds: ISO8601DateFormatter = {
@@ -346,6 +389,12 @@ extension GoogleCalendarAPIClient {
         struct ConferenceData: Decodable {
             struct EntryPoint: Decodable {
                 let uri: String?
+                let entryPointType: String?
+
+                init(uri: String?, entryPointType: String? = nil) {
+                    self.uri = uri
+                    self.entryPointType = entryPointType
+                }
             }
 
             let entryPoints: [EntryPoint]
@@ -360,12 +409,47 @@ extension GoogleCalendarAPIClient {
         let start: EventDateTime
         let end: EventDateTime
         let originalStartTime: EventDateTime?
+        let recurringEventId: String?
         let conferenceData: ConferenceData?
         let eventType: String?
+
+        init(
+            id: String,
+            summary: String?,
+            description: String?,
+            iCalUID: String?,
+            htmlLink: String?,
+            hangoutLink: String?,
+            start: EventDateTime,
+            end: EventDateTime,
+            originalStartTime: EventDateTime?,
+            recurringEventId: String? = nil,
+            conferenceData: ConferenceData?,
+            eventType: String?
+        ) {
+            self.id = id
+            self.summary = summary
+            self.description = description
+            self.iCalUID = iCalUID
+            self.htmlLink = htmlLink
+            self.hangoutLink = hangoutLink
+            self.start = start
+            self.end = end
+            self.originalStartTime = originalStartTime
+            self.recurringEventId = recurringEventId
+            self.conferenceData = conferenceData
+            self.eventType = eventType
+        }
 
         var isIgnoredForUpcomingEvents: Bool {
             start.date != nil || eventType == "outOfOffice"
         }
+    }
+}
+
+private extension URL {
+    var isHTTPS: Bool {
+        scheme?.lowercased() == "https"
     }
 }
 

--- a/Sources/Dahlia/Services/MacCalendarStore.swift
+++ b/Sources/Dahlia/Services/MacCalendarStore.swift
@@ -329,6 +329,13 @@ final class EventKitMacCalendarEventStore: MacCalendarEventStoreProviding {
 
         let occurrenceDate = event.occurrenceDate ?? startDate
         let platformId = "\(event.eventIdentifier ?? event.calendarItemIdentifier)::\(Int(occurrenceDate.timeIntervalSince1970))"
+        let recurrenceId: String = if event.occurrenceDate == nil {
+            ICalendarRecurrenceID.singleEvent
+        } else if event.isAllDay {
+            ICalendarRecurrenceID.date(occurrenceDate, timeZone: event.timeZone ?? .current)
+        } else {
+            ICalendarRecurrenceID.dateTime(occurrenceDate)
+        }
         return CalendarEvent(
             id: "\(calendar.calendarIdentifier)::\(platformId)",
             calendarID: calendar.calendarIdentifier,
@@ -339,10 +346,11 @@ final class EventKitMacCalendarEventStore: MacCalendarEventStoreProviding {
             title: event.title.nilIfBlank ?? L10n.macOSCalendarUntitledEvent,
             description: event.notes?.nilIfBlank ?? "",
             icalUid: event.calendarItemExternalIdentifier.nilIfBlank,
+            recurrenceId: recurrenceId,
             startDate: startDate,
             endDate: max(endDate, startDate),
             isAllDay: event.isAllDay,
-            meetingURL: CalendarMeetingURLExtractor.meetingURL(
+            conferenceURI: CalendarConferenceURIExtractor.conferenceURI(
                 url: event.url,
                 textFields: [event.notes, event.location]
             )

--- a/Sources/Dahlia/Services/MacCalendarStore.swift
+++ b/Sources/Dahlia/Services/MacCalendarStore.swift
@@ -329,13 +329,10 @@ final class EventKitMacCalendarEventStore: MacCalendarEventStoreProviding {
 
         let occurrenceDate = event.occurrenceDate ?? startDate
         let platformId = "\(event.eventIdentifier ?? event.calendarItemIdentifier)::\(Int(occurrenceDate.timeIntervalSince1970))"
-        let recurrenceId: String = if event.occurrenceDate == nil {
-            ICalendarRecurrenceID.singleEvent
-        } else if event.isAllDay {
-            ICalendarRecurrenceID.date(occurrenceDate, timeZone: event.timeZone ?? .current)
-        } else {
-            ICalendarRecurrenceID.dateTime(occurrenceDate)
-        }
+        let recurrenceId = recurrenceId(
+            occurrenceDate: event.occurrenceDate,
+            isAllDay: event.isAllDay
+        )
         return CalendarEvent(
             id: "\(calendar.calendarIdentifier)::\(platformId)",
             calendarID: calendar.calendarIdentifier,
@@ -373,6 +370,17 @@ final class EventKitMacCalendarEventStore: MacCalendarEventStoreProviding {
                 }
                 return lhs.id < rhs.id
             }
+    }
+
+    static func recurrenceId(
+        occurrenceDate: Date?,
+        isAllDay: Bool,
+        defaultTimeZone: TimeZone = .current
+    ) -> String {
+        guard let occurrenceDate else { return ICalendarRecurrenceID.singleEvent }
+        return isAllDay
+            ? ICalendarRecurrenceID.date(occurrenceDate, timeZone: defaultTimeZone)
+            : ICalendarRecurrenceID.dateTime(occurrenceDate)
     }
 
     private static func authorizationStatus(from status: EKAuthorizationStatus) -> MacCalendarAuthorizationStatus {

--- a/Sources/Dahlia/Services/MeetingNotificationService.swift
+++ b/Sources/Dahlia/Services/MeetingNotificationService.swift
@@ -341,7 +341,7 @@ final class MeetingNotificationService: NSObject, UNUserNotificationCenterDelega
             bundleIdentifier: event.platform,
             calendarEvent: event
         )
-        let categoryIdentifier = event.meetingURL == nil
+        let categoryIdentifier = event.conferenceURI == nil
             ? Self.calendarCategoryIdentifier
             : Self.calendarJoinCategoryIdentifier
         let content = try notificationContent(

--- a/Sources/Dahlia/Services/MeetingPersistenceService.swift
+++ b/Sources/Dahlia/Services/MeetingPersistenceService.swift
@@ -53,6 +53,7 @@ final class MeetingPersistenceService {
         vaultId: UUID,
         projectId: UUID?,
         initialName: String,
+        allowsCalendarSeriesProjectInheritance: Bool = true,
         calendarEvent: CalendarEvent? = nil,
         recordingSessionId: UUID = .v7(),
         transcriptionMode: TranscriptionMode = .realtime,
@@ -87,6 +88,7 @@ final class MeetingPersistenceService {
                 requestedProjectId: projectId,
                 calendarEvent: calendarEvent,
                 vaultId: vaultId,
+                allowsCalendarSeriesProjectInheritance: allowsCalendarSeriesProjectInheritance,
                 in: db
             )
             let meeting = MeetingRecord(

--- a/Sources/Dahlia/Services/MeetingPersistenceService.swift
+++ b/Sources/Dahlia/Services/MeetingPersistenceService.swift
@@ -34,6 +34,7 @@ final class MeetingPersistenceService {
     private let store: TranscriptStore
     private let dbQueue: DatabaseQueue
     let meetingId: UUID
+    private(set) var projectId: UUID?
     private var cancellable: AnyCancellable?
     private var persistedSegmentIds: Set<UUID> = []
     private var persistedSegmentTranslations: [UUID: String?] = [:]
@@ -61,6 +62,7 @@ final class MeetingPersistenceService {
         self.store = store
         self.dbQueue = dbQueue
         self.meetingId = .v7()
+        self.projectId = projectId
         self.createsMeeting = true
         self.persistencePolicy = persistencePolicy
 
@@ -75,23 +77,34 @@ final class MeetingPersistenceService {
         )
         self.recordingSession = session
         let trimmedInitialName = initialName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let calendarEventKey = calendarEvent?.key
 
-        let meeting = MeetingRecord(
-            id: meetingId,
-            vaultId: vaultId,
-            projectId: projectId,
-            name: trimmedInitialName,
-            status: transcriptionMode == .realtime ? .ready : .transcriptNotFound,
-            createdAt: now,
-            updatedAt: now
-        )
-        try dbQueue.write { db in
+        let resolvedProjectId = try dbQueue.write { db in
+            if let calendarEvent {
+                try CalendarEventRecord.upsert(event: calendarEvent, now: now, in: db)
+            }
+            let resolvedProjectId = try MeetingRecord.resolvedProjectIdForNewMeeting(
+                requestedProjectId: projectId,
+                calendarEvent: calendarEvent,
+                vaultId: vaultId,
+                in: db
+            )
+            let meeting = MeetingRecord(
+                id: meetingId,
+                vaultId: vaultId,
+                projectId: resolvedProjectId,
+                name: trimmedInitialName,
+                status: transcriptionMode == .realtime ? .ready : .transcriptNotFound,
+                createdAt: now,
+                updatedAt: now,
+                calendarEventIcalUid: calendarEventKey?.icalUid,
+                calendarEventRecurrenceId: calendarEventKey?.recurrenceId
+            )
             try meeting.insert(db)
             try session.insert(db)
-            if let calendarEvent {
-                try CalendarEventRecord(meetingId: meetingId, now: now, event: calendarEvent).insert(db)
-            }
+            return resolvedProjectId
         }
+        self.projectId = resolvedProjectId
 
         store.upsertRecordingSession(RecordingSessionTimeline(from: session))
         startObserving()
@@ -113,6 +126,7 @@ final class MeetingPersistenceService {
         self.store = store
         self.dbQueue = dbQueue
         self.meetingId = existingMeetingId
+        self.projectId = nil
         self.createsMeeting = false
         self.persistencePolicy = persistencePolicy
         self.persistedSegmentIds = existingSegmentIds

--- a/Sources/Dahlia/Utilities/CalendarConferenceURIExtractor.swift
+++ b/Sources/Dahlia/Utilities/CalendarConferenceURIExtractor.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-enum CalendarMeetingURLExtractor {
-    private static let urlRegex = try! NSRegularExpression(pattern: #"https?://[^\s<>"']+"#)
+enum CalendarConferenceURIExtractor {
+    private static let urlRegex = try? NSRegularExpression(pattern: #"https?://[^\s<>"']+"#)
     private static let knownMeetingDomains = [
         "meet.google.com",
         "zoom.us",
@@ -13,33 +13,33 @@ enum CalendarMeetingURLExtractor {
         "chime.aws",
     ]
 
-    static func meetingURL(url: URL?, textFields: [String?]) -> URL? {
-        if let url, isKnownMeetingURL(url) {
-            return url
+    static func conferenceURI(url: URL?, textFields: [String?]) -> URL? {
+        var candidates: [URL] = []
+        if let url, isKnownMeetingURI(url) {
+            candidates.append(url)
         }
 
         for text in textFields {
             guard let text else { continue }
-            for candidate in urls(in: text) where isKnownMeetingURL(candidate) {
-                return candidate
-            }
+            candidates.append(contentsOf: uris(in: text).filter(isKnownMeetingURI))
         }
 
-        return nil
+        return candidates.first { $0.scheme?.lowercased() == "https" } ?? candidates.first
     }
 
-    private static func urls(in text: String) -> [URL] {
+    private static func uris(in text: String) -> [URL] {
+        guard let urlRegex else { return [] }
         let range = NSRange(text.startIndex..., in: text)
         return urlRegex.matches(in: text, range: range).compactMap { match in
             guard let matchRange = Range(match.range, in: text) else { return nil }
-            let rawURL = String(text[matchRange])
+            let rawURI = String(text[matchRange])
                 .trimmingCharacters(in: CharacterSet(charactersIn: ".,;:!?)]}"))
-            return URL(string: rawURL)
+            return URL(string: rawURI)
         }
     }
 
-    private static func isKnownMeetingURL(_ url: URL) -> Bool {
-        guard let host = url.host?.lowercased() else { return false }
+    private static func isKnownMeetingURI(_ uri: URL) -> Bool {
+        guard let host = uri.host?.lowercased() else { return false }
         return knownMeetingDomains.contains { domain in
             host == domain || host.hasSuffix(".\(domain)")
         }

--- a/Sources/Dahlia/Utilities/ICalendarRecurrenceID.swift
+++ b/Sources/Dahlia/Utilities/ICalendarRecurrenceID.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// RECURRENCE-ID をソース間で比較できる RFC 5545 形式へ正規化する。
+enum ICalendarRecurrenceID {
+    static let singleEvent = ""
+
+    static func dateTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
+        return formatter.string(from: date)
+    }
+
+    static func date(_ value: String) -> String? {
+        let components = value.split(separator: "-", omittingEmptySubsequences: false)
+        guard components.count == 3,
+              components[0].count == 4,
+              components[1].count == 2,
+              components[2].count == 2,
+              components.allSatisfy({ $0.allSatisfy(\.isNumber) })
+        else { return nil }
+
+        return "VALUE=DATE:\(components.joined())"
+    }
+
+    static func date(_ date: Date, timeZone: TimeZone) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = timeZone
+        formatter.dateFormat = "yyyyMMdd"
+        return "VALUE=DATE:\(formatter.string(from: date))"
+    }
+}

--- a/Sources/Dahlia/Utilities/ICalendarRecurrenceID.swift
+++ b/Sources/Dahlia/Utilities/ICalendarRecurrenceID.swift
@@ -22,7 +22,7 @@ enum ICalendarRecurrenceID {
               components.allSatisfy({ $0.allSatisfy(\.isNumber) })
         else { return nil }
 
-        return "VALUE=DATE:\(components.joined())"
+        return components.joined()
     }
 
     static func date(_ date: Date, timeZone: TimeZone) -> String {
@@ -31,6 +31,6 @@ enum ICalendarRecurrenceID {
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = timeZone
         formatter.dateFormat = "yyyyMMdd"
-        return "VALUE=DATE:\(formatter.string(from: date))"
+        return formatter.string(from: date)
     }
 }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -883,27 +883,38 @@ final class CaptionViewModel: ObservableObject {
               let vault = AppSettings.shared.currentVault,
               let vaultURL = currentVaultURL else { return nil }
 
-        let resolvedProjectURL = projectURL ?? draftMeeting.projectURL ?? currentProjectURL
-        let resolvedProjectId = projectId ?? draftMeeting.projectId ?? currentProjectId
-        let resolvedProjectName = projectName ?? draftMeeting.projectName ?? currentProjectName
+        let requestedProjectURL = projectURL ?? draftMeeting.projectURL ?? currentProjectURL
+        let requestedProjectId = projectId ?? draftMeeting.projectId ?? currentProjectId
+        let requestedProjectName = projectName ?? draftMeeting.projectName ?? currentProjectName
         let meetingId = UUID.v7()
-        let now = Date()
-        let record = MeetingRecord(
-            id: meetingId,
-            vaultId: vault.id,
-            projectId: resolvedProjectId,
-            name: draftMeeting.title.trimmingCharacters(in: .whitespacesAndNewlines),
-            status: .transcriptNotFound,
-            duration: nil,
-            createdAt: now,
-            updatedAt: now
-        )
+        let now = Date.now
+        let calendarEventKey = draftMeeting.linkedCalendarEvent?.key
+        let assignedProjectId: UUID?
         do {
-            try dbQueue.write { db in
-                try record.insert(db)
+            assignedProjectId = try dbQueue.write { db in
                 if let event = draftMeeting.linkedCalendarEvent {
-                    try CalendarEventRecord(meetingId: meetingId, now: now, event: event).insert(db)
+                    try CalendarEventRecord.upsert(event: event, now: now, in: db)
                 }
+                let assignedProjectId = try MeetingRecord.resolvedProjectIdForNewMeeting(
+                    requestedProjectId: requestedProjectId,
+                    calendarEvent: draftMeeting.linkedCalendarEvent,
+                    vaultId: vault.id,
+                    in: db
+                )
+                let record = MeetingRecord(
+                    id: meetingId,
+                    vaultId: vault.id,
+                    projectId: assignedProjectId,
+                    name: draftMeeting.title.trimmingCharacters(in: .whitespacesAndNewlines),
+                    status: .transcriptNotFound,
+                    duration: nil,
+                    createdAt: now,
+                    updatedAt: now,
+                    calendarEventIcalUid: calendarEventKey?.icalUid,
+                    calendarEventRecurrenceId: calendarEventKey?.recurrenceId
+                )
+                try record.insert(db)
+                return assignedProjectId
             }
         } catch {
             errorMessage = error.localizedDescription
@@ -911,12 +922,17 @@ final class CaptionViewModel: ObservableObject {
             return nil
         }
 
+        let resolvedProject = Self.projectContext(
+            projectId: assignedProjectId,
+            dbQueue: dbQueue,
+            vaultURL: vaultURL
+        )
         setMeetingContext(
             id: meetingId,
             dbQueue: dbQueue,
-            projectURL: resolvedProjectURL,
-            projectId: resolvedProjectId,
-            projectName: resolvedProjectName,
+            projectURL: resolvedProject?.url ?? requestedProjectURL,
+            projectId: assignedProjectId,
+            projectName: resolvedProject?.name ?? requestedProjectName,
             vaultURL: vaultURL
         )
         if !noteText.isEmpty {
@@ -1078,6 +1094,22 @@ final class CaptionViewModel: ObservableObject {
         draftMeeting = nil
         resetSummaryState()
         setupNoteAutoSave()
+    }
+
+    private static func projectContext(
+        projectId: UUID?,
+        dbQueue: DatabaseQueue,
+        vaultURL: URL
+    ) -> (url: URL, name: String)? {
+        guard let projectId,
+              let project = try? dbQueue.read({ db in
+                  try ProjectRecord.fetchOne(db, key: projectId)
+              }) else { return nil }
+
+        return (
+            vaultURL.appending(path: project.name, directoryHint: .isDirectory),
+            project.name
+        )
     }
 
     func updateCurrentProjectContext(projectURL: URL?, projectId: UUID?, projectName: String?) {
@@ -1364,7 +1396,7 @@ final class CaptionViewModel: ObservableObject {
         }
 
         let initialName = request.draftMeeting?.title.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        persistenceService = try MeetingPersistenceService(
+        let service = try MeetingPersistenceService(
             store: store,
             dbQueue: request.dbQueue,
             vaultId: request.vaultId,
@@ -1376,7 +1408,25 @@ final class CaptionViewModel: ObservableObject {
             persistencePolicy: request.persistencePolicy,
             retainAudioAfterBatch: request.retainAudioAfterBatch
         )
-        currentMeetingId = persistenceService?.meetingId
+        persistenceService = service
+        currentMeetingId = service.meetingId
+
+        let resolvedProject = currentVaultURL.flatMap { vaultURL in
+            Self.projectContext(
+                projectId: service.projectId,
+                dbQueue: request.dbQueue,
+                vaultURL: vaultURL
+            )
+        }
+        let projectWasInherited = service.projectId != request.projectId
+        currentProjectId = service.projectId
+        if let resolvedProject {
+            currentProjectURL = resolvedProject.url
+            currentProjectName = resolvedProject.name
+        } else if projectWasInherited {
+            currentProjectURL = nil
+            currentProjectName = nil
+        }
     }
 
     private func completePersistenceStart(existingMeetingId: UUID?) {

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -899,6 +899,7 @@ final class CaptionViewModel: ObservableObject {
                     requestedProjectId: requestedProjectId,
                     calendarEvent: draftMeeting.linkedCalendarEvent,
                     vaultId: vault.id,
+                    allowsCalendarSeriesProjectInheritance: draftMeeting.allowsCalendarSeriesProjectInheritance,
                     in: db
                 )
                 let record = MeetingRecord(
@@ -1112,10 +1113,14 @@ final class CaptionViewModel: ObservableObject {
         )
     }
 
-    func updateCurrentProjectContext(projectURL: URL?, projectId: UUID?, projectName: String?) {
+    func setExplicitProjectContext(projectURL: URL?, projectId: UUID?, projectName: String?) {
         currentProjectURL = projectURL
         currentProjectId = projectId
         currentProjectName = projectName
+        draftMeeting?.projectURL = projectURL
+        draftMeeting?.projectId = projectId
+        draftMeeting?.projectName = projectName
+        draftMeeting?.allowsCalendarSeriesProjectInheritance = false
     }
 
     // MARK: - Analyzer Preparation
@@ -1402,6 +1407,7 @@ final class CaptionViewModel: ObservableObject {
             vaultId: request.vaultId,
             projectId: request.projectId,
             initialName: initialName,
+            allowsCalendarSeriesProjectInheritance: request.draftMeeting?.allowsCalendarSeriesProjectInheritance ?? true,
             calendarEvent: request.draftMeeting?.linkedCalendarEvent,
             recordingSessionId: request.recordingSessionId,
             transcriptionMode: request.transcriptionMode,

--- a/Sources/Dahlia/Views/CalendarScheduleView.swift
+++ b/Sources/Dahlia/Views/CalendarScheduleView.swift
@@ -356,7 +356,7 @@ private struct CalendarScheduleSectionView: View {
                     CalendarScheduleEventRow(
                         event: event,
                         onSelect: { onSelectEvent(event) },
-                        onJoin: event.meetingURL.map { url in
+                        onJoin: event.conferenceURI.map { url in
                             { onOpenURL(url) }
                         }
                     )

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -122,7 +122,7 @@ struct ContentView: View {
               let vault = sidebarViewModel.currentVault else { return }
 
         let repository = MeetingRepository(dbQueue: dbQueue)
-        if let existingMeetingId = try? repository.fetchMeetingIdForCalendarEvent(event),
+        if let existingMeetingId = try? repository.fetchMeetingIdForCalendarEvent(event, vaultId: vault.id),
            sidebarViewModel.allMeetings.contains(where: { $0.meetingId == existingMeetingId }) {
             sidebarViewModel.selectMeeting(existingMeetingId)
             return

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -122,10 +122,8 @@ struct ContentView: View {
               let vault = sidebarViewModel.currentVault else { return }
 
         let repository = MeetingRepository(dbQueue: dbQueue)
-        if let existingMeetingId = try? repository.fetchMeetingIdForCalendarEvent(
-            platform: event.platform,
-            platformId: event.platformId
-        ), sidebarViewModel.allMeetings.contains(where: { $0.meetingId == existingMeetingId }) {
+        if let existingMeetingId = try? repository.fetchMeetingIdForCalendarEvent(event),
+           sidebarViewModel.allMeetings.contains(where: { $0.meetingId == existingMeetingId }) {
             sidebarViewModel.selectMeeting(existingMeetingId)
             return
         }

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -122,9 +122,13 @@ struct ContentView: View {
               let vault = sidebarViewModel.currentVault else { return }
 
         let repository = MeetingRepository(dbQueue: dbQueue)
-        if let existingMeetingId = try? repository.fetchMeetingIdForCalendarEvent(event, vaultId: vault.id),
-           sidebarViewModel.allMeetings.contains(where: { $0.meetingId == existingMeetingId }) {
-            sidebarViewModel.selectMeeting(existingMeetingId)
+        do {
+            if let existingMeetingId = try repository.resolveMeetingIdForCalendarEvent(event, vaultId: vault.id) {
+                sidebarViewModel.selectMeeting(existingMeetingId)
+                return
+            }
+        } catch {
+            viewModel.errorMessage = error.localizedDescription
             return
         }
 
@@ -138,17 +142,23 @@ struct ContentView: View {
 
     private func handleMeetingSelection(_ meetingId: UUID) {
         guard let dbQueue = sidebarViewModel.dbQueue,
-              let vault = sidebarViewModel.currentVault,
-              let item = sidebarViewModel.allMeetings.first(where: { $0.meetingId == meetingId }) else { return }
+              let vault = sidebarViewModel.currentVault else { return }
 
-        viewModel.loadMeeting(
-            meetingId,
-            dbQueue: dbQueue,
-            projectURL: item.projectName.map { sidebarViewModel.projectURL(for: $0) },
-            projectId: item.projectId,
-            projectName: item.projectName,
-            vaultURL: vault.url
-        )
+        do {
+            let repository = MeetingRepository(dbQueue: dbQueue)
+            guard let meeting = try repository.fetchMeeting(id: meetingId) else { return }
+            let project = try meeting.projectId.flatMap { try repository.fetchProject(id: $0) }
+            viewModel.loadMeeting(
+                meetingId,
+                dbQueue: dbQueue,
+                projectURL: project.map { vault.url.appending(path: $0.name, directoryHint: .isDirectory) },
+                projectId: project?.id,
+                projectName: project?.name,
+                vaultURL: vault.url
+            )
+        } catch {
+            viewModel.errorMessage = error.localizedDescription
+        }
     }
 }
 

--- a/Sources/Dahlia/Views/MeetingMetadataBar.swift
+++ b/Sources/Dahlia/Views/MeetingMetadataBar.swift
@@ -428,16 +428,13 @@ struct MeetingProjectPicker: View {
     }
 
     private func clearProject() {
-        guard viewModel.currentProjectId != nil else {
-            projectInput = ""
-            showProjectPopover = false
-            return
+        let existingMeetingId = viewModel.currentMeetingId
+        let removesPersistedProject = viewModel.currentProjectId != nil
+        viewModel.setExplicitProjectContext(projectURL: nil, projectId: nil, projectName: nil)
+        if removesPersistedProject, let existingMeetingId {
+            sidebarViewModel.moveMeeting(id: existingMeetingId, toProjectId: nil)
+            sidebarViewModel.selectMeeting(existingMeetingId)
         }
-
-        guard let meetingId = viewModel.materializeDraftMeeting() else { return }
-        sidebarViewModel.moveMeeting(id: meetingId, toProjectId: nil)
-        viewModel.updateCurrentProjectContext(projectURL: nil, projectId: nil, projectName: nil)
-        sidebarViewModel.selectMeeting(meetingId)
         projectInput = ""
         showProjectPopover = false
     }
@@ -453,7 +450,7 @@ struct MeetingProjectPicker: View {
         if projectId != viewModel.currentProjectId {
             sidebarViewModel.moveMeeting(id: meetingId, toProjectId: projectId)
         }
-        viewModel.updateCurrentProjectContext(
+        viewModel.setExplicitProjectContext(
             projectURL: projectURL,
             projectId: projectId,
             projectName: projectName

--- a/Tests/DahliaTests/CalendarEventDatabaseTests.swift
+++ b/Tests/DahliaTests/CalendarEventDatabaseTests.swift
@@ -110,6 +110,62 @@ import GRDB
         }
 
         @Test
+        func meetingLookupIsScopedToTheActiveVault() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
+            let activeVault = VaultRecord(
+                id: .v7(),
+                path: "/tmp/calendar-active-vault",
+                name: "Active Vault",
+                createdAt: .now,
+                lastOpenedAt: .now
+            )
+            let otherVault = VaultRecord(
+                id: .v7(),
+                path: "/tmp/calendar-other-vault",
+                name: "Other Vault",
+                createdAt: .now,
+                lastOpenedAt: .now
+            )
+            let event = calendarEvent(recurrenceId: "")
+            let key = try #require(event.key)
+            let activeMeetingId = UUID.v7()
+            let otherMeetingId = UUID.v7()
+            let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
+
+            try database.dbQueue.write { db in
+                try activeVault.insert(db)
+                try otherVault.insert(db)
+                try CalendarEventRecord.upsert(event: event, now: createdAt, in: db)
+                try insertCalendarMeeting(
+                    id: activeMeetingId,
+                    named: "Active vault meeting",
+                    vaultId: activeVault.id,
+                    createdAt: createdAt,
+                    key: key,
+                    in: db
+                )
+                try insertCalendarMeeting(
+                    id: otherMeetingId,
+                    named: "Newer meeting in another vault",
+                    vaultId: otherVault.id,
+                    createdAt: createdAt.addingTimeInterval(60),
+                    key: key,
+                    in: db
+                )
+            }
+
+            let repository = MeetingRepository(dbQueue: database.dbQueue)
+            #expect(
+                try repository.fetchMeetingIdForCalendarEvent(event, vaultId: activeVault.id)
+                    == activeMeetingId
+            )
+            #expect(
+                try repository.fetchMeetingIdForCalendarEvent(event, vaultId: otherVault.id)
+                    == otherMeetingId
+            )
+        }
+
+        @Test
         func migrationPreservesMeetingsAndDiscardsLegacyCalendarRows() throws {
             let databaseURL = URL.temporaryDirectory
                 .appending(path: UUID().uuidString)
@@ -184,6 +240,26 @@ import GRDB
                 calendarEventRecurrenceId: recurrenceId
             ).insert(db)
         }
+    }
+
+    private func insertCalendarMeeting(
+        id: UUID,
+        named name: String,
+        vaultId: UUID,
+        createdAt: Date,
+        key: CalendarEventKey,
+        in db: Database
+    ) throws {
+        try MeetingRecord(
+            id: id,
+            vaultId: vaultId,
+            projectId: nil,
+            name: name,
+            createdAt: createdAt,
+            updatedAt: createdAt,
+            calendarEventIcalUid: key.icalUid,
+            calendarEventRecurrenceId: key.recurrenceId
+        ).insert(db)
     }
 
     private func calendarEvent(recurrenceId: String, url: URL? = nil) -> CalendarEvent {

--- a/Tests/DahliaTests/CalendarEventDatabaseTests.swift
+++ b/Tests/DahliaTests/CalendarEventDatabaseTests.swift
@@ -17,7 +17,8 @@ import GRDB
                     String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('calendar_events') WHERE pk > 0 ORDER BY pk"),
                     String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('meetings')"),
                     db.tableExists("calendar_event_sources"),
-                    String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('calendar_event_sources')")
+                    String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('calendar_event_sources')"),
+                    String.fetchAll(db, sql: "SELECT name FROM pragma_index_info('meetings_on_calendar_event') ORDER BY seqno")
                 )
             }
 
@@ -32,6 +33,13 @@ import GRDB
             #expect(schema.2.contains("calendar_event_recurrence_id"))
             #expect(schema.3)
             #expect(!schema.4.contains("source_event_url"))
+            #expect(schema.5 == [
+                "vaultId",
+                "calendar_event_ical_uid",
+                "calendar_event_recurrence_id",
+                "createdAt",
+                "id",
+            ])
         }
 
         @Test
@@ -128,7 +136,8 @@ import GRDB
             )
             let event = calendarEvent(recurrenceId: "")
             let key = try #require(event.key)
-            let activeMeetingId = UUID.v7()
+            let activeMeetingId = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000001"))
+            let tiedActiveMeetingId = try #require(UUID(uuidString: "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"))
             let otherMeetingId = UUID.v7()
             let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
 
@@ -152,15 +161,23 @@ import GRDB
                     key: key,
                     in: db
                 )
+                try insertCalendarMeeting(
+                    id: tiedActiveMeetingId,
+                    named: "Deterministic tie winner",
+                    vaultId: activeVault.id,
+                    createdAt: createdAt,
+                    key: key,
+                    in: db
+                )
             }
 
             let repository = MeetingRepository(dbQueue: database.dbQueue)
             #expect(
-                try repository.fetchMeetingIdForCalendarEvent(event, vaultId: activeVault.id)
-                    == activeMeetingId
+                try repository.resolveMeetingIdForCalendarEvent(event, vaultId: activeVault.id)
+                    == tiedActiveMeetingId
             )
             #expect(
-                try repository.fetchMeetingIdForCalendarEvent(event, vaultId: otherVault.id)
+                try repository.resolveMeetingIdForCalendarEvent(event, vaultId: otherVault.id)
                     == otherMeetingId
             )
         }
@@ -196,7 +213,7 @@ import GRDB
         }
 
         @Test
-        func migrationMovesURLFromSourceToCalendarEvent() throws {
+        func migrationMovesURLAndNormalizesDateRecurrenceId() throws {
             let databaseURL = URL.temporaryDirectory
                 .appending(path: UUID().uuidString)
                 .appendingPathExtension("sqlite")
@@ -209,7 +226,7 @@ import GRDB
             let result = try migrated.dbQueue.read { db in
                 try (
                     CalendarEventRecord.fetch(
-                        key: CalendarEventKey(icalUid: "planning@google.com", recurrenceId: ""),
+                        key: CalendarEventKey(icalUid: "planning@google.com", recurrenceId: "20260417"),
                         in: db
                     ),
                     String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('calendar_event_sources')")
@@ -262,13 +279,17 @@ import GRDB
         ).insert(db)
     }
 
-    private func calendarEvent(recurrenceId: String, url: URL? = nil) -> CalendarEvent {
+    private func calendarEvent(
+        recurrenceId: String,
+        url: URL? = nil
+    ) -> CalendarEvent {
         let start = Date(timeIntervalSince1970: 1_776_384_000)
         return CalendarEvent(
-            id: recurrenceId,
+            id: "google::\(recurrenceId)",
             calendarID: "primary",
             calendarName: "Primary",
             calendarColorHex: nil,
+            platform: CalendarEventPlatform.googleCalendar,
             platformId: recurrenceId,
             title: "Planning",
             description: "",
@@ -348,7 +369,7 @@ import GRDB
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             arguments: [
-                "planning@google.com", "", now, now, "Planning", "", now,
+                "planning@google.com", "VALUE=DATE:20260417", now, now, "Planning", "", now,
                 now.addingTimeInterval(3600), false, nil,
             ]
         )
@@ -362,7 +383,7 @@ import GRDB
             """,
             arguments: [
                 CalendarEventPlatform.googleCalendar, "primary", "planning",
-                "planning@google.com", "", eventURL, now, now,
+                "planning@google.com", "VALUE=DATE:20260417", eventURL, now, now,
             ]
         )
     }

--- a/Tests/DahliaTests/CalendarEventDatabaseTests.swift
+++ b/Tests/DahliaTests/CalendarEventDatabaseTests.swift
@@ -1,0 +1,400 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct CalendarEventDatabaseTests {
+        @Test
+        func initializesCalendarEventIdentitySchema() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
+
+            let schema = try database.dbQueue.read { db in
+                try (
+                    String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('calendar_events') ORDER BY cid"),
+                    String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('calendar_events') WHERE pk > 0 ORDER BY pk"),
+                    String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('meetings')"),
+                    db.tableExists("calendar_event_sources"),
+                    String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('calendar_event_sources')")
+                )
+            }
+
+            #expect(schema.0.contains("ical_uid"))
+            #expect(schema.0.contains("recurrence_id"))
+            #expect(schema.0.contains("description"))
+            #expect(schema.0.contains("conference_uri"))
+            #expect(schema.0.contains("url"))
+            #expect(!schema.0.contains("id"))
+            #expect(schema.1 == ["ical_uid", "recurrence_id"])
+            #expect(schema.2.contains("calendar_event_ical_uid"))
+            #expect(schema.2.contains("calendar_event_recurrence_id"))
+            #expect(schema.3)
+            #expect(!schema.4.contains("source_event_url"))
+        }
+
+        @Test
+        func meetingCalendarReferenceRejectsIncompleteAndMissingKeys() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
+            let vault = VaultRecord(
+                id: .v7(),
+                path: "/tmp/calendar-reference-test",
+                name: "Calendar Reference Test",
+                createdAt: .now,
+                lastOpenedAt: .now
+            )
+            try database.dbQueue.write { db in
+                try vault.insert(db)
+            }
+
+            #expect(throws: Error.self) {
+                try insertMeeting(
+                    named: "Incomplete",
+                    vaultId: vault.id,
+                    calendarUID: "event@example.com",
+                    recurrenceId: nil,
+                    in: database.dbQueue
+                )
+            }
+            #expect(throws: Error.self) {
+                try insertMeeting(
+                    named: "Missing",
+                    vaultId: vault.id,
+                    calendarUID: "missing@example.com",
+                    recurrenceId: "",
+                    in: database.dbQueue
+                )
+            }
+        }
+
+        @Test
+        func uidAndRecurrenceIdFormTheCalendarEventPrimaryKey() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
+            let first = calendarEvent(recurrenceId: "20260417T003000Z")
+            let second = calendarEvent(recurrenceId: "20260424T003000Z")
+
+            try database.dbQueue.write { db in
+                try CalendarEventRecord.upsert(event: first, now: .now, in: db)
+                try CalendarEventRecord.upsert(event: second, now: .now, in: db)
+            }
+
+            let count = try database.dbQueue.read { db in
+                try CalendarEventRecord.fetchCount(db)
+            }
+            #expect(count == 2)
+
+            let firstKey = try #require(first.key)
+            #expect(throws: Error.self) {
+                try database.dbQueue.write { db in
+                    try CalendarEventRecord(now: .now, event: first, key: firstKey).insert(db)
+                }
+            }
+        }
+
+        @Test
+        func upsertWithoutURLPreservesExistingCalendarEventURL() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
+            let eventURL = try #require(URL(string: "https://calendar.google.com/calendar/event?eid=planning"))
+            let withURL = calendarEvent(recurrenceId: "", url: eventURL)
+            let withoutURL = calendarEvent(recurrenceId: "")
+            let key = try #require(withURL.key)
+
+            let persisted = try database.dbQueue.write { db in
+                try CalendarEventRecord.upsert(event: withURL, now: .now, in: db)
+                try CalendarEventRecord.upsert(event: withoutURL, now: .now, in: db)
+                return try CalendarEventRecord.fetch(key: key, in: db)
+            }
+
+            #expect(persisted?.url == eventURL.absoluteString)
+        }
+
+        @Test
+        func migrationPreservesMeetingsAndDiscardsLegacyCalendarRows() throws {
+            let databaseURL = URL.temporaryDirectory
+                .appending(path: UUID().uuidString)
+                .appendingPathExtension("sqlite")
+            let meetingId = UUID.v7()
+            let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
+            defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+            try prepareLegacyV14Database(
+                at: databaseURL,
+                meetingId: meetingId,
+                createdAt: createdAt
+            )
+
+            let migrated = try AppDatabaseManager(path: databaseURL.path)
+            let result = try migrated.dbQueue.read { db in
+                try (
+                    MeetingRecord.fetchOne(db, key: meetingId),
+                    CalendarEventRecord.fetchCount(db)
+                )
+            }
+
+            let meeting = try #require(result.0)
+            #expect(meeting.name == "Keep me")
+            #expect(meeting.calendarEventIcalUid == nil)
+            #expect(meeting.calendarEventRecurrenceId == nil)
+            #expect(result.1 == 0)
+        }
+
+        @Test
+        func migrationMovesURLFromSourceToCalendarEvent() throws {
+            let databaseURL = URL.temporaryDirectory
+                .appending(path: UUID().uuidString)
+                .appendingPathExtension("sqlite")
+            let eventURL = "https://calendar.google.com/calendar/event?eid=planning"
+            defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+            try prepareLegacyV15Database(at: databaseURL, eventURL: eventURL)
+
+            let migrated = try AppDatabaseManager(path: databaseURL.path)
+            let result = try migrated.dbQueue.read { db in
+                try (
+                    CalendarEventRecord.fetch(
+                        key: CalendarEventKey(icalUid: "planning@google.com", recurrenceId: ""),
+                        in: db
+                    ),
+                    String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('calendar_event_sources')")
+                )
+            }
+
+            #expect(result.0?.url == eventURL)
+            #expect(!result.1.contains("source_event_url"))
+        }
+    }
+
+    private func insertMeeting(
+        named name: String,
+        vaultId: UUID,
+        calendarUID: String?,
+        recurrenceId: String?,
+        in dbQueue: DatabaseQueue
+    ) throws {
+        try dbQueue.write { db in
+            try MeetingRecord(
+                id: .v7(),
+                vaultId: vaultId,
+                projectId: nil,
+                name: name,
+                createdAt: .now,
+                updatedAt: .now,
+                calendarEventIcalUid: calendarUID,
+                calendarEventRecurrenceId: recurrenceId
+            ).insert(db)
+        }
+    }
+
+    private func calendarEvent(recurrenceId: String, url: URL? = nil) -> CalendarEvent {
+        let start = Date(timeIntervalSince1970: 1_776_384_000)
+        return CalendarEvent(
+            id: recurrenceId,
+            calendarID: "primary",
+            calendarName: "Primary",
+            calendarColorHex: nil,
+            platformId: recurrenceId,
+            title: "Planning",
+            description: "",
+            icalUid: "series@example.com",
+            recurrenceId: recurrenceId,
+            startDate: start,
+            endDate: start.addingTimeInterval(3600),
+            isAllDay: false,
+            conferenceURI: nil,
+            url: url
+        )
+    }
+
+    private func prepareLegacyV15Database(at databaseURL: URL, eventURL: String) throws {
+        let queue = try DatabaseQueue(path: databaseURL.path)
+        try queue.write { db in
+            try createLegacyV15CalendarTables(in: db)
+            try markMigrationsThroughV14Applied(in: db)
+            try db.execute(
+                sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
+                arguments: ["v15_calendarEventIdentity"]
+            )
+            try insertLegacyV15CalendarEvent(eventURL: eventURL, in: db)
+        }
+    }
+
+    private func createLegacyV15CalendarTables(in db: Database) throws {
+        try db.execute(
+            sql: """
+            CREATE TABLE calendar_events (
+                ical_uid TEXT NOT NULL,
+                recurrence_id TEXT NOT NULL DEFAULT '',
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                title TEXT NOT NULL DEFAULT '',
+                description TEXT NOT NULL DEFAULT '',
+                start DATETIME NOT NULL,
+                "end" DATETIME NOT NULL,
+                is_all_day BOOLEAN NOT NULL DEFAULT 0,
+                conference_uri TEXT,
+                PRIMARY KEY (ical_uid, recurrence_id)
+            ) WITHOUT ROWID
+            """
+        )
+        try db.execute(
+            sql: """
+            CREATE TABLE calendar_event_sources (
+                platform TEXT NOT NULL,
+                calendar_id TEXT NOT NULL,
+                platform_id TEXT NOT NULL,
+                ical_uid TEXT NOT NULL,
+                recurrence_id TEXT NOT NULL,
+                source_event_url TEXT,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                PRIMARY KEY (platform, calendar_id, platform_id),
+                FOREIGN KEY (ical_uid, recurrence_id)
+                    REFERENCES calendar_events (ical_uid, recurrence_id)
+                    ON UPDATE CASCADE
+                    ON DELETE CASCADE
+            ) WITHOUT ROWID
+            """
+        )
+        try db.create(table: "grdb_migrations") { table in
+            table.column("identifier", .text).primaryKey()
+        }
+    }
+
+    private func insertLegacyV15CalendarEvent(eventURL: String, in db: Database) throws {
+        let now = Date(timeIntervalSince1970: 1_776_384_000)
+        try db.execute(
+            sql: """
+            INSERT INTO calendar_events (
+                ical_uid, recurrence_id, created_at, updated_at, title, description,
+                start, "end", is_all_day, conference_uri
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            arguments: [
+                "planning@google.com", "", now, now, "Planning", "", now,
+                now.addingTimeInterval(3600), false, nil,
+            ]
+        )
+        try db.execute(
+            sql: """
+            INSERT INTO calendar_event_sources (
+                platform, calendar_id, platform_id, ical_uid, recurrence_id,
+                source_event_url, created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            arguments: [
+                CalendarEventPlatform.googleCalendar, "primary", "planning",
+                "planning@google.com", "", eventURL, now, now,
+            ]
+        )
+    }
+
+    private func prepareLegacyV14Database(
+        at databaseURL: URL,
+        meetingId: UUID,
+        createdAt: Date
+    ) throws {
+        let queue = try DatabaseQueue(path: databaseURL.path)
+        try queue.write { db in
+            try createLegacyCalendarTables(in: db)
+            try markMigrationsThroughV14Applied(in: db)
+            try insertLegacyMeetingAndCalendarEvent(meetingId: meetingId, createdAt: createdAt, in: db)
+        }
+    }
+
+    private func createLegacyCalendarTables(in db: Database) throws {
+        try db.execute(
+            sql: """
+            CREATE TABLE meetings (
+                id BLOB PRIMARY KEY,
+                vaultId BLOB NOT NULL,
+                projectId BLOB,
+                name TEXT NOT NULL DEFAULT '',
+                status TEXT NOT NULL DEFAULT 'READY',
+                duration DOUBLE,
+                createdAt DATETIME NOT NULL,
+                updatedAt DATETIME NOT NULL
+            )
+            """
+        )
+        try db.execute(
+            sql: """
+            CREATE TABLE calendar_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                meetingId BLOB NOT NULL UNIQUE,
+                createdAt DATETIME NOT NULL,
+                updatedAt DATETIME NOT NULL,
+                platform TEXT NOT NULL,
+                platformId TEXT NOT NULL,
+                description TEXT NOT NULL DEFAULT '',
+                icalUid TEXT,
+                start DATETIME NOT NULL,
+                "end" DATETIME NOT NULL,
+                meetingUrl TEXT,
+                UNIQUE(platform, platformId)
+            )
+            """
+        )
+        try db.create(table: "grdb_migrations") { table in
+            table.column("identifier", .text).primaryKey()
+        }
+    }
+
+    private func markMigrationsThroughV14Applied(in db: Database) throws {
+        for migration in [
+            "v3_googleDriveFolderSchema",
+            "v4_instructionsSchema",
+            "v5_summaryGoogleFileId",
+            "v6_transcriptSegmentTranslation",
+            "v7_normalizeLegacyMeetingStatus",
+            "v8_recordingSessions",
+            "v9_summaryDocument",
+            "v10_batchTranscription",
+            "v11_batchAudioStorageLocation",
+            "v12_batchTranscriptionDiscard",
+            "v13_summaryVaultRelativePath",
+            "v14_projectDescription",
+        ] {
+            try db.execute(
+                sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
+                arguments: [migration]
+            )
+        }
+    }
+
+    private func insertLegacyMeetingAndCalendarEvent(
+        meetingId: UUID,
+        createdAt: Date,
+        in db: Database
+    ) throws {
+        try db.execute(
+            sql: """
+            INSERT INTO meetings (id, vaultId, name, status, createdAt, updatedAt)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            arguments: [meetingId, UUID.v7(), "Keep me", MeetingStatus.ready.rawValue, createdAt, createdAt]
+        )
+        try db.execute(
+            sql: """
+            INSERT INTO calendar_events (
+                meetingId, createdAt, updatedAt, platform, platformId, description, icalUid, start, "end", meetingUrl
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            arguments: [
+                meetingId,
+                createdAt,
+                createdAt,
+                CalendarEventPlatform.googleCalendar,
+                "legacy-event",
+                "Discard me",
+                "legacy@example.com",
+                createdAt,
+                createdAt.addingTimeInterval(3600),
+                "https://meet.example.com/legacy",
+            ]
+        )
+    }
+#endif

--- a/Tests/DahliaTests/CalendarEventIdentityTests.swift
+++ b/Tests/DahliaTests/CalendarEventIdentityTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct CalendarEventIdentityTests {
+        @Test
+        func recurrenceIdUsesRFC5545UTCDateTimeAndDateForms() {
+            let date = Date(timeIntervalSince1970: 1_776_382_200)
+
+            #expect(ICalendarRecurrenceID.dateTime(date) == "20260416T233000Z")
+            #expect(ICalendarRecurrenceID.date("2026-04-17") == "VALUE=DATE:20260417")
+            #expect(ICalendarRecurrenceID.date("2026-4-17") == nil)
+        }
+
+        @Test
+        func singleEventUsesEmptyRecurrenceId() {
+            let event = makeEvent(platform: CalendarEventPlatform.googleCalendar)
+
+            #expect(event.recurrenceId.isEmpty)
+            #expect(event.key == CalendarEventKey(icalUid: "shared@example.com", recurrenceId: ""))
+        }
+
+        @Test
+        func deduplicationUsesOriginalOccurrenceInsteadOfCurrentStart() {
+            let recurrenceId = "20260417T003000Z"
+            let macEvent = makeEvent(
+                platform: CalendarEventPlatform.macOSCalendar,
+                recurrenceId: recurrenceId,
+                startDate: Date(timeIntervalSince1970: 1_776_390_600)
+            )
+            let googleEvent = makeEvent(
+                platform: CalendarEventPlatform.googleCalendar,
+                recurrenceId: recurrenceId,
+                startDate: Date(timeIntervalSince1970: 1_776_391_200)
+            )
+
+            let result = [macEvent, googleEvent].deduplicatedAcrossSources()
+
+            #expect(result == [googleEvent])
+        }
+
+        @Test
+        func differentOccurrencesRemainDistinct() {
+            let first = makeEvent(
+                platform: CalendarEventPlatform.macOSCalendar,
+                recurrenceId: "20260417T003000Z"
+            )
+            let second = makeEvent(
+                platform: CalendarEventPlatform.googleCalendar,
+                recurrenceId: "20260424T003000Z"
+            )
+
+            #expect([first, second].deduplicatedAcrossSources() == [first, second])
+        }
+    }
+
+    private func makeEvent(
+        platform: String,
+        recurrenceId: String = ICalendarRecurrenceID.singleEvent,
+        startDate: Date = Date(timeIntervalSince1970: 1_776_387_600)
+    ) -> CalendarEvent {
+        CalendarEvent(
+            id: "\(platform)-event",
+            calendarID: platform,
+            calendarName: platform,
+            calendarColorHex: nil,
+            platform: platform,
+            platformId: "source-event",
+            title: "Planning",
+            description: "",
+            icalUid: "shared@example.com",
+            recurrenceId: recurrenceId,
+            startDate: startDate,
+            endDate: startDate.addingTimeInterval(3600),
+            isAllDay: false,
+            conferenceURI: nil
+        )
+    }
+#endif

--- a/Tests/DahliaTests/CalendarEventIdentityTests.swift
+++ b/Tests/DahliaTests/CalendarEventIdentityTests.swift
@@ -10,7 +10,7 @@ import Foundation
             let date = Date(timeIntervalSince1970: 1_776_382_200)
 
             #expect(ICalendarRecurrenceID.dateTime(date) == "20260416T233000Z")
-            #expect(ICalendarRecurrenceID.date("2026-04-17") == "VALUE=DATE:20260417")
+            #expect(ICalendarRecurrenceID.date("2026-04-17") == "20260417")
             #expect(ICalendarRecurrenceID.date("2026-4-17") == nil)
         }
 
@@ -54,12 +54,43 @@ import Foundation
 
             #expect([first, second].deduplicatedAcrossSources() == [first, second])
         }
+
+        @Test
+        func deduplicationKeepsComplementaryMetadataFromMacOS() {
+            let recurrenceId = "20260417T003000Z"
+            let conferenceURI = URL(string: "https://zoom.us/j/123456789")
+            let eventURL = URL(string: "https://calendar.google.com/calendar/event?eid=planning")
+            let googleEvent = makeEvent(
+                platform: CalendarEventPlatform.googleCalendar,
+                recurrenceId: recurrenceId,
+                url: eventURL
+            )
+            let macEvent = makeEvent(
+                platform: CalendarEventPlatform.macOSCalendar,
+                recurrenceId: recurrenceId,
+                description: "Join the weekly planning call",
+                conferenceURI: conferenceURI
+            )
+            let expected = makeEvent(
+                platform: CalendarEventPlatform.googleCalendar,
+                recurrenceId: recurrenceId,
+                description: macEvent.description,
+                conferenceURI: conferenceURI,
+                url: eventURL
+            )
+
+            #expect([googleEvent, macEvent].deduplicatedAcrossSources() == [expected])
+            #expect([macEvent, googleEvent].deduplicatedAcrossSources() == [expected])
+        }
     }
 
     private func makeEvent(
         platform: String,
         recurrenceId: String = ICalendarRecurrenceID.singleEvent,
-        startDate: Date = Date(timeIntervalSince1970: 1_776_387_600)
+        startDate: Date = Date(timeIntervalSince1970: 1_776_387_600),
+        description: String = "",
+        conferenceURI: URL? = nil,
+        url: URL? = nil
     ) -> CalendarEvent {
         CalendarEvent(
             id: "\(platform)-event",
@@ -69,13 +100,14 @@ import Foundation
             platform: platform,
             platformId: "source-event",
             title: "Planning",
-            description: "",
+            description: description,
             icalUid: "shared@example.com",
             recurrenceId: recurrenceId,
             startDate: startDate,
             endDate: startDate.addingTimeInterval(3600),
             isAllDay: false,
-            conferenceURI: nil
+            conferenceURI: conferenceURI,
+            url: url
         )
     }
 #endif

--- a/Tests/DahliaTests/CalendarEventLifecycleTests.swift
+++ b/Tests/DahliaTests/CalendarEventLifecycleTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct CalendarEventLifecycleTests {
+        @Test
+        func upsertFromSparseSourcePreservesRicherCanonicalMetadata() throws {
+            let (database, _) = try makeDatabase(named: "Canonical Merge")
+            let conferenceURI = try #require(URL(string: "https://meet.google.com/planning"))
+            let eventURL = try #require(URL(string: "https://calendar.google.com/calendar/event?eid=planning"))
+            let richEvent = event(
+                url: eventURL,
+                description: "Quarterly planning",
+                conferenceURI: conferenceURI
+            )
+            let sparseEvent = event(
+                platform: CalendarEventPlatform.macOSCalendar,
+                calendarID: "mac-calendar",
+                platformId: "mac-event"
+            )
+            let key = try #require(richEvent.key)
+
+            let persisted = try database.dbQueue.write { db in
+                try CalendarEventRecord.upsert(event: richEvent, now: .now, in: db)
+                try CalendarEventRecord.upsert(event: sparseEvent, now: .now, in: db)
+                return try CalendarEventRecord.fetch(key: key, in: db)
+            }
+
+            #expect(persisted?.description == richEvent.description)
+            #expect(persisted?.conferenceURI == conferenceURI.absoluteString)
+            #expect(persisted?.url == eventURL.absoluteString)
+        }
+
+        @Test
+        func resolvingExistingMeetingRefreshesCanonicalEventAndSourceMapping() throws {
+            let (database, vault) = try makeDatabase(named: "Source Refresh")
+            let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
+            let meetingId = UUID.v7()
+            let macEvent = event(
+                platform: CalendarEventPlatform.macOSCalendar,
+                calendarID: "mac-calendar",
+                platformId: "mac-event"
+            )
+            let googleURL = try #require(URL(string: "https://calendar.google.com/calendar/event?eid=planning"))
+            let googleEvent = event(url: googleURL, platformId: "google-event")
+            let key = try #require(macEvent.key)
+
+            try database.dbQueue.write { db in
+                try CalendarEventRecord.upsert(event: macEvent, now: createdAt, in: db)
+                try insertMeeting(id: meetingId, vaultId: vault.id, createdAt: createdAt, key: key, in: db)
+            }
+
+            let repository = MeetingRepository(dbQueue: database.dbQueue)
+            let resolvedMeetingId = try repository.resolveMeetingIdForCalendarEvent(
+                googleEvent,
+                vaultId: vault.id,
+                observedAt: createdAt.addingTimeInterval(60)
+            )
+            let persisted = try database.dbQueue.read { db in
+                try (
+                    CalendarEventRecord.fetch(key: key, in: db),
+                    CalendarEventSourceRecord.fetchCount(db)
+                )
+            }
+
+            #expect(resolvedMeetingId == meetingId)
+            #expect(persisted.0?.url == googleURL.absoluteString)
+            #expect(persisted.1 == 2)
+        }
+
+        @Test
+        func calendarEventIsDeletedAfterItsLastMeetingReference() throws {
+            let (database, vault) = try makeDatabase(named: "Reference Cleanup")
+            let calendarEvent = event()
+            let key = try #require(calendarEvent.key)
+            let firstMeetingId = UUID.v7()
+            let secondMeetingId = UUID.v7()
+
+            try database.dbQueue.write { db in
+                try CalendarEventRecord.upsert(event: calendarEvent, now: .now, in: db)
+                try insertMeeting(id: firstMeetingId, vaultId: vault.id, createdAt: .now, key: key, in: db)
+                try insertMeeting(id: secondMeetingId, vaultId: vault.id, createdAt: .now, key: key, in: db)
+                _ = try MeetingRecord.deleteOne(db, key: firstMeetingId)
+            }
+
+            let afterFirstDeletion = try calendarRecordCounts(in: database)
+            #expect(afterFirstDeletion.events == 1)
+            #expect(afterFirstDeletion.sources == 1)
+
+            try database.dbQueue.write { db in
+                _ = try MeetingRecord.deleteOne(db, key: secondMeetingId)
+            }
+            let afterLastDeletion = try calendarRecordCounts(in: database)
+            #expect(afterLastDeletion.events == 0)
+            #expect(afterLastDeletion.sources == 0)
+        }
+
+        @Test
+        func cancellingNewMeetingDeletesUnreferencedCalendarEvent() throws {
+            let (database, vault) = try makeDatabase(named: "Cancellation Cleanup")
+            let calendarEvent = event()
+            let service = try MeetingPersistenceService(
+                store: TranscriptStore(),
+                dbQueue: database.dbQueue,
+                vaultId: vault.id,
+                projectId: nil,
+                initialName: calendarEvent.title,
+                calendarEvent: calendarEvent
+            )
+
+            service.cancel()
+
+            let meetingCount = try database.dbQueue.read { db in
+                try MeetingRecord.fetchCount(db)
+            }
+            let calendarCounts = try calendarRecordCounts(in: database)
+            #expect(meetingCount == 0)
+            #expect(calendarCounts.events == 0)
+            #expect(calendarCounts.sources == 0)
+        }
+
+        private func makeDatabase(named name: String) throws -> (AppDatabaseManager, VaultRecord) {
+            let database = try AppDatabaseManager(path: ":memory:")
+            let vault = VaultRecord(
+                id: .v7(),
+                path: "/tmp/calendar-lifecycle-\(UUID().uuidString)",
+                name: name,
+                createdAt: .now,
+                lastOpenedAt: .now
+            )
+            try database.dbQueue.write { db in
+                try vault.insert(db)
+            }
+            return (database, vault)
+        }
+
+        private func event(
+            url: URL? = nil,
+            platform: String = CalendarEventPlatform.googleCalendar,
+            calendarID: String = "primary",
+            platformId: String = "planning",
+            description: String = "",
+            conferenceURI: URL? = nil
+        ) -> CalendarEvent {
+            let start = Date(timeIntervalSince1970: 1_776_384_000)
+            return CalendarEvent(
+                id: "\(platform)::\(platformId)",
+                calendarID: calendarID,
+                calendarName: "Primary",
+                calendarColorHex: nil,
+                platform: platform,
+                platformId: platformId,
+                title: "Planning",
+                description: description,
+                icalUid: "planning@example.com",
+                startDate: start,
+                endDate: start.addingTimeInterval(3600),
+                isAllDay: false,
+                conferenceURI: conferenceURI,
+                url: url
+            )
+        }
+
+        private func insertMeeting(
+            id: UUID,
+            vaultId: UUID,
+            createdAt: Date,
+            key: CalendarEventKey,
+            in db: Database
+        ) throws {
+            try MeetingRecord(
+                id: id,
+                vaultId: vaultId,
+                projectId: nil,
+                name: "Planning",
+                createdAt: createdAt,
+                updatedAt: createdAt,
+                calendarEventIcalUid: key.icalUid,
+                calendarEventRecurrenceId: key.recurrenceId
+            ).insert(db)
+        }
+
+        private func calendarRecordCounts(
+            in database: AppDatabaseManager
+        ) throws -> (events: Int, sources: Int) {
+            try database.dbQueue.read { db in
+                try (CalendarEventRecord.fetchCount(db), CalendarEventSourceRecord.fetchCount(db))
+            }
+        }
+    }
+#endif

--- a/Tests/DahliaTests/CalendarEventTitleTests.swift
+++ b/Tests/DahliaTests/CalendarEventTitleTests.swift
@@ -31,6 +31,6 @@ private func calendarEvent(title: String) -> CalendarEvent {
         startDate: startDate,
         endDate: startDate.addingTimeInterval(3600),
         isAllDay: false,
-        meetingURL: nil
+        conferenceURI: nil
     )
 }

--- a/Tests/DahliaTests/CalendarMeetingNotificationPlannerTests.swift
+++ b/Tests/DahliaTests/CalendarMeetingNotificationPlannerTests.swift
@@ -64,6 +64,6 @@ private func calendarEvent(startDate: Date, isAllDay: Bool = false) -> CalendarE
         startDate: startDate,
         endDate: startDate.addingTimeInterval(3600),
         isAllDay: isAllDay,
-        meetingURL: URL(string: "https://meet.example.com/planning")
+        conferenceURI: URL(string: "https://meet.example.com/planning")
     )
 }

--- a/Tests/DahliaTests/CalendarSeriesProjectAssignmentTests.swift
+++ b/Tests/DahliaTests/CalendarSeriesProjectAssignmentTests.swift
@@ -61,6 +61,50 @@ import GRDB
         }
 
         @Test
+        func newMeetingSkipsMostRecentProjectWhenItsFolderIsMissing() throws {
+            let (database, vault) = try makeDatabase()
+            let availableProject = project(named: "Available project", vaultId: vault.id)
+            var missingProject = project(named: "Missing project", vaultId: vault.id)
+            missingProject.missingOnDisk = true
+            let olderStart = Date(timeIntervalSince1970: 1_776_200_000)
+            let recentStart = Date(timeIntervalSince1970: 1_776_300_000)
+            let currentStart = Date(timeIntervalSince1970: 1_776_400_000)
+
+            try database.dbQueue.write { db in
+                try availableProject.insert(db)
+                try missingProject.insert(db)
+                try insertSeriesMeeting(
+                    event: seriesEvent(startDate: olderStart, recurrenceId: "20260414T090000Z"),
+                    projectId: availableProject.id,
+                    vaultId: vault.id,
+                    createdAt: olderStart,
+                    in: db
+                )
+                try insertSeriesMeeting(
+                    event: seriesEvent(startDate: recentStart, recurrenceId: "20260415T090000Z"),
+                    projectId: missingProject.id,
+                    vaultId: vault.id,
+                    createdAt: recentStart,
+                    in: db
+                )
+            }
+
+            let service = try MeetingPersistenceService(
+                store: TranscriptStore(),
+                dbQueue: database.dbQueue,
+                vaultId: vault.id,
+                projectId: nil,
+                initialName: "Current occurrence",
+                calendarEvent: seriesEvent(startDate: currentStart, recurrenceId: "20260416T090000Z")
+            )
+            service.stop()
+
+            let meeting = try fetchMeeting(id: service.meetingId, from: database.dbQueue)
+            #expect(meeting.projectId == availableProject.id)
+            #expect(service.projectId == availableProject.id)
+        }
+
+        @Test
         func explicitlySelectedProjectOverridesSeriesProject() throws {
             let (database, vault) = try makeDatabase()
             let seriesProject = project(named: "Series project", vaultId: vault.id)
@@ -93,6 +137,40 @@ import GRDB
             let meeting = try fetchMeeting(id: service.meetingId, from: database.dbQueue)
             #expect(meeting.projectId == selectedProject.id)
             #expect(service.projectId == selectedProject.id)
+        }
+
+        @Test
+        func explicitNoProjectPreventsSeriesInheritanceWhenRecordingStarts() throws {
+            let (database, vault) = try makeDatabase()
+            let inheritedProject = project(named: "Planning", vaultId: vault.id)
+            let previousStart = Date(timeIntervalSince1970: 1_776_300_000)
+            let currentStart = Date(timeIntervalSince1970: 1_776_400_000)
+
+            try database.dbQueue.write { db in
+                try inheritedProject.insert(db)
+                try insertSeriesMeeting(
+                    event: seriesEvent(startDate: previousStart, recurrenceId: "20260415T090000Z"),
+                    projectId: inheritedProject.id,
+                    vaultId: vault.id,
+                    createdAt: previousStart,
+                    in: db
+                )
+            }
+
+            let service = try MeetingPersistenceService(
+                store: TranscriptStore(),
+                dbQueue: database.dbQueue,
+                vaultId: vault.id,
+                projectId: nil,
+                initialName: "Current occurrence",
+                allowsCalendarSeriesProjectInheritance: false,
+                calendarEvent: seriesEvent(startDate: currentStart, recurrenceId: "20260416T090000Z")
+            )
+            service.stop()
+
+            let meeting = try fetchMeeting(id: service.meetingId, from: database.dbQueue)
+            #expect(meeting.projectId == nil)
+            #expect(service.projectId == nil)
         }
 
         @Test
@@ -134,6 +212,45 @@ import GRDB
                 viewModel.currentProjectURL
                     == vault.url.appending(path: inheritedProject.name, directoryHint: .isDirectory)
             )
+        }
+
+        @Test
+        func materializedDraftPreservesExplicitNoProjectSelection() throws {
+            let (database, vault) = try makeDatabase()
+            let inheritedProject = project(named: "Planning", vaultId: vault.id)
+            let previousStart = Date(timeIntervalSince1970: 1_776_300_000)
+            let currentStart = Date(timeIntervalSince1970: 1_776_400_000)
+
+            try database.dbQueue.write { db in
+                try inheritedProject.insert(db)
+                try insertSeriesMeeting(
+                    event: seriesEvent(startDate: previousStart, recurrenceId: "20260415T090000Z"),
+                    projectId: inheritedProject.id,
+                    vaultId: vault.id,
+                    createdAt: previousStart,
+                    in: db
+                )
+            }
+
+            let previousVault = AppSettings.shared.currentVault
+            AppSettings.shared.currentVault = vault
+            defer { AppSettings.shared.currentVault = previousVault }
+
+            let viewModel = CaptionViewModel()
+            viewModel.beginDraftMeeting(
+                from: seriesEvent(startDate: currentStart, recurrenceId: "20260416T090000Z"),
+                dbQueue: database.dbQueue,
+                vaultURL: vault.url
+            )
+            viewModel.setExplicitProjectContext(projectURL: nil, projectId: nil, projectName: nil)
+
+            let meetingId = try #require(viewModel.materializeDraftMeeting())
+            let meeting = try fetchMeeting(id: meetingId, from: database.dbQueue)
+
+            #expect(meeting.projectId == nil)
+            #expect(viewModel.currentProjectId == nil)
+            #expect(viewModel.currentProjectName == nil)
+            #expect(viewModel.currentProjectURL == nil)
         }
     }
 

--- a/Tests/DahliaTests/CalendarSeriesProjectAssignmentTests.swift
+++ b/Tests/DahliaTests/CalendarSeriesProjectAssignmentTests.swift
@@ -1,0 +1,210 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct CalendarSeriesProjectAssignmentTests {
+        @Test
+        func newMeetingInheritsProjectFromMostRecentEarlierOccurrence() throws {
+            let (database, vault) = try makeDatabase()
+            let olderProject = project(named: "Older project", vaultId: vault.id)
+            let recentProject = project(named: "Recent project", vaultId: vault.id)
+            let futureProject = project(named: "Future project", vaultId: vault.id)
+            let olderStart = Date(timeIntervalSince1970: 1_776_200_000)
+            let recentStart = Date(timeIntervalSince1970: 1_776_300_000)
+            let currentStart = Date(timeIntervalSince1970: 1_776_400_000)
+            let futureStart = Date(timeIntervalSince1970: 1_776_500_000)
+
+            try database.dbQueue.write { db in
+                try olderProject.insert(db)
+                try recentProject.insert(db)
+                try futureProject.insert(db)
+                try insertSeriesMeeting(
+                    event: seriesEvent(startDate: olderStart, recurrenceId: "20260414T090000Z"),
+                    projectId: olderProject.id,
+                    vaultId: vault.id,
+                    createdAt: recentStart.addingTimeInterval(100),
+                    in: db
+                )
+                try insertSeriesMeeting(
+                    event: seriesEvent(startDate: recentStart, recurrenceId: "20260415T090000Z"),
+                    projectId: recentProject.id,
+                    vaultId: vault.id,
+                    createdAt: olderStart,
+                    in: db
+                )
+                try insertSeriesMeeting(
+                    event: seriesEvent(startDate: futureStart, recurrenceId: "20260417T090000Z"),
+                    projectId: futureProject.id,
+                    vaultId: vault.id,
+                    createdAt: futureStart,
+                    in: db
+                )
+            }
+
+            let service = try MeetingPersistenceService(
+                store: TranscriptStore(),
+                dbQueue: database.dbQueue,
+                vaultId: vault.id,
+                projectId: nil,
+                initialName: "Current occurrence",
+                calendarEvent: seriesEvent(startDate: currentStart, recurrenceId: "20260416T090000Z")
+            )
+            service.stop()
+
+            let meeting = try fetchMeeting(id: service.meetingId, from: database.dbQueue)
+            #expect(meeting.projectId == recentProject.id)
+            #expect(service.projectId == recentProject.id)
+        }
+
+        @Test
+        func explicitlySelectedProjectOverridesSeriesProject() throws {
+            let (database, vault) = try makeDatabase()
+            let seriesProject = project(named: "Series project", vaultId: vault.id)
+            let selectedProject = project(named: "Selected project", vaultId: vault.id)
+            let previousStart = Date(timeIntervalSince1970: 1_776_300_000)
+            let currentStart = Date(timeIntervalSince1970: 1_776_400_000)
+
+            try database.dbQueue.write { db in
+                try seriesProject.insert(db)
+                try selectedProject.insert(db)
+                try insertSeriesMeeting(
+                    event: seriesEvent(startDate: previousStart, recurrenceId: "20260415T090000Z"),
+                    projectId: seriesProject.id,
+                    vaultId: vault.id,
+                    createdAt: previousStart,
+                    in: db
+                )
+            }
+
+            let service = try MeetingPersistenceService(
+                store: TranscriptStore(),
+                dbQueue: database.dbQueue,
+                vaultId: vault.id,
+                projectId: selectedProject.id,
+                initialName: "Current occurrence",
+                calendarEvent: seriesEvent(startDate: currentStart, recurrenceId: "20260416T090000Z")
+            )
+            service.stop()
+
+            let meeting = try fetchMeeting(id: service.meetingId, from: database.dbQueue)
+            #expect(meeting.projectId == selectedProject.id)
+            #expect(service.projectId == selectedProject.id)
+        }
+
+        @Test
+        func materializedDraftInheritsProjectAndUpdatesViewModelContext() throws {
+            let (database, vault) = try makeDatabase()
+            let inheritedProject = project(named: "Planning", vaultId: vault.id)
+            let previousStart = Date(timeIntervalSince1970: 1_776_300_000)
+            let currentStart = Date(timeIntervalSince1970: 1_776_400_000)
+
+            try database.dbQueue.write { db in
+                try inheritedProject.insert(db)
+                try insertSeriesMeeting(
+                    event: seriesEvent(startDate: previousStart, recurrenceId: "20260415T090000Z"),
+                    projectId: inheritedProject.id,
+                    vaultId: vault.id,
+                    createdAt: previousStart,
+                    in: db
+                )
+            }
+
+            let previousVault = AppSettings.shared.currentVault
+            AppSettings.shared.currentVault = vault
+            defer { AppSettings.shared.currentVault = previousVault }
+
+            let viewModel = CaptionViewModel()
+            viewModel.beginDraftMeeting(
+                from: seriesEvent(startDate: currentStart, recurrenceId: "20260416T090000Z"),
+                dbQueue: database.dbQueue,
+                vaultURL: vault.url
+            )
+
+            let meetingId = try #require(viewModel.materializeDraftMeeting())
+            let meeting = try fetchMeeting(id: meetingId, from: database.dbQueue)
+
+            #expect(meeting.projectId == inheritedProject.id)
+            #expect(viewModel.currentProjectId == inheritedProject.id)
+            #expect(viewModel.currentProjectName == inheritedProject.name)
+            #expect(
+                viewModel.currentProjectURL
+                    == vault.url.appending(path: inheritedProject.name, directoryHint: .isDirectory)
+            )
+        }
+    }
+
+    private func makeDatabase() throws -> (database: AppDatabaseManager, vault: VaultRecord) {
+        let database = try AppDatabaseManager(path: ":memory:")
+        let vault = VaultRecord(
+            id: .v7(),
+            path: URL.temporaryDirectory.appending(path: UUID().uuidString, directoryHint: .isDirectory).path,
+            name: "Test Vault",
+            createdAt: .now,
+            lastOpenedAt: .now
+        )
+        try database.dbQueue.write { db in
+            try vault.insert(db)
+        }
+        return (database, vault)
+    }
+
+    private func project(named name: String, vaultId: UUID) -> ProjectRecord {
+        ProjectRecord(
+            id: .v7(),
+            vaultId: vaultId,
+            name: name,
+            createdAt: .now
+        )
+    }
+
+    private func insertSeriesMeeting(
+        event: CalendarEvent,
+        projectId: UUID,
+        vaultId: UUID,
+        createdAt: Date,
+        in db: Database
+    ) throws {
+        guard let key = event.key else { throw CocoaError(.coderInvalidValue) }
+        try CalendarEventRecord.upsert(event: event, now: createdAt, in: db)
+        try MeetingRecord(
+            id: .v7(),
+            vaultId: vaultId,
+            projectId: projectId,
+            name: event.title,
+            createdAt: createdAt,
+            updatedAt: createdAt,
+            calendarEventIcalUid: key.icalUid,
+            calendarEventRecurrenceId: key.recurrenceId
+        ).insert(db)
+    }
+
+    private func seriesEvent(startDate: Date, recurrenceId: String) -> CalendarEvent {
+        CalendarEvent(
+            id: "primary::series-\(recurrenceId)",
+            calendarID: "primary",
+            calendarName: "Primary",
+            calendarColorHex: "#4285F4",
+            platformId: "series-\(recurrenceId)",
+            title: "Weekly planning",
+            description: "",
+            icalUid: "weekly-planning@google.com",
+            recurrenceId: recurrenceId,
+            startDate: startDate,
+            endDate: startDate.addingTimeInterval(3600),
+            isAllDay: false,
+            conferenceURI: nil
+        )
+    }
+
+    private func fetchMeeting(id: UUID, from dbQueue: DatabaseQueue) throws -> MeetingRecord {
+        let record = try dbQueue.read { db in
+            try MeetingRecord.fetchOne(db, key: id)
+        }
+        guard let record else { throw CocoaError(.coderInvalidValue) }
+        return record
+    }
+#endif

--- a/Tests/DahliaTests/CaptionViewModelTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelTests.swift
@@ -265,7 +265,7 @@ import GRDB
                 startDate: Date(timeIntervalSince1970: 1_776_384_000),
                 endDate: Date(timeIntervalSince1970: 1_776_387_600),
                 isAllDay: false,
-                meetingURL: URL(string: "https://meet.google.com/test-link")
+                conferenceURI: URL(string: "https://meet.google.com/test-link")
             )
             let vaultId = UUID.v7()
             try database.dbQueue.write { db in
@@ -312,7 +312,7 @@ import GRDB
                 startDate: Date(timeIntervalSince1970: 1_776_384_000),
                 endDate: Date(timeIntervalSince1970: 1_776_387_600),
                 isAllDay: false,
-                meetingURL: nil
+                conferenceURI: nil
             )
 
             viewModel.beginDraftMeeting(
@@ -363,7 +363,7 @@ import GRDB
                     startDate: Date(timeIntervalSince1970: 1_776_384_000),
                     endDate: Date(timeIntervalSince1970: 1_776_387_600),
                     isAllDay: false,
-                    meetingURL: URL(string: "https://meet.google.com/test-link")
+                    conferenceURI: URL(string: "https://meet.google.com/test-link")
                 ),
                 dbQueue: database.dbQueue,
                 vaultURL: testVaultURL
@@ -372,16 +372,23 @@ import GRDB
             let meetingId = try #require(viewModel.materializeDraftMeeting())
             let persisted = try database.dbQueue.read { db in
                 let meeting = try MeetingRecord.fetchOne(db, key: meetingId)
-                let calendarEvent = try CalendarEventRecord.filter(Column("meetingId") == meetingId).fetchOne(db)
+                let calendarEvent = try linkedCalendarEvent(meetingId: meetingId, in: db)
+                let source = try CalendarEventSourceRecord
+                    .filter(Column("platform") == CalendarEventPlatform.googleCalendar)
+                    .filter(Column("platform_id") == "event-1")
+                    .fetchOne(db)
                 return try (
                     #require(meeting),
-                    #require(calendarEvent)
+                    #require(calendarEvent),
+                    #require(source)
                 )
             }
 
             #expect(persisted.0.name == "Design review")
-            #expect(persisted.1.platformId == "event-1")
-            #expect(persisted.1.meetingUrl == "https://meet.google.com/test-link")
+            #expect(persisted.0.calendarEventIcalUid == "event-1@google.com")
+            #expect(persisted.0.calendarEventRecurrenceId?.isEmpty == true)
+            #expect(persisted.1.conferenceURI == "https://meet.google.com/test-link")
+            #expect(persisted.2.platformId == "event-1")
             #expect(!viewModel.hasDraftMeeting)
             #expect(viewModel.currentMeetingId == meetingId)
         }
@@ -424,7 +431,7 @@ import GRDB
                     startDate: Date(timeIntervalSince1970: 1_776_384_000),
                     endDate: Date(timeIntervalSince1970: 1_776_387_600),
                     isAllDay: false,
-                    meetingURL: URL(string: "https://zoom.us/j/123456789")
+                    conferenceURI: URL(string: "https://zoom.us/j/123456789")
                 ),
                 dbQueue: database.dbQueue,
                 vaultURL: testVaultURL
@@ -432,13 +439,17 @@ import GRDB
 
             let meetingId = try #require(viewModel.materializeDraftMeeting())
             let persisted = try database.dbQueue.read { db in
-                let calendarEvent = try CalendarEventRecord.filter(Column("meetingId") == meetingId).fetchOne(db)
-                return try #require(calendarEvent)
+                let calendarEvent = try linkedCalendarEvent(meetingId: meetingId, in: db)
+                let source = try CalendarEventSourceRecord
+                    .filter(Column("platform") == CalendarEventPlatform.macOSCalendar)
+                    .filter(Column("platform_id") == "mac-event-1::1776384000")
+                    .fetchOne(db)
+                return try (#require(calendarEvent), #require(source))
             }
 
-            #expect(persisted.platform == "MacOSCalendar")
-            #expect(persisted.platformId == "mac-event-1::1776384000")
-            #expect(persisted.meetingUrl == "https://zoom.us/j/123456789")
+            #expect(persisted.0.icalUid == "mac-event-1@local")
+            #expect(persisted.0.conferenceURI == "https://zoom.us/j/123456789")
+            #expect(persisted.1.platform == CalendarEventPlatform.macOSCalendar)
         }
 
     }
@@ -524,7 +535,7 @@ import GRDB
                 startDate: Date(timeIntervalSince1970: 1_776_384_000),
                 endDate: Date(timeIntervalSince1970: 1_776_387_600),
                 isAllDay: false,
-                meetingURL: URL(string: "https://meet.google.com/test-link")
+                conferenceURI: URL(string: "https://meet.google.com/test-link")
             )
             let vaultId = UUID.v7()
             try database.dbQueue.write { db in
@@ -570,7 +581,7 @@ import GRDB
                 startDate: Date(timeIntervalSince1970: 1_776_384_000),
                 endDate: Date(timeIntervalSince1970: 1_776_387_600),
                 isAllDay: false,
-                meetingURL: nil
+                conferenceURI: nil
             )
 
             let dbQueue = try DatabaseQueue(path: ":memory:")
@@ -621,7 +632,7 @@ import GRDB
                     startDate: Date(timeIntervalSince1970: 1_776_384_000),
                     endDate: Date(timeIntervalSince1970: 1_776_387_600),
                     isAllDay: false,
-                    meetingURL: URL(string: "https://meet.google.com/test-link")
+                    conferenceURI: URL(string: "https://meet.google.com/test-link")
                 ),
                 dbQueue: database.dbQueue,
                 vaultURL: testVaultURL
@@ -631,15 +642,34 @@ import GRDB
             let persisted = try database.dbQueue.read { db in
                 try (
                     XCTUnwrap(MeetingRecord.fetchOne(db, key: meetingId)),
-                    XCTUnwrap(CalendarEventRecord.filter(Column("meetingId") == meetingId).fetchOne(db))
+                    XCTUnwrap(linkedCalendarEvent(meetingId: meetingId, in: db)),
+                    XCTUnwrap(
+                        CalendarEventSourceRecord
+                            .filter(Column("platform") == CalendarEventPlatform.googleCalendar)
+                            .filter(Column("platform_id") == "event-1")
+                            .fetchOne(db)
+                    )
                 )
             }
 
             XCTAssertEqual(persisted.0.name, "Design review")
-            XCTAssertEqual(persisted.1.platformId, "event-1")
-            XCTAssertEqual(persisted.1.meetingUrl, "https://meet.google.com/test-link")
+            XCTAssertEqual(persisted.0.calendarEventIcalUid, "event-1@google.com")
+            XCTAssertEqual(persisted.1.conferenceURI, "https://meet.google.com/test-link")
+            XCTAssertEqual(persisted.2.platformId, "event-1")
             XCTAssertFalse(viewModel.hasDraftMeeting)
             XCTAssertEqual(viewModel.currentMeetingId, meetingId)
         }
-    }
+}
 #endif
+
+private func linkedCalendarEvent(meetingId: UUID, in db: Database) throws -> CalendarEventRecord? {
+    guard let meeting = try MeetingRecord.fetchOne(db, key: meetingId),
+          let icalUid = meeting.calendarEventIcalUid,
+          let recurrenceId = meeting.calendarEventRecurrenceId
+    else { return nil }
+
+    return try CalendarEventRecord.fetch(
+        key: CalendarEventKey(icalUid: icalUid, recurrenceId: recurrenceId),
+        in: db
+    )
+}

--- a/Tests/DahliaTests/DetectedMeetingCodableTests.swift
+++ b/Tests/DahliaTests/DetectedMeetingCodableTests.swift
@@ -21,7 +21,8 @@ import Foundation
                 startDate: startDate,
                 endDate: startDate.addingTimeInterval(3600),
                 isAllDay: false,
-                meetingURL: URL(string: "https://meet.example.com/planning")
+                conferenceURI: URL(string: "https://meet.example.com/planning"),
+                url: URL(string: "https://calendar.example.com/events/planning")
             )
             let meeting = DetectedMeeting(
                 title: event.title,
@@ -36,6 +37,37 @@ import Foundation
             #expect(decoded.id == meeting.id)
             #expect(decoded.title == meeting.title)
             #expect(decoded.calendarEvent == event)
+        }
+
+        @Test
+        func decodesLegacyMeetingAndSourceEventURLs() throws {
+            let event = CalendarEvent(
+                id: "event-id",
+                calendarID: "calendar-id",
+                calendarName: "Work",
+                calendarColorHex: nil,
+                platformId: "platform-id",
+                title: "Planning",
+                description: "",
+                icalUid: "uid",
+                startDate: Date(timeIntervalSince1970: 1_700_000_000),
+                endDate: Date(timeIntervalSince1970: 1_700_003_600),
+                isAllDay: false,
+                conferenceURI: URL(string: "https://meet.example.com/planning"),
+                url: URL(string: "https://calendar.example.com/events/planning")
+            )
+            let encoded = try JSONEncoder().encode(event)
+            var legacyObject = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+            legacyObject["meetingURL"] = legacyObject.removeValue(forKey: "conferenceURI")
+            legacyObject["sourceEventURL"] = legacyObject.removeValue(forKey: "url")
+            legacyObject.removeValue(forKey: "recurrenceId")
+            let legacyData = try JSONSerialization.data(withJSONObject: legacyObject)
+
+            let decoded = try JSONDecoder().decode(CalendarEvent.self, from: legacyData)
+
+            #expect(decoded.conferenceURI == event.conferenceURI)
+            #expect(decoded.url == event.url)
+            #expect(decoded.recurrenceId.isEmpty)
         }
     }
 #endif

--- a/Tests/DahliaTests/GoogleCalendarAPIClientTests.swift
+++ b/Tests/DahliaTests/GoogleCalendarAPIClientTests.swift
@@ -74,9 +74,11 @@ struct GoogleCalendarAPIClientTests {
             summary: "Planning",
             description: "Quarterly planning",
             iCalUID: "planning@google.com",
+            htmlLink: "https://calendar.google.com/calendar/event?eid=planning",
             hangoutLink: "https://meet.google.com/test-room",
             start: .init(date: nil, dateTime: "2026-04-17T01:00:00Z"),
             end: .init(date: nil, dateTime: "2026-04-17T02:00:00Z"),
+            originalStartTime: .init(date: nil, dateTime: "2026-04-17T00:30:00Z"),
             conferenceData: nil,
             eventType: nil
         )
@@ -96,9 +98,40 @@ struct GoogleCalendarAPIClientTests {
         #expect(event.platformId == "google-event-id")
         #expect(event.description == "Quarterly planning")
         #expect(event.icalUid == "planning@google.com")
-        #expect(event.meetingURL?.absoluteString == "https://meet.google.com/test-room")
+        #expect(event.recurrenceId == "20260417T003000Z")
+        #expect(event.conferenceURI?.absoluteString == "https://meet.google.com/test-room")
+        #expect(event.url?.absoluteString == "https://calendar.google.com/calendar/event?eid=planning")
         #expect(event.startDate == Date(timeIntervalSince1970: 1_776_387_600))
         #expect(event.endDate == Date(timeIntervalSince1970: 1_776_391_200))
+    }
+
+    @Test
+    func eventPayloadDecodesOriginalStartTimeAndEventURL() throws {
+        let data = Data("""
+        {
+          "items": [
+            {
+              "id": "recurring-instance",
+              "iCalUID": "series@google.com",
+              "htmlLink": "https://calendar.google.com/calendar/event?eid=instance",
+              "start": { "dateTime": "2026-04-17T01:00:00Z" },
+              "end": { "dateTime": "2026-04-17T02:00:00Z" },
+              "originalStartTime": { "dateTime": "2026-04-17T00:30:00Z" }
+            }
+          ]
+        }
+        """.utf8)
+
+        let response = try JSONDecoder().decode(GoogleCalendarAPIClient.EventListResponse.self, from: data)
+        let item = try #require(response.items.first)
+        let transformed = try GoogleCalendarAPIClient.makeEvent(
+            from: item,
+            calendarItem: GoogleCalendarListItem(id: "primary", title: "Primary", colorHex: nil, isPrimary: true)
+        )
+        let event = try #require(transformed)
+
+        #expect(event.recurrenceId == "20260417T003000Z")
+        #expect(event.url?.absoluteString == "https://calendar.google.com/calendar/event?eid=instance")
     }
 }
 
@@ -171,9 +204,11 @@ final class GoogleCalendarAPIClientTests: XCTestCase {
             summary: "Planning",
             description: "Quarterly planning",
             iCalUID: "planning@google.com",
+            htmlLink: "https://calendar.google.com/calendar/event?eid=planning",
             hangoutLink: "https://meet.google.com/test-room",
             start: .init(date: nil, dateTime: "2026-04-17T01:00:00Z"),
             end: .init(date: nil, dateTime: "2026-04-17T02:00:00Z"),
+            originalStartTime: .init(date: nil, dateTime: "2026-04-17T00:30:00Z"),
             conferenceData: nil,
             eventType: nil
         )
@@ -194,7 +229,9 @@ final class GoogleCalendarAPIClientTests: XCTestCase {
         XCTAssertEqual(event.platformId, "google-event-id")
         XCTAssertEqual(event.description, "Quarterly planning")
         XCTAssertEqual(event.icalUid, "planning@google.com")
-        XCTAssertEqual(event.meetingURL?.absoluteString, "https://meet.google.com/test-room")
+        XCTAssertEqual(event.recurrenceId, "20260417T003000Z")
+        XCTAssertEqual(event.conferenceURI?.absoluteString, "https://meet.google.com/test-room")
+        XCTAssertEqual(event.url?.absoluteString, "https://calendar.google.com/calendar/event?eid=planning")
         XCTAssertEqual(event.startDate, Date(timeIntervalSince1970: 1_776_387_600))
         XCTAssertEqual(event.endDate, Date(timeIntervalSince1970: 1_776_391_200))
     }

--- a/Tests/DahliaTests/GoogleCalendarAPIClientTests.swift
+++ b/Tests/DahliaTests/GoogleCalendarAPIClientTests.swift
@@ -79,6 +79,7 @@ struct GoogleCalendarAPIClientTests {
             start: .init(date: nil, dateTime: "2026-04-17T01:00:00Z"),
             end: .init(date: nil, dateTime: "2026-04-17T02:00:00Z"),
             originalStartTime: .init(date: nil, dateTime: "2026-04-17T00:30:00Z"),
+            recurringEventId: "series-id",
             conferenceData: nil,
             eventType: nil
         )
@@ -132,6 +133,57 @@ struct GoogleCalendarAPIClientTests {
 
         #expect(event.recurrenceId == "20260417T003000Z")
         #expect(event.url?.absoluteString == "https://calendar.google.com/calendar/event?eid=instance")
+    }
+
+    @Test
+    func originalStartTimeUsesItsIANATimeZoneWhenOffsetIsOmitted() throws {
+        let data = Data("""
+        {
+          "items": [
+            {
+              "id": "recurring-instance",
+              "recurringEventId": "series-id",
+              "iCalUID": "series@google.com",
+              "start": { "dateTime": "2026-04-17T01:00:00-07:00" },
+              "end": { "dateTime": "2026-04-17T02:00:00-07:00" },
+              "originalStartTime": {
+                "dateTime": "2026-04-17T00:30:00",
+                "timeZone": "America/Los_Angeles"
+              }
+            }
+          ]
+        }
+        """.utf8)
+
+        let response = try JSONDecoder().decode(GoogleCalendarAPIClient.EventListResponse.self, from: data)
+        let item = try #require(response.items.first)
+        let transformed = try GoogleCalendarAPIClient.makeEvent(
+            from: item,
+            calendarItem: GoogleCalendarListItem(id: "primary", title: "Primary", colorHex: nil, isPrimary: true)
+        )
+
+        #expect(transformed?.recurrenceId == "20260417T073000Z")
+    }
+
+    @Test
+    func conferenceURIKeepsHTTPSHangoutAheadOfPhoneEntryPoint() {
+        let item = GoogleCalendarAPIClient.EventItem(
+            id: "google-event-id",
+            summary: "Planning",
+            description: nil,
+            iCalUID: "planning@google.com",
+            htmlLink: nil,
+            hangoutLink: "https://meet.google.com/test-room",
+            start: .init(date: nil, dateTime: "2026-04-17T01:00:00Z"),
+            end: .init(date: nil, dateTime: "2026-04-17T02:00:00Z"),
+            originalStartTime: nil,
+            conferenceData: .init(entryPoints: [
+                .init(uri: "tel:+1-555-0100", entryPointType: "phone"),
+            ]),
+            eventType: nil
+        )
+
+        #expect(GoogleCalendarAPIClient.conferenceURI(for: item)?.absoluteString == item.hangoutLink)
     }
 }
 
@@ -209,6 +261,7 @@ final class GoogleCalendarAPIClientTests: XCTestCase {
             start: .init(date: nil, dateTime: "2026-04-17T01:00:00Z"),
             end: .init(date: nil, dateTime: "2026-04-17T02:00:00Z"),
             originalStartTime: .init(date: nil, dateTime: "2026-04-17T00:30:00Z"),
+            recurringEventId: "series-id",
             conferenceData: nil,
             eventType: nil
         )

--- a/Tests/DahliaTests/GoogleCalendarStoreTests.swift
+++ b/Tests/DahliaTests/GoogleCalendarStoreTests.swift
@@ -197,10 +197,15 @@ struct GoogleCalendarStoreTests {
             summary: "Weekly sync",
             description: "Discuss launch plan",
             iCalUID: "event-1@google.com",
+            htmlLink: nil,
             hangoutLink: nil,
             start: .init(date: nil, dateTime: "2026-04-17T01:00:00Z"),
             end: .init(date: nil, dateTime: "2026-04-17T02:00:00Z"),
-            conferenceData: .init(entryPoints: [.init(uri: "https://meet.google.com/abc-defg-hij")]),
+            originalStartTime: nil,
+            conferenceData: .init(entryPoints: [
+                .init(uri: "tel:+81-3-1234-5678"),
+                .init(uri: "https://meet.google.com/abc-defg-hij"),
+            ]),
             eventType: nil
         )
         let transformedEvent = try GoogleCalendarAPIClient.makeEvent(
@@ -210,10 +215,11 @@ struct GoogleCalendarStoreTests {
         )
         let event = try #require(transformedEvent)
 
-        #expect(event.meetingURL?.absoluteString == "https://meet.google.com/abc-defg-hij")
+        #expect(event.conferenceURI?.absoluteString == "https://meet.google.com/abc-defg-hij")
         #expect(event.platformId == "event-1")
         #expect(event.description == "Discuss launch plan")
         #expect(event.icalUid == "event-1@google.com")
+        #expect(event.recurrenceId.isEmpty)
         #expect(!event.isAllDay)
 
         let intervalEnd = Calendar.current.date(byAdding: .day, value: 7, to: fixtureNow)!
@@ -232,7 +238,7 @@ struct GoogleCalendarStoreTests {
                     startDate: Calendar.current.date(byAdding: .day, value: 9, to: fixtureNow)!,
                     endDate: Calendar.current.date(byAdding: .day, value: 9, to: fixtureNow)!,
                     isAllDay: true,
-                    meetingURL: nil
+                    conferenceURI: nil
                 ),
             ],
             now: fixtureNow,
@@ -249,9 +255,11 @@ struct GoogleCalendarStoreTests {
             summary: nil,
             description: nil,
             iCalUID: nil,
+            htmlLink: nil,
             hangoutLink: nil,
             start: .init(date: "2026-04-18", dateTime: nil),
             end: .init(date: "2026-04-19", dateTime: nil),
+            originalStartTime: nil,
             conferenceData: nil,
             eventType: nil
         )
@@ -272,9 +280,11 @@ struct GoogleCalendarStoreTests {
             summary: "Out of office",
             description: nil,
             iCalUID: nil,
+            htmlLink: nil,
             hangoutLink: nil,
             start: .init(date: nil, dateTime: "2026-04-18T01:00:00Z"),
             end: .init(date: nil, dateTime: "2026-04-18T02:00:00Z"),
+            originalStartTime: nil,
             conferenceData: nil,
             eventType: "outOfOffice"
         )
@@ -397,7 +407,7 @@ private let fixtureEvent = GoogleCalendarEvent(
     startDate: fixtureNow.addingTimeInterval(3600),
     endDate: fixtureNow.addingTimeInterval(7200),
     isAllDay: false,
-    meetingURL: URL(string: "https://meet.google.com/test-link")
+    conferenceURI: URL(string: "https://meet.google.com/test-link")
 )
 
 @MainActor

--- a/Tests/DahliaTests/MacCalendarStoreTests.swift
+++ b/Tests/DahliaTests/MacCalendarStoreTests.swift
@@ -130,7 +130,7 @@ struct MacCalendarStoreTests {
             startDate: fixtureNow.addingTimeInterval(7200),
             endDate: fixtureNow.addingTimeInterval(9000),
             isAllDay: false,
-            meetingURL: nil
+            conferenceURI: nil
         )
         let outsideWindow = CalendarEvent(
             id: "work::outside",
@@ -145,7 +145,7 @@ struct MacCalendarStoreTests {
             startDate: fixtureNow.addingTimeInterval(9 * 24 * 60 * 60),
             endDate: fixtureNow.addingTimeInterval(9 * 24 * 60 * 60 + 3600),
             isAllDay: false,
-            meetingURL: nil
+            conferenceURI: nil
         )
 
         let filtered = EventKitMacCalendarEventStore.sortAndFilter(
@@ -158,9 +158,9 @@ struct MacCalendarStoreTests {
     }
 
     @Test
-    func meetingURLExtractorFindsKnownMeetingLinksInNotes() {
-        let url = CalendarMeetingURLExtractor.meetingURL(
-            url: URL(string: "https://example.com/not-a-meeting"),
+    func conferenceURIExtractorFindsKnownMeetingLinksAndPrefersHTTPS() {
+        let url = CalendarConferenceURIExtractor.conferenceURI(
+            url: URL(string: "http://zoom.us/j/123"),
             textFields: ["Join from https://teams.microsoft.com/l/meetup-join/abc."]
         )
 
@@ -197,7 +197,7 @@ private let fixtureEvent = CalendarEvent(
     startDate: fixtureNow.addingTimeInterval(3600),
     endDate: fixtureNow.addingTimeInterval(7200),
     isAllDay: false,
-    meetingURL: URL(string: "https://meet.google.com/test-link")
+    conferenceURI: URL(string: "https://meet.google.com/test-link")
 )
 
 @MainActor

--- a/Tests/DahliaTests/MacCalendarStoreTests.swift
+++ b/Tests/DahliaTests/MacCalendarStoreTests.swift
@@ -166,6 +166,20 @@ struct MacCalendarStoreTests {
 
         #expect(url?.absoluteString == "https://teams.microsoft.com/l/meetup-join/abc")
     }
+
+    @Test
+    func allDayRecurrenceIdUsesEventKitDefaultTimeZone() throws {
+        let defaultTimeZone = try #require(TimeZone(identifier: "Asia/Tokyo"))
+        let occurrenceDate = Date(timeIntervalSince1970: 1_776_387_600)
+
+        let recurrenceId = EventKitMacCalendarEventStore.recurrenceId(
+            occurrenceDate: occurrenceDate,
+            isAllDay: true,
+            defaultTimeZone: defaultTimeZone
+        )
+
+        #expect(recurrenceId == "20260417")
+    }
 }
 
 private let fixtureNow = Date(timeIntervalSince1970: 1_776_384_000)

--- a/Tests/DahliaTests/MeetingPersistenceServiceTests.swift
+++ b/Tests/DahliaTests/MeetingPersistenceServiceTests.swift
@@ -455,7 +455,7 @@ import GRDB
             #expect(linkedMeetingCount == 2)
 
             let repository = MeetingRepository(dbQueue: database.dbQueue)
-            #expect(try repository.fetchMeetingIdForCalendarEvent(event) == secondMeetingId)
+            #expect(try repository.fetchMeetingIdForCalendarEvent(event, vaultId: testVault.id) == secondMeetingId)
 
             #expect(throws: Error.self) {
                 try database.dbQueue.write { db in
@@ -500,7 +500,7 @@ import GRDB
             }
 
             let repository = MeetingRepository(dbQueue: database.dbQueue)
-            let resolvedMeetingId = try repository.fetchMeetingIdForCalendarEvent(event)
+            let resolvedMeetingId = try repository.fetchMeetingIdForCalendarEvent(event, vaultId: testVault.id)
 
             #expect(resolvedMeetingId == meetingId)
         }
@@ -729,7 +729,10 @@ import GRDB
             }
 
             let repository = MeetingRepository(dbQueue: database.dbQueue)
-            XCTAssertEqual(try repository.fetchMeetingIdForCalendarEvent(event), secondMeetingId)
+            XCTAssertEqual(
+                try repository.fetchMeetingIdForCalendarEvent(event, vaultId: testVault.id),
+                secondMeetingId
+            )
             try repository.deleteMeeting(id: firstMeetingId)
 
             let calendarEventCount = try database.dbQueue.read { db in
@@ -763,7 +766,7 @@ import GRDB
             }
 
             let repository = MeetingRepository(dbQueue: database.dbQueue)
-            let resolvedMeetingId = try repository.fetchMeetingIdForCalendarEvent(event)
+            let resolvedMeetingId = try repository.fetchMeetingIdForCalendarEvent(event, vaultId: testVault.id)
 
             XCTAssertEqual(resolvedMeetingId, meetingId)
         }

--- a/Tests/DahliaTests/MeetingPersistenceServiceTests.swift
+++ b/Tests/DahliaTests/MeetingPersistenceServiceTests.swift
@@ -271,21 +271,28 @@ import GRDB
 
             let persisted = try database.dbQueue.read { db in
                 let meeting = try MeetingRecord.fetchOne(db, key: service.meetingId)
-                let calendarEvent = try CalendarEventRecord.filter(Column("meetingId") == service.meetingId).fetchOne(db)
+                let calendarEvent = try linkedCalendarEvent(meetingId: service.meetingId, in: db)
+                let source = try CalendarEventSourceRecord
+                    .filter(Column("platform") == CalendarEventPlatform.googleCalendar)
+                    .filter(Column("platform_id") == "event-1")
+                    .fetchOne(db)
                 return try (
                     #require(meeting),
-                    #require(calendarEvent)
+                    #require(calendarEvent),
+                    #require(source)
                 )
             }
 
             #expect(persisted.0.name == "Design review")
-            #expect(persisted.1.platform == "GoogleCalendar")
-            #expect(persisted.1.platformId == "event-1")
+            #expect(persisted.0.calendarEventIcalUid == "event-1@google.com")
+            #expect(persisted.0.calendarEventRecurrenceId?.isEmpty == true)
             #expect(persisted.1.description == "Review launch checklist")
             #expect(persisted.1.icalUid == "event-1@google.com")
             #expect(persisted.1.start == startDate)
             #expect(persisted.1.end == startDate.addingTimeInterval(3600))
-            #expect(persisted.1.meetingUrl == "https://meet.google.com/test-link")
+            #expect(persisted.1.conferenceURI == "https://meet.google.com/test-link")
+            #expect(persisted.1.url == "https://calendar.google.com/calendar/event?eid=event-1")
+            #expect(persisted.2.platformId == "event-1")
         }
 
         @Test
@@ -306,14 +313,61 @@ import GRDB
             service.stop()
 
             let persisted = try database.dbQueue.read { db in
-                let calendarEvent = try CalendarEventRecord.filter(Column("meetingId") == service.meetingId).fetchOne(db)
-                return try #require(calendarEvent)
+                let calendarEvent = try linkedCalendarEvent(meetingId: service.meetingId, in: db)
+                let source = try CalendarEventSourceRecord
+                    .filter(Column("platform") == CalendarEventPlatform.macOSCalendar)
+                    .filter(Column("platform_id") == "mac-event-1::1776384000")
+                    .fetchOne(db)
+                return try (#require(calendarEvent), #require(source))
             }
 
-            #expect(persisted.platform == "MacOSCalendar")
-            #expect(persisted.platformId == "mac-event-1::1776384000")
-            #expect(persisted.description == "Local calendar notes")
-            #expect(persisted.icalUid == "mac-event-1@local")
+            #expect(persisted.0.description == "Local calendar notes")
+            #expect(persisted.0.icalUid == "mac-event-1@local")
+            #expect(persisted.1.platform == CalendarEventPlatform.macOSCalendar)
+            #expect(persisted.1.platformId == "mac-event-1::1776384000")
+        }
+
+        @Test
+        func eventWithoutUIDCreatesMeetingWithoutSyntheticCalendarLink() throws {
+            let database = try makeDatabase()
+            let startDate = Date(timeIntervalSince1970: 1_776_384_000)
+            let event = CalendarEvent(
+                id: "local::missing-uid",
+                calendarID: "local",
+                calendarName: "Local",
+                calendarColorHex: nil,
+                platform: CalendarEventPlatform.macOSCalendar,
+                platformId: "missing-uid",
+                title: "Local event",
+                description: "",
+                icalUid: nil,
+                startDate: startDate,
+                endDate: startDate.addingTimeInterval(3600),
+                isAllDay: false,
+                conferenceURI: nil
+            )
+
+            let service = try MeetingPersistenceService(
+                store: TranscriptStore(),
+                dbQueue: database.dbQueue,
+                vaultId: testVault.id,
+                projectId: nil,
+                initialName: event.title,
+                calendarEvent: event
+            )
+            service.stop()
+
+            let result = try database.dbQueue.read { db in
+                let meeting = try MeetingRecord.fetchOne(db, key: service.meetingId)
+                return try (
+                    #require(meeting),
+                    CalendarEventRecord.fetchCount(db)
+                )
+            }
+
+            #expect(result.0.calendarEventIcalUid == nil)
+            #expect(result.0.calendarEventRecurrenceId == nil)
+            #expect(result.1 == 0)
         }
 
         @Test
@@ -321,8 +375,11 @@ import GRDB
             let database = try makeDatabase()
             let meetingId = UUID.v7()
             let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
+            let event = fixtureEvent(startDate: createdAt)
+            let key = try #require(event.key)
 
             try database.dbQueue.write { db in
+                try CalendarEventRecord.upsert(event: event, now: createdAt, in: db)
                 try MeetingRecord(
                     id: meetingId,
                     vaultId: testVault.id,
@@ -331,19 +388,9 @@ import GRDB
                     status: .ready,
                     duration: 120,
                     createdAt: createdAt,
-                    updatedAt: createdAt
-                ).insert(db)
-                try CalendarEventRecord(
-                    meetingId: meetingId,
-                    createdAt: createdAt,
                     updatedAt: createdAt,
-                    platform: "GoogleCalendar",
-                    platformId: "event-1",
-                    description: "Review launch checklist",
-                    icalUid: "event-1@google.com",
-                    start: createdAt,
-                    end: createdAt.addingTimeInterval(3600),
-                    meetingUrl: "https://meet.google.com/test-link"
+                    calendarEventIcalUid: key.icalUid,
+                    calendarEventRecurrenceId: key.recurrenceId
                 ).insert(db)
             }
 
@@ -363,13 +410,16 @@ import GRDB
         }
 
         @Test
-        func calendarEventConstraintsEnforceUniquenessAndCascadeDelete() throws {
+        func sameCalendarEventCanLinkMultipleMeetingsAndSurvivesMeetingDeletion() throws {
             let database = try makeDatabase()
             let firstMeetingId = UUID.v7()
             let secondMeetingId = UUID.v7()
             let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
+            let event = fixtureEvent(startDate: createdAt)
+            let key = try #require(event.key)
 
             try database.dbQueue.write { db in
+                try CalendarEventRecord.upsert(event: event, now: createdAt, in: db)
                 try MeetingRecord(
                     id: firstMeetingId,
                     vaultId: testVault.id,
@@ -378,7 +428,9 @@ import GRDB
                     status: .ready,
                     duration: nil,
                     createdAt: createdAt,
-                    updatedAt: createdAt
+                    updatedAt: createdAt,
+                    calendarEventIcalUid: key.icalUid,
+                    calendarEventRecurrenceId: key.recurrenceId
                 ).insert(db)
                 try MeetingRecord(
                     id: secondMeetingId,
@@ -387,48 +439,40 @@ import GRDB
                     name: "Second",
                     status: .ready,
                     duration: nil,
-                    createdAt: createdAt,
-                    updatedAt: createdAt
-                ).insert(db)
-                try CalendarEventRecord(
-                    meetingId: firstMeetingId,
-                    createdAt: createdAt,
-                    updatedAt: createdAt,
-                    platform: "GoogleCalendar",
-                    platformId: "event-1",
-                    description: "",
-                    icalUid: nil,
-                    start: createdAt,
-                    end: createdAt.addingTimeInterval(3600),
-                    meetingUrl: nil
+                    createdAt: createdAt.addingTimeInterval(1),
+                    updatedAt: createdAt.addingTimeInterval(1),
+                    calendarEventIcalUid: key.icalUid,
+                    calendarEventRecurrenceId: key.recurrenceId
                 ).insert(db)
             }
+
+            let linkedMeetingCount = try database.dbQueue.read { db in
+                try MeetingRecord
+                    .filter(Column("calendar_event_ical_uid") == key.icalUid)
+                    .filter(Column("calendar_event_recurrence_id") == key.recurrenceId)
+                    .fetchCount(db)
+            }
+            #expect(linkedMeetingCount == 2)
+
+            let repository = MeetingRepository(dbQueue: database.dbQueue)
+            #expect(try repository.fetchMeetingIdForCalendarEvent(event) == secondMeetingId)
 
             #expect(throws: Error.self) {
                 try database.dbQueue.write { db in
-                    try CalendarEventRecord(
-                        meetingId: secondMeetingId,
-                        createdAt: createdAt,
-                        updatedAt: createdAt,
-                        platform: "GoogleCalendar",
-                        platformId: "event-1",
-                        description: "",
-                        icalUid: nil,
-                        start: createdAt,
-                        end: createdAt.addingTimeInterval(3600),
-                        meetingUrl: nil
-                    ).insert(db)
+                    _ = try CalendarEventRecord
+                        .filter(Column("ical_uid") == key.icalUid)
+                        .filter(Column("recurrence_id") == key.recurrenceId)
+                        .deleteAll(db)
                 }
             }
 
-            let repository = MeetingRepository(dbQueue: database.dbQueue)
             try repository.deleteMeeting(id: firstMeetingId)
 
             let calendarEventCount = try database.dbQueue.read { db in
                 try CalendarEventRecord.fetchCount(db)
             }
 
-            #expect(calendarEventCount == 0)
+            #expect(calendarEventCount == 1)
         }
 
         @Test
@@ -436,8 +480,11 @@ import GRDB
             let database = try makeDatabase()
             let meetingId = UUID.v7()
             let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
+            let event = fixtureEvent(startDate: createdAt)
+            let key = try #require(event.key)
 
             try database.dbQueue.write { db in
+                try CalendarEventRecord.upsert(event: event, now: createdAt, in: db)
                 try MeetingRecord(
                     id: meetingId,
                     vaultId: testVault.id,
@@ -446,27 +493,14 @@ import GRDB
                     status: .ready,
                     duration: nil,
                     createdAt: createdAt,
-                    updatedAt: createdAt
-                ).insert(db)
-                try CalendarEventRecord(
-                    meetingId: meetingId,
-                    createdAt: createdAt,
                     updatedAt: createdAt,
-                    platform: "GoogleCalendar",
-                    platformId: "event-1",
-                    description: "",
-                    icalUid: nil,
-                    start: createdAt,
-                    end: createdAt.addingTimeInterval(3600),
-                    meetingUrl: nil
+                    calendarEventIcalUid: key.icalUid,
+                    calendarEventRecurrenceId: key.recurrenceId
                 ).insert(db)
             }
 
             let repository = MeetingRepository(dbQueue: database.dbQueue)
-            let resolvedMeetingId = try repository.fetchMeetingIdForCalendarEvent(
-                platform: "GoogleCalendar",
-                platformId: "event-1"
-            )
+            let resolvedMeetingId = try repository.fetchMeetingIdForCalendarEvent(event)
 
             #expect(resolvedMeetingId == meetingId)
         }
@@ -600,26 +634,35 @@ import GRDB
             let persisted = try database.dbQueue.read { db in
                 try (
                     XCTUnwrap(MeetingRecord.fetchOne(db, key: service.meetingId)),
-                    XCTUnwrap(CalendarEventRecord.filter(Column("meetingId") == service.meetingId).fetchOne(db))
+                    XCTUnwrap(linkedCalendarEvent(meetingId: service.meetingId, in: db)),
+                    XCTUnwrap(
+                        CalendarEventSourceRecord
+                            .filter(Column("platform") == CalendarEventPlatform.googleCalendar)
+                            .filter(Column("platform_id") == "event-1")
+                            .fetchOne(db)
+                    )
                 )
             }
 
             XCTAssertEqual(persisted.0.name, "Design review")
-            XCTAssertEqual(persisted.1.platform, "GoogleCalendar")
-            XCTAssertEqual(persisted.1.platformId, "event-1")
+            XCTAssertEqual(persisted.0.calendarEventIcalUid, "event-1@google.com")
             XCTAssertEqual(persisted.1.description, "Review launch checklist")
             XCTAssertEqual(persisted.1.icalUid, "event-1@google.com")
             XCTAssertEqual(persisted.1.start, startDate)
             XCTAssertEqual(persisted.1.end, startDate.addingTimeInterval(3600))
-            XCTAssertEqual(persisted.1.meetingUrl, "https://meet.google.com/test-link")
+            XCTAssertEqual(persisted.1.conferenceURI, "https://meet.google.com/test-link")
+            XCTAssertEqual(persisted.2.platformId, "event-1")
         }
 
         func testAppendModeDoesNotCreateAdditionalCalendarEvent() throws {
             let database = try makeDatabase()
             let meetingId = UUID.v7()
             let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
+            let event = fixtureEvent(startDate: createdAt)
+            let key = try XCTUnwrap(event.key)
 
             try database.dbQueue.write { db in
+                try CalendarEventRecord.upsert(event: event, now: createdAt, in: db)
                 try MeetingRecord(
                     id: meetingId,
                     vaultId: testVault.id,
@@ -628,19 +671,9 @@ import GRDB
                     status: .ready,
                     duration: 120,
                     createdAt: createdAt,
-                    updatedAt: createdAt
-                ).insert(db)
-                try CalendarEventRecord(
-                    meetingId: meetingId,
-                    createdAt: createdAt,
                     updatedAt: createdAt,
-                    platform: "GoogleCalendar",
-                    platformId: "event-1",
-                    description: "Review launch checklist",
-                    icalUid: "event-1@google.com",
-                    start: createdAt,
-                    end: createdAt.addingTimeInterval(3600),
-                    meetingUrl: "https://meet.google.com/test-link"
+                    calendarEventIcalUid: key.icalUid,
+                    calendarEventRecurrenceId: key.recurrenceId
                 ).insert(db)
             }
 
@@ -659,13 +692,16 @@ import GRDB
             XCTAssertEqual(calendarEventCount, 1)
         }
 
-        func testCalendarEventConstraintsEnforceUniquenessAndCascadeDelete() throws {
+        func testSameCalendarEventCanLinkMultipleMeetingsAndSurvivesMeetingDeletion() throws {
             let database = try makeDatabase()
             let firstMeetingId = UUID.v7()
             let secondMeetingId = UUID.v7()
             let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
+            let event = fixtureEvent(startDate: createdAt)
+            let key = try XCTUnwrap(event.key)
 
             try database.dbQueue.write { db in
+                try CalendarEventRecord.upsert(event: event, now: createdAt, in: db)
                 try MeetingRecord(
                     id: firstMeetingId,
                     vaultId: testVault.id,
@@ -674,7 +710,9 @@ import GRDB
                     status: .ready,
                     duration: nil,
                     createdAt: createdAt,
-                    updatedAt: createdAt
+                    updatedAt: createdAt,
+                    calendarEventIcalUid: key.icalUid,
+                    calendarEventRecurrenceId: key.recurrenceId
                 ).insert(db)
                 try MeetingRecord(
                     id: secondMeetingId,
@@ -683,56 +721,33 @@ import GRDB
                     name: "Second",
                     status: .ready,
                     duration: nil,
-                    createdAt: createdAt,
-                    updatedAt: createdAt
-                ).insert(db)
-                try CalendarEventRecord(
-                    meetingId: firstMeetingId,
-                    createdAt: createdAt,
-                    updatedAt: createdAt,
-                    platform: "GoogleCalendar",
-                    platformId: "event-1",
-                    description: "",
-                    icalUid: nil,
-                    start: createdAt,
-                    end: createdAt.addingTimeInterval(3600),
-                    meetingUrl: nil
+                    createdAt: createdAt.addingTimeInterval(1),
+                    updatedAt: createdAt.addingTimeInterval(1),
+                    calendarEventIcalUid: key.icalUid,
+                    calendarEventRecurrenceId: key.recurrenceId
                 ).insert(db)
             }
 
-            XCTAssertThrowsError(
-                try database.dbQueue.write { db in
-                    try CalendarEventRecord(
-                        meetingId: secondMeetingId,
-                        createdAt: createdAt,
-                        updatedAt: createdAt,
-                        platform: "GoogleCalendar",
-                        platformId: "event-1",
-                        description: "",
-                        icalUid: nil,
-                        start: createdAt,
-                        end: createdAt.addingTimeInterval(3600),
-                        meetingUrl: nil
-                    ).insert(db)
-                }
-            )
-
             let repository = MeetingRepository(dbQueue: database.dbQueue)
+            XCTAssertEqual(try repository.fetchMeetingIdForCalendarEvent(event), secondMeetingId)
             try repository.deleteMeeting(id: firstMeetingId)
 
             let calendarEventCount = try database.dbQueue.read { db in
                 try CalendarEventRecord.fetchCount(db)
             }
 
-            XCTAssertEqual(calendarEventCount, 0)
+            XCTAssertEqual(calendarEventCount, 1)
         }
 
         func testFetchMeetingIdForCalendarEventReturnsPersistedMeeting() throws {
             let database = try makeDatabase()
             let meetingId = UUID.v7()
             let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
+            let event = fixtureEvent(startDate: createdAt)
+            let key = try XCTUnwrap(event.key)
 
             try database.dbQueue.write { db in
+                try CalendarEventRecord.upsert(event: event, now: createdAt, in: db)
                 try MeetingRecord(
                     id: meetingId,
                     vaultId: testVault.id,
@@ -741,27 +756,14 @@ import GRDB
                     status: .ready,
                     duration: nil,
                     createdAt: createdAt,
-                    updatedAt: createdAt
-                ).insert(db)
-                try CalendarEventRecord(
-                    meetingId: meetingId,
-                    createdAt: createdAt,
                     updatedAt: createdAt,
-                    platform: "GoogleCalendar",
-                    platformId: "event-1",
-                    description: "",
-                    icalUid: nil,
-                    start: createdAt,
-                    end: createdAt.addingTimeInterval(3600),
-                    meetingUrl: nil
+                    calendarEventIcalUid: key.icalUid,
+                    calendarEventRecurrenceId: key.recurrenceId
                 ).insert(db)
             }
 
             let repository = MeetingRepository(dbQueue: database.dbQueue)
-            let resolvedMeetingId = try repository.fetchMeetingIdForCalendarEvent(
-                platform: "GoogleCalendar",
-                platformId: "event-1"
-            )
+            let resolvedMeetingId = try repository.fetchMeetingIdForCalendarEvent(event)
 
             XCTAssertEqual(resolvedMeetingId, meetingId)
         }
@@ -925,6 +927,18 @@ private func fetchAppendPersistence(
     }
 }
 
+private func linkedCalendarEvent(meetingId: UUID, in db: Database) throws -> CalendarEventRecord? {
+    guard let meeting = try MeetingRecord.fetchOne(db, key: meetingId),
+          let icalUid = meeting.calendarEventIcalUid,
+          let recurrenceId = meeting.calendarEventRecurrenceId
+    else { return nil }
+
+    return try CalendarEventRecord.fetch(
+        key: CalendarEventKey(icalUid: icalUid, recurrenceId: recurrenceId),
+        in: db
+    )
+}
+
 private func fixtureEvent(startDate: Date) -> GoogleCalendarEvent {
     GoogleCalendarEvent(
         id: "primary::event-1",
@@ -938,7 +952,8 @@ private func fixtureEvent(startDate: Date) -> GoogleCalendarEvent {
         startDate: startDate,
         endDate: startDate.addingTimeInterval(3600),
         isAllDay: false,
-        meetingURL: URL(string: "https://meet.google.com/test-link")
+        conferenceURI: URL(string: "https://meet.google.com/test-link"),
+        url: URL(string: "https://calendar.google.com/calendar/event?eid=event-1")
     )
 }
 
@@ -956,6 +971,6 @@ private func fixtureMacCalendarEvent(startDate: Date) -> CalendarEvent {
         startDate: startDate,
         endDate: startDate.addingTimeInterval(3600),
         isAllDay: false,
-        meetingURL: URL(string: "https://zoom.us/j/123456789")
+        conferenceURI: URL(string: "https://zoom.us/j/123456789")
     )
 }

--- a/Tests/DahliaTests/MeetingPersistenceServiceTests.swift
+++ b/Tests/DahliaTests/MeetingPersistenceServiceTests.swift
@@ -455,7 +455,7 @@ import GRDB
             #expect(linkedMeetingCount == 2)
 
             let repository = MeetingRepository(dbQueue: database.dbQueue)
-            #expect(try repository.fetchMeetingIdForCalendarEvent(event, vaultId: testVault.id) == secondMeetingId)
+            #expect(try repository.resolveMeetingIdForCalendarEvent(event, vaultId: testVault.id) == secondMeetingId)
 
             #expect(throws: Error.self) {
                 try database.dbQueue.write { db in
@@ -476,7 +476,7 @@ import GRDB
         }
 
         @Test
-        func fetchMeetingIdForCalendarEventReturnsPersistedMeeting() throws {
+        func resolveMeetingIdForCalendarEventReturnsPersistedMeeting() throws {
             let database = try makeDatabase()
             let meetingId = UUID.v7()
             let createdAt = Date(timeIntervalSince1970: 1_776_384_000)
@@ -500,7 +500,7 @@ import GRDB
             }
 
             let repository = MeetingRepository(dbQueue: database.dbQueue)
-            let resolvedMeetingId = try repository.fetchMeetingIdForCalendarEvent(event, vaultId: testVault.id)
+            let resolvedMeetingId = try repository.resolveMeetingIdForCalendarEvent(event, vaultId: testVault.id)
 
             #expect(resolvedMeetingId == meetingId)
         }
@@ -730,7 +730,7 @@ import GRDB
 
             let repository = MeetingRepository(dbQueue: database.dbQueue)
             XCTAssertEqual(
-                try repository.fetchMeetingIdForCalendarEvent(event, vaultId: testVault.id),
+                try repository.resolveMeetingIdForCalendarEvent(event, vaultId: testVault.id),
                 secondMeetingId
             )
             try repository.deleteMeeting(id: firstMeetingId)
@@ -766,7 +766,7 @@ import GRDB
             }
 
             let repository = MeetingRepository(dbQueue: database.dbQueue)
-            let resolvedMeetingId = try repository.fetchMeetingIdForCalendarEvent(event, vaultId: testVault.id)
+            let resolvedMeetingId = try repository.resolveMeetingIdForCalendarEvent(event, vaultId: testVault.id)
 
             XCTAssertEqual(resolvedMeetingId, meetingId)
         }

--- a/docs/calendar-event-schema.md
+++ b/docs/calendar-event-schema.md
@@ -1,0 +1,71 @@
+# Calendar event persistence schema
+
+この文書は、カレンダー予定とMeetingをSQLiteおよび将来のDatabricks連携で同一に解釈するための永続化契約を定義する。
+
+## 論理キー
+
+`calendar_events` の主キーは `(ical_uid, recurrence_id)` である。
+
+- `ical_uid`: iCalendar `UID`。前後の空白を除去し、空値は保存しない。
+- `recurrence_id`: iCalendar `RECURRENCE-ID` の値をRFC 5545のbasic形式へ正規化した文字列。
+  - 単発予定: `""`（Dahliaの規約。VEVENTにRECURRENCE-IDが存在しないことを表す）
+  - DATE: `20260417`
+  - UTC DATE-TIME: `20260417T003000Z`
+
+DATEの値に`VALUE=DATE:`を付けない。`VALUE=DATE`はcontent lineのパラメータであり、`RECURRENCE-ID;VALUE=DATE:20260417`の値部分は`20260417`である。
+
+繰り返し予定では、変更後の開始時刻ではなく元のoccurrenceを示す値を使う。Google Calendar APIの`originalStartTime`とEventKitの`occurrenceDate`をこの形式へ正規化する。
+
+## テーブルとカーディナリティ
+
+```text
+calendar_events (ical_uid, recurrence_id)
+    1 ─── 0..N calendar_event_sources
+    1 ─── 0..N meetings
+
+meetings
+    1 ─── 0..N recording_sessions
+    1 ─── 0..1 summaries
+```
+
+同じ予定に複数のMeetingを関連付けられる。各ユーザー・Vault・録音成果はMeetingとして分離し、文字起こし、録音セッション、サマリーもMeeting配下に保持する。
+
+`meetings.calendar_event_ical_uid`と`meetings.calendar_event_recurrence_id`は、両方NULLまたは両方非NULLでなければならない。非NULLの場合は対応するcanonical eventが必要である。
+
+## `calendar_events`
+
+予定のcanonical情報を保持する。
+
+| Column | Meaning |
+|---|---|
+| `ical_uid`, `recurrence_id` | 論理主キー |
+| `title`, `description` | 予定の表示情報 |
+| `start`, `end`, `is_all_day` | 現在観測している開催時刻 |
+| `conference_uri` | Meet、Zoom、Teams、電話、SIPなどの参加先URI |
+| `url` | Google Calendar Web UIなど、予定自体を参照するURL |
+| `created_at`, `updated_at` | Dahliaでの初回・最終観測時刻 |
+
+別ソースから同じキーを観測した場合、開催時刻などの基本情報は最新の観測で更新する。一方、空description、NULLの`conference_uri`、NULLの`url`は、他ソースで取得済みの有効値を消去しない。
+
+## `calendar_event_sources`
+
+provider固有の識別子をcanonical eventへ対応付ける。
+
+主キーは `(platform, calendar_id, platform_id)`。`ical_uid`と`recurrence_id`は`calendar_events`を参照し、canonical eventの削除・キー更新に追従する。
+
+`platform_id`だけではカレンダー間で一意とは限らないため、`calendar_id`を必ず含める。source行は、該当ソースから予定を観測して既存Meetingを解決した場合にもupsertする。
+
+## ライフサイクル
+
+- 新規Meeting作成時にcanonical eventとsourceをupsertしてからMeetingを関連付ける。
+- 既存Meetingの解決時にも、最新のcanonical情報とsource mappingをupsertする。
+- 最後の参照Meetingが削除された時点でcanonical eventを削除する。
+- `calendar_event_sources`は外部キーのcascadeで削除する。
+- 同じeventを参照するMeetingが残っている間はcanonical eventを削除しない。
+
+## Databricks連携時の注意
+
+- `calendar_events`は`ical_uid`単独ではなく、必ず`(ical_uid, recurrence_id)`でmergeする。
+- `meetings.id`はUUIDv7であり、同一eventに複数値を許容する。
+- source単位の重複排除には`(platform, calendar_id, platform_id)`を使う。
+- `description`、`conference_uri`、`url`には機微情報が含まれ得るため、アクセス制御と削除伝播をMeetingデータと同じ水準で扱う。


### PR DESCRIPTION
## Summary

- model calendar events with the RFC 5545 `UID` + `RECURRENCE-ID` composite identity
- separate provider-specific calendar source identifiers from canonical event data
- persist descriptions, conference URIs, provider event URLs, and Google Calendar `htmlLink` values
- allow multiple meetings to reference the same calendar event occurrence
- normalize Google Calendar and EventKit recurrence identifiers for cross-source deduplication
- automatically assign a new meeting to the most recent project used by an earlier occurrence in the same iCalendar series

## Why

The previous calendar persistence model was tied to provider event IDs and a one-to-one meeting relationship. That made the same event appear different across Google Calendar and macOS Calendar, did not model recurring occurrences with the iCalendar standard identity, and could not support multiple transcripts for one occurrence. New meetings also lost the project context established by earlier occurrences in the same series.

## Impact

Calendar events now use canonical iCalendar identity while retaining provider source mappings. Existing calendar cache rows are replaced during the v15 migration as permitted, while meeting and other user-authored data are preserved. The v16 migration moves provider event URLs into `calendar_events.url`. When no project is explicitly selected, a new meeting inherits the project from the latest project-assigned occurrence with the same iCal UID in the current vault; explicit project selection still wins.

## Validation

- `swift build`
- `swift test` — 292 tests passed (289 Swift Testing + 3 XCTest)
- `CI=true ./scripts/lint.sh` — SwiftFormat clean; pre-existing repository-wide SwiftLint violations remain non-blocking
- `git diff --check`
