### PR TITLE
Configure Google Drive export folder

### DIFF
--- a/Sources/Dahlia/DahliaApp.swift
+++ b/Sources/Dahlia/DahliaApp.swift
@@ -65,12 +65,14 @@ struct DahliaApp: App {
                 _ = liveSubtitleOverlayCoordinator
                 initializeAppIfNeeded()
                 let settings = AppSettings.shared
+                async let driveRestore: Void = GoogleDriveStore.shared.restoreSessionIfNeeded()
                 if settings.isCalendarSourceEnabled(.google) {
                     await GoogleCalendarStore.shared.restoreSessionIfNeeded()
                 }
                 if settings.isCalendarSourceEnabled(.macOS) {
                     await MacCalendarStore.shared.refreshIfNeeded()
                 }
+                await driveRestore
             }
         }
         .windowResizability(.contentMinSize)

--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -127,6 +127,17 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
         return googleDriveExportFolderID.nilIfBlank
     }
 
+    func googleDriveExportFolderURL(forAccountID accountID: String) -> URL? {
+        guard let folderID = googleDriveExportFolderID(forAccountID: accountID) else { return nil }
+        return Self.googleDriveExportFolderURL(folderID: folderID)
+    }
+
+    nonisolated static func googleDriveExportFolderURL(folderID: String) -> URL? {
+        guard !folderID.isEmpty,
+              let baseURL = URL(string: "https://drive.google.com/drive/folders") else { return nil }
+        return baseURL.appending(path: folderID)
+    }
+
     func setGoogleDriveExportFolder(
         name: String,
         id: String,

--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -76,7 +76,7 @@ enum LLMProvider: String, CaseIterable, Identifiable {
 
 /// アプリ設定の一元管理。@AppStorage で UserDefaults に永続化。
 @MainActor
-final class AppSettings: ObservableObject {
+final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProviding {
     static let shared = AppSettings()
     nonisolated static let automaticScreenshotIntervalOptions = [
         5,
@@ -93,6 +93,7 @@ final class AppSettings: ObservableObject {
     ]
     nonisolated static let automaticScreenshotIntervalSecondsUserDefaultsKey = "automaticScreenshotIntervalSeconds"
     nonisolated static let automaticScreenshotChangeThresholdPercentUserDefaultsKey = "automaticScreenshotChangeThresholdPercent"
+    nonisolated static let defaultGoogleDriveExportFolderName = "Meeting Notes"
     fileprivate nonisolated static let defaultAutomaticScreenshotIntervalSeconds = 30
     fileprivate nonisolated static let defaultAutomaticScreenshotChangeThresholdPercent = 20
     nonisolated static let defaultLLMMaxTokens = 16000
@@ -104,6 +105,41 @@ final class AppSettings: ObservableObject {
     var appLanguage: AppLanguage {
         get { AppLanguage(rawValue: appLanguageRawValue) ?? .system }
         set { appLanguageRawValue = newValue.rawValue }
+    }
+
+    // MARK: - Google Drive
+
+    @AppStorage("googleDriveExportFolderName") var googleDriveExportFolderName = AppSettings.defaultGoogleDriveExportFolderName
+    @AppStorage("googleDriveExportFolderID") private var googleDriveExportFolderID = ""
+    @AppStorage("googleDriveExportFolderAccountID") private var googleDriveExportFolderAccountID = ""
+
+    var resolvedGoogleDriveExportFolderName: String {
+        Self.resolvedGoogleDriveExportFolderName(googleDriveExportFolderName)
+    }
+
+    nonisolated static func resolvedGoogleDriveExportFolderName(_ folderName: String) -> String {
+        folderName.trimmingCharacters(in: .whitespacesAndNewlines).nilIfBlank
+            ?? defaultGoogleDriveExportFolderName
+    }
+
+    func googleDriveExportFolderID(forAccountID accountID: String) -> String? {
+        guard googleDriveExportFolderAccountID == accountID else { return nil }
+        return googleDriveExportFolderID.nilIfBlank
+    }
+
+    func setGoogleDriveExportFolder(
+        name: String,
+        id: String,
+        accountID: String
+    ) {
+        googleDriveExportFolderName = Self.resolvedGoogleDriveExportFolderName(name)
+        googleDriveExportFolderID = id
+        googleDriveExportFolderAccountID = accountID
+    }
+
+    func clearGoogleDriveExportFolderID(forAccountID accountID: String) {
+        guard googleDriveExportFolderAccountID == accountID else { return }
+        googleDriveExportFolderID = ""
     }
 
     // MARK: - 音声認識設定

--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -109,21 +109,14 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
 
     // MARK: - Google Drive
 
-    @AppStorage("googleDriveExportFolderName") var googleDriveExportFolderName = AppSettings.defaultGoogleDriveExportFolderName
+    /// 変更可能だった試用版の保存先 ID を Meeting Notes として再利用しないため、旧フォルダ名も照合する。
+    @AppStorage("googleDriveExportFolderName") private var storedGoogleDriveExportFolderName = AppSettings.defaultGoogleDriveExportFolderName
     @AppStorage("googleDriveExportFolderID") private var googleDriveExportFolderID = ""
     @AppStorage("googleDriveExportFolderAccountID") private var googleDriveExportFolderAccountID = ""
 
-    var resolvedGoogleDriveExportFolderName: String {
-        Self.resolvedGoogleDriveExportFolderName(googleDriveExportFolderName)
-    }
-
-    nonisolated static func resolvedGoogleDriveExportFolderName(_ folderName: String) -> String {
-        folderName.trimmingCharacters(in: .whitespacesAndNewlines).nilIfBlank
-            ?? defaultGoogleDriveExportFolderName
-    }
-
     func googleDriveExportFolderID(forAccountID accountID: String) -> String? {
-        guard googleDriveExportFolderAccountID == accountID else { return nil }
+        guard googleDriveExportFolderAccountID == accountID,
+              storedGoogleDriveExportFolderName == Self.defaultGoogleDriveExportFolderName else { return nil }
         return googleDriveExportFolderID.nilIfBlank
     }
 
@@ -139,11 +132,10 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     }
 
     func setGoogleDriveExportFolder(
-        name: String,
         id: String,
         accountID: String
     ) {
-        googleDriveExportFolderName = Self.resolvedGoogleDriveExportFolderName(name)
+        storedGoogleDriveExportFolderName = Self.defaultGoogleDriveExportFolderName
         googleDriveExportFolderID = id
         googleDriveExportFolderAccountID = accountID
     }

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -414,8 +414,10 @@
 "Export Destination" = "Export Destination";
 "Export Folder" = "Export Folder";
 "Folder name" = "Folder name";
+"Change Folder" = "Change Folder";
+"Open in Google Drive" = "Open in Google Drive";
 "My Drive" = "My Drive";
-"Dahlia creates this folder directly under My Drive and exports Google Docs into it. If left blank, Meeting Notes is used." = "Dahlia creates this folder directly under My Drive and exports Google Docs into it. If left blank, Meeting Notes is used.";
+"Dahlia creates this folder directly under My Drive and exports Google Docs into it. Change the name to switch the destination. If left blank, Meeting Notes is used." = "Dahlia creates this folder directly under My Drive and exports Google Docs into it. Change the name to switch the destination. If left blank, Meeting Notes is used.";
 "The Google Drive export folder has not been configured." = "The Google Drive export folder has not been configured.";
 "Could not configure the Google Drive export folder." = "Could not configure the Google Drive export folder.";
 "Open Cloud Storage Settings" = "Open Cloud Storage Settings";

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -411,6 +411,14 @@
 "Connect a Google account to export summaries, including images, to Google Docs from the Share menu." = "Connect a Google account to export summaries, including images, to Google Docs from the Share menu.";
 "Sign in with Google to export summaries to Google Docs." = "Sign in with Google to export summaries to Google Docs.";
 "Google Docs connected" = "Google Docs connected";
+"Export Destination" = "Export Destination";
+"Export Folder" = "Export Folder";
+"Folder name" = "Folder name";
+"My Drive" = "My Drive";
+"Dahlia creates this folder directly under My Drive and exports Google Docs into it. If left blank, Meeting Notes is used." = "Dahlia creates this folder directly under My Drive and exports Google Docs into it. If left blank, Meeting Notes is used.";
+"The Google Drive export folder has not been configured." = "The Google Drive export folder has not been configured.";
+"Could not configure the Google Drive export folder." = "Could not configure the Google Drive export folder.";
+"Open Cloud Storage Settings" = "Open Cloud Storage Settings";
 "No previous Google session was found." = "No previous Google session was found.";
 "Set GOOGLE_CLIENT_ID before connecting Google services." = "Set GOOGLE_CLIENT_ID in Developer Settings or the environment before connecting Google services.";
 "Unexpected response from Google" = "Unexpected response from Google";

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -413,11 +413,9 @@
 "Google Docs connected" = "Google Docs connected";
 "Export Destination" = "Export Destination";
 "Export Folder" = "Export Folder";
-"Folder name" = "Folder name";
-"Change Folder" = "Change Folder";
 "Open in Google Drive" = "Open in Google Drive";
 "My Drive" = "My Drive";
-"Dahlia creates this folder directly under My Drive and exports Google Docs into it. Change the name to switch the destination. If left blank, Meeting Notes is used." = "Dahlia creates this folder directly under My Drive and exports Google Docs into it. Change the name to switch the destination. If left blank, Meeting Notes is used.";
+"On first connection, Dahlia creates Meeting Notes directly under My Drive and exports Google Docs into it. The export destination is fixed to this folder." = "On first connection, Dahlia creates Meeting Notes directly under My Drive and exports Google Docs into it. The export destination is fixed to this folder.";
 "The Google Drive export folder has not been configured." = "The Google Drive export folder has not been configured.";
 "Could not configure the Google Drive export folder." = "Could not configure the Google Drive export folder.";
 "Open Cloud Storage Settings" = "Open Cloud Storage Settings";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -414,8 +414,10 @@
 "Export Destination" = "書き出し先";
 "Export Folder" = "書き出しフォルダ";
 "Folder name" = "フォルダ名";
+"Change Folder" = "フォルダを変更";
+"Open in Google Drive" = "Google Drive で開く";
 "My Drive" = "マイドライブ";
-"Dahlia creates this folder directly under My Drive and exports Google Docs into it. If left blank, Meeting Notes is used." = "マイドライブ直下にこのフォルダを作成し、Google Docs を書き出します。空欄の場合は Meeting Notes を使用します。";
+"Dahlia creates this folder directly under My Drive and exports Google Docs into it. Change the name to switch the destination. If left blank, Meeting Notes is used." = "マイドライブ直下にこのフォルダを作成し、Google Docs を書き出します。フォルダ名を変更すると書き出し先を切り替えます。空欄の場合は Meeting Notes を使用します。";
 "The Google Drive export folder has not been configured." = "Google Drive の書き出しフォルダが設定されていません。";
 "Could not configure the Google Drive export folder." = "Google Drive の書き出しフォルダを設定できませんでした。";
 "Open Cloud Storage Settings" = "Cloud Storage 設定を開く";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -411,6 +411,14 @@
 "Connect a Google account to export summaries, including images, to Google Docs from the Share menu." = "Google アカウントを接続し、共有メニューから画像を含む要約を Google Docs に書き出します。";
 "Sign in with Google to export summaries to Google Docs." = "Google にサインインして要約を Google Docs に書き出します。";
 "Google Docs connected" = "Google Docs 接続済み";
+"Export Destination" = "書き出し先";
+"Export Folder" = "書き出しフォルダ";
+"Folder name" = "フォルダ名";
+"My Drive" = "マイドライブ";
+"Dahlia creates this folder directly under My Drive and exports Google Docs into it. If left blank, Meeting Notes is used." = "マイドライブ直下にこのフォルダを作成し、Google Docs を書き出します。空欄の場合は Meeting Notes を使用します。";
+"The Google Drive export folder has not been configured." = "Google Drive の書き出しフォルダが設定されていません。";
+"Could not configure the Google Drive export folder." = "Google Drive の書き出しフォルダを設定できませんでした。";
+"Open Cloud Storage Settings" = "Cloud Storage 設定を開く";
 "No previous Google session was found." = "以前の Google セッションは見つかりませんでした。";
 "Set GOOGLE_CLIENT_ID before connecting Google services." = "Google サービスを接続する前に、開発者設定または環境変数で GOOGLE_CLIENT_ID を設定してください。";
 "Unexpected response from Google" = "Google から予期しないレスポンスが返されました";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -413,11 +413,9 @@
 "Google Docs connected" = "Google Docs 接続済み";
 "Export Destination" = "書き出し先";
 "Export Folder" = "書き出しフォルダ";
-"Folder name" = "フォルダ名";
-"Change Folder" = "フォルダを変更";
 "Open in Google Drive" = "Google Drive で開く";
 "My Drive" = "マイドライブ";
-"Dahlia creates this folder directly under My Drive and exports Google Docs into it. Change the name to switch the destination. If left blank, Meeting Notes is used." = "マイドライブ直下にこのフォルダを作成し、Google Docs を書き出します。フォルダ名を変更すると書き出し先を切り替えます。空欄の場合は Meeting Notes を使用します。";
+"On first connection, Dahlia creates Meeting Notes directly under My Drive and exports Google Docs into it. The export destination is fixed to this folder." = "初回接続時にマイドライブ直下へ Meeting Notes フォルダを作成し、Google Docs を書き出します。書き出し先はこのフォルダに固定されます。";
 "The Google Drive export folder has not been configured." = "Google Drive の書き出しフォルダが設定されていません。";
 "Could not configure the Google Drive export folder." = "Google Drive の書き出しフォルダを設定できませんでした。";
 "Open Cloud Storage Settings" = "Cloud Storage 設定を開く";

--- a/Sources/Dahlia/Services/GoogleDocsSummaryExportService.swift
+++ b/Sources/Dahlia/Services/GoogleDocsSummaryExportService.swift
@@ -7,7 +7,8 @@ enum GoogleDocsSummaryExportService {
         context: SummaryRenderContext,
         fileName: String,
         driveStore: GoogleDriveStore = .shared,
-        apiClient: any GoogleDriveAPIClientProviding = GoogleDriveAPIClient()
+        apiClient: any GoogleDriveAPIClientProviding = GoogleDriveAPIClient(),
+        settings: any GoogleDriveExportFolderSettingsProviding = AppSettings.shared
     ) async throws -> String {
         let actionItemsHeading = L10n.actionItems
         let imageUnavailableText = L10n.summaryImageUnavailable
@@ -23,15 +24,32 @@ enum GoogleDocsSummaryExportService {
             "dahliaKind": "summary",
             "dahliaMeetingId": context.meetingId.uuidString,
         ]
+        guard let accountID = driveStore.account?.id,
+              let exportFolderID = settings.googleDriveExportFolderID(forAccountID: accountID) else {
+            throw GoogleDriveAPIError.exportFolderNotConfigured
+        }
 
-        return try await driveStore.performAuthorizedOperation { session in
-            try await apiClient.upsertGoogleDocument(
-                accessToken: session.accessToken,
-                fileName: fileName,
-                data: rendered.data,
-                dataMimeType: rendered.mimeType,
-                appProperties: properties
-            )
+        do {
+            return try await driveStore.performAuthorizedOperation { session in
+                guard session.account.id == accountID else {
+                    throw GoogleDriveAPIError.exportFolderNotConfigured
+                }
+                return try await apiClient.upsertGoogleDocument(
+                    accessToken: session.accessToken,
+                    fileName: fileName,
+                    data: rendered.data,
+                    dataMimeType: rendered.mimeType,
+                    appProperties: properties,
+                    parentFolderID: exportFolderID
+                )
+            }
+        } catch {
+            if case let .httpError(statusCode, _) = error as? GoogleDriveAPIError,
+               [403, 404].contains(statusCode) {
+                settings.clearGoogleDriveExportFolderID(forAccountID: accountID)
+                throw GoogleDriveAPIError.exportFolderNotConfigured
+            }
+            throw error
         }
     }
 }

--- a/Sources/Dahlia/Services/GoogleDriveAPIClient.swift
+++ b/Sources/Dahlia/Services/GoogleDriveAPIClient.swift
@@ -1,23 +1,37 @@
 import Foundation
 
 protocol GoogleDriveAPIClientProviding: AnyObject, Sendable {
+    func isExportFolderAvailable(
+        accessToken: String,
+        folderID: String
+    ) async throws -> Bool
+
+    func resolveExportFolderID(
+        accessToken: String,
+        folderName: String
+    ) async throws -> String
+
     func upsertGoogleDocument(
         accessToken: String,
         fileName: String,
         data: Data,
         dataMimeType: String,
-        appProperties: [String: String]
+        appProperties: [String: String],
+        parentFolderID: String
     ) async throws -> String
 }
 
-enum GoogleDriveAPIError: LocalizedError {
+enum GoogleDriveAPIError: LocalizedError, Equatable {
     case invalidResponse
+    case exportFolderNotConfigured
     case httpError(statusCode: Int, detail: String)
 
     var errorDescription: String? {
         switch self {
         case .invalidResponse:
             L10n.googleDriveUnexpectedResponse
+        case .exportFolderNotConfigured:
+            L10n.googleDriveExportFolderNotConfigured
         case let .httpError(statusCode, detail):
             L10n.googleDriveHTTPError(statusCode, detail)
         }
@@ -31,35 +45,135 @@ final class GoogleDriveAPIClient: GoogleDriveAPIClientProviding, @unchecked Send
         self.session = session
     }
 
+    func isExportFolderAvailable(
+        accessToken: String,
+        folderID: String
+    ) async throws -> Bool {
+        guard var components = URLComponents(string: "https://www.googleapis.com/drive/v3/files/\(folderID)") else {
+            throw GoogleDriveAPIError.invalidResponse
+        }
+        components.queryItems = [
+            .init(name: "supportsAllDrives", value: "true"),
+            .init(name: "fields", value: "mimeType,trashed"),
+        ]
+        guard let url = components.url else {
+            throw GoogleDriveAPIError.invalidResponse
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw GoogleDriveAPIError.invalidResponse
+        }
+        if [403, 404].contains(httpResponse.statusCode) {
+            return false
+        }
+        try Self.validate(response: response, data: data)
+        let folder = try JSONDecoder().decode(DriveFolderValidationPayload.self, from: data)
+        return folder.mimeType == Self.googleFolderMimeType && !folder.trashed
+    }
+
+    func resolveExportFolderID(
+        accessToken: String,
+        folderName: String
+    ) async throws -> String {
+        if let existingFolderID = try await findExportFolderID(
+            accessToken: accessToken,
+            folderName: folderName
+        ) {
+            return existingFolderID
+        }
+        return try await createExportFolder(
+            accessToken: accessToken,
+            folderName: folderName
+        )
+    }
+
     func upsertGoogleDocument(
         accessToken: String,
         fileName: String,
         data: Data,
         dataMimeType: String,
-        appProperties: [String: String]
+        appProperties: [String: String],
+        parentFolderID: String
     ) async throws -> String {
-        let existingFileID = try await findExistingFileID(
+        let existingFile = try await findExistingFile(
             accessToken: accessToken,
             appProperties: appProperties
         )
         let metadata = GoogleDocumentMetadata(
             name: Self.googleDocumentName(for: fileName),
             mimeType: Self.googleDocumentMimeType,
-            appProperties: appProperties
+            appProperties: appProperties,
+            parents: existingFile == nil ? [parentFolderID] : nil
         )
         return try await uploadResumable(
             accessToken: accessToken,
-            existingFileID: existingFileID,
+            existingFile: existingFile,
+            parentFolderID: parentFolderID,
             metadata: metadata,
             data: data,
             dataMimeType: dataMimeType
         )
     }
 
-    private func findExistingFileID(
+    private func findExportFolderID(
+        accessToken: String,
+        folderName: String
+    ) async throws -> String? {
+        let predicates = [
+            "mimeType = '\(Self.googleFolderMimeType)'",
+            "name = '\(Self.escapeQueryLiteral(folderName))'",
+            "'root' in parents",
+            "trashed = false",
+            "appProperties has { key='dahliaKind' and value='exportFolder' }",
+        ]
+        let files = try await listFiles(
+            accessToken: accessToken,
+            predicates: predicates,
+            corpora: "user",
+            pageSize: 1
+        )
+        return files.first?.id
+    }
+
+    private func createExportFolder(
+        accessToken: String,
+        folderName: String
+    ) async throws -> String {
+        guard var components = URLComponents(string: "https://www.googleapis.com/drive/v3/files") else {
+            throw GoogleDriveAPIError.invalidResponse
+        }
+        components.queryItems = [
+            .init(name: "supportsAllDrives", value: "true"),
+            .init(name: "fields", value: "id"),
+        ]
+        guard let url = components.url else {
+            throw GoogleDriveAPIError.invalidResponse
+        }
+
+        let metadata = DriveFolderMetadata(
+            name: folderName,
+            mimeType: Self.googleFolderMimeType,
+            parents: ["root"],
+            appProperties: ["dahliaKind": "exportFolder"]
+        )
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json; charset=UTF-8", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(metadata)
+
+        let (data, response) = try await session.data(for: request)
+        try Self.validate(response: response, data: data)
+        return try JSONDecoder().decode(DriveFilePayload.self, from: data).id
+    }
+
+    private func findExistingFile(
         accessToken: String,
         appProperties: [String: String]
-    ) async throws -> String? {
+    ) async throws -> DriveFilePayload? {
         let propertyPredicates = appProperties.sorted { $0.key < $1.key }.map { key, value in
             "appProperties has { key='\(Self.escapeQueryLiteral(key))' and value='\(Self.escapeQueryLiteral(value))' }"
         }
@@ -69,17 +183,31 @@ final class GoogleDriveAPIClient: GoogleDriveAPIClientProviding, @unchecked Send
         ]
         predicates.append(contentsOf: propertyPredicates)
 
+        return try await listFiles(
+            accessToken: accessToken,
+            predicates: predicates,
+            corpora: "allDrives",
+            pageSize: 10
+        ).first
+    }
+
+    private func listFiles(
+        accessToken: String,
+        predicates: [String],
+        corpora: String,
+        pageSize: Int
+    ) async throws -> [DriveFilePayload] {
         guard var components = URLComponents(string: "https://www.googleapis.com/drive/v3/files") else {
             throw GoogleDriveAPIError.invalidResponse
         }
         components.queryItems = [
             .init(name: "q", value: predicates.joined(separator: " and ")),
             .init(name: "spaces", value: "drive"),
-            .init(name: "corpora", value: "allDrives"),
+            .init(name: "corpora", value: corpora),
             .init(name: "includeItemsFromAllDrives", value: "true"),
             .init(name: "supportsAllDrives", value: "true"),
-            .init(name: "pageSize", value: "10"),
-            .init(name: "fields", value: "files(id)"),
+            .init(name: "pageSize", value: String(pageSize)),
+            .init(name: "fields", value: "files(id,parents)"),
         ]
         guard let url = components.url else {
             throw GoogleDriveAPIError.invalidResponse
@@ -89,19 +217,23 @@ final class GoogleDriveAPIClient: GoogleDriveAPIClientProviding, @unchecked Send
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         let (data, response) = try await session.data(for: request)
         try Self.validate(response: response, data: data)
-        return try JSONDecoder().decode(DriveFilesListResponse.self, from: data).files.first?.id
+        return try JSONDecoder().decode(DriveFilesListResponse.self, from: data).files
     }
 
     private func uploadResumable(
         accessToken: String,
-        existingFileID: String?,
+        existingFile: DriveFilePayload?,
+        parentFolderID: String,
         metadata: GoogleDocumentMetadata,
         data: Data,
         dataMimeType: String
     ) async throws -> String {
-        let initialURL = try Self.resumableUploadURL(existingFileID: existingFileID)
+        let initialURL = try Self.resumableUploadURL(
+            existingFile: existingFile,
+            parentFolderID: parentFolderID
+        )
         var initialRequest = URLRequest(url: initialURL)
-        initialRequest.httpMethod = existingFileID == nil ? "POST" : "PATCH"
+        initialRequest.httpMethod = existingFile == nil ? "POST" : "PATCH"
         initialRequest.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         initialRequest.setValue("application/json; charset=UTF-8", forHTTPHeaderField: "Content-Type")
         initialRequest.setValue(dataMimeType, forHTTPHeaderField: "X-Upload-Content-Type")
@@ -128,9 +260,12 @@ final class GoogleDriveAPIClient: GoogleDriveAPIClientProviding, @unchecked Send
         return try JSONDecoder().decode(DriveFilePayload.self, from: responseData).id
     }
 
-    private static func resumableUploadURL(existingFileID: String?) throws -> URL {
-        let endpoint = if let existingFileID {
-            "https://www.googleapis.com/upload/drive/v3/files/\(existingFileID)"
+    private static func resumableUploadURL(
+        existingFile: DriveFilePayload?,
+        parentFolderID: String
+    ) throws -> URL {
+        let endpoint = if let existingFile {
+            "https://www.googleapis.com/upload/drive/v3/files/\(existingFile.id)"
         } else {
             "https://www.googleapis.com/upload/drive/v3/files"
         }
@@ -142,6 +277,12 @@ final class GoogleDriveAPIClient: GoogleDriveAPIClientProviding, @unchecked Send
             .init(name: "supportsAllDrives", value: "true"),
             .init(name: "fields", value: "id"),
         ]
+        if let existingFile, existingFile.parents?.contains(parentFolderID) != true {
+            components.queryItems?.append(.init(name: "addParents", value: parentFolderID))
+            if let parents = existingFile.parents, !parents.isEmpty {
+                components.queryItems?.append(.init(name: "removeParents", value: parents.joined(separator: ",")))
+            }
+        }
         guard let url = components.url else {
             throw GoogleDriveAPIError.invalidResponse
         }
@@ -170,7 +311,9 @@ final class GoogleDriveAPIClient: GoogleDriveAPIClientProviding, @unchecked Send
     }
 
     private static func escapeQueryLiteral(_ value: String) -> String {
-        value.replacing("'", with: "\\'")
+        value
+            .replacing("\\", with: "\\\\")
+            .replacing("'", with: "\\'")
     }
 
     private static func googleDocumentName(for fileName: String) -> String {
@@ -184,6 +327,7 @@ final class GoogleDriveAPIClient: GoogleDriveAPIClientProviding, @unchecked Send
     }
 
     private static let googleDocumentMimeType = "application/vnd.google-apps.document"
+    private static let googleFolderMimeType = "application/vnd.google-apps.folder"
 }
 
 private struct DriveFilesListResponse: Decodable {
@@ -192,10 +336,24 @@ private struct DriveFilesListResponse: Decodable {
 
 private struct DriveFilePayload: Decodable {
     let id: String
+    let parents: [String]?
 }
 
 private struct GoogleDocumentMetadata: Encodable {
     let name: String
     let mimeType: String
     let appProperties: [String: String]
+    let parents: [String]?
+}
+
+private struct DriveFolderMetadata: Encodable {
+    let name: String
+    let mimeType: String
+    let parents: [String]
+    let appProperties: [String: String]
+}
+
+private struct DriveFolderValidationPayload: Decodable {
+    let mimeType: String
+    let trashed: Bool
 }

--- a/Sources/Dahlia/Services/GoogleDriveExportFolderConfigurationService.swift
+++ b/Sources/Dahlia/Services/GoogleDriveExportFolderConfigurationService.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+@MainActor
+final class GoogleDriveExportFolderConfigurationService: GoogleDriveExportFolderConfiguring {
+    static let shared = GoogleDriveExportFolderConfigurationService()
+
+    private let apiClient: any GoogleDriveAPIClientProviding
+    private let settings: any GoogleDriveExportFolderSettingsProviding
+    private var inFlightConfiguration: (id: UUID, key: String, task: Task<Void, Error>)?
+
+    init(
+        apiClient: any GoogleDriveAPIClientProviding = GoogleDriveAPIClient(),
+        settings: any GoogleDriveExportFolderSettingsProviding = AppSettings.shared
+    ) {
+        self.apiClient = apiClient
+        self.settings = settings
+    }
+
+    func configure(
+        folderName: String,
+        session: GoogleSession
+    ) async throws {
+        let resolvedFolderName = AppSettings.resolvedGoogleDriveExportFolderName(folderName)
+        let apiClient = apiClient
+        let settings = settings
+        try await performSingleFlight(
+            key: configurationKey(accountID: session.account.id, folderName: resolvedFolderName)
+        ) {
+            let folderID = try await apiClient.resolveExportFolderID(
+                accessToken: session.accessToken,
+                folderName: resolvedFolderName
+            )
+            settings.setGoogleDriveExportFolder(
+                name: resolvedFolderName,
+                id: folderID,
+                accountID: session.account.id
+            )
+        }
+    }
+
+    func configureIfNeeded(session: GoogleSession) async throws {
+        let folderName = settings.resolvedGoogleDriveExportFolderName
+        let apiClient = apiClient
+        let settings = settings
+        try await performSingleFlight(
+            key: configurationKey(accountID: session.account.id, folderName: folderName)
+        ) {
+            if let folderID = settings.googleDriveExportFolderID(forAccountID: session.account.id) {
+                let isAvailable = try await apiClient.isExportFolderAvailable(
+                    accessToken: session.accessToken,
+                    folderID: folderID
+                )
+                if isAvailable {
+                    return
+                }
+                settings.clearGoogleDriveExportFolderID(forAccountID: session.account.id)
+            }
+
+            let folderID = try await apiClient.resolveExportFolderID(
+                accessToken: session.accessToken,
+                folderName: folderName
+            )
+            settings.setGoogleDriveExportFolder(
+                name: folderName,
+                id: folderID,
+                accountID: session.account.id
+            )
+        }
+    }
+
+    private func performSingleFlight(
+        key: String,
+        operation: @escaping @MainActor () async throws -> Void
+    ) async throws {
+        while let current = inFlightConfiguration {
+            if current.key == key {
+                try await current.task.value
+                return
+            }
+            _ = try? await current.task.value
+        }
+
+        let id = UUID()
+        let task = Task { @MainActor [weak self] in
+            defer { self?.clearInFlightConfiguration(id: id) }
+            try await operation()
+        }
+        inFlightConfiguration = (id: id, key: key, task: task)
+        try await task.value
+    }
+
+    private func clearInFlightConfiguration(id: UUID) {
+        guard inFlightConfiguration?.id == id else { return }
+        inFlightConfiguration = nil
+    }
+
+    private func configurationKey(accountID: String, folderName: String) -> String {
+        "\(accountID)\u{0}\(folderName)"
+    }
+}

--- a/Sources/Dahlia/Services/GoogleDriveExportFolderConfigurationService.swift
+++ b/Sources/Dahlia/Services/GoogleDriveExportFolderConfigurationService.swift
@@ -16,34 +16,12 @@ final class GoogleDriveExportFolderConfigurationService: GoogleDriveExportFolder
         self.settings = settings
     }
 
-    func configure(
-        folderName: String,
-        session: GoogleSession
-    ) async throws {
-        let resolvedFolderName = AppSettings.resolvedGoogleDriveExportFolderName(folderName)
-        let apiClient = apiClient
-        let settings = settings
-        try await performSingleFlight(
-            key: configurationKey(accountID: session.account.id, folderName: resolvedFolderName)
-        ) {
-            let folderID = try await apiClient.resolveExportFolderID(
-                accessToken: session.accessToken,
-                folderName: resolvedFolderName
-            )
-            settings.setGoogleDriveExportFolder(
-                name: resolvedFolderName,
-                id: folderID,
-                accountID: session.account.id
-            )
-        }
-    }
-
     func configureIfNeeded(session: GoogleSession) async throws {
-        let folderName = settings.resolvedGoogleDriveExportFolderName
+        let folderName = AppSettings.defaultGoogleDriveExportFolderName
         let apiClient = apiClient
         let settings = settings
         try await performSingleFlight(
-            key: configurationKey(accountID: session.account.id, folderName: folderName)
+            key: configurationKey(accountID: session.account.id)
         ) {
             if let folderID = settings.googleDriveExportFolderID(forAccountID: session.account.id) {
                 let isAvailable = try await apiClient.isExportFolderAvailable(
@@ -61,7 +39,6 @@ final class GoogleDriveExportFolderConfigurationService: GoogleDriveExportFolder
                 folderName: folderName
             )
             settings.setGoogleDriveExportFolder(
-                name: folderName,
                 id: folderID,
                 accountID: session.account.id
             )
@@ -94,7 +71,7 @@ final class GoogleDriveExportFolderConfigurationService: GoogleDriveExportFolder
         inFlightConfiguration = nil
     }
 
-    private func configurationKey(accountID: String, folderName: String) -> String {
-        "\(accountID)\u{0}\(folderName)"
+    private func configurationKey(accountID: String) -> String {
+        "default\u{0}\(accountID)"
     }
 }

--- a/Sources/Dahlia/Services/GoogleDriveExportFolderConfiguring.swift
+++ b/Sources/Dahlia/Services/GoogleDriveExportFolderConfiguring.swift
@@ -1,0 +1,9 @@
+@MainActor
+protocol GoogleDriveExportFolderConfiguring: AnyObject {
+    func configure(
+        folderName: String,
+        session: GoogleSession
+    ) async throws
+
+    func configureIfNeeded(session: GoogleSession) async throws
+}

--- a/Sources/Dahlia/Services/GoogleDriveExportFolderConfiguring.swift
+++ b/Sources/Dahlia/Services/GoogleDriveExportFolderConfiguring.swift
@@ -1,9 +1,4 @@
 @MainActor
 protocol GoogleDriveExportFolderConfiguring: AnyObject {
-    func configure(
-        folderName: String,
-        session: GoogleSession
-    ) async throws
-
     func configureIfNeeded(session: GoogleSession) async throws
 }

--- a/Sources/Dahlia/Services/GoogleDriveExportFolderSettingsProviding.swift
+++ b/Sources/Dahlia/Services/GoogleDriveExportFolderSettingsProviding.swift
@@ -1,0 +1,14 @@
+@MainActor
+protocol GoogleDriveExportFolderSettingsProviding: AnyObject {
+    var resolvedGoogleDriveExportFolderName: String { get }
+
+    func googleDriveExportFolderID(forAccountID accountID: String) -> String?
+
+    func setGoogleDriveExportFolder(
+        name: String,
+        id: String,
+        accountID: String
+    )
+
+    func clearGoogleDriveExportFolderID(forAccountID accountID: String)
+}

--- a/Sources/Dahlia/Services/GoogleDriveExportFolderSettingsProviding.swift
+++ b/Sources/Dahlia/Services/GoogleDriveExportFolderSettingsProviding.swift
@@ -1,11 +1,8 @@
 @MainActor
 protocol GoogleDriveExportFolderSettingsProviding: AnyObject {
-    var resolvedGoogleDriveExportFolderName: String { get }
-
     func googleDriveExportFolderID(forAccountID accountID: String) -> String?
 
     func setGoogleDriveExportFolder(
-        name: String,
         id: String,
         accountID: String
     )

--- a/Sources/Dahlia/Services/GoogleDriveStore.swift
+++ b/Sources/Dahlia/Services/GoogleDriveStore.swift
@@ -16,6 +16,7 @@ final class GoogleDriveStore: ObservableObject {
     @Published private(set) var state: State
     @Published private(set) var account: GoogleCalendarAccount?
     @Published private(set) var lastErrorMessage: String?
+    @Published private(set) var exportFolderErrorMessage: String?
 
     var isConfigured: Bool {
         signInProvider.isConfigured
@@ -30,6 +31,7 @@ final class GoogleDriveStore: ObservableObject {
     }
 
     private let signInProvider: any GoogleSignInProviding
+    private let exportFolderConfiguration: any GoogleDriveExportFolderConfiguring
     private let presentingWindowProvider: @MainActor () -> NSWindow?
     private var currentSession: GoogleSession?
     private var didAttemptRestore = false
@@ -37,9 +39,11 @@ final class GoogleDriveStore: ObservableObject {
 
     init(
         signInProvider: any GoogleSignInProviding = GoogleSignInAdapter(sessionKind: .drive),
+        exportFolderConfiguration: any GoogleDriveExportFolderConfiguring = GoogleDriveExportFolderConfigurationService.shared,
         presentingWindowProvider: @escaping @MainActor () -> NSWindow? = { NSApp.keyWindow ?? NSApp.mainWindow }
     ) {
         self.signInProvider = signInProvider
+        self.exportFolderConfiguration = exportFolderConfiguration
         self.presentingWindowProvider = presentingWindowProvider
         let sessionDidChangeNotification = signInProvider.sessionDidChangeNotification
         self.state = signInProvider.isConfigured ? .signedOut : .unconfigured
@@ -74,6 +78,7 @@ final class GoogleDriveStore: ObservableObject {
         do {
             let session = try await signInProvider.restorePreviousSignIn()
             applySession(session)
+            await configureExportFolderIfNeeded(for: session)
         } catch GoogleSignInError.noPreviousSignIn {
             clearRuntimeState()
             recomputeState()
@@ -103,6 +108,7 @@ final class GoogleDriveStore: ObservableObject {
                 requestedScopes: GoogleOAuthScope.drive
             )
             applySession(session)
+            await configureExportFolderIfNeeded(for: session)
         } catch {
             handle(error)
             recomputeStateIfNeeded()
@@ -117,7 +123,34 @@ final class GoogleDriveStore: ObservableObject {
             handle(error)
         }
         clearRuntimeState()
+        exportFolderErrorMessage = nil
         recomputeState()
+    }
+
+    func configureExportFolder(named folderName: String) async throws {
+        let session = try await refreshedAuthorizedSession()
+        state = .loading
+        defer { recomputeState() }
+        do {
+            try await exportFolderConfiguration.configure(
+                folderName: folderName,
+                session: session
+            )
+            exportFolderErrorMessage = nil
+        } catch {
+            recordExportFolderError(error)
+            throw error
+        }
+    }
+
+    func refreshExportFolderConfiguration() async {
+        guard isAuthorized else { return }
+        do {
+            let session = try await refreshedAuthorizedSession()
+            await configureExportFolderIfNeeded(for: session)
+        } catch {
+            recordExportFolderError(error)
+        }
     }
 
     func performAuthorizedOperation<T: Sendable>(
@@ -150,6 +183,26 @@ final class GoogleDriveStore: ObservableObject {
         if account != nil { account = nil }
     }
 
+    private func configureExportFolderIfNeeded(for session: GoogleSession) async {
+        guard session.hasScopes(GoogleOAuthScope.drive) else { return }
+        state = .loading
+        defer { recomputeState() }
+        do {
+            try await exportFolderConfiguration.configureIfNeeded(session: session)
+            exportFolderErrorMessage = nil
+        } catch {
+            recordExportFolderError(error)
+        }
+    }
+
+    private func recordExportFolderError(_ error: Error) {
+        exportFolderErrorMessage = GoogleAuthErrorFormatter.message(
+            for: error,
+            defaultMessage: L10n.googleDriveUnexpectedResponse
+        )
+        ErrorReportingService.capture(error, context: ["source": "googleDriveExportFolder"])
+    }
+
     private func handle(_ error: Error) {
         lastErrorMessage = GoogleAuthErrorFormatter.message(for: error, defaultMessage: L10n.googleDriveUnexpectedResponse)
         state = .failed
@@ -178,6 +231,7 @@ final class GoogleDriveStore: ObservableObject {
 
     private func transitionToUnconfiguredState() {
         clearRuntimeState()
+        exportFolderErrorMessage = nil
         state = .unconfigured
     }
 
@@ -187,6 +241,7 @@ final class GoogleDriveStore: ObservableObject {
             await restoreSessionIfNeeded()
         } else {
             clearRuntimeState()
+            exportFolderErrorMessage = nil
             recomputeState()
         }
     }

--- a/Sources/Dahlia/Services/GoogleDriveStore.swift
+++ b/Sources/Dahlia/Services/GoogleDriveStore.swift
@@ -127,22 +127,6 @@ final class GoogleDriveStore: ObservableObject {
         recomputeState()
     }
 
-    func configureExportFolder(named folderName: String) async throws {
-        let session = try await refreshedAuthorizedSession()
-        state = .loading
-        defer { recomputeState() }
-        do {
-            try await exportFolderConfiguration.configure(
-                folderName: folderName,
-                session: session
-            )
-            exportFolderErrorMessage = nil
-        } catch {
-            recordExportFolderError(error)
-            throw error
-        }
-    }
-
     func refreshExportFolderConfiguration() async {
         guard isAuthorized else { return }
         do {

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -461,6 +461,23 @@ enum L10n {
     ) }
     static var googleDocsConnected: String { String(localized: "Google Docs connected", bundle: bundle) }
     static var googleDocsNotConnected: String { googleCalendarNotConnected }
+    static var googleDriveExportDestination: String { String(localized: "Export Destination", bundle: bundle) }
+    static var googleDriveExportFolder: String { String(localized: "Export Folder", bundle: bundle) }
+    static var googleDriveExportFolderName: String { String(localized: "Folder name", bundle: bundle) }
+    static var myDrive: String { String(localized: "My Drive", bundle: bundle) }
+    static var googleDriveExportDestinationDescription: String { String(
+        localized: "Dahlia creates this folder directly under My Drive and exports Google Docs into it. If left blank, Meeting Notes is used.",
+        bundle: bundle
+    ) }
+    static var googleDriveExportFolderNotConfigured: String { String(
+        localized: "The Google Drive export folder has not been configured.",
+        bundle: bundle
+    ) }
+    static var googleDriveExportFolderConfigurationFailed: String { String(
+        localized: "Could not configure the Google Drive export folder.",
+        bundle: bundle
+    ) }
+    static var openCloudStorageSettings: String { String(localized: "Open Cloud Storage Settings", bundle: bundle) }
     static var googleCalendarPrimaryCalendar: String { String(localized: "Primary calendar", bundle: bundle) }
     static var calendarPrimaryCalendar: String { googleCalendarPrimaryCalendar }
     static var googleCalendarNoCalendars: String { String(localized: "No calendars are available for this Google account.", bundle: bundle) }

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -464,9 +464,11 @@ enum L10n {
     static var googleDriveExportDestination: String { String(localized: "Export Destination", bundle: bundle) }
     static var googleDriveExportFolder: String { String(localized: "Export Folder", bundle: bundle) }
     static var googleDriveExportFolderName: String { String(localized: "Folder name", bundle: bundle) }
+    static var googleDriveChangeExportFolder: String { String(localized: "Change Folder", bundle: bundle) }
+    static var openInGoogleDrive: String { String(localized: "Open in Google Drive", bundle: bundle) }
     static var myDrive: String { String(localized: "My Drive", bundle: bundle) }
     static var googleDriveExportDestinationDescription: String { String(
-        localized: "Dahlia creates this folder directly under My Drive and exports Google Docs into it. If left blank, Meeting Notes is used.",
+        localized: "Dahlia creates this folder directly under My Drive and exports Google Docs into it. Change the name to switch the destination. If left blank, Meeting Notes is used.",
         bundle: bundle
     ) }
     static var googleDriveExportFolderNotConfigured: String { String(

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -463,12 +463,10 @@ enum L10n {
     static var googleDocsNotConnected: String { googleCalendarNotConnected }
     static var googleDriveExportDestination: String { String(localized: "Export Destination", bundle: bundle) }
     static var googleDriveExportFolder: String { String(localized: "Export Folder", bundle: bundle) }
-    static var googleDriveExportFolderName: String { String(localized: "Folder name", bundle: bundle) }
-    static var googleDriveChangeExportFolder: String { String(localized: "Change Folder", bundle: bundle) }
     static var openInGoogleDrive: String { String(localized: "Open in Google Drive", bundle: bundle) }
     static var myDrive: String { String(localized: "My Drive", bundle: bundle) }
     static var googleDriveExportDestinationDescription: String { String(
-        localized: "Dahlia creates this folder directly under My Drive and exports Google Docs into it. Change the name to switch the destination. If left blank, Meeting Notes is used.",
+        localized: "On first connection, Dahlia creates Meeting Notes directly under My Drive and exports Google Docs into it. The export destination is fixed to this folder.",
         bundle: bundle
     ) }
     static var googleDriveExportFolderNotConfigured: String { String(

--- a/Sources/Dahlia/Views/Settings/CloudStorageSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/CloudStorageSettingsView.swift
@@ -2,6 +2,12 @@ import SwiftUI
 
 struct CloudStorageSettingsView: View {
     @ObservedObject private var driveStore = GoogleDriveStore.shared
+    @ObservedObject private var settings = AppSettings.shared
+    @State private var exportFolderName = AppSettings.defaultGoogleDriveExportFolderName
+    @State private var exportFolderStatusMessage: String?
+    @State private var exportFolderSaveFailed = false
+    @State private var exportFolderAlertMessage = ""
+    @State private var isShowingExportFolderAlert = false
 
     var body: some View {
         Form {
@@ -20,10 +26,64 @@ struct CloudStorageSettingsView: View {
             } footer: {
                 Text(L10n.googleDocsSettingsDescription)
             }
+
+            Section {
+                LabeledContent {
+                    HStack {
+                        TextField(L10n.googleDriveExportFolderName, text: $exportFolderName)
+                            .multilineTextAlignment(.trailing)
+                            .disabled(!canConfigureExportFolder)
+                        Button(L10n.apply, action: configureExportFolder)
+                            .disabled(!canConfigureExportFolder)
+                    }
+                } label: {
+                    Text(L10n.googleDriveExportFolder)
+                    Text(L10n.myDrive)
+                }
+
+                if let exportFolderStatusMessage {
+                    SettingsStatusMessage(
+                        text: exportFolderStatusMessage,
+                        systemImage: exportFolderSaveFailed ? "exclamationmark.triangle" : "checkmark.circle",
+                        tint: exportFolderSaveFailed ? .orange : .secondary
+                    )
+                }
+            } header: {
+                Text(L10n.googleDriveExportDestination)
+            } footer: {
+                Text(L10n.googleDriveExportDestinationDescription)
+            }
         }
         .formStyle(.grouped)
         .task {
             await driveStore.restoreSessionIfNeeded()
+            await driveStore.refreshExportFolderConfiguration()
+            exportFolderName = settings.resolvedGoogleDriveExportFolderName
+            if let message = driveStore.exportFolderErrorMessage {
+                presentExportFolderError(message)
+            }
+        }
+        .onChange(of: driveStore.isAuthorized) { _, isAuthorized in
+            guard !isAuthorized else { return }
+            resetExportFolderStatus()
+        }
+        .onChange(of: driveStore.account?.id) { _, _ in
+            exportFolderName = settings.resolvedGoogleDriveExportFolderName
+            resetExportFolderStatus()
+        }
+        .onChange(of: exportFolderName) { _, _ in
+            guard AppSettings.resolvedGoogleDriveExportFolderName(exportFolderName)
+                != settings.resolvedGoogleDriveExportFolderName else { return }
+            resetExportFolderStatus()
+        }
+        .onChange(of: driveStore.exportFolderErrorMessage) { _, message in
+            guard let message else { return }
+            presentExportFolderError(message)
+        }
+        .alert(L10n.googleDriveExportFolderConfigurationFailed, isPresented: $isShowingExportFolderAlert) {
+            Button(L10n.close, role: .cancel) {}
+        } message: {
+            Text(exportFolderAlertMessage)
         }
     }
 
@@ -67,5 +127,38 @@ struct CloudStorageSettingsView: View {
         }
 
         return L10n.googleDocsConnectDescription
+    }
+
+    private var canConfigureExportFolder: Bool {
+        driveStore.isAuthorized && !driveStore.isBusy
+    }
+
+    private func configureExportFolder() {
+        Task { @MainActor in
+            do {
+                try await driveStore.configureExportFolder(named: exportFolderName)
+                exportFolderName = settings.resolvedGoogleDriveExportFolderName
+                exportFolderStatusMessage = L10n.saved
+                exportFolderSaveFailed = false
+            } catch {
+                let message = GoogleAuthErrorFormatter.message(
+                    for: error,
+                    defaultMessage: L10n.googleDriveUnexpectedResponse
+                )
+                presentExportFolderError(message)
+            }
+        }
+    }
+
+    private func presentExportFolderError(_ message: String) {
+        exportFolderStatusMessage = message
+        exportFolderSaveFailed = true
+        exportFolderAlertMessage = message
+        isShowingExportFolderAlert = true
+    }
+
+    private func resetExportFolderStatus() {
+        exportFolderStatusMessage = nil
+        exportFolderSaveFailed = false
     }
 }

--- a/Sources/Dahlia/Views/Settings/CloudStorageSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/CloudStorageSettingsView.swift
@@ -33,12 +33,18 @@ struct CloudStorageSettingsView: View {
                         TextField(L10n.googleDriveExportFolderName, text: $exportFolderName)
                             .multilineTextAlignment(.trailing)
                             .disabled(!canConfigureExportFolder)
-                        Button(L10n.apply, action: configureExportFolder)
+                        Button(L10n.googleDriveChangeExportFolder, action: configureExportFolder)
                             .disabled(!canConfigureExportFolder)
                     }
                 } label: {
                     Text(L10n.googleDriveExportFolder)
                     Text(L10n.myDrive)
+                }
+
+                if let exportFolderURL {
+                    Link(destination: exportFolderURL) {
+                        Label(L10n.openInGoogleDrive, systemImage: "arrow.up.right.square")
+                    }
                 }
 
                 if let exportFolderStatusMessage {
@@ -131,6 +137,11 @@ struct CloudStorageSettingsView: View {
 
     private var canConfigureExportFolder: Bool {
         driveStore.isAuthorized && !driveStore.isBusy
+    }
+
+    private var exportFolderURL: URL? {
+        guard let accountID = driveStore.account?.id else { return nil }
+        return settings.googleDriveExportFolderURL(forAccountID: accountID)
     }
 
     private func configureExportFolder() {

--- a/Sources/Dahlia/Views/Settings/CloudStorageSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/CloudStorageSettingsView.swift
@@ -3,9 +3,7 @@ import SwiftUI
 struct CloudStorageSettingsView: View {
     @ObservedObject private var driveStore = GoogleDriveStore.shared
     @ObservedObject private var settings = AppSettings.shared
-    @State private var exportFolderName = AppSettings.defaultGoogleDriveExportFolderName
     @State private var exportFolderStatusMessage: String?
-    @State private var exportFolderSaveFailed = false
     @State private var exportFolderAlertMessage = ""
     @State private var isShowingExportFolderAlert = false
 
@@ -29,13 +27,7 @@ struct CloudStorageSettingsView: View {
 
             Section {
                 LabeledContent {
-                    HStack {
-                        TextField(L10n.googleDriveExportFolderName, text: $exportFolderName)
-                            .multilineTextAlignment(.trailing)
-                            .disabled(!canConfigureExportFolder)
-                        Button(L10n.googleDriveChangeExportFolder, action: configureExportFolder)
-                            .disabled(!canConfigureExportFolder)
-                    }
+                    Text(AppSettings.defaultGoogleDriveExportFolderName)
                 } label: {
                     Text(L10n.googleDriveExportFolder)
                     Text(L10n.myDrive)
@@ -50,8 +42,8 @@ struct CloudStorageSettingsView: View {
                 if let exportFolderStatusMessage {
                     SettingsStatusMessage(
                         text: exportFolderStatusMessage,
-                        systemImage: exportFolderSaveFailed ? "exclamationmark.triangle" : "checkmark.circle",
-                        tint: exportFolderSaveFailed ? .orange : .secondary
+                        systemImage: "exclamationmark.triangle",
+                        tint: .orange
                     )
                 }
             } header: {
@@ -64,7 +56,6 @@ struct CloudStorageSettingsView: View {
         .task {
             await driveStore.restoreSessionIfNeeded()
             await driveStore.refreshExportFolderConfiguration()
-            exportFolderName = settings.resolvedGoogleDriveExportFolderName
             if let message = driveStore.exportFolderErrorMessage {
                 presentExportFolderError(message)
             }
@@ -74,12 +65,6 @@ struct CloudStorageSettingsView: View {
             resetExportFolderStatus()
         }
         .onChange(of: driveStore.account?.id) { _, _ in
-            exportFolderName = settings.resolvedGoogleDriveExportFolderName
-            resetExportFolderStatus()
-        }
-        .onChange(of: exportFolderName) { _, _ in
-            guard AppSettings.resolvedGoogleDriveExportFolderName(exportFolderName)
-                != settings.resolvedGoogleDriveExportFolderName else { return }
             resetExportFolderStatus()
         }
         .onChange(of: driveStore.exportFolderErrorMessage) { _, message in
@@ -135,41 +120,18 @@ struct CloudStorageSettingsView: View {
         return L10n.googleDocsConnectDescription
     }
 
-    private var canConfigureExportFolder: Bool {
-        driveStore.isAuthorized && !driveStore.isBusy
-    }
-
     private var exportFolderURL: URL? {
         guard let accountID = driveStore.account?.id else { return nil }
         return settings.googleDriveExportFolderURL(forAccountID: accountID)
     }
 
-    private func configureExportFolder() {
-        Task { @MainActor in
-            do {
-                try await driveStore.configureExportFolder(named: exportFolderName)
-                exportFolderName = settings.resolvedGoogleDriveExportFolderName
-                exportFolderStatusMessage = L10n.saved
-                exportFolderSaveFailed = false
-            } catch {
-                let message = GoogleAuthErrorFormatter.message(
-                    for: error,
-                    defaultMessage: L10n.googleDriveUnexpectedResponse
-                )
-                presentExportFolderError(message)
-            }
-        }
-    }
-
     private func presentExportFolderError(_ message: String) {
         exportFolderStatusMessage = message
-        exportFolderSaveFailed = true
         exportFolderAlertMessage = message
         isShowingExportFolderAlert = true
     }
 
     private func resetExportFolderStatus() {
         exportFolderStatusMessage = nil
-        exportFolderSaveFailed = false
     }
 }

--- a/Sources/Dahlia/Views/Toolbar/SessionControls.swift
+++ b/Sources/Dahlia/Views/Toolbar/SessionControls.swift
@@ -124,9 +124,13 @@ struct ShareSummaryToolbarButton: View {
 }
 
 private struct SummarySharePopover: View {
+    @Environment(\.openSettings) private var openSettings
     @ObservedObject var viewModel: CaptionViewModel
     @ObservedObject private var driveStore = GoogleDriveStore.shared
+    @ObservedObject private var settings = AppSettings.shared
     @State private var isGoogleDocsExportRunning = false
+    @State private var exportFolderAlertMessage = ""
+    @State private var isShowingExportFolderAlert = false
     let dismiss: () -> Void
 
     private var title: String {
@@ -164,7 +168,7 @@ private struct SummarySharePopover: View {
                 SummarySharePopoverRow(
                     title: L10n.exportToGoogleDocs,
                     systemImage: "doc.badge.arrow.up",
-                    isDisabled: isGoogleDocsExportRunning || driveStore.isBusy,
+                    isDisabled: isGoogleDocsExportRunning || driveStore.isBusy || !canExportToGoogleDocs,
                     isLoading: isGoogleDocsExportRunning || driveStore.isBusy
                 ) {
                     exportToGoogleDocs()
@@ -174,6 +178,14 @@ private struct SummarySharePopover: View {
                 }
                 SummarySharePopoverRow(title: L10n.copySummaryForSlack, systemImage: "message") {
                     copySummary(for: .slack)
+                }
+                if needsGoogleDriveSetup {
+                    SummarySharePopoverRow(
+                        title: L10n.openCloudStorageSettings,
+                        systemImage: "gearshape"
+                    ) {
+                        openCloudStorageSettings()
+                    }
                 }
             }
             .padding(.horizontal, 12)
@@ -189,8 +201,21 @@ private struct SummarySharePopover: View {
         }
         .frame(width: 320)
         .padding(.vertical, 8)
-        .task {
-            await driveStore.restoreSessionIfNeeded()
+        .onAppear {
+            guard let message = driveStore.exportFolderErrorMessage else { return }
+            exportFolderAlertMessage = message
+            isShowingExportFolderAlert = true
+        }
+        .onChange(of: driveStore.exportFolderErrorMessage) { _, message in
+            guard let message else { return }
+            exportFolderAlertMessage = message
+            isShowingExportFolderAlert = true
+        }
+        .alert(L10n.googleDriveExportFolderConfigurationFailed, isPresented: $isShowingExportFolderAlert) {
+            Button(L10n.close, role: .cancel) {}
+            Button(L10n.openCloudStorageSettings, action: openCloudStorageSettings)
+        } message: {
+            Text(exportFolderAlertMessage)
         }
     }
 
@@ -200,7 +225,18 @@ private struct SummarySharePopover: View {
     }
 
     private var googleDocsErrorMessage: String? {
-        viewModel.googleDocsExportError ?? driveStore.lastErrorMessage
+        viewModel.googleDocsExportError ?? driveStore.exportFolderErrorMessage ?? driveStore.lastErrorMessage
+    }
+
+    private var canExportToGoogleDocs: Bool {
+        guard driveStore.isAuthorized,
+              driveStore.exportFolderErrorMessage == nil,
+              let accountID = driveStore.account?.id else { return false }
+        return settings.googleDriveExportFolderID(forAccountID: accountID) != nil
+    }
+
+    private var needsGoogleDriveSetup: Bool {
+        !driveStore.isBusy && !canExportToGoogleDocs
     }
 
     private func exportToGoogleDocs() {
@@ -208,15 +244,20 @@ private struct SummarySharePopover: View {
         isGoogleDocsExportRunning = true
         Task { @MainActor in
             defer { isGoogleDocsExportRunning = false }
-            await driveStore.restoreSessionIfNeeded()
-            if !driveStore.isAuthorized {
-                await driveStore.signIn()
-            }
-            guard driveStore.isAuthorized else { return }
+            guard canExportToGoogleDocs else { return }
             if await viewModel.exportCurrentSummaryToGoogleDocs() {
                 dismiss()
             }
         }
+    }
+
+    private func openCloudStorageSettings() {
+        UserDefaults.standard.set(
+            SettingsCategory.cloudStorage.rawValue,
+            forKey: SettingsNavigation.selectedCategoryDefaultsKey
+        )
+        openSettings()
+        dismiss()
     }
 }
 

--- a/Tests/DahliaTests/GoogleDriveAPIClientTests.swift
+++ b/Tests/DahliaTests/GoogleDriveAPIClientTests.swift
@@ -4,7 +4,40 @@ import Foundation
 #if canImport(Testing)
     import Testing
 
+    @Suite(.serialized)
     struct GoogleDriveAPIClientTests {
+        @Test
+        func validatesStoredExportFolderByID() async throws {
+            let recorder = GoogleDriveRequestRecorder(responses: [
+                .init(data: Data(#"{"mimeType":"application/vnd.google-apps.folder","trashed":false}"#.utf8)),
+            ])
+            let client = GoogleDriveAPIClient(session: makeGoogleDriveRecordingSession(recorder: recorder))
+
+            let isAvailable = try await client.isExportFolderAvailable(
+                accessToken: "access-token",
+                folderID: "folder-1"
+            )
+
+            #expect(isAvailable)
+            #expect(recorder.requests.count == 1)
+            #expect(recorder.requests[0].url?.path == "/drive/v3/files/folder-1")
+        }
+
+        @Test
+        func unavailableStoredExportFolderReturnsFalse() async throws {
+            let recorder = GoogleDriveRequestRecorder(responses: [
+                .init(statusCode: 404, data: Data(#"{"error":{"message":"Not found"}}"#.utf8)),
+            ])
+            let client = GoogleDriveAPIClient(session: makeGoogleDriveRecordingSession(recorder: recorder))
+
+            let isAvailable = try await client.isExportFolderAvailable(
+                accessToken: "access-token",
+                folderID: "missing-folder"
+            )
+
+            #expect(!isAvailable)
+        }
+
         @Test
         func createsGoogleDocumentWithResumableRTFUpload() async throws {
             let recorder = GoogleDriveRequestRecorder()
@@ -20,7 +53,8 @@ import Foundation
                 appProperties: [
                     "dahliaKind": "summary",
                     "dahliaMeetingId": "meeting-1",
-                ]
+                ],
+                parentFolderID: "folder-1"
             )
 
             #expect(fileID == "document-1")
@@ -56,17 +90,129 @@ import Foundation
             let metadata = try JSONSerialization.jsonObject(with: #require(metadataRequest.httpBody)) as? [String: Any]
             #expect(metadata?["name"] as? String == "Weekly / Sync")
             #expect(metadata?["mimeType"] as? String == "application/vnd.google-apps.document")
+            #expect(metadata?["parents"] as? [String] == ["folder-1"])
 
             let uploadRequest = requests[2]
             #expect(uploadRequest.httpMethod == "PUT")
             #expect(uploadRequest.url?.absoluteString == "https://upload.example.com/session-1")
             #expect(uploadRequest.httpBody == rtfData)
         }
+
+        @Test
+        func createsConfiguredExportFolderInMyDriveWhenMissing() async throws {
+            let recorder = GoogleDriveRequestRecorder(responses: [
+                .init(data: Data(#"{"files":[]}"#.utf8)),
+                .init(data: Data(#"{"id":"folder-1"}"#.utf8)),
+            ])
+            let client = GoogleDriveAPIClient(session: makeGoogleDriveRecordingSession(recorder: recorder))
+
+            let folderID = try await client.resolveExportFolderID(
+                accessToken: "access-token",
+                folderName: "Meeting Notes"
+            )
+
+            #expect(folderID == "folder-1")
+            let requests = recorder.requests
+            #expect(requests.count == 2)
+
+            let searchURL = try #require(requests[0].url)
+            let searchQuery = try #require(
+                URLComponents(url: searchURL, resolvingAgainstBaseURL: false)?
+                    .queryItems?
+                    .first(where: { $0.name == "q" })?
+                    .value
+            )
+            #expect(searchQuery.contains("name = 'Meeting Notes'"))
+            #expect(searchQuery.contains("'root' in parents"))
+            #expect(searchQuery.contains("dahliaKind"))
+
+            let createRequest = requests[1]
+            #expect(createRequest.httpMethod == "POST")
+            let metadata = try JSONSerialization.jsonObject(with: #require(createRequest.httpBody)) as? [String: Any]
+            #expect(metadata?["name"] as? String == "Meeting Notes")
+            #expect(metadata?["mimeType"] as? String == "application/vnd.google-apps.folder")
+            #expect(metadata?["parents"] as? [String] == ["root"])
+        }
+
+        @Test
+        func reusesExistingConfiguredExportFolder() async throws {
+            let recorder = GoogleDriveRequestRecorder(responses: [
+                .init(data: Data(#"{"files":[{"id":"folder-1","parents":["root"]}]}"#.utf8)),
+            ])
+            let client = GoogleDriveAPIClient(session: makeGoogleDriveRecordingSession(recorder: recorder))
+
+            let folderID = try await client.resolveExportFolderID(
+                accessToken: "access-token",
+                folderName: "Meeting Notes"
+            )
+
+            #expect(folderID == "folder-1")
+            #expect(recorder.requests.count == 1)
+        }
+
+        @Test
+        func movesExistingDocumentToConfiguredFolder() async throws {
+            let recorder = GoogleDriveRequestRecorder(responses: [
+                .init(data: Data(#"{"files":[{"id":"document-1","parents":["old-folder"]}]}"#.utf8)),
+                .init(
+                    headers: ["Location": "https://upload.example.com/session-1"],
+                    data: Data()
+                ),
+                .init(data: Data(#"{"id":"document-1"}"#.utf8)),
+            ])
+            let client = GoogleDriveAPIClient(session: makeGoogleDriveRecordingSession(recorder: recorder))
+
+            _ = try await client.upsertGoogleDocument(
+                accessToken: "access-token",
+                fileName: "Weekly Sync.rtf",
+                data: Data(#"{\rtf1 Summary}"#.utf8),
+                dataMimeType: "application/rtf",
+                appProperties: ["dahliaMeetingId": "meeting-1"],
+                parentFolderID: "new-folder"
+            )
+
+            let metadataRequest = recorder.requests[1]
+            #expect(metadataRequest.httpMethod == "PATCH")
+            let metadataURL = try #require(metadataRequest.url)
+            let queryItems = try #require(
+                URLComponents(url: metadataURL, resolvingAgainstBaseURL: false)?.queryItems
+            )
+            #expect(queryItems.first(where: { $0.name == "addParents" })?.value == "new-folder")
+            #expect(queryItems.first(where: { $0.name == "removeParents" })?.value == "old-folder")
+        }
+    }
+
+    private struct GoogleDriveStubResponse: Sendable {
+        let statusCode: Int
+        let headers: [String: String]
+        let data: Data
+
+        init(
+            statusCode: Int = 200,
+            headers: [String: String] = [:],
+            data: Data
+        ) {
+            self.statusCode = statusCode
+            self.headers = headers
+            self.data = data
+        }
     }
 
     private final class GoogleDriveRequestRecorder: @unchecked Sendable {
         private let lock = NSLock()
         private var storedRequests: [URLRequest] = []
+        private let responses: [GoogleDriveStubResponse]
+
+        init(responses: [GoogleDriveStubResponse] = [
+            .init(data: Data(#"{"files":[]}"#.utf8)),
+            .init(
+                headers: ["Location": "https://upload.example.com/session-1"],
+                data: Data()
+            ),
+            .init(data: Data(#"{"id":"document-1"}"#.utf8)),
+        ]) {
+            self.responses = responses
+        }
 
         var requests: [URLRequest] {
             lock.withLock { storedRequests }
@@ -82,6 +228,13 @@ import Foundation
                 storedRequests.append(recordedRequest)
                 return storedRequests.count
             }
+        }
+
+        func response(at requestIndex: Int) -> GoogleDriveStubResponse {
+            guard responses.indices.contains(requestIndex - 1) else {
+                return .init(statusCode: 500, data: Data(#"{"error":{"message":"Missing stub response"}}"#.utf8))
+            }
+            return responses[requestIndex - 1]
         }
 
         private static func read(_ stream: InputStream) -> Data {
@@ -121,34 +274,25 @@ import Foundation
         }
 
         override func startLoading() {
-            let requestIndex = Self.recorder?.record(request) ?? 0
-            let response: HTTPURLResponse
-            let data: Data
-
-            switch requestIndex {
-            case 1:
-                response = makeResponse()
-                data = Data(#"{"files":[]}"#.utf8)
-            case 2:
-                response = makeResponse(headers: ["Location": "https://upload.example.com/session-1"])
-                data = Data()
-            default:
-                response = makeResponse()
-                data = Data(#"{"id":"document-1"}"#.utf8)
+            guard let recorder = Self.recorder else {
+                fatalError("GoogleDriveRecordingURLProtocol recorder is not configured")
             }
+            let requestIndex = recorder.record(request)
+            let stub = recorder.response(at: requestIndex)
+            let response = makeResponse(statusCode: stub.statusCode, headers: stub.headers)
 
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocol(self, didLoad: stub.data)
             client?.urlProtocolDidFinishLoading(self)
         }
 
         override func stopLoading() {}
 
-        private func makeResponse(headers: [String: String] = [:]) -> HTTPURLResponse {
+        private func makeResponse(statusCode: Int, headers: [String: String]) -> HTTPURLResponse {
             guard let url = request.url,
                   let response = HTTPURLResponse(
                       url: url,
-                      statusCode: 200,
+                      statusCode: statusCode,
                       httpVersion: nil,
                       headerFields: headers
                   ) else {

--- a/Tests/DahliaTests/GoogleDriveExportFolderConfigurationServiceTests.swift
+++ b/Tests/DahliaTests/GoogleDriveExportFolderConfigurationServiceTests.swift
@@ -21,6 +21,14 @@ import Foundation
         }
 
         @Test
+        func exportFolderURLUsesGoogleDriveFolderID() {
+            let url = AppSettings.googleDriveExportFolderURL(folderID: "folder-1_abc")
+
+            #expect(url?.absoluteString == "https://drive.google.com/drive/folders/folder-1_abc")
+            #expect(AppSettings.googleDriveExportFolderURL(folderID: "") == nil)
+        }
+
+        @Test
         func existingAvailableFolderIDSkipsFolderLookup() async throws {
             let apiClient = FolderConfigurationAPIClient(folderID: "unused-folder")
             let settings = FolderConfigurationSettings()

--- a/Tests/DahliaTests/GoogleDriveExportFolderConfigurationServiceTests.swift
+++ b/Tests/DahliaTests/GoogleDriveExportFolderConfigurationServiceTests.swift
@@ -1,0 +1,280 @@
+import AppKit
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct GoogleDriveExportFolderConfigurationServiceTests {
+        @Test
+        func configuringBlankNameStoresDefaultFolderIDForConnectedAccount() async throws {
+            let apiClient = FolderConfigurationAPIClient(folderID: "folder-1")
+            let settings = FolderConfigurationSettings()
+            let service = GoogleDriveExportFolderConfigurationService(apiClient: apiClient, settings: settings)
+
+            try await service.configure(folderName: "  ", session: defaultDriveSession)
+
+            #expect(await apiClient.resolvedFolderNames == ["Meeting Notes"])
+            #expect(settings.resolvedGoogleDriveExportFolderName == "Meeting Notes")
+            #expect(settings.googleDriveExportFolderID(forAccountID: "user-1") == "folder-1")
+        }
+
+        @Test
+        func existingAvailableFolderIDSkipsFolderLookup() async throws {
+            let apiClient = FolderConfigurationAPIClient(folderID: "unused-folder")
+            let settings = FolderConfigurationSettings()
+            settings.setGoogleDriveExportFolder(name: "Team Notes", id: "folder-1", accountID: "user-1")
+            let service = GoogleDriveExportFolderConfigurationService(apiClient: apiClient, settings: settings)
+
+            try await service.configureIfNeeded(session: defaultDriveSession)
+
+            #expect(await apiClient.validatedFolderIDs == ["folder-1"])
+            #expect(await apiClient.resolvedFolderNames.isEmpty)
+            #expect(settings.googleDriveExportFolderID(forAccountID: "user-1") == "folder-1")
+        }
+
+        @Test
+        func concurrentConfigurationUsesSingleFolderResolution() async throws {
+            let apiClient = FolderConfigurationAPIClient(folderID: "folder-1", resolveDelay: .milliseconds(50))
+            let settings = FolderConfigurationSettings()
+            let service = GoogleDriveExportFolderConfigurationService(apiClient: apiClient, settings: settings)
+
+            async let first: Void = service.configureIfNeeded(session: defaultDriveSession)
+            async let second: Void = service.configureIfNeeded(session: defaultDriveSession)
+            _ = try await (first, second)
+
+            #expect(await apiClient.resolvedFolderNames == ["Meeting Notes"])
+            #expect(settings.googleDriveExportFolderID(forAccountID: "user-1") == "folder-1")
+        }
+
+        @Test
+        func unavailableStoredFolderIsResolvedAndReplaced() async throws {
+            let apiClient = FolderConfigurationAPIClient(folderID: "replacement-folder", isFolderAvailable: false)
+            let settings = FolderConfigurationSettings()
+            settings.setGoogleDriveExportFolder(name: "Team Notes", id: "stale-folder", accountID: "user-1")
+            let service = GoogleDriveExportFolderConfigurationService(apiClient: apiClient, settings: settings)
+
+            try await service.configureIfNeeded(session: defaultDriveSession)
+
+            #expect(await apiClient.validatedFolderIDs == ["stale-folder"])
+            #expect(await apiClient.resolvedFolderNames == ["Team Notes"])
+            #expect(settings.googleDriveExportFolderID(forAccountID: "user-1") == "replacement-folder")
+        }
+
+        @Test
+        func folderIDFromAnotherAccountIsNotReused() async throws {
+            let apiClient = FolderConfigurationAPIClient(folderID: "account-2-folder")
+            let settings = FolderConfigurationSettings()
+            settings.setGoogleDriveExportFolder(name: "Team Notes", id: "account-1-folder", accountID: "user-1")
+            let service = GoogleDriveExportFolderConfigurationService(apiClient: apiClient, settings: settings)
+
+            try await service.configureIfNeeded(session: makeDriveSession(accountID: "user-2"))
+
+            #expect(await apiClient.validatedFolderIDs.isEmpty)
+            #expect(await apiClient.resolvedFolderNames == ["Team Notes"])
+            #expect(settings.googleDriveExportFolderID(forAccountID: "user-2") == "account-2-folder")
+        }
+
+        @Test
+        func summaryExportUsesStoredFolderIDWithoutFolderLookup() async throws {
+            let driveStore = makeAuthorizedDriveStore()
+            let apiClient = FolderConfigurationAPIClient(folderID: "unused-folder")
+            let settings = FolderConfigurationSettings()
+            settings.setGoogleDriveExportFolder(name: "Team Notes", id: "folder-1", accountID: "user-1")
+            await driveStore.restoreSessionIfNeeded()
+
+            let fileID = try await exportSummary(
+                driveStore: driveStore,
+                apiClient: apiClient,
+                settings: settings
+            )
+
+            #expect(fileID == "document-1")
+            #expect(await apiClient.validatedFolderIDs.isEmpty)
+            #expect(await apiClient.resolvedFolderNames.isEmpty)
+            #expect(await apiClient.uploadedParentFolderIDs == ["folder-1"])
+        }
+
+        @Test
+        func summaryExportRejectsFolderIDFromAnotherAccount() async {
+            let driveStore = makeAuthorizedDriveStore()
+            let apiClient = FolderConfigurationAPIClient(folderID: "unused-folder")
+            let settings = FolderConfigurationSettings()
+            settings.setGoogleDriveExportFolder(name: "Team Notes", id: "folder-2", accountID: "user-2")
+            await driveStore.restoreSessionIfNeeded()
+
+            do {
+                _ = try await exportSummary(
+                    driveStore: driveStore,
+                    apiClient: apiClient,
+                    settings: settings
+                )
+                Issue.record("Expected export to reject a folder from another account")
+            } catch {
+                #expect(error as? GoogleDriveAPIError == .exportFolderNotConfigured)
+            }
+            #expect(await apiClient.uploadedParentFolderIDs.isEmpty)
+        }
+
+        @Test
+        func unavailableFolderResponseClearsStoredID() async {
+            let driveStore = makeAuthorizedDriveStore()
+            let apiClient = FolderConfigurationAPIClient(folderID: "unused-folder", uploadStatusCode: 404)
+            let settings = FolderConfigurationSettings()
+            settings.setGoogleDriveExportFolder(name: "Team Notes", id: "stale-folder", accountID: "user-1")
+            await driveStore.restoreSessionIfNeeded()
+
+            do {
+                _ = try await exportSummary(
+                    driveStore: driveStore,
+                    apiClient: apiClient,
+                    settings: settings
+                )
+                Issue.record("Expected export to reject an unavailable folder")
+            } catch {
+                #expect(error as? GoogleDriveAPIError == .exportFolderNotConfigured)
+            }
+            #expect(settings.googleDriveExportFolderID(forAccountID: "user-1") == nil)
+        }
+
+        private func makeAuthorizedDriveStore() -> GoogleDriveStore {
+            GoogleDriveStore(
+                signInProvider: FolderConfigurationSignInProvider(hasPreviousSignIn: true),
+                exportFolderConfiguration: NoOpFolderConfiguration()
+            )
+        }
+
+        private func exportSummary(
+            driveStore: GoogleDriveStore,
+            apiClient: FolderConfigurationAPIClient,
+            settings: FolderConfigurationSettings
+        ) async throws -> String {
+            try await GoogleDocsSummaryExportService.exportSummary(
+                document: SummaryDocument(title: "Weekly Sync", sections: []),
+                context: SummaryRenderContext(meetingId: .v7(), createdAt: .now),
+                fileName: "Weekly Sync.rtf",
+                driveStore: driveStore,
+                apiClient: apiClient,
+                settings: settings
+            )
+        }
+    }
+
+    @MainActor
+    private final class FolderConfigurationSettings: GoogleDriveExportFolderSettingsProviding {
+        private var folderName = AppSettings.defaultGoogleDriveExportFolderName
+        private var folderID: String?
+        private var accountID: String?
+
+        var resolvedGoogleDriveExportFolderName: String {
+            AppSettings.resolvedGoogleDriveExportFolderName(folderName)
+        }
+
+        func googleDriveExportFolderID(forAccountID accountID: String) -> String? {
+            self.accountID == accountID ? folderID : nil
+        }
+
+        func setGoogleDriveExportFolder(name: String, id: String, accountID: String) {
+            folderName = name
+            folderID = id
+            self.accountID = accountID
+        }
+
+        func clearGoogleDriveExportFolderID(forAccountID accountID: String) {
+            guard self.accountID == accountID else { return }
+            folderID = nil
+        }
+    }
+
+    private actor FolderConfigurationAPIClient: GoogleDriveAPIClientProviding {
+        private(set) var validatedFolderIDs: [String] = []
+        private(set) var resolvedFolderNames: [String] = []
+        private(set) var uploadedParentFolderIDs: [String] = []
+        private let folderID: String
+        private let isFolderAvailable: Bool
+        private let resolveDelay: Duration
+        private let uploadStatusCode: Int?
+
+        init(
+            folderID: String,
+            isFolderAvailable: Bool = true,
+            resolveDelay: Duration = .zero,
+            uploadStatusCode: Int? = nil
+        ) {
+            self.folderID = folderID
+            self.isFolderAvailable = isFolderAvailable
+            self.resolveDelay = resolveDelay
+            self.uploadStatusCode = uploadStatusCode
+        }
+
+        func isExportFolderAvailable(accessToken _: String, folderID: String) async throws -> Bool {
+            validatedFolderIDs.append(folderID)
+            return isFolderAvailable
+        }
+
+        func resolveExportFolderID(accessToken _: String, folderName: String) async throws -> String {
+            resolvedFolderNames.append(folderName)
+            if resolveDelay > .zero {
+                try await Task.sleep(for: resolveDelay)
+            }
+            return folderID
+        }
+
+        func upsertGoogleDocument(
+            accessToken _: String,
+            fileName _: String,
+            data _: Data,
+            dataMimeType _: String,
+            appProperties _: [String: String],
+            parentFolderID: String
+        ) async throws -> String {
+            uploadedParentFolderIDs.append(parentFolderID)
+            if let uploadStatusCode {
+                throw GoogleDriveAPIError.httpError(statusCode: uploadStatusCode, detail: "Unavailable folder")
+            }
+            return "document-1"
+        }
+    }
+
+    @MainActor
+    private final class NoOpFolderConfiguration: GoogleDriveExportFolderConfiguring {
+        func configure(folderName _: String, session _: GoogleSession) async throws {}
+        func configureIfNeeded(session _: GoogleSession) async throws {}
+    }
+
+    @MainActor
+    private final class FolderConfigurationSignInProvider: GoogleSignInProviding {
+        let isConfigured = true
+        let hasPreviousSignIn: Bool
+        let sessionDidChangeNotification = Notification.Name("FolderConfigurationSignInProvider.sessionDidChange")
+
+        init(hasPreviousSignIn: Bool = false) {
+            self.hasPreviousSignIn = hasPreviousSignIn
+        }
+
+        func restorePreviousSignIn() async throws -> GoogleSession {
+            defaultDriveSession
+        }
+
+        func signIn(withPresentingWindow _: NSWindow, requestedScopes _: Set<String>) async throws -> GoogleSession {
+            defaultDriveSession
+        }
+
+        func refreshCurrentSession() async throws -> GoogleSession? {
+            defaultDriveSession
+        }
+
+        func disconnect() async throws {}
+    }
+
+    private let defaultDriveSession = makeDriveSession(accountID: "user-1")
+
+    private func makeDriveSession(accountID: String) -> GoogleSession {
+        GoogleSession(
+            account: GoogleCalendarAccount(id: accountID, displayName: "Kazuki", email: "kazuki@example.com"),
+            accessToken: "drive-token",
+            grantedScopes: GoogleOAuthScope.authorizationScopes(for: GoogleOAuthScope.drive)
+        )
+    }
+#endif

--- a/Tests/DahliaTests/GoogleDriveExportFolderConfigurationServiceTests.swift
+++ b/Tests/DahliaTests/GoogleDriveExportFolderConfigurationServiceTests.swift
@@ -8,15 +8,14 @@ import Foundation
     @MainActor
     struct GoogleDriveExportFolderConfigurationServiceTests {
         @Test
-        func configuringBlankNameStoresDefaultFolderIDForConnectedAccount() async throws {
+        func initialConfigurationStoresMeetingNotesFolderForConnectedAccount() async throws {
             let apiClient = FolderConfigurationAPIClient(folderID: "folder-1")
             let settings = FolderConfigurationSettings()
             let service = GoogleDriveExportFolderConfigurationService(apiClient: apiClient, settings: settings)
 
-            try await service.configure(folderName: "  ", session: defaultDriveSession)
+            try await service.configureIfNeeded(session: defaultDriveSession)
 
             #expect(await apiClient.resolvedFolderNames == ["Meeting Notes"])
-            #expect(settings.resolvedGoogleDriveExportFolderName == "Meeting Notes")
             #expect(settings.googleDriveExportFolderID(forAccountID: "user-1") == "folder-1")
         }
 
@@ -32,7 +31,7 @@ import Foundation
         func existingAvailableFolderIDSkipsFolderLookup() async throws {
             let apiClient = FolderConfigurationAPIClient(folderID: "unused-folder")
             let settings = FolderConfigurationSettings()
-            settings.setGoogleDriveExportFolder(name: "Team Notes", id: "folder-1", accountID: "user-1")
+            settings.setGoogleDriveExportFolder(id: "folder-1", accountID: "user-1")
             let service = GoogleDriveExportFolderConfigurationService(apiClient: apiClient, settings: settings)
 
             try await service.configureIfNeeded(session: defaultDriveSession)
@@ -60,13 +59,13 @@ import Foundation
         func unavailableStoredFolderIsResolvedAndReplaced() async throws {
             let apiClient = FolderConfigurationAPIClient(folderID: "replacement-folder", isFolderAvailable: false)
             let settings = FolderConfigurationSettings()
-            settings.setGoogleDriveExportFolder(name: "Team Notes", id: "stale-folder", accountID: "user-1")
+            settings.setGoogleDriveExportFolder(id: "stale-folder", accountID: "user-1")
             let service = GoogleDriveExportFolderConfigurationService(apiClient: apiClient, settings: settings)
 
             try await service.configureIfNeeded(session: defaultDriveSession)
 
             #expect(await apiClient.validatedFolderIDs == ["stale-folder"])
-            #expect(await apiClient.resolvedFolderNames == ["Team Notes"])
+            #expect(await apiClient.resolvedFolderNames == ["Meeting Notes"])
             #expect(settings.googleDriveExportFolderID(forAccountID: "user-1") == "replacement-folder")
         }
 
@@ -74,13 +73,13 @@ import Foundation
         func folderIDFromAnotherAccountIsNotReused() async throws {
             let apiClient = FolderConfigurationAPIClient(folderID: "account-2-folder")
             let settings = FolderConfigurationSettings()
-            settings.setGoogleDriveExportFolder(name: "Team Notes", id: "account-1-folder", accountID: "user-1")
+            settings.setGoogleDriveExportFolder(id: "account-1-folder", accountID: "user-1")
             let service = GoogleDriveExportFolderConfigurationService(apiClient: apiClient, settings: settings)
 
             try await service.configureIfNeeded(session: makeDriveSession(accountID: "user-2"))
 
             #expect(await apiClient.validatedFolderIDs.isEmpty)
-            #expect(await apiClient.resolvedFolderNames == ["Team Notes"])
+            #expect(await apiClient.resolvedFolderNames == ["Meeting Notes"])
             #expect(settings.googleDriveExportFolderID(forAccountID: "user-2") == "account-2-folder")
         }
 
@@ -89,7 +88,7 @@ import Foundation
             let driveStore = makeAuthorizedDriveStore()
             let apiClient = FolderConfigurationAPIClient(folderID: "unused-folder")
             let settings = FolderConfigurationSettings()
-            settings.setGoogleDriveExportFolder(name: "Team Notes", id: "folder-1", accountID: "user-1")
+            settings.setGoogleDriveExportFolder(id: "folder-1", accountID: "user-1")
             await driveStore.restoreSessionIfNeeded()
 
             let fileID = try await exportSummary(
@@ -109,7 +108,7 @@ import Foundation
             let driveStore = makeAuthorizedDriveStore()
             let apiClient = FolderConfigurationAPIClient(folderID: "unused-folder")
             let settings = FolderConfigurationSettings()
-            settings.setGoogleDriveExportFolder(name: "Team Notes", id: "folder-2", accountID: "user-2")
+            settings.setGoogleDriveExportFolder(id: "folder-2", accountID: "user-2")
             await driveStore.restoreSessionIfNeeded()
 
             do {
@@ -130,7 +129,7 @@ import Foundation
             let driveStore = makeAuthorizedDriveStore()
             let apiClient = FolderConfigurationAPIClient(folderID: "unused-folder", uploadStatusCode: 404)
             let settings = FolderConfigurationSettings()
-            settings.setGoogleDriveExportFolder(name: "Team Notes", id: "stale-folder", accountID: "user-1")
+            settings.setGoogleDriveExportFolder(id: "stale-folder", accountID: "user-1")
             await driveStore.restoreSessionIfNeeded()
 
             do {
@@ -171,20 +170,14 @@ import Foundation
 
     @MainActor
     private final class FolderConfigurationSettings: GoogleDriveExportFolderSettingsProviding {
-        private var folderName = AppSettings.defaultGoogleDriveExportFolderName
         private var folderID: String?
         private var accountID: String?
-
-        var resolvedGoogleDriveExportFolderName: String {
-            AppSettings.resolvedGoogleDriveExportFolderName(folderName)
-        }
 
         func googleDriveExportFolderID(forAccountID accountID: String) -> String? {
             self.accountID == accountID ? folderID : nil
         }
 
-        func setGoogleDriveExportFolder(name: String, id: String, accountID: String) {
-            folderName = name
+        func setGoogleDriveExportFolder(id: String, accountID: String) {
             folderID = id
             self.accountID = accountID
         }
@@ -247,7 +240,6 @@ import Foundation
 
     @MainActor
     private final class NoOpFolderConfiguration: GoogleDriveExportFolderConfiguring {
-        func configure(folderName _: String, session _: GoogleSession) async throws {}
         func configureIfNeeded(session _: GoogleSession) async throws {}
     }
 

--- a/Tests/DahliaTests/GoogleDriveStoreTests.swift
+++ b/Tests/DahliaTests/GoogleDriveStoreTests.swift
@@ -20,6 +20,7 @@ import Foundation
             )
             let store = GoogleDriveStore(
                 signInProvider: signInProvider,
+                exportFolderConfiguration: MockGoogleDriveExportFolderConfiguration(),
                 presentingWindowProvider: { NSWindow() }
             )
 
@@ -36,7 +37,10 @@ import Foundation
                 hasPreviousSignIn: true,
                 restoreResult: .failure(GoogleSignInError.authorizationFailed("Expired session"))
             )
-            let store = GoogleDriveStore(signInProvider: signInProvider)
+            let store = GoogleDriveStore(
+                signInProvider: signInProvider,
+                exportFolderConfiguration: MockGoogleDriveExportFolderConfiguration()
+            )
 
             await store.restoreSessionIfNeeded()
             signInProvider.restoreResult = .success(driveSession)
@@ -49,7 +53,10 @@ import Foundation
 
         @Test
         func authorizedOperationReportsBusyUntilCompletion() async throws {
-            let store = GoogleDriveStore(signInProvider: MockGoogleSignInProvider())
+            let store = GoogleDriveStore(
+                signInProvider: MockGoogleSignInProvider(),
+                exportFolderConfiguration: MockGoogleDriveExportFolderConfiguration()
+            )
 
             let wasBusy = try await store.performAuthorizedOperation { _ in
                 await MainActor.run { store.isBusy }
@@ -64,14 +71,35 @@ import Foundation
             let signInProvider = MockGoogleSignInProvider(
                 signInResult: .success(driveSession)
             )
+            let folderConfiguration = MockGoogleDriveExportFolderConfiguration()
             let store = GoogleDriveStore(
                 signInProvider: signInProvider,
+                exportFolderConfiguration: folderConfiguration,
                 presentingWindowProvider: { NSWindow() }
             )
 
             await store.signIn()
 
             #expect(signInProvider.signInRequestedScopes == [GoogleOAuthScope.drive])
+            #expect(folderConfiguration.configureIfNeededCallCount == 1)
+        }
+
+        @Test
+        func folderConfigurationFailureKeepsAuthorizedSessionAndReportsError() async {
+            let folderConfiguration = MockGoogleDriveExportFolderConfiguration(
+                result: .failure(GoogleDriveAPIError.httpError(statusCode: 503, detail: "Unavailable"))
+            )
+            let store = GoogleDriveStore(
+                signInProvider: MockGoogleSignInProvider(signInResult: .success(driveSession)),
+                exportFolderConfiguration: folderConfiguration,
+                presentingWindowProvider: { NSWindow() }
+            )
+
+            await store.signIn()
+
+            #expect(store.isAuthorized)
+            #expect(store.state == .connected)
+            #expect(store.exportFolderErrorMessage != nil)
         }
 
         @Test
@@ -83,7 +111,10 @@ import Foundation
                 sessionDidChangeNotification: watchedNotification,
                 restoreResult: .success(driveSession)
             )
-            let store = GoogleDriveStore(signInProvider: signInProvider)
+            let store = GoogleDriveStore(
+                signInProvider: signInProvider,
+                exportFolderConfiguration: MockGoogleDriveExportFolderConfiguration()
+            )
 
             NotificationCenter.default.post(name: ignoredNotification, object: nil)
             await Task.yield()
@@ -147,6 +178,25 @@ import Foundation
         }
 
         func disconnect() async throws {}
+    }
+
+    @MainActor
+    private final class MockGoogleDriveExportFolderConfiguration: GoogleDriveExportFolderConfiguring {
+        private let result: Result<Void, Error>
+        private(set) var configureIfNeededCallCount = 0
+
+        init(result: Result<Void, Error> = .success(())) {
+            self.result = result
+        }
+
+        func configure(folderName _: String, session _: GoogleSession) async throws {
+            try result.get()
+        }
+
+        func configureIfNeeded(session _: GoogleSession) async throws {
+            configureIfNeededCallCount += 1
+            try result.get()
+        }
     }
 
 #endif

--- a/Tests/DahliaTests/GoogleDriveStoreTests.swift
+++ b/Tests/DahliaTests/GoogleDriveStoreTests.swift
@@ -189,10 +189,6 @@ import Foundation
             self.result = result
         }
 
-        func configure(folderName _: String, session _: GoogleSession) async throws {
-            try result.get()
-        }
-
         func configureIfNeeded(session _: GoogleSession) async throws {
             configureIfNeededCallCount += 1
             try result.get()


### PR DESCRIPTION
## Summary

- create or reuse a fixed `Meeting Notes` folder under My Drive
- persist and validate the Drive folder ID per Google account
- move folder provisioning out of the export path and serialize concurrent configuration
- let users open the configured folder in Google Drive
- add recovery UI, localization, and regression coverage

## Why

Google Docs exports previously landed directly in My Drive. Dahlia needs a stable destination folder ID so exports do not search by name each time.

## User impact

Dahlia now creates or reuses `Meeting Notes` under My Drive and always exports summaries there. Cloud Storage settings show the fixed destination and can open it in Google Drive. Missing or inaccessible folders are detected and repaired during the configuration lifecycle.

## Validation

- `swift build`
- `swift test --filter GoogleDriveExportFolderConfigurationServiceTests` (9 passed)
- `swift test --filter GoogleDriveStoreTests` (7 passed)
- `swift test --filter GoogleDriveAPIClientTests` (6 passed)
- full suite: 313/315 passed; two existing environment-dependent failures reproduce standalone
- SwiftFormat: clean
- SwiftLint unavailable because SourceKit could not load `sourcekitdInProc`
