### PR TITLE
Open main window after vault setup

### DIFF
--- a/Sources/Dahlia/Views/VaultPickerView.swift
+++ b/Sources/Dahlia/Views/VaultPickerView.swift
@@ -6,6 +6,7 @@ struct VaultPickerView: View {
     let appDatabase: AppDatabaseManager?
     let onVaultSelected: (VaultRecord) -> Void
 
+    @Environment(\.openWindow) private var openWindow
     @ObservedObject private var settings = AppSettings.shared
     @State private var vaults: [VaultRecord] = []
     @State private var selectedVaultId: UUID?
@@ -100,7 +101,7 @@ struct VaultPickerView: View {
         let normalizedURL = url.standardizedFileURL
         if let existingVault = vaults.first(where: { $0.url.standardizedFileURL == normalizedURL }) {
             selectedVaultId = existingVault.id
-            onVaultSelected(existingVault)
+            openVault(existingVault)
             return
         }
 
@@ -116,7 +117,7 @@ struct VaultPickerView: View {
         do {
             try repository.insertVault(vault)
             loadVaults(preferredSelection: vault.id)
-            onVaultSelected(vault)
+            openVault(vault)
         } catch {
             presentError(L10n.vaultAddFailed, error: error, source: "registerVault")
         }
@@ -138,7 +139,13 @@ struct VaultPickerView: View {
 
     private func openSelectedVault() {
         guard let selectedVault else { return }
-        onVaultSelected(selectedVault)
+        openVault(selectedVault)
+    }
+
+    private func openVault(_ vault: VaultRecord) {
+        onVaultSelected(vault)
+        openWindow(id: WindowID.main)
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     private func presentError(_ message: String, error: any Error, source: String) {


### PR DESCRIPTION
## Summary

- open the main Dahlia window after a vault is registered or selected
- bring the app to the foreground after vault setup
- consolidate all vault-opening paths through one helper

## Root cause

Vault selection updated the active vault and switched the app state, but it did not explicitly open the main window. When first-time setup was completed from the vault manager opened through the menu bar, the main window was therefore never created.

## User impact

After initial vault setup, users are now taken directly to the main Dahlia window regardless of whether they selected an existing vault, registered a new vault, or opened a vault from the details view.

## Validation

- `swift build` — passed
- SwiftFormat — passed
- Full test run executed 324 tests; one pre-existing failure remains in `GoogleCalendarConfigurationTests.clientSecretOverrideIsPreferredOverEnvironment`
- SwiftLint could not complete because SourceKit failed to load in the current environment
