### PR TITLE
Auto-stop recording when microphone capture ends

### DIFF
--- a/Sources/Dahlia/Audio/AudioCaptureManager.swift
+++ b/Sources/Dahlia/Audio/AudioCaptureManager.swift
@@ -24,13 +24,29 @@ enum AudioCaptureError: Error, LocalizedError {
 
 /// AVAudioEngine を使用してマイクからオーディオをキャプチャし、
 /// 指定されたターゲットフォーマットに変換して AVAudioPCMBuffer で出力する。
-final class AudioCaptureManager {
+final class AudioCaptureManager: NSObject {
     private let engine = AVAudioEngine()
     private var converter: AVAudioConverter?
     private var captureFormat: AVAudioFormat?
+    private var didReportUnexpectedStop = false
 
     /// 変換済み AVAudioPCMBuffer のコールバック（オーディオスレッドから呼ばれる）
     var onAudioBuffer: ((AVAudioPCMBuffer) -> Void)?
+    var onUnexpectedStop: (() -> Void)?
+
+    override init() {
+        super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(engineConfigurationDidChange),
+            name: .AVAudioEngineConfigurationChange,
+            object: engine
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
 
     /// マイクのパーミッションを確認・要求する。
     static func requestMicrophonePermission() async -> Bool {
@@ -115,6 +131,7 @@ final class AudioCaptureManager {
         selectedDeviceID: AudioDeviceID? = nil,
         bufferSize: AVAudioFrameCount = 4096
     ) throws {
+        didReportUnexpectedStop = false
         self.captureFormat = targetFormat
         let inputNode = engine.inputNode
 
@@ -152,6 +169,14 @@ final class AudioCaptureManager {
         engine.stop()
         converter = nil
         captureFormat = nil
+    }
+
+    @objc private func engineConfigurationDidChange() {
+        guard captureFormat != nil,
+              !engine.isRunning,
+              !didReportUnexpectedStop else { return }
+        didReportUnexpectedStop = true
+        onUnexpectedStop?()
     }
 
     private func processAudioBuffer(_ inputBuffer: AVAudioPCMBuffer) {

--- a/Sources/Dahlia/Audio/DefaultAudioCaptureSessionFactory.swift
+++ b/Sources/Dahlia/Audio/DefaultAudioCaptureSessionFactory.swift
@@ -15,7 +15,10 @@ struct DefaultAudioCaptureSessionFactory: AudioCaptureSessionFactory {
     ) -> any AudioCaptureSession {
         switch pipeline.source {
         case .microphone:
-            MicrophoneAudioCaptureSession(pipeline: pipeline)
+            MicrophoneAudioCaptureSession(
+                pipeline: pipeline,
+                onUnexpectedStop: onUnexpectedStop
+            )
         case .system:
             SystemAudioCaptureSession(
                 pipeline: pipeline,

--- a/Sources/Dahlia/Audio/MicrophoneAudioCaptureSession.swift
+++ b/Sources/Dahlia/Audio/MicrophoneAudioCaptureSession.swift
@@ -2,17 +2,29 @@
 actor MicrophoneAudioCaptureSession: AudioCaptureSession {
     private let manager: AudioCaptureManager
     private let pipeline: AudioSourcePipeline
+    private let onUnexpectedStop: AudioCaptureUnexpectedStopHandler
+    private var isStopping = false
 
-    init(pipeline: AudioSourcePipeline) {
+    init(
+        pipeline: AudioSourcePipeline,
+        onUnexpectedStop: @escaping AudioCaptureUnexpectedStopHandler
+    ) {
         self.pipeline = pipeline
+        self.onUnexpectedStop = onUnexpectedStop
         let manager = AudioCaptureManager()
         manager.onAudioBuffer = { [pipeline] buffer in
             pipeline.router.route(pipeline.capture(buffer))
         }
         self.manager = manager
+        manager.onUnexpectedStop = { [weak self] in
+            Task {
+                await self?.captureStoppedUnexpectedly()
+            }
+        }
     }
 
     func start() throws {
+        isStopping = false
         try manager.startCapture(
             targetFormat: pipeline.captureFormat,
             selectedDeviceID: pipeline.captureDeviceID,
@@ -21,6 +33,12 @@ actor MicrophoneAudioCaptureSession: AudioCaptureSession {
     }
 
     func stop() {
+        isStopping = true
         manager.stopCapture()
+    }
+
+    private func captureStoppedUnexpectedly() {
+        guard !isStopping else { return }
+        onUnexpectedStop(nil)
     }
 }

--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -280,6 +280,10 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     @AppStorage("microphoneMeetingNotificationsEnabled") var microphoneMeetingNotificationsEnabled = true
     @AppStorage("calendarEventMeetingNotificationsEnabled") var calendarEventMeetingNotificationsEnabled = false
 
+    // MARK: - 録音設定
+
+    @AppStorage("automaticallyStopRecordingWhenMicrophoneStops") var automaticallyStopRecordingWhenMicrophoneStops = false
+
     // MARK: - カレンダー設定
 
     @AppStorage("calendarSource") var calendarSourceRawValue = CalendarSource.google.rawValue

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -393,6 +393,10 @@
 "Could not update action item: %@" = "Could not update action item: %@";
 "Speech recognition is not ready" = "Speech recognition is not ready";
 "System audio capture stopped" = "System audio capture stopped";
+"Microphone capture stopped" = "Microphone capture stopped";
+"Automatically Stop Recording" = "Automatically Stop Recording";
+"Recording" = "Recording";
+"Stop and save the recording when Dahlia's microphone capture stops unexpectedly." = "Stop and save the recording when Dahlia's microphone capture stops unexpectedly.";
 
 /* Sidebar Footer */
 "Switch Vault" = "Switch Vault";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -393,6 +393,10 @@
 "Could not update action item: %@" = "アクションアイテムを更新できませんでした: %@";
 "Speech recognition is not ready" = "音声認識が準備されていません";
 "System audio capture stopped" = "システム音声キャプチャが停止しました";
+"Microphone capture stopped" = "マイクのキャプチャが停止しました";
+"Automatically Stop Recording" = "録音を自動停止";
+"Recording" = "録音";
+"Stop and save the recording when Dahlia's microphone capture stops unexpectedly." = "Dahlia のマイクキャプチャが予期せず停止したときに、録音を停止して保存します。";
 
 /* Sidebar Footer */
 "Switch Vault" = "保管庫を切り替え";

--- a/Sources/Dahlia/Services/RecordingSessionController+Runtime.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController+Runtime.swift
@@ -268,7 +268,11 @@ extension RecordingSessionController {
         sessionId: UUID
     ) -> AudioCaptureUnexpectedStopHandler {
         { [weak self] error in
-            let message = error?.localizedDescription ?? L10n.systemAudioCaptureStopped
+            let fallbackMessage: String = switch source {
+            case .microphone: L10n.microphoneCaptureStopped
+            case .system: L10n.systemAudioCaptureStopped
+            }
+            let message = error?.localizedDescription ?? fallbackMessage
             Task {
                 await self?.handleUnexpectedCaptureStop(
                     source: source,

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -793,6 +793,13 @@ enum L10n {
     static func actionItemUpdateFailed(_ error: String) -> String { String(localized: "Could not update action item: \(error)", bundle: bundle) }
     static var speechRecognitionNotReady: String { String(localized: "Speech recognition is not ready", bundle: bundle) }
     static var systemAudioCaptureStopped: String { String(localized: "System audio capture stopped", bundle: bundle) }
+    static var microphoneCaptureStopped: String { String(localized: "Microphone capture stopped", bundle: bundle) }
+    static var automaticallyStopRecording: String { String(localized: "Automatically Stop Recording", bundle: bundle) }
+    static var recording: String { String(localized: "Recording", bundle: bundle) }
+    static var automaticallyStopRecordingDescription: String { String(
+        localized: "Stop and save the recording when Dahlia's microphone capture stops unexpectedly.",
+        bundle: bundle
+    ) }
 
     // MARK: - Sidebar Footer
 

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -2467,8 +2467,13 @@ final class CaptionViewModel: ObservableObject {
     ) {
         guard activeRecordingSessionId == recordingSessionId else { return }
         errorMessage = message
+        let shouldStopRecording = Self.shouldStopRecording(
+            afterFailureFrom: source,
+            isFatal: isFatal,
+            autoStopOnMicrophoneFailure: AppSettings.shared.automaticallyStopRecordingWhenMicrophoneStops
+        )
         if case .starting = recordingLifecycle {
-            if isFatal {
+            if shouldStopRecording {
                 pendingRealtimeRecognitionFailure = (source, message)
             } else {
                 pendingLiveSubtitleWarning = message
@@ -2483,11 +2488,7 @@ final class CaptionViewModel: ObservableObject {
                snapshot.sessionId == recordingSessionId {
                 self.activeControllerSources = snapshot.enabledSources
             }
-            if Self.shouldStopRecording(
-                afterFailureFrom: source,
-                isFatal: isFatal,
-                autoStopOnMicrophoneFailure: AppSettings.shared.automaticallyStopRecordingWhenMicrophoneStops
-            ) {
+            if shouldStopRecording {
                 self.stopListening()
             }
         }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -2483,10 +2483,22 @@ final class CaptionViewModel: ObservableObject {
                snapshot.sessionId == recordingSessionId {
                 self.activeControllerSources = snapshot.enabledSources
             }
-            if isFatal {
+            if Self.shouldStopRecording(
+                afterFailureFrom: source,
+                isFatal: isFatal,
+                autoStopOnMicrophoneFailure: AppSettings.shared.automaticallyStopRecordingWhenMicrophoneStops
+            ) {
                 self.stopListening()
             }
         }
+    }
+
+    nonisolated static func shouldStopRecording(
+        afterFailureFrom source: RecordingAudioSource?,
+        isFatal: Bool,
+        autoStopOnMicrophoneFailure: Bool
+    ) -> Bool {
+        isFatal || (source == .microphone && autoStopOnMicrophoneFailure)
     }
 
     private func handleLiveSubtitleSettingChange(isEnabled: Bool) {

--- a/Sources/Dahlia/Views/Settings/GeneralSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/GeneralSettingsView.swift
@@ -75,6 +75,14 @@ struct GeneralSettingsView: View {
             } footer: {
                 Text(L10n.notificationSettingsDescription)
             }
+
+            Section(L10n.recording) {
+                Toggle(isOn: $settings.automaticallyStopRecordingWhenMicrophoneStops) {
+                    Text(L10n.automaticallyStopRecording)
+                    Text(L10n.automaticallyStopRecordingDescription)
+                }
+                .toggleStyle(.switch)
+            }
         }
         .formStyle(.grouped)
     }

--- a/Tests/DahliaTests/CaptionViewModelTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelTests.swift
@@ -55,6 +55,34 @@ import GRDB
         }
 
         @Test
+        func microphoneCaptureStopOnlyStopsRecordingWhenEnabled() {
+            #expect(CaptionViewModel.shouldStopRecording(
+                afterFailureFrom: .microphone,
+                isFatal: false,
+                autoStopOnMicrophoneFailure: true
+            ))
+            #expect(!CaptionViewModel.shouldStopRecording(
+                afterFailureFrom: .microphone,
+                isFatal: false,
+                autoStopOnMicrophoneFailure: false
+            ))
+            #expect(!CaptionViewModel.shouldStopRecording(
+                afterFailureFrom: .system,
+                isFatal: false,
+                autoStopOnMicrophoneFailure: true
+            ))
+        }
+
+        @Test
+        func fatalCaptureFailureAlwaysStopsRecording() {
+            #expect(CaptionViewModel.shouldStopRecording(
+                afterFailureFrom: .system,
+                isFatal: true,
+                autoStopOnMicrophoneFailure: false
+            ))
+        }
+
+        @Test
         func unsupportedLocaleFallsBackToPreferredSupportedLanguageVariant() {
             let supportedLocales = [
                 Locale(identifier: "en_AU"),


### PR DESCRIPTION
## Summary

- detect unexpected termination of Dahlia's own microphone capture
- optionally stop and save the entire recording when microphone capture ends
- add an opt-in General > Recording setting with Japanese and English localization
- keep manual stops, silence, mute state, and other applications' microphone activity out of scope

## Why

When Dahlia's microphone capture ends unexpectedly, a recording that also contains system audio could previously continue without microphone input. This adds an opt-in policy that routes that microphone failure through the existing safe recording finalization flow.

## Validation

- `swift build`
- `swift test --filter CaptionViewModelTests` — 19 tests passed
- `swift test` — 326 Swift Testing tests and 3 XCTest tests passed
- `CI=true ./scripts/lint.sh` — SwiftFormat passed; SwiftLint reported pre-existing repository violations
