### PR TITLE
Add summary follow-up to batch transcription

### DIFF
--- a/Sources/Dahlia/Models/BatchTranscriptionConfirmation.swift
+++ b/Sources/Dahlia/Models/BatchTranscriptionConfirmation.swift
@@ -5,6 +5,7 @@ struct BatchTranscriptionConfirmation: Identifiable, Equatable {
     let meetingId: UUID
     let suggestedLocaleIdentifier: String
     let retainAudioAfterBatch: Bool
+    let generateSummaryAfterTranscription: Bool
 
     var id: UUID { sessionId }
 }

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -467,6 +467,8 @@
 "The selected language is used for single-language recordings. Language changes made during recording are preserved. The audio is kept until transcription succeeds." = "The selected language is used for single-language recordings. Language changes made during recording are preserved. The audio is kept until transcription succeeds.";
 "Delete Recording Files After Transcription" = "Delete Recording Files After Transcription";
 "Delete the recording files after batch transcription succeeds. They are kept if transcription fails." = "Delete the recording files after batch transcription succeeds. They are kept if transcription fails.";
+"Generate Summary After Transcription" = "Generate Summary After Transcription";
+"Automatically generate a summary when batch transcription succeeds." = "Automatically generate a summary when batch transcription succeeds.";
 "Later" = "Later";
 "Discard Failed Recording" = "Discard Failed Recording";
 "Discard this failed recording?" = "Discard this failed recording?";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -467,6 +467,8 @@
 "The selected language is used for single-language recordings. Language changes made during recording are preserved. The audio is kept until transcription succeeds." = "単一言語の録音には選択した言語を使用します。録音中に切り替えた言語区間は保持されます。文字起こしが成功するまで音声データは保持されます。";
 "Delete Recording Files After Transcription" = "文字起こし後に録音ファイルを削除";
 "Delete the recording files after batch transcription succeeds. They are kept if transcription fails." = "バッチ文字起こしが成功したら録音ファイルを削除します。失敗した場合は再試行のため保持されます。";
+"Generate Summary After Transcription" = "文字起こし後に要約を生成";
+"Automatically generate a summary when batch transcription succeeds." = "バッチ文字起こしが成功したら、自動的に要約を生成します。";
 "Later" = "あとで";
 "Discard Failed Recording" = "失敗した録音を破棄";
 "Discard this failed recording?" = "失敗した録音を破棄しますか？";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -277,6 +277,14 @@ enum L10n {
         localized: "Delete the recording files after batch transcription succeeds. They are kept if transcription fails.",
         bundle: bundle
     ) }
+    static var generateSummaryAfterBatchTranscription: String { String(
+        localized: "Generate Summary After Transcription",
+        bundle: bundle
+    ) }
+    static var generateSummaryAfterBatchTranscriptionDescription: String { String(
+        localized: "Automatically generate a summary when batch transcription succeeds.",
+        bundle: bundle
+    ) }
     static var later: String { String(localized: "Later", bundle: bundle) }
     static var discardFailedBatchRecording: String { String(localized: "Discard Failed Recording", bundle: bundle) }
     static var discardFailedBatchRecordingConfirmation: String { String(localized: "Discard this failed recording?", bundle: bundle) }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -133,6 +133,7 @@ final class CaptionViewModel: ObservableObject {
 
     @Published var summaryGeneratingMeetingId: UUID?
     var isSummaryGenerating: Bool { summaryGeneratingMeetingId != nil }
+    private var pendingBatchSummaryMeetingIdsBySessionId: [UUID: UUID] = [:]
     @Published var summaryError: String?
     @Published private(set) var googleDocsExportError: String?
     private var isExportingCurrentSummaryToGoogleDocs = false
@@ -469,15 +470,25 @@ final class CaptionViewModel: ObservableObject {
         pendingBatchTranscriptionConfirmation = nil
     }
 
-    func confirmBatchTranscription(localeIdentifier: String, retainAudioAfterBatch: Bool) {
+    func confirmBatchTranscription(
+        localeIdentifier: String,
+        retainAudioAfterBatch: Bool,
+        generateSummaryAfterTranscription: Bool
+    ) {
         guard let confirmation = pendingBatchTranscriptionConfirmation,
               let coordinator = batchTranscriptionCoordinator else { return }
         let retryConfirmation = BatchTranscriptionConfirmation(
             sessionId: confirmation.sessionId,
             meetingId: confirmation.meetingId,
             suggestedLocaleIdentifier: localeIdentifier,
-            retainAudioAfterBatch: retainAudioAfterBatch
+            retainAudioAfterBatch: retainAudioAfterBatch,
+            generateSummaryAfterTranscription: generateSummaryAfterTranscription
         )
+        if generateSummaryAfterTranscription {
+            pendingBatchSummaryMeetingIdsBySessionId[confirmation.sessionId] = confirmation.meetingId
+        } else {
+            pendingBatchSummaryMeetingIdsBySessionId.removeValue(forKey: confirmation.sessionId)
+        }
         pendingBatchTranscriptionConfirmation = nil
         if currentMeetingId == confirmation.meetingId {
             batchTranscriptionState = .queued(sessionId: confirmation.sessionId)
@@ -561,6 +572,7 @@ final class CaptionViewModel: ObservableObject {
             store.loadRecordingSessions(loaded.recordingSessions)
             store.loadSegments(loaded.segments)
             applyLoadedDetail(loaded)
+            generatePendingBatchSummaryIfReady(meetingId: meetingId)
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -793,6 +805,7 @@ final class CaptionViewModel: ObservableObject {
             self.store.loadRecordingSessions(loaded.recordingSessions)
             self.store.loadSegments(loaded.segments)
             self.applyLoadedDetail(loaded)
+            self.generatePendingBatchSummaryIfReady(meetingId: meetingId)
         }
     }
 
@@ -1765,7 +1778,8 @@ final class CaptionViewModel: ObservableObject {
             retainAudioAfterBatch: batchAudioRetentionPreference(
                 sessionId: sessionId,
                 dbQueue: dbQueue
-            )
+            ),
+            generateSummaryAfterTranscription: false
         )
         MainWindowOpener.shared.openMainWindow()
     }
@@ -1871,6 +1885,19 @@ final class CaptionViewModel: ObservableObject {
                 recordingSessions: recordingSessions
             )
         }
+    }
+
+    private func generatePendingBatchSummaryIfReady(meetingId: UUID) {
+        let pendingSessionIds = pendingBatchSummaryMeetingIdsBySessionId.compactMap { sessionId, pendingMeetingId in
+            pendingMeetingId == meetingId ? sessionId : nil
+        }
+        guard currentMeetingId == meetingId,
+              canGenerateSummary,
+              !pendingSessionIds.isEmpty else { return }
+        for sessionId in pendingSessionIds {
+            pendingBatchSummaryMeetingIdsBySessionId.removeValue(forKey: sessionId)
+        }
+        triggerManualSummary()
     }
 
     func generateSummary(

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -520,6 +520,7 @@ final class CaptionViewModel: ObservableObject {
             do {
                 let repository = MeetingRepository(dbQueue: dbQueue)
                 guard try repository.discardFailedBatchSession(id: sessionId) else { return }
+                pendingBatchSummaryMeetingIdsBySessionId.removeValue(forKey: sessionId)
                 try refreshBatchTranscriptionState(meetingId: meetingId, dbQueue: dbQueue)
             } catch {
                 errorMessage = error.localizedDescription

--- a/Sources/Dahlia/Views/BatchTranscriptionConfirmationView.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionConfirmationView.swift
@@ -2,17 +2,19 @@ import SwiftUI
 
 struct BatchTranscriptionConfirmationView: View {
     let locales: [Locale]
-    let onStart: (String, Bool) -> Void
+    let onStart: (String, Bool, Bool) -> Void
     let onPostpone: () -> Void
 
     @State private var selectedLocaleIdentifier: String
     @State private var deleteAudioAfterTranscription: Bool
+    @State private var generateSummaryAfterTranscription: Bool
 
     init(
         locales: [Locale],
         initialLocaleIdentifier: String,
         initiallyRetainsAudioAfterBatch: Bool,
-        onStart: @escaping (String, Bool) -> Void,
+        initiallyGeneratesSummaryAfterTranscription: Bool,
+        onStart: @escaping (String, Bool, Bool) -> Void,
         onPostpone: @escaping () -> Void
     ) {
         self.locales = locales
@@ -20,6 +22,7 @@ struct BatchTranscriptionConfirmationView: View {
         self.onPostpone = onPostpone
         _selectedLocaleIdentifier = State(initialValue: initialLocaleIdentifier)
         _deleteAudioAfterTranscription = State(initialValue: !initiallyRetainsAudioAfterBatch)
+        _generateSummaryAfterTranscription = State(initialValue: initiallyGeneratesSummaryAfterTranscription)
     }
 
     var body: some View {
@@ -48,6 +51,16 @@ struct BatchTranscriptionConfirmationView: View {
             }
             .toggleStyle(.checkbox)
 
+            Toggle(isOn: $generateSummaryAfterTranscription) {
+                VStack(alignment: .leading) {
+                    Text(L10n.generateSummaryAfterBatchTranscription)
+                    Text(L10n.generateSummaryAfterBatchTranscriptionDescription)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .toggleStyle(.checkbox)
+
             Divider()
 
             HStack {
@@ -69,6 +82,10 @@ struct BatchTranscriptionConfirmationView: View {
     }
 
     private func startTranscription() {
-        onStart(selectedLocaleIdentifier, !deleteAudioAfterTranscription)
+        onStart(
+            selectedLocaleIdentifier,
+            !deleteAudioAfterTranscription,
+            generateSummaryAfterTranscription
+        )
     }
 }

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -61,6 +61,7 @@ struct ContentView: View {
                 ),
                 initialLocaleIdentifier: confirmation.suggestedLocaleIdentifier,
                 initiallyRetainsAudioAfterBatch: confirmation.retainAudioAfterBatch,
+                initiallyGeneratesSummaryAfterTranscription: confirmation.generateSummaryAfterTranscription,
                 onStart: viewModel.confirmBatchTranscription,
                 onPostpone: viewModel.postponeBatchTranscription
             )

--- a/Tests/DahliaTests/CaptionViewModelBatchUpdateTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelBatchUpdateTests.swift
@@ -89,6 +89,91 @@ import GRDB
             #expect(viewModel.recordingMeetingId == prepared.recordingMeeting.id)
         }
 
+        @Test
+        func discardingFailedBatchCancelsPendingSummaryGeneration() async throws {
+            let batch = try BatchAudioTestFixture(
+                name: "discard-cancels-summary",
+                meetingStatus: .ready,
+                endedAt: Date(timeIntervalSince1970: 1_776_384_001),
+                duration: 1
+            )
+            defer { batch.removeFiles() }
+            let audioFile = batch.makeAudioRecord(finalizedAt: batch.now, totalFrameCount: 160)
+            let range = RecordingAudioRangeRecord(
+                id: .v7(),
+                audioFileId: audioFile.id,
+                startFrame: 0,
+                frameCount: 160,
+                sessionOffsetSeconds: 0,
+                localeIdentifier: "ja_JP",
+                createdAt: batch.now,
+                updatedAt: batch.now
+            )
+            let existingSegment = TranscriptSegmentRecord(
+                id: .v7(),
+                meetingId: batch.meeting.id,
+                startTime: batch.now,
+                endTime: nil,
+                text: "Existing transcript",
+                translatedText: nil,
+                isConfirmed: true,
+                speakerLabel: "mic"
+            )
+            try await batch.database.dbQueue.write { db in
+                try audioFile.insert(db)
+                try range.insert(db)
+                try existingSegment.insert(db)
+            }
+
+            let viewModel = CaptionViewModel()
+            viewModel.configureBatchTranscription(dbQueue: batch.database.dbQueue)
+            viewModel.loadMeeting(
+                batch.meeting.id,
+                dbQueue: batch.database.dbQueue,
+                projectURL: nil,
+                projectId: nil,
+                vaultURL: batch.vaultURL
+            )
+            #expect(await waitUntil {
+                viewModel.batchTranscriptionState == .awaitingConfirmation(sessionId: batch.session.id)
+            })
+
+            viewModel.pendingBatchTranscriptionConfirmation = BatchTranscriptionConfirmation(
+                sessionId: batch.session.id,
+                meetingId: batch.meeting.id,
+                suggestedLocaleIdentifier: "ja_JP",
+                retainAudioAfterBatch: false,
+                generateSummaryAfterTranscription: true
+            )
+            viewModel.confirmBatchTranscription(
+                localeIdentifier: "ja_JP",
+                retainAudioAfterBatch: false,
+                generateSummaryAfterTranscription: true
+            )
+            #expect(await waitUntil {
+                if case .failed = viewModel.batchTranscriptionState {
+                    true
+                } else {
+                    false
+                }
+            })
+
+            viewModel.discardFailedBatchTranscription()
+            #expect(await waitUntil { viewModel.batchTranscriptionState == nil })
+
+            viewModel.loadMeeting(
+                batch.meeting.id,
+                dbQueue: batch.database.dbQueue,
+                projectURL: nil,
+                projectId: nil,
+                vaultURL: batch.vaultURL
+            )
+            #expect(await waitUntil {
+                viewModel.store.segments.contains(where: { $0.id == existingSegment.id })
+            })
+            #expect(!viewModel.requestShowSummaryTab)
+        }
+
         private func makeFixture(name: String) throws -> Fixture {
             let batch = try BatchAudioTestFixture(
                 name: name,


### PR DESCRIPTION
## Summary

- add an option to the batch transcription confirmation sheet to generate a summary after transcription
- reload the completed transcript before starting summary generation
- retain the follow-up intent while navigating between meetings or retrying confirmation
- add Japanese and English localization for the new option

## Impact

Users can start high-accuracy batch transcription and have Dahlia continue directly into summary generation without a second manual action.

## Validation

- `swift build`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter CaptionViewModelBatchUpdateTests` (2 tests passed)
- `CI=true ./scripts/lint.sh` (SwiftFormat clean; SwiftLint reports pre-existing repository-wide violations)