### PR TITLE
Bump version to 0.3.3

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundleVersion</key>
     <string>12</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.3.2</string>
+    <string>0.3.3</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>


### PR DESCRIPTION
## Summary

- update `CFBundleShortVersionString` from 0.3.2 to 0.3.3

## Why

Prepare the application metadata for the 0.3.3 release.

## Impact

The app and release artifacts now report version 0.3.3. No runtime behavior or database schema changes are included.

## Validation

- `plutil -lint Resources/Info.plist`
- confirmed `CFBundleShortVersionString` resolves to `0.3.3`
- `git diff --check`
