### PR TITLE
Fix screenshot grid hang

### DIFF
--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -163,7 +163,7 @@ private struct ScreenshotThumbnailView: View {
             }
         }
         .padding(6)
-        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 8))
+        .background(Color.primary.opacity(0.05), in: RoundedRectangle(cornerRadius: 8))
         .task(id: screenshot.id) {
             thumbnailImage = nil
             thumbnailImage = await Self.makeThumbnail(from: screenshot.imageData)


### PR DESCRIPTION
## What changed

- Replaced the per-thumbnail Liquid Glass effect in the screenshots grid with a lightweight rounded background.

## Why

Sentry issue [DAHLIA-APP-15](https://dahlia-app.sentry.io/issues/7607221669/) showed the main thread hanging in `SwiftUICore.GlassEntryLayout.placeSubviews` while displaying the screenshots screen. Each lazy-grid thumbnail created its own Glass layout entry, triggering repeated coordinate and union-bounds work on macOS 26.5.1.

The new background preserves the card shape and interaction while keeping thumbnails out of the Glass layout system.

## Validation

- `swift build`
- `swift test` — 328 Swift Testing tests and 3 XCTest tests passed
- SwiftFormat — no formatting changes required
- Claude Sonnet high-effort code review — no findings

SwiftLint still reports pre-existing repository-wide violations unrelated to this change.
