### PR TITLE
Fix automatic recording stop and bump version

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>12</string>
+    <string>13</string>
     <key>CFBundleShortVersionString</key>
     <string>0.3.4</string>
     <key>CFBundlePackageType</key>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundleVersion</key>
     <string>12</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.3.3</string>
+    <string>0.3.4</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/Audio/AudioCaptureManager.swift
+++ b/Sources/Dahlia/Audio/AudioCaptureManager.swift
@@ -63,6 +63,7 @@ final class AudioCaptureManager: NSObject, @unchecked Sendable {
     private struct HandlerState {
         var audioBuffer: (@Sendable (AVAudioPCMBuffer) -> Void)?
         var inputLevels: (@Sendable ([Double]) -> Void)?
+        var interruption: AudioCaptureInterruptionHandler?
         var unexpectedStop: (@Sendable (AudioCaptureError?) -> Void)?
     }
 
@@ -84,6 +85,11 @@ final class AudioCaptureManager: NSObject, @unchecked Sendable {
     var onInputLevels: (@Sendable ([Double]) -> Void)? {
         get { handlerState.withLock { $0.inputLevels } }
         set { handlerState.withLock { $0.inputLevels = newValue } }
+    }
+
+    var onInterruption: AudioCaptureInterruptionHandler? {
+        get { handlerState.withLock { $0.interruption } }
+        set { handlerState.withLock { $0.interruption = newValue } }
     }
 
     var onUnexpectedStop: (@Sendable (AudioCaptureError?) -> Void)? {
@@ -329,6 +335,16 @@ extension AudioCaptureManager {
               let request = activeRequest else { return }
         lifecycleState = .restarting
         activeRequest = nil
+        if let onInterruption {
+            Task {
+                await onInterruption()
+            }
+        }
+        restartCaptureAfterConfigurationChange(request)
+    }
+
+    private func restartCaptureAfterConfigurationChange(_ request: CaptureRequest) {
+        guard lifecycleState == .restarting else { return }
         Self.logger.notice("Restarting microphone engine after a configuration change")
         resetCaptureAttempt()
         do {

--- a/Sources/Dahlia/Audio/DefaultAudioCaptureSessionFactory.swift
+++ b/Sources/Dahlia/Audio/DefaultAudioCaptureSessionFactory.swift
@@ -11,12 +11,14 @@ struct DefaultAudioCaptureSessionFactory: AudioCaptureSessionFactory {
 
     func makeSession(
         for pipeline: AudioSourcePipeline,
+        onInterruption: @escaping AudioCaptureInterruptionHandler,
         onUnexpectedStop: @escaping AudioCaptureUnexpectedStopHandler
     ) -> any AudioCaptureSession {
         switch pipeline.source {
         case .microphone:
             MicrophoneAudioCaptureSession(
                 pipeline: pipeline,
+                onInterruption: onInterruption,
                 onUnexpectedStop: onUnexpectedStop
             )
         case .system:

--- a/Sources/Dahlia/Audio/MicrophoneAudioCaptureSession.swift
+++ b/Sources/Dahlia/Audio/MicrophoneAudioCaptureSession.swift
@@ -7,6 +7,7 @@ actor MicrophoneAudioCaptureSession: AudioCaptureSession {
 
     init(
         pipeline: AudioSourcePipeline,
+        onInterruption: @escaping AudioCaptureInterruptionHandler,
         onUnexpectedStop: @escaping AudioCaptureUnexpectedStopHandler
     ) {
         self.pipeline = pipeline
@@ -16,6 +17,7 @@ actor MicrophoneAudioCaptureSession: AudioCaptureSession {
             pipeline.router.route(pipeline.capture(buffer))
         }
         self.manager = manager
+        manager.onInterruption = onInterruption
         manager.onUnexpectedStop = { [weak self] error in
             Task {
                 await self?.captureStoppedUnexpectedly(error)

--- a/Sources/Dahlia/Services/RecordingSessionController+Runtime.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController+Runtime.swift
@@ -1,6 +1,32 @@
 import Foundation
 
 extension RecordingSessionController {
+    func captureInterruptionHandler(
+        source: RecordingAudioSource,
+        runtimeID: UUID,
+        sessionId: UUID
+    ) -> AudioCaptureInterruptionHandler {
+        { [weak self] in
+            await self?.handleCaptureInterruption(
+                source: source,
+                runtimeID: runtimeID,
+                sessionId: sessionId
+            )
+        }
+    }
+
+    private func handleCaptureInterruption(
+        source: RecordingAudioSource,
+        runtimeID: UUID,
+        sessionId: UUID
+    ) async {
+        guard case let .capturing(snapshot) = state,
+              snapshot.sessionId == sessionId,
+              sourceRuntimeGenerations[source] == runtimeID,
+              sourceRuntimes[source]?.id == runtimeID else { return }
+        await onCaptureInterruption?(source)
+    }
+
     func startRecognition(
         _ recognition: any ProgressiveRecognitionSession,
         source: RecordingAudioSource,

--- a/Sources/Dahlia/Services/RecordingSessionController+SourceReconfiguration.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController+SourceReconfiguration.swift
@@ -134,6 +134,11 @@ extension RecordingSessionController {
             runtimeID = newRuntimeID
             let newCapture = captureFactory.makeSession(
                 for: preparation.pipeline,
+                onInterruption: captureInterruptionHandler(
+                    source: preparation.source,
+                    runtimeID: newRuntimeID,
+                    sessionId: snapshot.sessionId
+                ),
                 onUnexpectedStop: captureFailureHandler(
                     source: preparation.source,
                     runtimeID: newRuntimeID,
@@ -316,6 +321,11 @@ extension RecordingSessionController {
             runtimeID = replacementRuntimeID
             let replacementCapture = captureFactory.makeSession(
                 for: preparation.pipeline,
+                onInterruption: captureInterruptionHandler(
+                    source: preparation.source,
+                    runtimeID: replacementRuntimeID,
+                    sessionId: snapshot.sessionId
+                ),
                 onUnexpectedStop: captureFailureHandler(
                     source: preparation.source,
                     runtimeID: replacementRuntimeID,

--- a/Sources/Dahlia/Services/RecordingSessionController+Startup.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController+Startup.swift
@@ -46,6 +46,7 @@ extension RecordingSessionController {
         )
         let capture = captureFactory.makeSession(
             for: pipeline,
+            onInterruption: captureInterruptionHandler(source: configuration.source, runtimeID: runtimeID, sessionId: snapshot.sessionId),
             onUnexpectedStop: captureFailureHandler(
                 source: configuration.source,
                 runtimeID: runtimeID,

--- a/Sources/Dahlia/Services/RecordingSessionController.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController.swift
@@ -12,6 +12,7 @@ actor RecordingSessionController {
         _ message: String,
         _ isFatal: Bool
     ) -> Void
+    typealias CaptureInterruptionHandler = @MainActor @Sendable (_ source: RecordingAudioSource) -> Void
 
     struct SourceConfiguration: Equatable {
         let source: RecordingAudioSource
@@ -134,6 +135,7 @@ actor RecordingSessionController {
     var batchRecording: (any BatchRecordingSession)?
     private var batchScheduler: (any BatchTranscriptionScheduling)?
     var onEvent: EventHandler?
+    var onCaptureInterruption: CaptureInterruptionHandler?
     var onRuntimeFailure: RuntimeFailureHandler?
     var currentLocale: Locale?
     var batchRuntimeFailureMessage: String?
@@ -152,6 +154,7 @@ actor RecordingSessionController {
     func prepare(
         _ request: PreparationRequest,
         onEvent: @escaping EventHandler,
+        onCaptureInterruption: @escaping CaptureInterruptionHandler = { _ in },
         onRuntimeFailure: @escaping RuntimeFailureHandler
     ) async throws {
         guard case .idle = state else {
@@ -242,6 +245,7 @@ actor RecordingSessionController {
             )
             batchScheduler = request.batchScheduler
             self.onEvent = onEvent
+            self.onCaptureInterruption = onCaptureInterruption
             self.onRuntimeFailure = onRuntimeFailure
             currentLocale = request.locale
             state = .prepared(snapshot)
@@ -401,6 +405,7 @@ actor RecordingSessionController {
         batchRecording = nil
         batchScheduler = nil
         onEvent = nil
+        onCaptureInterruption = nil
         onRuntimeFailure = nil
         currentLocale = nil
         batchRuntimeFailureMessage = nil

--- a/Sources/Dahlia/Services/RecordingSessionRuntimeProtocols.swift
+++ b/Sources/Dahlia/Services/RecordingSessionRuntimeProtocols.swift
@@ -3,6 +3,7 @@ import Foundation
 import GRDB
 
 typealias AudioCaptureUnexpectedStopHandler = @Sendable (Error?) -> Void
+typealias AudioCaptureInterruptionHandler = @Sendable () async -> Void
 typealias ProgressiveTranscriptionEventHandler = @MainActor @Sendable (TranscriptionEvent) async -> Void
 typealias ProgressiveSegmentTranslationHandler = @Sendable (TranscriptSegment) async -> String?
 
@@ -18,6 +19,7 @@ protocol AudioCaptureSessionFactory: Sendable {
 
     func makeSession(
         for pipeline: AudioSourcePipeline,
+        onInterruption: @escaping AudioCaptureInterruptionHandler,
         onUnexpectedStop: @escaping AudioCaptureUnexpectedStopHandler
     ) -> any AudioCaptureSession
 }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -1366,6 +1366,11 @@ final class CaptionViewModel: ObservableObject {
             )
         ) { [weak self] event in
             self?.handleTranscriptionEvent(event)
+        } onCaptureInterruption: { [weak self] source in
+            self?.handleControllerCaptureInterruption(
+                source: source,
+                recordingSessionId: request.sessionId
+            )
         } onRuntimeFailure: { [weak self] source, message, isFatal in
             self?.handleControllerRuntimeFailure(
                 source: source,
@@ -2525,6 +2530,34 @@ final class CaptionViewModel: ObservableObject {
                 self.stopListening()
             }
         }
+    }
+
+    private func handleControllerCaptureInterruption(
+        source: RecordingAudioSource,
+        recordingSessionId: UUID
+    ) {
+        guard activeRecordingSessionId == recordingSessionId else { return }
+        let shouldStop = Self.shouldStopRecording(
+            afterInterruptionFrom: source,
+            autoStopOnMicrophoneInterruption: AppSettings.shared.automaticallyStopRecordingWhenMicrophoneStops
+        )
+        guard shouldStop else { return }
+
+        switch recordingLifecycle {
+        case .recording:
+            stopListening()
+        case .starting:
+            pendingRealtimeRecognitionFailure = (source, L10n.microphoneCaptureStopped)
+        case .stopping, .idle:
+            break
+        }
+    }
+
+    nonisolated static func shouldStopRecording(
+        afterInterruptionFrom source: RecordingAudioSource,
+        autoStopOnMicrophoneInterruption: Bool
+    ) -> Bool {
+        source == .microphone && autoStopOnMicrophoneInterruption
     }
 
     nonisolated static func shouldStopRecording(

--- a/Tests/DahliaTests/CaptionViewModelTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelTests.swift
@@ -88,6 +88,22 @@ import GRDB
         }
 
         @Test
+        func microphoneCaptureInterruptionOnlyStopsRecordingWhenEnabled() {
+            #expect(CaptionViewModel.shouldStopRecording(
+                afterInterruptionFrom: .microphone,
+                autoStopOnMicrophoneInterruption: true
+            ))
+            #expect(!CaptionViewModel.shouldStopRecording(
+                afterInterruptionFrom: .microphone,
+                autoStopOnMicrophoneInterruption: false
+            ))
+            #expect(!CaptionViewModel.shouldStopRecording(
+                afterInterruptionFrom: .system,
+                autoStopOnMicrophoneInterruption: true
+            ))
+        }
+
+        @Test
         func fatalCaptureFailureAlwaysStopsRecording() {
             #expect(CaptionViewModel.shouldStopRecording(
                 afterFailureFrom: .system,

--- a/Tests/DahliaTests/RecordingSessionControllerTests.swift
+++ b/Tests/DahliaTests/RecordingSessionControllerTests.swift
@@ -566,6 +566,7 @@
 
         func makeSession(
             for pipeline: AudioSourcePipeline,
+            onInterruption _: @escaping AudioCaptureInterruptionHandler,
             onUnexpectedStop _: @escaping AudioCaptureUnexpectedStopHandler
         ) -> any AudioCaptureSession {
             let deviceShouldFail = failingDeviceID.map { pipeline.captureDeviceID == $0 } ?? false


### PR DESCRIPTION
## Summary

- propagate recoverable microphone interruptions to the recording policy
- stop and save the active recording when automatic stop is enabled
- keep immediate microphone engine recovery when automatic stop is disabled
- bump the app version from 0.3.3 to 0.3.4

## Root cause

The voice-isolation capture recovery path restarted `AVAudioEngine` after a configuration interruption, but only reported the interruption when recovery itself failed. As a result, the automatic-stop setting never observed normal capture interruptions and nothing happened when the meeting ended.

## Validation

- `swift test --disable-sandbox --filter RecordingSessionControllerTests` — 13 tests passed
- `swift test --disable-sandbox --filter CaptionViewModelTests` — 21 tests passed
- `plutil -lint Resources/Info.plist` — passed; marketing version is 0.3.4
- `CI=true ./scripts/lint.sh` — SwiftFormat clean; existing repository SwiftLint violations remain
- Full `swift test --disable-sandbox` — 345/346 passed. The Keychain-dependent `GoogleCalendarConfigurationTests.clientSecretOverrideIsPreferredOverEnvironment` test also fails in isolation in this unsigned/sandboxed environment.

Manual verification with a real meeting was not performed.
