### PR TITLE
Persist batch summary setting

### DIFF
--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -150,6 +150,7 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     @AppStorage("transcriptionLocale") var transcriptionLocale: String = Locale.current.identifier
     @AppStorage(TranscriptionMode.userDefaultsKey) var transcriptionModeRawValue = TranscriptionMode.defaultMode.rawValue
     @AppStorage("retainAudioAfterBatchTranscription") var retainAudioAfterBatchTranscription = false
+    @AppStorage("generateSummaryAfterBatchTranscription") var generateSummaryAfterBatchTranscription = false
     @AppStorage("transcriptTranslationEnabled") var transcriptTranslationEnabled = true
     @AppStorage("transcriptTranslationTargetLanguage") var transcriptTranslationTargetLanguage = TranscriptTranslationLanguage.defaultIdentifier
     @AppStorage("liveSubtitleOverlayEnabled") var liveSubtitleOverlayEnabled = false

--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -93,6 +93,7 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     ]
     nonisolated static let automaticScreenshotIntervalSecondsUserDefaultsKey = "automaticScreenshotIntervalSeconds"
     nonisolated static let automaticScreenshotChangeThresholdPercentUserDefaultsKey = "automaticScreenshotChangeThresholdPercent"
+    nonisolated static let generateSummaryAfterBatchTranscriptionUserDefaultsKey = "generateSummaryAfterBatchTranscription"
     nonisolated static let defaultGoogleDriveExportFolderName = "Meeting Notes"
     fileprivate nonisolated static let defaultAutomaticScreenshotIntervalSeconds = 30
     fileprivate nonisolated static let defaultAutomaticScreenshotChangeThresholdPercent = 20
@@ -150,7 +151,7 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     @AppStorage("transcriptionLocale") var transcriptionLocale: String = Locale.current.identifier
     @AppStorage(TranscriptionMode.userDefaultsKey) var transcriptionModeRawValue = TranscriptionMode.defaultMode.rawValue
     @AppStorage("retainAudioAfterBatchTranscription") var retainAudioAfterBatchTranscription = false
-    @AppStorage("generateSummaryAfterBatchTranscription") var generateSummaryAfterBatchTranscription = false
+    @AppStorage(AppSettings.generateSummaryAfterBatchTranscriptionUserDefaultsKey) var generateSummaryAfterBatchTranscription = false
     @AppStorage("transcriptTranslationEnabled") var transcriptTranslationEnabled = true
     @AppStorage("transcriptTranslationTargetLanguage") var transcriptTranslationTargetLanguage = TranscriptTranslationLanguage.defaultIdentifier
     @AppStorage("liveSubtitleOverlayEnabled") var liveSubtitleOverlayEnabled = false

--- a/Sources/Dahlia/Models/BatchTranscriptionConfirmation.swift
+++ b/Sources/Dahlia/Models/BatchTranscriptionConfirmation.swift
@@ -5,7 +5,6 @@ struct BatchTranscriptionConfirmation: Identifiable, Equatable {
     let meetingId: UUID
     let suggestedLocaleIdentifier: String
     let retainAudioAfterBatch: Bool
-    let generateSummaryAfterTranscription: Bool
 
     var id: UUID { sessionId }
 }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -477,8 +477,7 @@ final class CaptionViewModel: ObservableObject {
 
     func confirmBatchTranscription(
         localeIdentifier: String,
-        retainAudioAfterBatch: Bool,
-        generateSummaryAfterTranscription: Bool
+        retainAudioAfterBatch: Bool
     ) {
         guard let confirmation = pendingBatchTranscriptionConfirmation,
               let coordinator = batchTranscriptionCoordinator else { return }
@@ -486,10 +485,9 @@ final class CaptionViewModel: ObservableObject {
             sessionId: confirmation.sessionId,
             meetingId: confirmation.meetingId,
             suggestedLocaleIdentifier: localeIdentifier,
-            retainAudioAfterBatch: retainAudioAfterBatch,
-            generateSummaryAfterTranscription: generateSummaryAfterTranscription
+            retainAudioAfterBatch: retainAudioAfterBatch
         )
-        if generateSummaryAfterTranscription {
+        if AppSettings.shared.generateSummaryAfterBatchTranscription {
             pendingBatchSummaryMeetingIdsBySessionId[confirmation.sessionId] = confirmation.meetingId
         } else {
             pendingBatchSummaryMeetingIdsBySessionId.removeValue(forKey: confirmation.sessionId)
@@ -1789,8 +1787,7 @@ final class CaptionViewModel: ObservableObject {
             retainAudioAfterBatch: batchAudioRetentionPreference(
                 sessionId: sessionId,
                 dbQueue: dbQueue
-            ),
-            generateSummaryAfterTranscription: false
+            )
         )
         MainWindowOpener.shared.openMainWindow()
     }

--- a/Sources/Dahlia/Views/BatchTranscriptionConfirmationView.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionConfirmationView.swift
@@ -2,19 +2,18 @@ import SwiftUI
 
 struct BatchTranscriptionConfirmationView: View {
     let locales: [Locale]
-    let onStart: (String, Bool, Bool) -> Void
+    let onStart: (String, Bool) -> Void
     let onPostpone: () -> Void
 
+    @ObservedObject private var settings = AppSettings.shared
     @State private var selectedLocaleIdentifier: String
     @State private var deleteAudioAfterTranscription: Bool
-    @State private var generateSummaryAfterTranscription: Bool
 
     init(
         locales: [Locale],
         initialLocaleIdentifier: String,
         initiallyRetainsAudioAfterBatch: Bool,
-        initiallyGeneratesSummaryAfterTranscription: Bool,
-        onStart: @escaping (String, Bool, Bool) -> Void,
+        onStart: @escaping (String, Bool) -> Void,
         onPostpone: @escaping () -> Void
     ) {
         self.locales = locales
@@ -22,7 +21,6 @@ struct BatchTranscriptionConfirmationView: View {
         self.onPostpone = onPostpone
         _selectedLocaleIdentifier = State(initialValue: initialLocaleIdentifier)
         _deleteAudioAfterTranscription = State(initialValue: !initiallyRetainsAudioAfterBatch)
-        _generateSummaryAfterTranscription = State(initialValue: initiallyGeneratesSummaryAfterTranscription)
     }
 
     var body: some View {
@@ -51,7 +49,7 @@ struct BatchTranscriptionConfirmationView: View {
             }
             .toggleStyle(.checkbox)
 
-            Toggle(isOn: $generateSummaryAfterTranscription) {
+            Toggle(isOn: $settings.generateSummaryAfterBatchTranscription) {
                 VStack(alignment: .leading) {
                     Text(L10n.generateSummaryAfterBatchTranscription)
                     Text(L10n.generateSummaryAfterBatchTranscriptionDescription)
@@ -84,8 +82,7 @@ struct BatchTranscriptionConfirmationView: View {
     private func startTranscription() {
         onStart(
             selectedLocaleIdentifier,
-            !deleteAudioAfterTranscription,
-            generateSummaryAfterTranscription
+            !deleteAudioAfterTranscription
         )
     }
 }

--- a/Sources/Dahlia/Views/BatchTranscriptionConfirmationView.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionConfirmationView.swift
@@ -5,7 +5,8 @@ struct BatchTranscriptionConfirmationView: View {
     let onStart: (String, Bool) -> Void
     let onPostpone: () -> Void
 
-    @ObservedObject private var settings = AppSettings.shared
+    @AppStorage(AppSettings.generateSummaryAfterBatchTranscriptionUserDefaultsKey)
+    private var generateSummaryAfterBatchTranscription = false
     @State private var selectedLocaleIdentifier: String
     @State private var deleteAudioAfterTranscription: Bool
 
@@ -49,7 +50,7 @@ struct BatchTranscriptionConfirmationView: View {
             }
             .toggleStyle(.checkbox)
 
-            Toggle(isOn: $settings.generateSummaryAfterBatchTranscription) {
+            Toggle(isOn: $generateSummaryAfterBatchTranscription) {
                 VStack(alignment: .leading) {
                     Text(L10n.generateSummaryAfterBatchTranscription)
                     Text(L10n.generateSummaryAfterBatchTranscriptionDescription)

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -61,7 +61,6 @@ struct ContentView: View {
                 ),
                 initialLocaleIdentifier: confirmation.suggestedLocaleIdentifier,
                 initiallyRetainsAudioAfterBatch: confirmation.retainAudioAfterBatch,
-                initiallyGeneratesSummaryAfterTranscription: confirmation.generateSummaryAfterTranscription,
                 onStart: viewModel.confirmBatchTranscription,
                 onPostpone: viewModel.postponeBatchTranscription
             )

--- a/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
@@ -23,6 +23,12 @@ struct TranscriptionSettingsView: View {
                         Text(L10n.retainBatchAudioDescription)
                     }
                     .toggleStyle(.switch)
+
+                    Toggle(isOn: $settings.generateSummaryAfterBatchTranscription) {
+                        Text(L10n.generateSummaryAfterBatchTranscription)
+                        Text(L10n.generateSummaryAfterBatchTranscriptionDescription)
+                    }
+                    .toggleStyle(.switch)
                 }
             } header: {
                 Text(L10n.transcriptionMethod)

--- a/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
@@ -4,6 +4,8 @@ import SwiftUI
 /// 設定画面「文字起こし」タブ。認識言語の表示フィルタを管理する。
 struct TranscriptionSettingsView: View {
     @ObservedObject private var settings = AppSettings.shared
+    @AppStorage(AppSettings.generateSummaryAfterBatchTranscriptionUserDefaultsKey)
+    private var generateSummaryAfterBatchTranscription = false
     @State private var supportedLocales: [Locale] = []
     @State private var isLoadingLocales = false
     @State private var localeSearchText = ""
@@ -24,7 +26,7 @@ struct TranscriptionSettingsView: View {
                     }
                     .toggleStyle(.switch)
 
-                    Toggle(isOn: $settings.generateSummaryAfterBatchTranscription) {
+                    Toggle(isOn: $generateSummaryAfterBatchTranscription) {
                         Text(L10n.generateSummaryAfterBatchTranscription)
                         Text(L10n.generateSummaryAfterBatchTranscriptionDescription)
                     }

--- a/Tests/DahliaTests/CaptionViewModelBatchUpdateTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelBatchUpdateTests.swift
@@ -91,6 +91,10 @@ import GRDB
 
         @Test
         func discardingFailedBatchCancelsPendingSummaryGeneration() async throws {
+            let previouslyGeneratesSummary = AppSettings.shared.generateSummaryAfterBatchTranscription
+            AppSettings.shared.generateSummaryAfterBatchTranscription = true
+            defer { AppSettings.shared.generateSummaryAfterBatchTranscription = previouslyGeneratesSummary }
+
             let batch = try BatchAudioTestFixture(
                 name: "discard-cancels-summary",
                 meetingStatus: .ready,
@@ -142,13 +146,11 @@ import GRDB
                 sessionId: batch.session.id,
                 meetingId: batch.meeting.id,
                 suggestedLocaleIdentifier: "ja_JP",
-                retainAudioAfterBatch: false,
-                generateSummaryAfterTranscription: true
+                retainAudioAfterBatch: false
             )
             viewModel.confirmBatchTranscription(
                 localeIdentifier: "ja_JP",
-                retainAudioAfterBatch: false,
-                generateSummaryAfterTranscription: true
+                retainAudioAfterBatch: false
             )
             #expect(await waitUntil {
                 if case .failed = viewModel.batchTranscriptionState {


### PR DESCRIPTION
## 概要

- バッチ文字起こし後の自動要約を `AppSettings` のグローバル設定として永続化
- バッチ文字起こし確認ダイアログと文字起こし設定画面を同じ設定へバインド
- バッチ開始時の設定値を使って、完了後の要約予約を決定
- 不要になった確認モデルのセッション固有フラグとコールバック引数を削除

## 背景

これまでは「文字起こし後に要約を生成」が確認ダイアログのローカル状態で、ダイアログを開き直すたびにオフへ戻っていました。設定を `UserDefaults` に永続化し、アプリ全体で一貫して利用できるようにします。

## ユーザーへの影響

確認ダイアログまたは設定画面で選択した値が次回以降も維持されます。すでに開始したバッチ文字起こしは、開始時点の設定に従います。

## 検証

- `swift build`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter CaptionViewModelBatchUpdateTests`（3 tests passed）
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer CI=true ./scripts/lint.sh`
  - SwiftFormat: 0/209 files require formatting
  - SwiftLint: 今回の差分外にある既存のリポジトリ全体違反を報告
