### PR TITLE
Split AI settings and fix Databricks OAuth endpoints

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>13</string>
+    <string>14</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.3.4</string>
+    <string>0.3.5</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -419,6 +419,7 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
         case .openAI:
             return Self.openAIEndpointURL
         case .databricks:
+            guard llmDatabricksAuthenticationType == .personalAccessToken else { return "" }
             guard let workspaceID = llmDatabricksWorkspaceID.nilIfBlank else { return "" }
             return Self.databricksEndpointURL(workspaceID: workspaceID)
         }
@@ -528,18 +529,11 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
 
     /// LLM の接続設定が揃っているかどうか。
     var isLLMConfigComplete: Bool {
-        guard resolvedLLMEndpointURL.nilIfBlank != nil else { return false }
-
-        switch llmProvider {
-        case .openAI:
-            return llmAPIToken.nilIfBlank != nil
-        case .databricks:
-            switch llmDatabricksAuthenticationType {
-            case .personalAccessToken:
-                return llmAPIToken.nilIfBlank != nil
-            case .oauthCLI:
-                return llmDatabricksProfile.nilIfBlank != nil
-            }
+        switch (llmProvider, llmDatabricksAuthenticationType) {
+        case (.openAI, _), (.databricks, .personalAccessToken):
+            resolvedLLMEndpointURL.nilIfBlank != nil && llmAPIToken.nilIfBlank != nil
+        case (.databricks, .oauthCLI):
+            llmDatabricksProfile.nilIfBlank != nil
         }
     }
 
@@ -548,6 +542,21 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     nonisolated static func databricksEndpointURL(workspaceID: String) -> String {
         let trimmedWorkspaceID = workspaceID.trimmingCharacters(in: .whitespacesAndNewlines)
         return "https://\(trimmedWorkspaceID).ai-gateway.cloud.databricks.com/mlflow/v1/chat/completions"
+    }
+
+    nonisolated static func databricksEndpointURL(workspaceHost: String) -> String? {
+        let trimmedHost = workspaceHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard var components = URLComponents(string: trimmedHost),
+              components.scheme == "https",
+              components.host?.isEmpty == false
+        else {
+            return nil
+        }
+
+        components.path = "/ai-gateway/mlflow/v1/chat/completions"
+        components.query = nil
+        components.fragment = nil
+        return components.url?.absoluteString
     }
 
     nonisolated static func resolvedDatabricksProfileSelection(

--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -379,7 +379,7 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     // MARK: - LLM 設定
 
     @AppStorage("llmProvider") var llmProviderRawValue = ""
-    @AppStorage("llmDatabricksWorkspaceID") var llmDatabricksWorkspaceID = ""
+    @AppStorage("llmDatabricksWorkspaceURL") var llmDatabricksWorkspaceURL = ""
     @AppStorage("llmDatabricksAuthenticationType") var llmDatabricksAuthenticationTypeRawValue =
         DatabricksAuthenticationType.personalAccessToken.rawValue
     @AppStorage("llmDatabricksProfile") var llmDatabricksProfile = ""
@@ -420,8 +420,7 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
             return Self.openAIEndpointURL
         case .databricks:
             guard llmDatabricksAuthenticationType == .personalAccessToken else { return "" }
-            guard let workspaceID = llmDatabricksWorkspaceID.nilIfBlank else { return "" }
-            return Self.databricksEndpointURL(workspaceID: workspaceID)
+            return Self.databricksEndpointURL(workspaceURL: llmDatabricksWorkspaceURL) ?? ""
         }
     }
 
@@ -539,14 +538,9 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
 
     nonisolated static let openAIEndpointURL = "https://api.openai.com/v1/chat/completions"
 
-    nonisolated static func databricksEndpointURL(workspaceID: String) -> String {
-        let trimmedWorkspaceID = workspaceID.trimmingCharacters(in: .whitespacesAndNewlines)
-        return "https://\(trimmedWorkspaceID).ai-gateway.cloud.databricks.com/mlflow/v1/chat/completions"
-    }
-
-    nonisolated static func databricksEndpointURL(workspaceHost: String) -> String? {
-        let trimmedHost = workspaceHost.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard var components = URLComponents(string: trimmedHost),
+    nonisolated static func databricksEndpointURL(workspaceURL: String) -> String? {
+        let trimmedURL = workspaceURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard var components = URLComponents(string: trimmedURL),
               components.scheme == "https",
               components.host?.isEmpty == false
         else {

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -187,7 +187,6 @@
 "General" = "General";
 "Notifications" = "Notifications";
 "Calendar" = "Calendar";
-"Account Management" = "Account Management";
 "AI Summary" = "AI Summary";
 "Developer Settings" = "Developer Settings";
 "Vault" = "Vault";
@@ -206,7 +205,7 @@
 "Target Language" = "Target Language";
 "Choose which language translated transcript lines should use." = "Choose which language translated transcript lines should use.";
 "Translation is automatically disabled when the target language matches the transcription language." = "Translation is automatically disabled when the target language matches the transcription language.";
-"Manage the OpenAI or Databricks account used for AI summaries." = "Manage the OpenAI or Databricks account used for AI summaries.";
+"Configure credentials and connection settings for the model provider used by AI summaries." = "Configure credentials and connection settings for the model provider used by AI summaries.";
 "Choose the model and output limit used to generate AI summaries." = "Choose the model and output limit used to generate AI summaries.";
 "Run a quick request to validate your endpoint, model, and token." = "Run a quick request to validate your provider settings, model, and token.";
 "Override developer-managed credentials used by external service integrations." = "Override developer-managed credentials used by external service integrations.";

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -187,7 +187,8 @@
 "General" = "General";
 "Notifications" = "Notifications";
 "Calendar" = "Calendar";
-"Foundation Models" = "Foundation Models";
+"Account Management" = "Account Management";
+"AI Summary" = "AI Summary";
 "Developer Settings" = "Developer Settings";
 "Vault" = "Vault";
 "Current Vault" = "Current Vault";
@@ -205,7 +206,8 @@
 "Target Language" = "Target Language";
 "Choose which language translated transcript lines should use." = "Choose which language translated transcript lines should use.";
 "Translation is automatically disabled when the target language matches the transcription language." = "Translation is automatically disabled when the target language matches the transcription language.";
-"Configure the LLM connection used for manual summary generation." = "Configure the LLM connection used for manual summary generation.";
+"Manage the OpenAI or Databricks account used for AI summaries." = "Manage the OpenAI or Databricks account used for AI summaries.";
+"Choose the model and output limit used to generate AI summaries." = "Choose the model and output limit used to generate AI summaries.";
 "Run a quick request to validate your endpoint, model, and token." = "Run a quick request to validate your provider settings, model, and token.";
 "Override developer-managed credentials used by external service integrations." = "Override developer-managed credentials used by external service integrations.";
 "Google OAuth Client ID" = "Google OAuth Client ID";
@@ -310,7 +312,6 @@
 "Only selected languages will appear in the language picker. All languages are shown if none are selected." = "Only selected languages will appear in the language picker. All languages are shown if none are selected.";
 
 /* Settings - LLM */
-"LLM Settings" = "Model Settings";
 "OpenAI" = "OpenAI";
 "Databricks" = "Databricks";
 "Model Provider" = "Model Provider";
@@ -329,6 +330,10 @@
 "Refresh Profiles" = "Refresh Profiles";
 "Databricks CLI was not found. Install it and relaunch Dahlia." = "Databricks CLI was not found. Install it and relaunch Dahlia.";
 "Enter a Databricks CLI profile." = "Enter a Databricks CLI profile.";
+"The selected Databricks CLI profile was not found." = "The selected Databricks CLI profile was not found.";
+"Enter a Databricks Workspace ID." = "Enter a Databricks Workspace ID.";
+"The selected Databricks CLI profile does not provide a Workspace ID." = "The selected Databricks CLI profile does not provide a Workspace ID.";
+"The selected Databricks CLI profile does not provide a valid workspace URL." = "The selected Databricks CLI profile does not provide a valid workspace URL.";
 "Databricks CLI authentication failed: %@" = "Databricks CLI authentication failed: %@";
 "Databricks CLI authentication failed." = "Databricks CLI authentication failed.";
 "Databricks CLI returned an invalid OAuth token response." = "Databricks CLI returned an invalid OAuth token response.";
@@ -345,7 +350,6 @@
 "Limits the number of tokens generated for each summary." = "Limits the number of tokens generated for each summary.";
 "API Token" = "API Token";
 "Token is stored securely in Keychain." = "Token is stored securely in Keychain.";
-"Configure an LLM endpoint for manual summary generation." = "Configure the model provider and connection settings used for manual summary generation.";
 "Test Connection" = "Test Connection";
 "Testing..." = "Testing...";
 "Connection successful" = "Connection successful";

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -319,7 +319,8 @@
 "Endpoint URL" = "Endpoint URL";
 "Uses OpenAI's Chat Completions API." = "Uses OpenAI's Chat Completions API.";
 "Databricks Workspace ID" = "Databricks Workspace ID";
-"Used to build the Databricks AI Gateway chat completions URL." = "Used to build the Databricks AI Gateway chat completions URL.";
+"Databricks Workspace URL" = "Databricks Workspace URL";
+"Enter the Workspace URL associated with this personal access token." = "Enter the Workspace URL associated with this personal access token.";
 "Authentication Type" = "Authentication Type";
 "Choose a Personal Access Token or OAuth through Databricks CLI." = "Choose a Personal Access Token or OAuth through Databricks CLI.";
 "Personal Access Token" = "Personal Access Token";
@@ -331,7 +332,7 @@
 "Databricks CLI was not found. Install it and relaunch Dahlia." = "Databricks CLI was not found. Install it and relaunch Dahlia.";
 "Enter a Databricks CLI profile." = "Enter a Databricks CLI profile.";
 "The selected Databricks CLI profile was not found." = "The selected Databricks CLI profile was not found.";
-"Enter a Databricks Workspace ID." = "Enter a Databricks Workspace ID.";
+"Enter a valid HTTPS Databricks Workspace URL." = "Enter a valid HTTPS Databricks Workspace URL.";
 "The selected Databricks CLI profile does not provide a Workspace ID." = "The selected Databricks CLI profile does not provide a Workspace ID.";
 "The selected Databricks CLI profile does not provide a valid workspace URL." = "The selected Databricks CLI profile does not provide a valid workspace URL.";
 "Databricks CLI authentication failed: %@" = "Databricks CLI authentication failed: %@";
@@ -340,7 +341,7 @@
 "Databricks CLI returned an invalid profiles response." = "Databricks CLI returned an invalid profiles response.";
 "Enter an OpenAI API token." = "Enter an OpenAI API token.";
 "Enter a Databricks personal access token." = "Enter a Databricks personal access token.";
-"Endpoint will be generated after entering a Workspace ID." = "Endpoint will be generated after entering a Workspace ID.";
+"Endpoint will be generated after entering a Workspace URL." = "Endpoint will be generated after entering a Workspace URL.";
 "The selected model is mapped to the provider's model ID." = "The selected model is mapped to the provider's model ID.";
 "GPT-5.6 Sol" = "GPT-5.6 Sol";
 "GPT-5.6 Terra" = "GPT-5.6 Terra";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -187,7 +187,6 @@
 "General" = "一般";
 "Notifications" = "通知";
 "Calendar" = "カレンダー";
-"Account Management" = "アカウント管理";
 "AI Summary" = "AI 要約";
 "Developer Settings" = "開発者設定";
 "Vault" = "保管庫";
@@ -206,7 +205,7 @@
 "Target Language" = "翻訳先の言語";
 "Choose which language translated transcript lines should use." = "翻訳済みの文字起こし行に使う言語を選びます。";
 "Translation is automatically disabled when the target language matches the transcription language." = "翻訳先の言語が文字起こし言語と同じ場合、翻訳は自動的に無効になります。";
-"Manage the OpenAI or Databricks account used for AI summaries." = "AI 要約に使用する OpenAI または Databricks アカウントを管理します。";
+"Configure credentials and connection settings for the model provider used by AI summaries." = "AI 要約に使用するモデルプロバイダーの認証情報と接続設定を管理します。";
 "Choose the model and output limit used to generate AI summaries." = "AI 要約の生成に使用するモデルと出力上限を設定します。";
 "Run a quick request to validate your endpoint, model, and token." = "プロバイダー設定、モデル、トークンの組み合わせを簡易的に検証します。";
 "Override developer-managed credentials used by external service integrations." = "外部サービス連携で使用する開発者管理の認証情報を上書きします。";
@@ -314,7 +313,7 @@
 /* Settings - LLM */
 "OpenAI" = "OpenAI";
 "Databricks" = "Databricks";
-"Model Provider" = "モデルプロバイダー";
+"Model Provider" = "Model Provider";
 "Choose OpenAI or Databricks AI Gateway." = "OpenAI または Databricks AI Gateway を選択します。";
 "Endpoint URL" = "エンドポイント URL";
 "Uses OpenAI's Chat Completions API." = "OpenAI の Chat Completions API を使用します。";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -319,7 +319,8 @@
 "Endpoint URL" = "エンドポイント URL";
 "Uses OpenAI's Chat Completions API." = "OpenAI の Chat Completions API を使用します。";
 "Databricks Workspace ID" = "Databricks Workspace ID";
-"Used to build the Databricks AI Gateway chat completions URL." = "Databricks AI Gateway の chat completions URL の生成に使用します。";
+"Databricks Workspace URL" = "Databricks Workspace URL";
+"Enter the Workspace URL associated with this personal access token." = "この Personal Access Token に対応する Workspace URL を入力します。";
 "Authentication Type" = "認証方式";
 "Choose a Personal Access Token or OAuth through Databricks CLI." = "Personal Access Token または Databricks CLI 経由の OAuth を選択します。";
 "Personal Access Token" = "Personal Access Token";
@@ -331,7 +332,7 @@
 "Databricks CLI was not found. Install it and relaunch Dahlia." = "Databricks CLI が見つかりません。インストールして Dahlia を再起動してください。";
 "Enter a Databricks CLI profile." = "Databricks CLI プロファイルを入力してください。";
 "The selected Databricks CLI profile was not found." = "選択した Databricks CLI プロファイルが見つかりません。";
-"Enter a Databricks Workspace ID." = "Databricks Workspace ID を入力してください。";
+"Enter a valid HTTPS Databricks Workspace URL." = "有効な HTTPS の Databricks Workspace URL を入力してください。";
 "The selected Databricks CLI profile does not provide a Workspace ID." = "選択した Databricks CLI プロファイルから Workspace ID を取得できません。";
 "The selected Databricks CLI profile does not provide a valid workspace URL." = "選択した Databricks CLI プロファイルから有効な Workspace URL を取得できません。";
 "Databricks CLI authentication failed: %@" = "Databricks CLI 認証に失敗しました: %@";
@@ -340,7 +341,7 @@
 "Databricks CLI returned an invalid profiles response." = "Databricks CLI から無効なプロファイルレスポンスが返されました。";
 "Enter an OpenAI API token." = "OpenAI API トークンを入力してください。";
 "Enter a Databricks personal access token." = "Databricks の Personal Access Token を入力してください。";
-"Endpoint will be generated after entering a Workspace ID." = "Workspace ID を入力するとエンドポイントが生成されます。";
+"Endpoint will be generated after entering a Workspace URL." = "Workspace URL を入力するとエンドポイントが生成されます。";
 "The selected model is mapped to the provider's model ID." = "選択したモデルをプロバイダー固有のモデル ID に変換します。";
 "GPT-5.6 Sol" = "GPT-5.6 Sol";
 "GPT-5.6 Terra" = "GPT-5.6 Terra";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -187,7 +187,8 @@
 "General" = "一般";
 "Notifications" = "通知";
 "Calendar" = "カレンダー";
-"Foundation Models" = "基盤モデル";
+"Account Management" = "アカウント管理";
+"AI Summary" = "AI 要約";
 "Developer Settings" = "開発者設定";
 "Vault" = "保管庫";
 "Current Vault" = "現在の保管庫";
@@ -205,7 +206,8 @@
 "Target Language" = "翻訳先の言語";
 "Choose which language translated transcript lines should use." = "翻訳済みの文字起こし行に使う言語を選びます。";
 "Translation is automatically disabled when the target language matches the transcription language." = "翻訳先の言語が文字起こし言語と同じ場合、翻訳は自動的に無効になります。";
-"Configure the LLM connection used for manual summary generation." = "手動の要約生成に使用する LLM 接続設定を管理します。";
+"Manage the OpenAI or Databricks account used for AI summaries." = "AI 要約に使用する OpenAI または Databricks アカウントを管理します。";
+"Choose the model and output limit used to generate AI summaries." = "AI 要約の生成に使用するモデルと出力上限を設定します。";
 "Run a quick request to validate your endpoint, model, and token." = "プロバイダー設定、モデル、トークンの組み合わせを簡易的に検証します。";
 "Override developer-managed credentials used by external service integrations." = "外部サービス連携で使用する開発者管理の認証情報を上書きします。";
 "Google OAuth Client ID" = "Google OAuth クライアント ID";
@@ -310,7 +312,6 @@
 "Only selected languages will appear in the language picker. All languages are shown if none are selected." = "選択した言語のみが言語ピッカーに表示されます。未選択の場合はすべての言語が表示されます。";
 
 /* Settings - LLM */
-"LLM Settings" = "モデル設定";
 "OpenAI" = "OpenAI";
 "Databricks" = "Databricks";
 "Model Provider" = "モデルプロバイダー";
@@ -329,6 +330,10 @@
 "Refresh Profiles" = "プロファイルを再読み込み";
 "Databricks CLI was not found. Install it and relaunch Dahlia." = "Databricks CLI が見つかりません。インストールして Dahlia を再起動してください。";
 "Enter a Databricks CLI profile." = "Databricks CLI プロファイルを入力してください。";
+"The selected Databricks CLI profile was not found." = "選択した Databricks CLI プロファイルが見つかりません。";
+"Enter a Databricks Workspace ID." = "Databricks Workspace ID を入力してください。";
+"The selected Databricks CLI profile does not provide a Workspace ID." = "選択した Databricks CLI プロファイルから Workspace ID を取得できません。";
+"The selected Databricks CLI profile does not provide a valid workspace URL." = "選択した Databricks CLI プロファイルから有効な Workspace URL を取得できません。";
 "Databricks CLI authentication failed: %@" = "Databricks CLI 認証に失敗しました: %@";
 "Databricks CLI authentication failed." = "Databricks CLI 認証に失敗しました。";
 "Databricks CLI returned an invalid OAuth token response." = "Databricks CLI から無効な OAuth トークンレスポンスが返されました。";
@@ -345,7 +350,6 @@
 "Limits the number of tokens generated for each summary." = "要約ごとに生成するトークン数の上限を指定します。";
 "API Token" = "API トークン";
 "Token is stored securely in Keychain." = "トークンはキーチェーンに安全に保存されます。";
-"Configure an LLM endpoint for manual summary generation." = "手動の要約生成に使用するモデルプロバイダーと接続設定を管理します。";
 "Test Connection" = "疎通確認";
 "Testing..." = "テスト中...";
 "Connection successful" = "接続成功";

--- a/Sources/Dahlia/Services/DatabricksCLIClient.swift
+++ b/Sources/Dahlia/Services/DatabricksCLIClient.swift
@@ -36,7 +36,7 @@ struct DatabricksCLIClient {
 
         var endpointURL: String? {
             guard let host else { return nil }
-            return AppSettings.databricksEndpointURL(workspaceHost: host)
+            return AppSettings.databricksEndpointURL(workspaceURL: host)
         }
 
         private enum CodingKeys: String, CodingKey {

--- a/Sources/Dahlia/Services/DatabricksCLIClient.swift
+++ b/Sources/Dahlia/Services/DatabricksCLIClient.swift
@@ -10,6 +10,8 @@ struct DatabricksCLIClient {
 
     struct Profile: Decodable, Hashable, Identifiable {
         let name: String
+        let host: String?
+        let workspaceID: String?
         private let authenticationType: String
 
         var id: String { name }
@@ -18,9 +20,30 @@ struct DatabricksCLIClient {
             authenticationType == "databricks-cli"
         }
 
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            name = try container.decode(String.self, forKey: .name)
+            host = try container.decodeIfPresent(String.self, forKey: .host)
+            authenticationType = try container.decode(String.self, forKey: .authenticationType)
+            if let stringValue = try? container.decode(String.self, forKey: .workspaceID) {
+                workspaceID = stringValue
+            } else if let integerValue = try? container.decode(Int64.self, forKey: .workspaceID) {
+                workspaceID = String(integerValue)
+            } else {
+                workspaceID = nil
+            }
+        }
+
+        var endpointURL: String? {
+            guard let host else { return nil }
+            return AppSettings.databricksEndpointURL(workspaceHost: host)
+        }
+
         private enum CodingKeys: String, CodingKey {
             case name
+            case host
             case authenticationType = "auth_type"
+            case workspaceID = "workspace_id"
         }
     }
 

--- a/Sources/Dahlia/Services/LLMEndpointError.swift
+++ b/Sources/Dahlia/Services/LLMEndpointError.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 enum LLMEndpointError: LocalizedError {
-    case workspaceIDRequired
+    case workspaceURLInvalid
     case profileNotFound
     case profileWorkspaceHostUnavailable
 
     var errorDescription: String? {
         switch self {
-        case .workspaceIDRequired:
-            L10n.databricksWorkspaceIDRequired
+        case .workspaceURLInvalid:
+            L10n.databricksWorkspaceURLInvalid
         case .profileNotFound:
             L10n.databricksProfileNotFound
         case .profileWorkspaceHostUnavailable:

--- a/Sources/Dahlia/Services/LLMEndpointError.swift
+++ b/Sources/Dahlia/Services/LLMEndpointError.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum LLMEndpointError: LocalizedError {
+    case workspaceIDRequired
+    case profileNotFound
+    case profileWorkspaceHostUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .workspaceIDRequired:
+            L10n.databricksWorkspaceIDRequired
+        case .profileNotFound:
+            L10n.databricksProfileNotFound
+        case .profileWorkspaceHostUnavailable:
+            L10n.workspaceHostUnavailableFromProfile
+        }
+    }
+}

--- a/Sources/Dahlia/Services/LLMEndpointResolver.swift
+++ b/Sources/Dahlia/Services/LLMEndpointResolver.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// LLM プロバイダーの認証設定から、リクエスト先の endpoint を解決する。
+struct LLMEndpointResolver {
+    private let databricksClient: DatabricksCLIClient
+
+    init(databricksClient: DatabricksCLIClient = DatabricksCLIClient()) {
+        self.databricksClient = databricksClient
+    }
+
+    func endpoint(
+        provider: LLMProvider,
+        databricksAuthenticationType: DatabricksAuthenticationType,
+        databricksWorkspaceID: String,
+        databricksProfile: String
+    ) async throws -> String {
+        switch (provider, databricksAuthenticationType) {
+        case (.openAI, _):
+            return AppSettings.openAIEndpointURL
+        case (.databricks, .personalAccessToken):
+            guard let workspaceID = databricksWorkspaceID.nilIfBlank else {
+                throw LLMEndpointError.workspaceIDRequired
+            }
+            return AppSettings.databricksEndpointURL(workspaceID: workspaceID)
+        case (.databricks, .oauthCLI):
+            let profiles = try await databricksClient.profiles()
+            guard let profile = profiles.first(where: { $0.name == databricksProfile }) else {
+                throw LLMEndpointError.profileNotFound
+            }
+            guard let endpoint = profile.endpointURL else {
+                throw LLMEndpointError.profileWorkspaceHostUnavailable
+            }
+            return endpoint
+        }
+    }
+}

--- a/Sources/Dahlia/Services/LLMEndpointResolver.swift
+++ b/Sources/Dahlia/Services/LLMEndpointResolver.swift
@@ -11,17 +11,17 @@ struct LLMEndpointResolver {
     func endpoint(
         provider: LLMProvider,
         databricksAuthenticationType: DatabricksAuthenticationType,
-        databricksWorkspaceID: String,
+        databricksWorkspaceURL: String,
         databricksProfile: String
     ) async throws -> String {
         switch (provider, databricksAuthenticationType) {
         case (.openAI, _):
             return AppSettings.openAIEndpointURL
         case (.databricks, .personalAccessToken):
-            guard let workspaceID = databricksWorkspaceID.nilIfBlank else {
-                throw LLMEndpointError.workspaceIDRequired
+            guard let endpoint = AppSettings.databricksEndpointURL(workspaceURL: databricksWorkspaceURL) else {
+                throw LLMEndpointError.workspaceURLInvalid
             }
-            return AppSettings.databricksEndpointURL(workspaceID: workspaceID)
+            return endpoint
         case (.databricks, .oauthCLI):
             let profiles = try await databricksClient.profiles()
             guard let profile = profiles.first(where: { $0.name == databricksProfile }) else {

--- a/Sources/Dahlia/Services/SummaryService.swift
+++ b/Sources/Dahlia/Services/SummaryService.swift
@@ -26,7 +26,7 @@ enum SummaryService {
         let endpoint = try await LLMEndpointResolver().endpoint(
             provider: settings.llmProvider,
             databricksAuthenticationType: settings.llmDatabricksAuthenticationType,
-            databricksWorkspaceID: settings.llmDatabricksWorkspaceID,
+            databricksWorkspaceURL: settings.llmDatabricksWorkspaceURL,
             databricksProfile: settings.llmDatabricksProfile
         )
         let model = settings.resolvedLLMModelName

--- a/Sources/Dahlia/Services/SummaryService.swift
+++ b/Sources/Dahlia/Services/SummaryService.swift
@@ -23,7 +23,12 @@ enum SummaryService {
         repository: MeetingRepository? = nil
     ) async throws -> GeneratedSummary {
         let settings = AppSettings.shared
-        let endpoint = settings.resolvedLLMEndpointURL
+        let endpoint = try await LLMEndpointResolver().endpoint(
+            provider: settings.llmProvider,
+            databricksAuthenticationType: settings.llmDatabricksAuthenticationType,
+            databricksWorkspaceID: settings.llmDatabricksWorkspaceID,
+            databricksProfile: settings.llmDatabricksProfile
+        )
         let model = settings.resolvedLLMModelName
         let maxTokens = settings.llmMaxTokens
         let token = try await LLMCredentialResolver().accessToken(

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -334,7 +334,6 @@ enum L10n {
     static var notifications: String { String(localized: "Notifications", bundle: bundle) }
     static var calendar: String { String(localized: "Calendar", bundle: bundle) }
     static var cloudStorage: String { String(localized: "Cloud Storage", bundle: bundle) }
-    static var accountManagement: String { String(localized: "Account Management", bundle: bundle) }
     static var aiSummary: String { String(localized: "AI Summary", bundle: bundle) }
     static var developerSettings: String { String(localized: "Developer Settings", bundle: bundle) }
     static var vault: String { String(localized: "Vault", bundle: bundle) }
@@ -383,8 +382,8 @@ enum L10n {
         localized: "Translation is automatically disabled when the target language matches the transcription language.",
         bundle: bundle
     ) }
-    static var accountSettingsDescription: String { String(
-        localized: "Manage the OpenAI or Databricks account used for AI summaries.",
+    static var modelProviderSettingsDescription: String { String(
+        localized: "Configure credentials and connection settings for the model provider used by AI summaries.",
         bundle: bundle
     ) }
     static var aiSummaryModelSettingsDescription: String { String(

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -673,8 +673,9 @@ enum L10n {
     static var endpointURL: String { String(localized: "Endpoint URL", bundle: bundle) }
     static var openAIEndpointDescription: String { String(localized: "Uses OpenAI's Chat Completions API.", bundle: bundle) }
     static var databricksWorkspaceID: String { String(localized: "Databricks Workspace ID", bundle: bundle) }
-    static var databricksWorkspaceIDDescription: String { String(
-        localized: "Used to build the Databricks AI Gateway chat completions URL.",
+    static var databricksWorkspaceURL: String { String(localized: "Databricks Workspace URL", bundle: bundle) }
+    static var databricksWorkspaceURLDescription: String { String(
+        localized: "Enter the Workspace URL associated with this personal access token.",
         bundle: bundle
     ) }
     static var authenticationType: String { String(localized: "Authentication Type", bundle: bundle) }
@@ -700,7 +701,7 @@ enum L10n {
     ) }
     static var databricksProfileRequired: String { String(localized: "Enter a Databricks CLI profile.", bundle: bundle) }
     static var databricksProfileNotFound: String { String(localized: "The selected Databricks CLI profile was not found.", bundle: bundle) }
-    static var databricksWorkspaceIDRequired: String { String(localized: "Enter a Databricks Workspace ID.", bundle: bundle) }
+    static var databricksWorkspaceURLInvalid: String { String(localized: "Enter a valid HTTPS Databricks Workspace URL.", bundle: bundle) }
     static var workspaceIDUnavailableFromProfile: String { String(
         localized: "The selected Databricks CLI profile does not provide a Workspace ID.",
         bundle: bundle
@@ -730,8 +731,8 @@ enum L10n {
         localized: "Enter a Databricks personal access token.",
         bundle: bundle
     ) }
-    static var endpointGeneratedFromWorkspaceID: String { String(
-        localized: "Endpoint will be generated after entering a Workspace ID.",
+    static var endpointGeneratedFromWorkspaceURL: String { String(
+        localized: "Endpoint will be generated after entering a Workspace URL.",
         bundle: bundle
     ) }
     static var modelDescription: String { String(

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -334,7 +334,8 @@ enum L10n {
     static var notifications: String { String(localized: "Notifications", bundle: bundle) }
     static var calendar: String { String(localized: "Calendar", bundle: bundle) }
     static var cloudStorage: String { String(localized: "Cloud Storage", bundle: bundle) }
-    static var foundationModels: String { String(localized: "Foundation Models", bundle: bundle) }
+    static var accountManagement: String { String(localized: "Account Management", bundle: bundle) }
+    static var aiSummary: String { String(localized: "AI Summary", bundle: bundle) }
     static var developerSettings: String { String(localized: "Developer Settings", bundle: bundle) }
     static var vault: String { String(localized: "Vault", bundle: bundle) }
     static var currentVault: String { String(localized: "Current Vault", bundle: bundle) }
@@ -382,8 +383,12 @@ enum L10n {
         localized: "Translation is automatically disabled when the target language matches the transcription language.",
         bundle: bundle
     ) }
-    static var aiSummarySettingsDescription: String { String(
-        localized: "Configure the LLM connection used for manual summary generation.",
+    static var accountSettingsDescription: String { String(
+        localized: "Manage the OpenAI or Databricks account used for AI summaries.",
+        bundle: bundle
+    ) }
+    static var aiSummaryModelSettingsDescription: String { String(
+        localized: "Choose the model and output limit used to generate AI summaries.",
         bundle: bundle
     ) }
     static var connectionDiagnosticsDescription: String { String(
@@ -658,7 +663,6 @@ enum L10n {
 
     static var model: String { String(localized: "Model", bundle: bundle) }
     static var templates: String { String(localized: "Templates", bundle: bundle) }
-    static var llmSettings: String { String(localized: "LLM Settings", bundle: bundle) }
     static var openAI: String { String(localized: "OpenAI", bundle: bundle) }
     static var databricks: String { String(localized: "Databricks", bundle: bundle) }
     static var modelProvider: String { String(localized: "Model Provider", bundle: bundle) }
@@ -695,6 +699,16 @@ enum L10n {
         bundle: bundle
     ) }
     static var databricksProfileRequired: String { String(localized: "Enter a Databricks CLI profile.", bundle: bundle) }
+    static var databricksProfileNotFound: String { String(localized: "The selected Databricks CLI profile was not found.", bundle: bundle) }
+    static var databricksWorkspaceIDRequired: String { String(localized: "Enter a Databricks Workspace ID.", bundle: bundle) }
+    static var workspaceIDUnavailableFromProfile: String { String(
+        localized: "The selected Databricks CLI profile does not provide a Workspace ID.",
+        bundle: bundle
+    ) }
+    static var workspaceHostUnavailableFromProfile: String { String(
+        localized: "The selected Databricks CLI profile does not provide a valid workspace URL.",
+        bundle: bundle
+    ) }
     static func databricksCLICommandFailed(_ detail: String) -> String { String(
         localized: "Databricks CLI authentication failed: \(detail)",
         bundle: bundle
@@ -735,7 +749,6 @@ enum L10n {
     ) }
     static var apiToken: String { String(localized: "API Token", bundle: bundle) }
     static var apiTokenStoredInKeychain: String { String(localized: "Token is stored securely in Keychain.", bundle: bundle) }
-    static var llmSettingsDescription: String { String(localized: "Configure an LLM endpoint for manual summary generation.", bundle: bundle) }
     static var testConnection: String { String(localized: "Test Connection", bundle: bundle) }
     static var testing: String { String(localized: "Testing...", bundle: bundle) }
     static var connectionSuccess: String { String(localized: "Connection successful", bundle: bundle) }

--- a/Sources/Dahlia/Views/Settings/AISummarySettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/AISummarySettingsView.swift
@@ -1,32 +1,12 @@
 import SwiftUI
 
-/// 設定画面「AI 要約」タブ。LLM プロバイダーとモデル設定を管理する。
+/// 設定画面「AI 要約」タブ。要約生成に使うモデルと出力上限を管理する。
 struct AISummarySettingsView: View {
     @ObservedObject private var settings = AppSettings.shared
-    @State private var apiToken = ""
-    @State private var isTestingConnection = false
-    @State private var isLoadingDatabricksProfiles = false
-    @State private var databricksProfiles: [DatabricksCLIClient.Profile] = []
-    @State private var connectionTestResult: ConnectionTestResult?
-    @State private var databricksProfileLoadError: String?
-    private enum ConnectionTestResult {
-        case success
-        case failure(String)
-    }
 
     var body: some View {
         Form {
             Section {
-                Picker(selection: $settings.llmProvider) {
-                    ForEach(LLMProvider.allCases) { provider in
-                        Text(provider.displayName).tag(provider)
-                    }
-                } label: {
-                    Text(L10n.modelProvider)
-                    Text(L10n.modelProviderDescription)
-                }
-                .pickerStyle(.menu)
-
                 Picker(selection: $settings.llmModel) {
                     ForEach(LLMModel.allCases) { model in
                         Text(model.displayName).tag(model)
@@ -37,8 +17,6 @@ struct AISummarySettingsView: View {
                 }
                 .pickerStyle(.menu)
 
-                providerConfigurationRows
-
                 LabeledContent {
                     TextField("", value: $settings.llmMaxTokens, format: .number)
                         .textFieldStyle(.roundedBorder)
@@ -46,273 +24,12 @@ struct AISummarySettingsView: View {
                     Text(L10n.maxTokens)
                     Text(L10n.maxTokensDescription)
                 }
-
-                if shouldShowAPITokenField {
-                    LabeledContent {
-                        SecureField("", text: $apiToken)
-                            .textFieldStyle(.roundedBorder)
-                            .onSubmit { settings.llmAPIToken = apiToken }
-                    } label: {
-                        Text(apiTokenLabel)
-                        Text(L10n.apiTokenStoredInKeychain)
-                    }
-                }
             } header: {
-                Text(L10n.llmSettings)
+                Text(L10n.aiSummary)
             } footer: {
-                Text(L10n.llmSettingsDescription)
-            }
-
-            Section {
-                connectionTestControl
-                connectionTestStatus
-            } header: {
-                Text(L10n.testConnection)
-            } footer: {
-                Text(L10n.connectionDiagnosticsDescription)
+                Text(L10n.aiSummaryModelSettingsDescription)
             }
         }
         .formStyle(.grouped)
-        .task {
-            apiToken = settings.llmAPIToken
-            if shouldLoadDatabricksProfiles {
-                await loadDatabricksProfiles()
-            }
-        }
-        .onDisappear {
-            settings.llmAPIToken = apiToken
-        }
-        .onChange(of: settings.llmProviderRawValue) { _, _ in
-            connectionTestResult = nil
-            if shouldLoadDatabricksProfiles {
-                Task { await loadDatabricksProfiles() }
-            }
-        }
-        .onChange(of: settings.llmModelRawValue) { _, _ in
-            connectionTestResult = nil
-        }
-        .onChange(of: settings.llmDatabricksProfile) { _, _ in
-            connectionTestResult = nil
-        }
-        .onChange(of: settings.llmDatabricksAuthenticationTypeRawValue) { _, _ in
-            connectionTestResult = nil
-            if shouldLoadDatabricksProfiles {
-                Task { await loadDatabricksProfiles() }
-            } else {
-                databricksProfileLoadError = nil
-            }
-        }
-    }
-
-    // MARK: - Private
-
-    private var isLLMConfigComplete: Bool {
-        guard settings.resolvedLLMEndpointURL.nilIfBlank != nil else { return false }
-
-        switch settings.llmProvider {
-        case .openAI:
-            return apiToken.nilIfBlank != nil
-        case .databricks:
-            switch settings.llmDatabricksAuthenticationType {
-            case .personalAccessToken:
-                return apiToken.nilIfBlank != nil
-            case .oauthCLI:
-                return databricksProfiles.contains { $0.name == settings.llmDatabricksProfile }
-            }
-        }
-    }
-
-    private var shouldShowAPITokenField: Bool {
-        switch settings.llmProvider {
-        case .openAI:
-            true
-        case .databricks:
-            settings.llmDatabricksAuthenticationType == .personalAccessToken
-        }
-    }
-
-    private var shouldLoadDatabricksProfiles: Bool {
-        settings.llmProvider == .databricks
-            && settings.llmDatabricksAuthenticationType == .oauthCLI
-    }
-
-    private var apiTokenLabel: String {
-        settings.llmProvider == .databricks ? L10n.personalAccessToken : L10n.apiToken
-    }
-
-    @ViewBuilder
-    private var connectionTestControl: some View {
-        if isTestingConnection {
-            HStack(spacing: 10) {
-                ProgressView()
-                    .controlSize(.small)
-                Text(L10n.testing)
-                    .foregroundStyle(.secondary)
-            }
-        } else {
-            Button(L10n.testConnection) {
-                testConnection()
-            }
-            .disabled(!isLLMConfigComplete)
-        }
-    }
-
-    @ViewBuilder
-    private var connectionTestStatus: some View {
-        if let result = connectionTestResult {
-            switch result {
-            case .success:
-                SettingsStatusMessage(
-                    text: L10n.connectionSuccess,
-                    systemImage: "checkmark.circle.fill",
-                    tint: .green
-                )
-            case let .failure(message):
-                SettingsStatusMessage(
-                    text: message,
-                    systemImage: "xmark.circle.fill",
-                    tint: .red
-                )
-            }
-        } else if !isLLMConfigComplete {
-            Text(L10n.llmConfigIncomplete)
-                .foregroundStyle(.secondary)
-        }
-    }
-
-    @ViewBuilder
-    private var providerConfigurationRows: some View {
-        switch settings.llmProvider {
-        case .openAI:
-            LabeledContent {
-                endpointPreview(settings.resolvedLLMEndpointURL)
-            } label: {
-                Text(L10n.endpointURL)
-                Text(L10n.openAIEndpointDescription)
-            }
-        case .databricks:
-            LabeledContent {
-                TextField(
-                    "",
-                    text: $settings.llmDatabricksWorkspaceID,
-                    prompt: Text("1234567890123456")
-                )
-                .textFieldStyle(.roundedBorder)
-            } label: {
-                Text(L10n.databricksWorkspaceID)
-                Text(L10n.databricksWorkspaceIDDescription)
-            }
-
-            LabeledContent(L10n.endpointURL) {
-                endpointPreview(settings.resolvedLLMEndpointURL)
-            }
-
-            Picker(selection: $settings.llmDatabricksAuthenticationType) {
-                ForEach(DatabricksAuthenticationType.allCases) { authenticationType in
-                    Text(authenticationType.displayName).tag(authenticationType)
-                }
-            } label: {
-                Text(L10n.authenticationType)
-                Text(L10n.databricksAuthenticationTypeDescription)
-            }
-            .pickerStyle(.menu)
-
-            if settings.llmDatabricksAuthenticationType == .oauthCLI {
-                LabeledContent {
-                    HStack {
-                        if isLoadingDatabricksProfiles {
-                            ProgressView()
-                                .controlSize(.small)
-                        } else if databricksProfiles.isEmpty {
-                            Text(L10n.noDatabricksProfiles)
-                                .foregroundStyle(.secondary)
-                        } else {
-                            Picker("", selection: $settings.llmDatabricksProfile) {
-                                ForEach(databricksProfiles) { profile in
-                                    Text(profile.name).tag(profile.name)
-                                }
-                            }
-                            .labelsHidden()
-                            .pickerStyle(.menu)
-                        }
-
-                        Button(L10n.refreshDatabricksProfiles, systemImage: "arrow.clockwise") {
-                            Task { await loadDatabricksProfiles() }
-                        }
-                        .labelStyle(.iconOnly)
-                        .disabled(isLoadingDatabricksProfiles)
-                    }
-                } label: {
-                    Text(L10n.databricksProfile)
-                    Text(L10n.databricksProfileDescription)
-                }
-
-                if let databricksProfileLoadError {
-                    SettingsStatusMessage(
-                        text: databricksProfileLoadError,
-                        systemImage: "xmark.circle.fill",
-                        tint: .red
-                    )
-                }
-            }
-        }
-    }
-
-    private func endpointPreview(_ endpoint: String) -> some View {
-        Text(endpoint.nilIfBlank ?? L10n.endpointGeneratedFromWorkspaceID)
-            .font(.callout.monospaced())
-            .foregroundStyle(endpoint.nilIfBlank == nil ? Color.secondary : Color.primary)
-            .lineLimit(2)
-            .multilineTextAlignment(.trailing)
-            .textSelection(.enabled)
-            .frame(maxWidth: .infinity, alignment: .trailing)
-    }
-
-    private func testConnection() {
-        if shouldShowAPITokenField {
-            settings.llmAPIToken = apiToken
-        }
-        connectionTestResult = nil
-        isTestingConnection = true
-        Task {
-            do {
-                let token = try await LLMCredentialResolver().accessToken(
-                    provider: settings.llmProvider,
-                    apiToken: apiToken,
-                    databricksAuthenticationType: settings.llmDatabricksAuthenticationType,
-                    databricksProfile: settings.llmDatabricksProfile
-                )
-                try await LLMService.testConnection(
-                    endpoint: settings.resolvedLLMEndpointURL,
-                    model: settings.resolvedLLMModelName,
-                    token: token
-                )
-                connectionTestResult = .success
-            } catch {
-                connectionTestResult = .failure(error.localizedDescription)
-            }
-            isTestingConnection = false
-        }
-    }
-
-    private func loadDatabricksProfiles() async {
-        isLoadingDatabricksProfiles = true
-        databricksProfileLoadError = nil
-        defer { isLoadingDatabricksProfiles = false }
-
-        do {
-            let profiles = try await DatabricksCLIClient().profiles()
-            databricksProfiles = profiles
-            let selectedProfile = AppSettings.resolvedDatabricksProfileSelection(
-                current: settings.llmDatabricksProfile,
-                availableProfiles: profiles.map(\.name)
-            )
-            if selectedProfile != settings.llmDatabricksProfile {
-                settings.llmDatabricksProfile = selectedProfile
-            }
-        } catch {
-            databricksProfiles = []
-            databricksProfileLoadError = error.localizedDescription
-        }
     }
 }

--- a/Sources/Dahlia/Views/Settings/AccountSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/AccountSettingsView.swift
@@ -66,7 +66,7 @@ struct AccountSettingsView: View {
         .onChange(of: settings.llmModelRawValue) { _, _ in
             connectionTestResult = nil
         }
-        .onChange(of: settings.llmDatabricksWorkspaceID) { _, _ in
+        .onChange(of: settings.llmDatabricksWorkspaceURL) { _, _ in
             connectionTestResult = nil
         }
         .onChange(of: settings.llmDatabricksProfile) { _, _ in
@@ -98,7 +98,7 @@ struct AccountSettingsView: View {
         if shouldLoadDatabricksProfiles {
             L10n.workspaceHostUnavailableFromProfile
         } else {
-            L10n.endpointGeneratedFromWorkspaceID
+            L10n.endpointGeneratedFromWorkspaceURL
         }
     }
 
@@ -191,13 +191,13 @@ struct AccountSettingsView: View {
             LabeledContent {
                 TextField(
                     "",
-                    text: $settings.llmDatabricksWorkspaceID,
-                    prompt: Text("1234567890123456")
+                    text: $settings.llmDatabricksWorkspaceURL,
+                    prompt: Text("https://e2-demo-tokyo.cloud.databricks.com")
                 )
                 .textFieldStyle(.roundedBorder)
             } label: {
-                Text(L10n.databricksWorkspaceID)
-                Text(L10n.databricksWorkspaceIDDescription)
+                Text(L10n.databricksWorkspaceURL)
+                Text(L10n.databricksWorkspaceURLDescription)
             }
         case .oauthCLI:
             DatabricksOAuthSettingsRows(
@@ -261,7 +261,7 @@ struct AccountSettingsView: View {
                 let endpoint = try await LLMEndpointResolver().endpoint(
                     provider: settings.llmProvider,
                     databricksAuthenticationType: settings.llmDatabricksAuthenticationType,
-                    databricksWorkspaceID: settings.llmDatabricksWorkspaceID,
+                    databricksWorkspaceURL: settings.llmDatabricksWorkspaceURL,
                     databricksProfile: settings.llmDatabricksProfile
                 )
                 let token = try await LLMCredentialResolver().accessToken(

--- a/Sources/Dahlia/Views/Settings/AccountSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/AccountSettingsView.swift
@@ -1,0 +1,305 @@
+import SwiftUI
+
+/// 設定画面「アカウント管理」タブ。LLM プロバイダーの認証と接続設定を管理する。
+struct AccountSettingsView: View {
+    @ObservedObject private var settings = AppSettings.shared
+    @State private var apiToken = ""
+    @State private var isTestingConnection = false
+    @State private var isLoadingDatabricksProfiles = false
+    @State private var databricksProfiles: [DatabricksCLIClient.Profile] = []
+    @State private var connectionTestResult: ConnectionTestResult?
+    @State private var databricksProfileLoadError: String?
+
+    private enum ConnectionTestResult {
+        case success
+        case failure(String)
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Picker(selection: $settings.llmProvider) {
+                    ForEach(LLMProvider.allCases) { provider in
+                        Text(provider.displayName).tag(provider)
+                    }
+                } label: {
+                    Text(L10n.modelProvider)
+                    Text(L10n.modelProviderDescription)
+                }
+                .pickerStyle(.menu)
+
+                providerConfigurationRows
+
+                if shouldShowAPITokenField {
+                    LabeledContent {
+                        SecureField("", text: $apiToken)
+                            .textFieldStyle(.roundedBorder)
+                            .onSubmit { settings.llmAPIToken = apiToken }
+                    } label: {
+                        Text(apiTokenLabel)
+                        Text(L10n.apiTokenStoredInKeychain)
+                    }
+                }
+            } header: {
+                Text(L10n.accountManagement)
+            } footer: {
+                Text(L10n.accountSettingsDescription)
+            }
+
+            Section {
+                connectionTestControl
+                connectionTestStatus
+            } header: {
+                Text(L10n.testConnection)
+            } footer: {
+                Text(L10n.connectionDiagnosticsDescription)
+            }
+        }
+        .formStyle(.grouped)
+        .task {
+            await loadInitialState()
+        }
+        .onDisappear(perform: saveAPIToken)
+        .onChange(of: settings.llmProviderRawValue) { _, _ in
+            providerConfigurationDidChange()
+        }
+        .onChange(of: settings.llmModelRawValue) { _, _ in
+            connectionTestResult = nil
+        }
+        .onChange(of: settings.llmDatabricksWorkspaceID) { _, _ in
+            connectionTestResult = nil
+        }
+        .onChange(of: settings.llmDatabricksProfile) { _, _ in
+            connectionTestResult = nil
+        }
+        .onChange(of: settings.llmDatabricksAuthenticationTypeRawValue) { _, _ in
+            providerConfigurationDidChange()
+        }
+    }
+
+    // MARK: - Private
+
+    private var selectedDatabricksProfile: DatabricksCLIClient.Profile? {
+        databricksProfiles.first { $0.name == settings.llmDatabricksProfile }
+    }
+
+    private var endpoint: String {
+        switch (settings.llmProvider, settings.llmDatabricksAuthenticationType) {
+        case (.openAI, _):
+            AppSettings.openAIEndpointURL
+        case (.databricks, .personalAccessToken):
+            settings.resolvedLLMEndpointURL
+        case (.databricks, .oauthCLI):
+            selectedDatabricksProfile?.endpointURL ?? ""
+        }
+    }
+
+    private var endpointPlaceholder: String {
+        if shouldLoadDatabricksProfiles {
+            L10n.workspaceHostUnavailableFromProfile
+        } else {
+            L10n.endpointGeneratedFromWorkspaceID
+        }
+    }
+
+    private var isConnectionConfigurationComplete: Bool {
+        endpoint.nilIfBlank != nil
+            && (!shouldShowAPITokenField || apiToken.nilIfBlank != nil)
+    }
+
+    private var shouldShowAPITokenField: Bool {
+        settings.llmProvider == .openAI
+            || settings.llmDatabricksAuthenticationType == .personalAccessToken
+    }
+
+    private var shouldLoadDatabricksProfiles: Bool {
+        settings.llmProvider == .databricks
+            && settings.llmDatabricksAuthenticationType == .oauthCLI
+    }
+
+    private var apiTokenLabel: String {
+        settings.llmProvider == .databricks ? L10n.personalAccessToken : L10n.apiToken
+    }
+
+    @ViewBuilder
+    private var connectionTestControl: some View {
+        if isTestingConnection {
+            HStack(spacing: 10) {
+                ProgressView()
+                    .controlSize(.small)
+                Text(L10n.testing)
+                    .foregroundStyle(.secondary)
+            }
+        } else {
+            Button(L10n.testConnection, action: testConnection)
+                .disabled(!isConnectionConfigurationComplete)
+        }
+    }
+
+    @ViewBuilder
+    private var connectionTestStatus: some View {
+        if let result = connectionTestResult {
+            switch result {
+            case .success:
+                SettingsStatusMessage(
+                    text: L10n.connectionSuccess,
+                    systemImage: "checkmark.circle.fill",
+                    tint: .green
+                )
+            case let .failure(message):
+                SettingsStatusMessage(
+                    text: message,
+                    systemImage: "xmark.circle.fill",
+                    tint: .red
+                )
+            }
+        } else if !isConnectionConfigurationComplete {
+            Text(L10n.llmConfigIncomplete)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var providerConfigurationRows: some View {
+        switch settings.llmProvider {
+        case .openAI:
+            LabeledContent {
+                endpointPreview(AppSettings.openAIEndpointURL)
+            } label: {
+                Text(L10n.endpointURL)
+                Text(L10n.openAIEndpointDescription)
+            }
+        case .databricks:
+            Picker(selection: $settings.llmDatabricksAuthenticationType) {
+                ForEach(DatabricksAuthenticationType.allCases) { authenticationType in
+                    Text(authenticationType.displayName).tag(authenticationType)
+                }
+            } label: {
+                Text(L10n.authenticationType)
+                Text(L10n.databricksAuthenticationTypeDescription)
+            }
+            .pickerStyle(.menu)
+
+            databricksConfigurationRows
+        }
+    }
+
+    @ViewBuilder
+    private var databricksConfigurationRows: some View {
+        switch settings.llmDatabricksAuthenticationType {
+        case .personalAccessToken:
+            LabeledContent {
+                TextField(
+                    "",
+                    text: $settings.llmDatabricksWorkspaceID,
+                    prompt: Text("1234567890123456")
+                )
+                .textFieldStyle(.roundedBorder)
+            } label: {
+                Text(L10n.databricksWorkspaceID)
+                Text(L10n.databricksWorkspaceIDDescription)
+            }
+        case .oauthCLI:
+            DatabricksOAuthSettingsRows(
+                selectedProfile: $settings.llmDatabricksProfile,
+                profiles: databricksProfiles,
+                isLoading: isLoadingDatabricksProfiles,
+                loadError: databricksProfileLoadError,
+                refreshProfiles: refreshDatabricksProfiles
+            )
+        }
+
+        LabeledContent(L10n.endpointURL) {
+            endpointPreview(endpoint)
+        }
+    }
+
+    private func endpointPreview(_ endpoint: String) -> some View {
+        let endpoint = endpoint.nilIfBlank
+        return Text(endpoint ?? endpointPlaceholder)
+            .font(.callout.monospaced())
+            .foregroundStyle(endpoint == nil ? Color.secondary : Color.primary)
+            .lineLimit(2)
+            .multilineTextAlignment(.trailing)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+
+    private func loadInitialState() async {
+        apiToken = settings.llmAPIToken
+        if shouldLoadDatabricksProfiles {
+            await loadDatabricksProfiles()
+        }
+    }
+
+    private func saveAPIToken() {
+        settings.llmAPIToken = apiToken
+    }
+
+    private func providerConfigurationDidChange() {
+        connectionTestResult = nil
+        if shouldLoadDatabricksProfiles {
+            refreshDatabricksProfiles()
+        } else {
+            databricksProfileLoadError = nil
+        }
+    }
+
+    private func refreshDatabricksProfiles() {
+        Task { await loadDatabricksProfiles() }
+    }
+
+    private func testConnection() {
+        if shouldShowAPITokenField {
+            settings.llmAPIToken = apiToken
+        }
+        connectionTestResult = nil
+        isTestingConnection = true
+        Task {
+            defer { isTestingConnection = false }
+            do {
+                let endpoint = try await LLMEndpointResolver().endpoint(
+                    provider: settings.llmProvider,
+                    databricksAuthenticationType: settings.llmDatabricksAuthenticationType,
+                    databricksWorkspaceID: settings.llmDatabricksWorkspaceID,
+                    databricksProfile: settings.llmDatabricksProfile
+                )
+                let token = try await LLMCredentialResolver().accessToken(
+                    provider: settings.llmProvider,
+                    apiToken: apiToken,
+                    databricksAuthenticationType: settings.llmDatabricksAuthenticationType,
+                    databricksProfile: settings.llmDatabricksProfile
+                )
+                try await LLMService.testConnection(
+                    endpoint: endpoint,
+                    model: settings.resolvedLLMModelName,
+                    token: token
+                )
+                connectionTestResult = .success
+            } catch {
+                connectionTestResult = .failure(error.localizedDescription)
+            }
+        }
+    }
+
+    private func loadDatabricksProfiles() async {
+        isLoadingDatabricksProfiles = true
+        databricksProfileLoadError = nil
+        defer { isLoadingDatabricksProfiles = false }
+
+        do {
+            let profiles = try await DatabricksCLIClient().profiles()
+            databricksProfiles = profiles
+            let selectedProfile = AppSettings.resolvedDatabricksProfileSelection(
+                current: settings.llmDatabricksProfile,
+                availableProfiles: profiles.map(\.name)
+            )
+            if selectedProfile != settings.llmDatabricksProfile {
+                settings.llmDatabricksProfile = selectedProfile
+            }
+        } catch {
+            databricksProfiles = []
+            databricksProfileLoadError = error.localizedDescription
+        }
+    }
+}

--- a/Sources/Dahlia/Views/Settings/AccountSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/AccountSettingsView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// 設定画面「アカウント管理」タブ。LLM プロバイダーの認証と接続設定を管理する。
+/// 設定画面「Model Provider」タブ。LLM プロバイダーの認証と接続設定を管理する。
 struct AccountSettingsView: View {
     @ObservedObject private var settings = AppSettings.shared
     @State private var apiToken = ""
@@ -40,10 +40,8 @@ struct AccountSettingsView: View {
                         Text(L10n.apiTokenStoredInKeychain)
                     }
                 }
-            } header: {
-                Text(L10n.accountManagement)
             } footer: {
-                Text(L10n.accountSettingsDescription)
+                Text(L10n.modelProviderSettingsDescription)
             }
 
             Section {

--- a/Sources/Dahlia/Views/Settings/DatabricksOAuthSettingsRows.swift
+++ b/Sources/Dahlia/Views/Settings/DatabricksOAuthSettingsRows.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct DatabricksOAuthSettingsRows: View {
+    @Binding var selectedProfile: String
+    let profiles: [DatabricksCLIClient.Profile]
+    let isLoading: Bool
+    let loadError: String?
+    let refreshProfiles: () -> Void
+
+    var body: some View {
+        LabeledContent {
+            HStack {
+                profilePicker
+
+                Button(
+                    L10n.refreshDatabricksProfiles,
+                    systemImage: "arrow.clockwise",
+                    action: refreshProfiles
+                )
+                .labelStyle(.iconOnly)
+                .disabled(isLoading)
+            }
+        } label: {
+            Text(L10n.databricksProfile)
+            Text(L10n.databricksProfileDescription)
+        }
+
+        LabeledContent(L10n.databricksWorkspaceID) {
+            Text(workspaceID ?? L10n.workspaceIDUnavailableFromProfile)
+                .foregroundStyle(workspaceID == nil ? Color.secondary : Color.primary)
+                .textSelection(.enabled)
+        }
+
+        if let loadError {
+            SettingsStatusMessage(
+                text: loadError,
+                systemImage: "xmark.circle.fill",
+                tint: .red
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var profilePicker: some View {
+        if isLoading {
+            ProgressView()
+                .controlSize(.small)
+        } else if profiles.isEmpty {
+            Text(L10n.noDatabricksProfiles)
+                .foregroundStyle(.secondary)
+        } else {
+            Picker("", selection: $selectedProfile) {
+                ForEach(profiles) { profile in
+                    Text(profile.name).tag(profile.name)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+        }
+    }
+
+    private var workspaceID: String? {
+        profiles.first { $0.name == selectedProfile }?.workspaceID?.nilIfBlank
+    }
+}

--- a/Sources/Dahlia/Views/SettingsView.swift
+++ b/Sources/Dahlia/Views/SettingsView.swift
@@ -7,7 +7,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
     case cloudStorage
     case transcription
     case screenshots
-    case accounts
+    case modelProvider = "accounts"
     case aiSummary
     case instructions
     case developer
@@ -23,7 +23,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .transcription: L10n.transcription
         case .audioDiagnostics: L10n.debug
         case .screenshots: L10n.screenshots
-        case .accounts: L10n.accountManagement
+        case .modelProvider: L10n.modelProvider
         case .aiSummary: L10n.aiSummary
         case .instructions: L10n.instructions
         case .developer: L10n.developerSettings
@@ -38,7 +38,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .transcription: "waveform"
         case .audioDiagnostics: "ladybug"
         case .screenshots: "photo.on.rectangle.angled"
-        case .accounts: "person.crop.circle"
+        case .modelProvider: "cpu"
         case .aiSummary: "sparkles"
         case .instructions: "list.bullet.clipboard"
         case .developer: "wrench.and.screwdriver"
@@ -102,9 +102,9 @@ struct SettingsView: View {
             }
 
             Tab(
-                SettingsCategory.accounts.label,
-                systemImage: SettingsCategory.accounts.systemImage,
-                value: SettingsCategory.accounts
+                SettingsCategory.modelProvider.label,
+                systemImage: SettingsCategory.modelProvider.systemImage,
+                value: SettingsCategory.modelProvider
             ) {
                 AccountSettingsView()
             }

--- a/Sources/Dahlia/Views/SettingsView.swift
+++ b/Sources/Dahlia/Views/SettingsView.swift
@@ -7,6 +7,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
     case cloudStorage
     case transcription
     case screenshots
+    case accounts
     case aiSummary
     case instructions
     case developer
@@ -22,7 +23,8 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .transcription: L10n.transcription
         case .audioDiagnostics: L10n.debug
         case .screenshots: L10n.screenshots
-        case .aiSummary: L10n.foundationModels
+        case .accounts: L10n.accountManagement
+        case .aiSummary: L10n.aiSummary
         case .instructions: L10n.instructions
         case .developer: L10n.developerSettings
         }
@@ -36,6 +38,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .transcription: "waveform"
         case .audioDiagnostics: "ladybug"
         case .screenshots: "photo.on.rectangle.angled"
+        case .accounts: "person.crop.circle"
         case .aiSummary: "sparkles"
         case .instructions: "list.bullet.clipboard"
         case .developer: "wrench.and.screwdriver"
@@ -96,6 +99,14 @@ struct SettingsView: View {
                 value: SettingsCategory.screenshots
             ) {
                 ScreenshotSettingsView()
+            }
+
+            Tab(
+                SettingsCategory.accounts.label,
+                systemImage: SettingsCategory.accounts.systemImage,
+                value: SettingsCategory.accounts
+            ) {
+                AccountSettingsView()
             }
 
             Tab(

--- a/Tests/DahliaTests/DatabricksCLIClientTests.swift
+++ b/Tests/DahliaTests/DatabricksCLIClientTests.swift
@@ -59,7 +59,7 @@ import Foundation
             let endpoint = try await resolver.endpoint(
                 provider: .databricks,
                 databricksAuthenticationType: .oauthCLI,
-                databricksWorkspaceID: "different-manual-value",
+                databricksWorkspaceURL: "https://different.example.com",
                 databricksProfile: "WORK"
             )
 
@@ -82,8 +82,39 @@ import Foundation
                 _ = try await resolver.endpoint(
                     provider: .databricks,
                     databricksAuthenticationType: .oauthCLI,
-                    databricksWorkspaceID: "manual-value",
+                    databricksWorkspaceURL: "https://manual.example.com",
                     databricksProfile: "WORK"
+                )
+            }
+        }
+
+        @Test
+        func endpointResolverUsesWorkspaceURLForPersonalAccessToken() async throws {
+            let resolver = LLMEndpointResolver()
+
+            let endpoint = try await resolver.endpoint(
+                provider: .databricks,
+                databricksAuthenticationType: .personalAccessToken,
+                databricksWorkspaceURL: " https://e2-demo-tokyo.cloud.databricks.com/ ",
+                databricksProfile: ""
+            )
+
+            #expect(
+                endpoint
+                    == "https://e2-demo-tokyo.cloud.databricks.com/ai-gateway/mlflow/v1/chat/completions"
+            )
+        }
+
+        @Test
+        func endpointResolverRejectsInvalidWorkspaceURLForPersonalAccessToken() async {
+            let resolver = LLMEndpointResolver()
+
+            await #expect(throws: LLMEndpointError.self) {
+                _ = try await resolver.endpoint(
+                    provider: .databricks,
+                    databricksAuthenticationType: .personalAccessToken,
+                    databricksWorkspaceURL: "984752964297111",
+                    databricksProfile: ""
                 )
             }
         }

--- a/Tests/DahliaTests/DatabricksCLIClientTests.swift
+++ b/Tests/DahliaTests/DatabricksCLIClientTests.swift
@@ -9,8 +9,12 @@ import Foundation
         func profilesReturnsOnlyOAuthU2MProfilesWithoutValidation() async throws {
             let recorder = CommandRecorder()
             let response = Data(
-                #"{"profiles":[{"name":"WORK","host":"https://work.example.com","auth_type":"pat"},{"name":"DEV","host":"https://dev.example.com","auth_type":"databricks-cli"}]}"#
-                    .utf8
+                """
+                {"profiles":[
+                    {"name":"WORK","host":"https://work.example.com","auth_type":"pat","workspace_id":"111"},
+                    {"name":"DEV","host":"https://adb-222.7.azuredatabricks.net/","auth_type":"databricks-cli","workspace_id":222}
+                ]}
+                """.utf8
             )
             let client = DatabricksCLIClient { arguments in
                 await recorder.record(arguments)
@@ -20,6 +24,12 @@ import Foundation
             let profiles = try await client.profiles()
 
             #expect(profiles.map(\.name) == ["DEV"])
+            #expect(profiles.compactMap(\.workspaceID) == ["222"])
+            #expect(profiles.first?.host == "https://adb-222.7.azuredatabricks.net/")
+            #expect(
+                profiles.first?.endpointURL
+                    == "https://adb-222.7.azuredatabricks.net/ai-gateway/mlflow/v1/chat/completions"
+            )
             #expect(await recorder.commands.last == [
                 "auth",
                 "profiles",
@@ -27,6 +37,55 @@ import Foundation
                 "--output",
                 "json",
             ])
+        }
+
+        @Test
+        func endpointResolverUsesGCPWorkspaceHostFromSelectedOAuthProfile() async throws {
+            let recorder = CommandRecorder()
+            let response = Data(
+                """
+                {"profiles":[
+                    {"name":"DEV","host":"https://dbc-dev.cloud.databricks.com","auth_type":"databricks-cli","workspace_id":"222"},
+                    {"name":"WORK","host":"https://3333333333333333.3.gcp.databricks.com","auth_type":"databricks-cli","workspace_id":"3333333333333333"}
+                ]}
+                """.utf8
+            )
+            let client = DatabricksCLIClient { arguments in
+                await recorder.record(arguments)
+                return .init(standardOutput: response, standardError: Data(), terminationStatus: 0)
+            }
+            let resolver = LLMEndpointResolver(databricksClient: client)
+
+            let endpoint = try await resolver.endpoint(
+                provider: .databricks,
+                databricksAuthenticationType: .oauthCLI,
+                databricksWorkspaceID: "different-manual-value",
+                databricksProfile: "WORK"
+            )
+
+            #expect(
+                endpoint
+                    == "https://3333333333333333.3.gcp.databricks.com/ai-gateway/mlflow/v1/chat/completions"
+            )
+            #expect(await recorder.commands.count == 1)
+        }
+
+        @Test
+        func endpointResolverRejectsOAuthProfileWithoutWorkspaceHost() async {
+            let response = Data(#"{"profiles":[{"name":"WORK","auth_type":"databricks-cli","workspace_id":"333"}]}"#.utf8)
+            let client = DatabricksCLIClient { _ in
+                .init(standardOutput: response, standardError: Data(), terminationStatus: 0)
+            }
+            let resolver = LLMEndpointResolver(databricksClient: client)
+
+            await #expect(throws: LLMEndpointError.self) {
+                _ = try await resolver.endpoint(
+                    provider: .databricks,
+                    databricksAuthenticationType: .oauthCLI,
+                    databricksWorkspaceID: "manual-value",
+                    databricksProfile: "WORK"
+                )
+            }
         }
 
         @Test

--- a/Tests/DahliaTests/DatabricksConfigurationTests.swift
+++ b/Tests/DahliaTests/DatabricksConfigurationTests.swift
@@ -27,18 +27,18 @@
         func oauthConfigurationRequiresOnlyCLIProfile() {
             let settings = AppSettings.shared
             let previousProviderRawValue = settings.llmProviderRawValue
-            let previousWorkspaceID = settings.llmDatabricksWorkspaceID
+            let previousWorkspaceURL = settings.llmDatabricksWorkspaceURL
             let previousAuthenticationTypeRawValue = settings.llmDatabricksAuthenticationTypeRawValue
             let previousProfile = settings.llmDatabricksProfile
             defer {
                 settings.llmProviderRawValue = previousProviderRawValue
-                settings.llmDatabricksWorkspaceID = previousWorkspaceID
+                settings.llmDatabricksWorkspaceURL = previousWorkspaceURL
                 settings.llmDatabricksAuthenticationTypeRawValue = previousAuthenticationTypeRawValue
                 settings.llmDatabricksProfile = previousProfile
             }
 
             settings.llmProvider = .databricks
-            settings.llmDatabricksWorkspaceID = ""
+            settings.llmDatabricksWorkspaceURL = ""
             settings.llmDatabricksAuthenticationType = .oauthCLI
             settings.llmDatabricksProfile = "WORK"
             #expect(settings.isLLMConfigComplete)

--- a/Tests/DahliaTests/DatabricksConfigurationTests.swift
+++ b/Tests/DahliaTests/DatabricksConfigurationTests.swift
@@ -24,7 +24,7 @@
         }
 
         @Test
-        func oauthConfigurationRequiresWorkspaceAndCLIProfile() {
+        func oauthConfigurationRequiresOnlyCLIProfile() {
             let settings = AppSettings.shared
             let previousProviderRawValue = settings.llmProviderRawValue
             let previousWorkspaceID = settings.llmDatabricksWorkspaceID
@@ -38,10 +38,11 @@
             }
 
             settings.llmProvider = .databricks
-            settings.llmDatabricksWorkspaceID = "1234567890123456"
+            settings.llmDatabricksWorkspaceID = ""
             settings.llmDatabricksAuthenticationType = .oauthCLI
             settings.llmDatabricksProfile = "WORK"
             #expect(settings.isLLMConfigComplete)
+            #expect(settings.resolvedLLMEndpointURL.isEmpty)
 
             settings.llmDatabricksProfile = "  "
             #expect(!settings.isLLMConfigComplete)

--- a/Tests/DahliaTests/SettingsCategoryTests.swift
+++ b/Tests/DahliaTests/SettingsCategoryTests.swift
@@ -5,12 +5,13 @@
 
     struct SettingsCategoryTests {
         @Test
-        func accountAndAISummarySettingsAreSeparateCategories() throws {
-            #expect(SettingsCategory.accounts.label == L10n.accountManagement)
+        func modelProviderAndAISummarySettingsAreSeparateCategories() throws {
+            #expect(SettingsCategory.modelProvider.label == L10n.modelProvider)
+            #expect(SettingsCategory.modelProvider.rawValue == "accounts")
             #expect(SettingsCategory.aiSummary.label == L10n.aiSummary)
-            let accountsIndex = try #require(SettingsCategory.allCases.firstIndex(of: .accounts))
+            let modelProviderIndex = try #require(SettingsCategory.allCases.firstIndex(of: .modelProvider))
             let aiSummaryIndex = try #require(SettingsCategory.allCases.firstIndex(of: .aiSummary))
-            #expect(accountsIndex < aiSummaryIndex)
+            #expect(modelProviderIndex < aiSummaryIndex)
         }
 
         @Test

--- a/Tests/DahliaTests/SettingsCategoryTests.swift
+++ b/Tests/DahliaTests/SettingsCategoryTests.swift
@@ -5,6 +5,15 @@
 
     struct SettingsCategoryTests {
         @Test
+        func accountAndAISummarySettingsAreSeparateCategories() throws {
+            #expect(SettingsCategory.accounts.label == L10n.accountManagement)
+            #expect(SettingsCategory.aiSummary.label == L10n.aiSummary)
+            let accountsIndex = try #require(SettingsCategory.allCases.firstIndex(of: .accounts))
+            let aiSummaryIndex = try #require(SettingsCategory.allCases.firstIndex(of: .aiSummary))
+            #expect(accountsIndex < aiSummaryIndex)
+        }
+
+        @Test
         func debugCategoryIsLastAndUsesDebugPresentation() {
             #expect(SettingsCategory.allCases.last == .audioDiagnostics)
             #expect(SettingsCategory.audioDiagnostics.label == L10n.debug)

--- a/Tests/DahliaTests/SummaryServiceTests.swift
+++ b/Tests/DahliaTests/SummaryServiceTests.swift
@@ -474,12 +474,15 @@ struct SummaryServiceTests {
         let settings = AppSettings.shared
         let previousProviderRawValue = settings.llmProviderRawValue
         let previousWorkspaceID = settings.llmDatabricksWorkspaceID
+        let previousAuthenticationTypeRawValue = settings.llmDatabricksAuthenticationTypeRawValue
         defer {
             settings.llmProviderRawValue = previousProviderRawValue
             settings.llmDatabricksWorkspaceID = previousWorkspaceID
+            settings.llmDatabricksAuthenticationTypeRawValue = previousAuthenticationTypeRawValue
         }
 
         settings.llmProvider = .databricks
+        settings.llmDatabricksAuthenticationType = .personalAccessToken
         settings.llmDatabricksWorkspaceID = " 1234567890123456 "
 
         #expect(

--- a/Tests/DahliaTests/SummaryServiceTests.swift
+++ b/Tests/DahliaTests/SummaryServiceTests.swift
@@ -470,24 +470,24 @@ struct SummaryServiceTests {
     }
 
     @Test
-    func llmProviderBuildsDatabricksAIGatewayEndpointFromWorkspaceID() {
+    func llmProviderBuildsDatabricksAIGatewayEndpointFromWorkspaceURL() {
         let settings = AppSettings.shared
         let previousProviderRawValue = settings.llmProviderRawValue
-        let previousWorkspaceID = settings.llmDatabricksWorkspaceID
+        let previousWorkspaceURL = settings.llmDatabricksWorkspaceURL
         let previousAuthenticationTypeRawValue = settings.llmDatabricksAuthenticationTypeRawValue
         defer {
             settings.llmProviderRawValue = previousProviderRawValue
-            settings.llmDatabricksWorkspaceID = previousWorkspaceID
+            settings.llmDatabricksWorkspaceURL = previousWorkspaceURL
             settings.llmDatabricksAuthenticationTypeRawValue = previousAuthenticationTypeRawValue
         }
 
         settings.llmProvider = .databricks
         settings.llmDatabricksAuthenticationType = .personalAccessToken
-        settings.llmDatabricksWorkspaceID = " 1234567890123456 "
+        settings.llmDatabricksWorkspaceURL = " https://adb-984752964297111.11.azuredatabricks.net/ "
 
         #expect(
             settings.resolvedLLMEndpointURL
-                == "https://1234567890123456.ai-gateway.cloud.databricks.com/mlflow/v1/chat/completions"
+                == "https://adb-984752964297111.11.azuredatabricks.net/ai-gateway/mlflow/v1/chat/completions"
         )
     }
 


### PR DESCRIPTION
## Summary

- Split the former Foundation Models settings into Account Management and AI Summary tabs
- Keep provider credentials and connection diagnostics under Account Management
- Keep model selection and max tokens under AI Summary
- Resolve Databricks OAuth endpoints from the selected CLI profile
- Accept a Databricks Workspace URL instead of a Workspace ID for personal access token authentication
- Generate Unity AI Gateway URLs from the workspace URL for AWS, Azure, and GCP
- Continue showing the workspace ID sourced from the selected OAuth profile

## Why

Authentication and workspace information were entered independently, so they could point to different Databricks workspaces. Constructing an AWS-only AI Gateway hostname from a Workspace ID also did not support Azure or GCP Workspace URL formats.

OAuth configuration now uses the selected Databricks CLI profile as the source of truth. Personal access token configuration requires the corresponding Workspace URL. Both authentication methods build the endpoint through the same flow:

`https://<workspace-url>/ai-gateway/mlflow/v1/chat/completions`

## Impact

Users can manage account credentials separately from summary generation settings. Databricks requests now target the configured workspace across AWS, Azure, and GCP regardless of whether OAuth or a personal access token is used.

## Validation

- `swift build --disable-sandbox`
- DatabricksCLIClientTests, DatabricksConfigurationTests, and SummaryServiceTests: 41 tests passed
- SwiftFormat: 0/213 files require formatting
- Targeted SwiftLint: no new errors
- Repository-wide SwiftLint still reports pre-existing violations and remains non-blocking