### PR TITLE
Reorganize settings for user workflows

### DIFF
--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -215,6 +215,12 @@
 
 /* Settings */
 "General" = "General";
+"App" = "App";
+"Integrations" = "Integrations";
+"AI" = "AI";
+"Advanced" = "Advanced";
+"AI Connection" = "AI Connection";
+"Diagnostics" = "Diagnostics";
 "Notifications" = "Notifications";
 "Calendar" = "Calendar";
 "AI Summary" = "AI Summary";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -215,6 +215,12 @@
 
 /* Settings */
 "General" = "一般";
+"App" = "アプリ";
+"Integrations" = "連携";
+"AI" = "AI";
+"Advanced" = "詳細";
+"AI Connection" = "AI 接続";
+"Diagnostics" = "診断";
 "Notifications" = "通知";
 "Calendar" = "カレンダー";
 "AI Summary" = "AI 要約";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -420,6 +420,12 @@ enum L10n {
     // MARK: - Settings
 
     static var general: String { String(localized: "General", bundle: bundle) }
+    static var app: String { String(localized: "App", bundle: bundle) }
+    static var integrations: String { String(localized: "Integrations", bundle: bundle) }
+    static var ai: String { String(localized: "AI", bundle: bundle) }
+    static var advanced: String { String(localized: "Advanced", bundle: bundle) }
+    static var aiConnection: String { String(localized: "AI Connection", bundle: bundle) }
+    static var diagnostics: String { String(localized: "Diagnostics", bundle: bundle) }
     static var notifications: String { String(localized: "Notifications", bundle: bundle) }
     static var calendar: String { String(localized: "Calendar", bundle: bundle) }
     static var cloudStorage: String { String(localized: "Cloud Storage", bundle: bundle) }

--- a/Sources/Dahlia/Views/Settings/SettingsCategory.swift
+++ b/Sources/Dahlia/Views/Settings/SettingsCategory.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// 設定項目。rawValue は保存済みの選択状態との互換性のため維持する。
+enum SettingsCategory: String, CaseIterable, Identifiable {
+    case general
+    case transcription
+    case screenshots
+    case calendar
+    case cloudStorage
+    case modelProvider = "accounts"
+    case aiSummary
+    case instructions
+    case developer
+    case audioDiagnostics
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .general: L10n.general
+        case .transcription: L10n.transcription
+        case .screenshots: L10n.screenshots
+        case .calendar: L10n.calendar
+        case .cloudStorage: L10n.export
+        case .modelProvider: L10n.aiConnection
+        case .aiSummary: L10n.aiSummary
+        case .instructions: L10n.instructions
+        case .developer: L10n.developerSettings
+        case .audioDiagnostics: L10n.diagnostics
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .general: "gearshape"
+        case .transcription: "waveform"
+        case .screenshots: "photo.on.rectangle.angled"
+        case .calendar: "calendar"
+        case .cloudStorage: "square.and.arrow.up"
+        case .modelProvider: "link"
+        case .aiSummary: "sparkles"
+        case .instructions: "list.bullet.clipboard"
+        case .developer: "wrench.and.screwdriver"
+        case .audioDiagnostics: "stethoscope"
+        }
+    }
+}

--- a/Sources/Dahlia/Views/Settings/SettingsDetailView.swift
+++ b/Sources/Dahlia/Views/Settings/SettingsDetailView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct SettingsDetailView: View {
+    let selection: SettingsCategory
+    var sidebarViewModel: SidebarViewModel
+    var onSelectVault: (VaultRecord) -> Void
+
+    var body: some View {
+        Group {
+            switch selection {
+            case .general:
+                GeneralSettingsView(sidebarViewModel: sidebarViewModel, onSelectVault: onSelectVault)
+            case .transcription:
+                TranscriptionSettingsView()
+            case .screenshots:
+                ScreenshotSettingsView()
+            case .calendar:
+                CalendarSettingsView()
+            case .cloudStorage:
+                CloudStorageSettingsView()
+            case .modelProvider:
+                AccountSettingsView()
+            case .aiSummary:
+                AISummarySettingsView()
+            case .instructions:
+                InstructionsSettingsView(sidebarViewModel: sidebarViewModel)
+            case .developer:
+                DeveloperSettingsView()
+            case .audioDiagnostics:
+                DebugSettingsView()
+            }
+        }
+        .navigationTitle(selection.label)
+    }
+}

--- a/Sources/Dahlia/Views/Settings/SettingsGroup.swift
+++ b/Sources/Dahlia/Views/Settings/SettingsGroup.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// サイドバーで設定項目をユーザーの目的別にまとめるグループ。
+enum SettingsGroup: CaseIterable, Identifiable {
+    case app
+    case recording
+    case integrations
+    case ai
+    case advanced
+
+    var id: Self { self }
+
+    var label: String {
+        switch self {
+        case .app: L10n.app
+        case .recording: L10n.recording
+        case .integrations: L10n.integrations
+        case .ai: L10n.ai
+        case .advanced: L10n.advanced
+        }
+    }
+
+    var categories: [SettingsCategory] {
+        switch self {
+        case .app: [.general]
+        case .recording: [.transcription, .screenshots]
+        case .integrations: [.calendar, .cloudStorage]
+        case .ai: [.modelProvider, .aiSummary, .instructions]
+        case .advanced: [.developer, .audioDiagnostics]
+        }
+    }
+}

--- a/Sources/Dahlia/Views/Settings/SettingsNavigation.swift
+++ b/Sources/Dahlia/Views/Settings/SettingsNavigation.swift
@@ -1,0 +1,3 @@
+enum SettingsNavigation {
+    static let selectedCategoryDefaultsKey = "settingsSelectedCategory"
+}

--- a/Sources/Dahlia/Views/Settings/SettingsSidebarView.swift
+++ b/Sources/Dahlia/Views/Settings/SettingsSidebarView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct SettingsSidebarView: View {
+    @Binding var selection: SettingsCategory
+
+    var body: some View {
+        List(selection: $selection) {
+            ForEach(SettingsGroup.allCases) { group in
+                Section(group.label) {
+                    ForEach(group.categories) { category in
+                        Label(category.label, systemImage: category.systemImage)
+                            .tag(category)
+                    }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .navigationTitle(L10n.settings)
+    }
+}

--- a/Sources/Dahlia/Views/SettingsView.swift
+++ b/Sources/Dahlia/Views/SettingsView.swift
@@ -1,55 +1,5 @@
 import SwiftUI
 
-/// 設定画面のカテゴリ。
-enum SettingsCategory: String, CaseIterable, Identifiable {
-    case general
-    case calendar
-    case cloudStorage
-    case transcription
-    case screenshots
-    case modelProvider = "accounts"
-    case aiSummary
-    case instructions
-    case developer
-    case audioDiagnostics
-
-    var id: String { rawValue }
-
-    var label: String {
-        switch self {
-        case .general: L10n.general
-        case .calendar: L10n.calendar
-        case .cloudStorage: L10n.cloudStorage
-        case .transcription: L10n.transcription
-        case .audioDiagnostics: L10n.debug
-        case .screenshots: L10n.screenshots
-        case .modelProvider: L10n.modelProvider
-        case .aiSummary: L10n.aiSummary
-        case .instructions: L10n.instructions
-        case .developer: L10n.developerSettings
-        }
-    }
-
-    var systemImage: String {
-        switch self {
-        case .general: "gearshape"
-        case .calendar: "calendar"
-        case .cloudStorage: "externaldrive.badge.icloud"
-        case .transcription: "waveform"
-        case .audioDiagnostics: "ladybug"
-        case .screenshots: "photo.on.rectangle.angled"
-        case .modelProvider: "cpu"
-        case .aiSummary: "sparkles"
-        case .instructions: "list.bullet.clipboard"
-        case .developer: "wrench.and.screwdriver"
-        }
-    }
-}
-
-enum SettingsNavigation {
-    static let selectedCategoryDefaultsKey = "settingsSelectedCategory"
-}
-
 /// 設定画面（Cmd+, で表示）。
 struct SettingsView: View {
     var sidebarViewModel: SidebarViewModel
@@ -59,87 +9,16 @@ struct SettingsView: View {
     private var selection: SettingsCategory = .general
 
     var body: some View {
-        TabView(selection: $selection) {
-            Tab(
-                SettingsCategory.general.label,
-                systemImage: SettingsCategory.general.systemImage,
-                value: SettingsCategory.general
-            ) {
-                GeneralSettingsView(sidebarViewModel: sidebarViewModel, onSelectVault: onSelectVault)
-            }
-
-            Tab(
-                SettingsCategory.calendar.label,
-                systemImage: SettingsCategory.calendar.systemImage,
-                value: SettingsCategory.calendar
-            ) {
-                CalendarSettingsView()
-            }
-
-            Tab(
-                SettingsCategory.cloudStorage.label,
-                systemImage: SettingsCategory.cloudStorage.systemImage,
-                value: SettingsCategory.cloudStorage
-            ) {
-                CloudStorageSettingsView()
-            }
-
-            Tab(
-                SettingsCategory.transcription.label,
-                systemImage: SettingsCategory.transcription.systemImage,
-                value: SettingsCategory.transcription
-            ) {
-                TranscriptionSettingsView()
-            }
-
-            Tab(
-                SettingsCategory.screenshots.label,
-                systemImage: SettingsCategory.screenshots.systemImage,
-                value: SettingsCategory.screenshots
-            ) {
-                ScreenshotSettingsView()
-            }
-
-            Tab(
-                SettingsCategory.modelProvider.label,
-                systemImage: SettingsCategory.modelProvider.systemImage,
-                value: SettingsCategory.modelProvider
-            ) {
-                AccountSettingsView()
-            }
-
-            Tab(
-                SettingsCategory.aiSummary.label,
-                systemImage: SettingsCategory.aiSummary.systemImage,
-                value: SettingsCategory.aiSummary
-            ) {
-                AISummarySettingsView()
-            }
-
-            Tab(
-                SettingsCategory.instructions.label,
-                systemImage: SettingsCategory.instructions.systemImage,
-                value: SettingsCategory.instructions
-            ) {
-                InstructionsSettingsView(sidebarViewModel: sidebarViewModel)
-            }
-
-            Tab(
-                SettingsCategory.developer.label,
-                systemImage: SettingsCategory.developer.systemImage,
-                value: SettingsCategory.developer
-            ) {
-                DeveloperSettingsView()
-            }
-
-            Tab(
-                SettingsCategory.audioDiagnostics.label,
-                systemImage: SettingsCategory.audioDiagnostics.systemImage,
-                value: SettingsCategory.audioDiagnostics
-            ) {
-                DebugSettingsView()
-            }
+        NavigationSplitView {
+            SettingsSidebarView(selection: $selection)
+        } detail: {
+            SettingsDetailView(
+                selection: selection,
+                sidebarViewModel: sidebarViewModel,
+                onSelectVault: onSelectVault
+            )
         }
-        .frame(minWidth: 680, minHeight: 500)
+        .navigationSplitViewStyle(.balanced)
+        .frame(minWidth: 860, minHeight: 560)
     }
 }

--- a/Tests/DahliaTests/SettingsCategoryTests.swift
+++ b/Tests/DahliaTests/SettingsCategoryTests.swift
@@ -5,20 +5,41 @@
 
     struct SettingsCategoryTests {
         @Test
-        func modelProviderAndAISummarySettingsAreSeparateCategories() throws {
-            #expect(SettingsCategory.modelProvider.label == L10n.modelProvider)
-            #expect(SettingsCategory.modelProvider.rawValue == "accounts")
-            #expect(SettingsCategory.aiSummary.label == L10n.aiSummary)
-            let modelProviderIndex = try #require(SettingsCategory.allCases.firstIndex(of: .modelProvider))
-            let aiSummaryIndex = try #require(SettingsCategory.allCases.firstIndex(of: .aiSummary))
-            #expect(modelProviderIndex < aiSummaryIndex)
+        func categoriesAreOrderedByUserWorkflow() {
+            #expect(SettingsCategory.allCases == [
+                .general,
+                .transcription,
+                .screenshots,
+                .calendar,
+                .cloudStorage,
+                .modelProvider,
+                .aiSummary,
+                .instructions,
+                .developer,
+                .audioDiagnostics,
+            ])
         }
 
         @Test
-        func debugCategoryIsLastAndUsesDebugPresentation() {
-            #expect(SettingsCategory.allCases.last == .audioDiagnostics)
-            #expect(SettingsCategory.audioDiagnostics.label == L10n.debug)
-            #expect(SettingsCategory.audioDiagnostics.systemImage == "ladybug")
+        func groupsContainEveryCategoryOnce() {
+            let groupedCategories = SettingsGroup.allCases.flatMap(\.categories)
+            #expect(groupedCategories == SettingsCategory.allCases)
+        }
+
+        @Test
+        func technicalCategoriesUseUserFacingLabelsWithoutChangingStoredValues() {
+            #expect(SettingsCategory.modelProvider.rawValue == "accounts")
+            #expect(SettingsCategory.modelProvider.label == L10n.aiConnection)
+            #expect(SettingsCategory.cloudStorage.rawValue == "cloudStorage")
+            #expect(SettingsCategory.cloudStorage.label == L10n.export)
+            #expect(SettingsCategory.audioDiagnostics.rawValue == "audioDiagnostics")
+            #expect(SettingsCategory.audioDiagnostics.label == L10n.diagnostics)
+        }
+
+        @Test
+        func advancedSettingsRemainAtTheEnd() {
+            #expect(SettingsGroup.allCases.last == .advanced)
+            #expect(SettingsGroup.advanced.categories == [.developer, .audioDiagnostics])
         }
     }
 #endif


### PR DESCRIPTION
## Summary

- replace the ten-tab settings layout with a purpose-based sidebar
- group settings into App, Recording, Integrations, AI, and Advanced sections
- rename technical destinations to user-facing labels such as AI Connection, Export, and Diagnostics
- preserve existing setting values and persisted category identifiers
- add English and Japanese localization plus category grouping regression tests

## Why

The growing horizontal tab strip made settings harder to scan and exposed implementation-oriented terminology. A grouped sidebar gives users a stable hierarchy organized around what they want to configure while keeping the underlying settings behavior unchanged.

## User impact

Users can find recording, integration, AI, and advanced options more quickly. Existing preferences and the last selected settings destination continue to work because the stored raw identifiers are unchanged.

## Validation

- `swift build` — passed
- `CI=true ./scripts/lint.sh` — SwiftFormat passed with 0 files requiring formatting
- `swift test --filter SettingsCategoryTests` — test target compiled, but the test runner did not execute tests because `xcode-select` points to Command Line Tools rather than Xcode
- SwiftLint could not run because SourceKit failed to load `sourcekitdInProc.framework` in the current Command Line Tools environment
