### PR TITLE
Show calendar event origin on meetings

### DIFF
--- a/Sources/Dahlia/Models/CalendarEventDisplayInfo.swift
+++ b/Sources/Dahlia/Models/CalendarEventDisplayInfo.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+struct CalendarEventDisplayInfo: Equatable {
+    let title: String
+    let description: String
+    let startDate: Date
+    let endDate: Date
+    let isAllDay: Bool
+
+    init(
+        title: String,
+        description: String,
+        startDate: Date,
+        endDate: Date,
+        isAllDay: Bool
+    ) {
+        self.title = title
+        self.description = description
+        self.startDate = startDate
+        self.endDate = endDate
+        self.isAllDay = isAllDay
+    }
+
+    init(event: CalendarEvent) {
+        self.init(
+            title: event.title,
+            description: event.description,
+            startDate: event.startDate,
+            endDate: event.endDate,
+            isAllDay: event.isAllDay
+        )
+    }
+}

--- a/Sources/Dahlia/Models/CalendarEventDisplayInfo.swift
+++ b/Sources/Dahlia/Models/CalendarEventDisplayInfo.swift
@@ -7,20 +7,12 @@ struct CalendarEventDisplayInfo: Equatable {
     let endDate: Date
     let isAllDay: Bool
 
-    init(
-        title: String,
-        description: String,
-        startDate: Date,
-        endDate: Date,
-        isAllDay: Bool
-    ) {
-        self.title = title
-        self.description = description
-        self.startDate = startDate
-        self.endDate = endDate
-        self.isAllDay = isAllDay
+    var resolvedTitle: String {
+        title.nilIfBlank ?? L10n.newMeeting
     }
+}
 
+extension CalendarEventDisplayInfo {
     init(event: CalendarEvent) {
         self.init(
             title: event.title,

--- a/Sources/Dahlia/Models/MeetingOverviewItem.swift
+++ b/Sources/Dahlia/Models/MeetingOverviewItem.swift
@@ -15,6 +15,7 @@ struct MeetingOverviewItem: Equatable, FetchableRecord, Identifiable {
     var segmentCount: Int
     var latestSegmentText: String?
     var tags: [TagInfo]
+    var calendarEvent: CalendarEventDisplayInfo?
 
     var id: UUID { meetingId }
 
@@ -34,7 +35,8 @@ struct MeetingOverviewItem: Equatable, FetchableRecord, Identifiable {
         hasSummary: Bool,
         segmentCount: Int,
         latestSegmentText: String?,
-        tags: [TagInfo]
+        tags: [TagInfo],
+        calendarEvent: CalendarEventDisplayInfo? = nil
     ) {
         self.meetingId = meetingId
         self.vaultId = vaultId
@@ -48,6 +50,7 @@ struct MeetingOverviewItem: Equatable, FetchableRecord, Identifiable {
         self.segmentCount = segmentCount
         self.latestSegmentText = latestSegmentText
         self.tags = tags
+        self.calendarEvent = calendarEvent
     }
 
     init(row: Row) throws {
@@ -72,6 +75,27 @@ struct MeetingOverviewItem: Equatable, FetchableRecord, Identifiable {
             }
         } else {
             tags = []
+        }
+
+        let calendarEventTitle: String? = row["calendarEventTitle"]
+        let calendarEventDescription: String? = row["calendarEventDescription"]
+        let calendarEventStart: Date? = row["calendarEventStart"]
+        let calendarEventEnd: Date? = row["calendarEventEnd"]
+        let calendarEventIsAllDay: Bool? = row["calendarEventIsAllDay"]
+        if let calendarEventTitle,
+           let calendarEventDescription,
+           let calendarEventStart,
+           let calendarEventEnd,
+           let calendarEventIsAllDay {
+            calendarEvent = CalendarEventDisplayInfo(
+                title: calendarEventTitle,
+                description: calendarEventDescription,
+                startDate: calendarEventStart,
+                endDate: calendarEventEnd,
+                isAllDay: calendarEventIsAllDay
+            )
+        } else {
+            calendarEvent = nil
         }
     }
 

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -254,6 +254,8 @@
 "Show events from the Calendar app on this Mac." = "Show events from the Calendar app on this Mac.";
 "Upcoming schedule" = "Upcoming schedule";
 "Show Upcoming Schedule" = "Show Upcoming Schedule";
+"From calendar event" = "From calendar event";
+"Calendar event: %@" = "Calendar event: %@";
 "Select a calendar event to prepare transcription." = "Select a calendar event to prepare transcription.";
 "Connect a Google account and choose which calendars appear on Home." = "Connect a Google account and choose which calendars appear on Home.";
 "Use events from the Calendar app on this Mac." = "Use events from the Calendar app on this Mac.";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -254,6 +254,8 @@
 "Show events from the Calendar app on this Mac." = "この Mac のカレンダーアプリの予定を表示します。";
 "Upcoming schedule" = "今後の予定";
 "Show Upcoming Schedule" = "今後の予定を表示";
+"From calendar event" = "カレンダーイベント由来";
+"Calendar event: %@" = "カレンダーイベント: %@";
 "Select a calendar event to prepare transcription." = "カレンダーの予定を選択して、文字起こし画面を準備します。";
 "Connect a Google account and choose which calendars appear on Home." = "Google アカウントを接続し、Home に表示するカレンダーを選びます。";
 "Use events from the Calendar app on this Mac." = "この Mac のカレンダーアプリの予定を使用します。";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -523,6 +523,12 @@ enum L10n {
     ) }
     static var calendarScheduleTitle: String { String(localized: "Upcoming schedule", bundle: bundle) }
     static var showUpcomingSchedule: String { String(localized: "Show Upcoming Schedule", bundle: bundle) }
+    static var calendarEventOriginTitle: String { String(localized: "From calendar event", bundle: bundle) }
+
+    static func calendarEventOrigin(_ title: String) -> String {
+        String(localized: "Calendar event: \(title)", bundle: bundle)
+    }
+
     static var calendarScheduleDescription: String { String(
         localized: "Select a calendar event to prepare transcription.",
         bundle: bundle

--- a/Sources/Dahlia/ViewModels/SidebarViewModel.swift
+++ b/Sources/Dahlia/ViewModels/SidebarViewModel.swift
@@ -171,6 +171,11 @@ final class SidebarViewModel {
                     meetings.status AS status,
                     meetings.duration AS duration,
                     meetings.createdAt AS createdAt,
+                    calendar_events.title AS calendarEventTitle,
+                    calendar_events.description AS calendarEventDescription,
+                    calendar_events.start AS calendarEventStart,
+                    calendar_events.end AS calendarEventEnd,
+                    calendar_events.is_all_day AS calendarEventIsAllDay,
                     EXISTS(SELECT 1 FROM summaries WHERE summaries.meetingId = meetings.id) AS hasSummary,
                     COUNT(segments.id) AS segmentCount,
                     (
@@ -186,6 +191,9 @@ final class SidebarViewModel {
                      WHERE mt.meetingId = meetings.id) AS tags
                 FROM meetings
                 LEFT JOIN projects ON projects.id = meetings.projectId
+                LEFT JOIN calendar_events
+                  ON calendar_events.ical_uid = meetings.calendar_event_ical_uid
+                 AND calendar_events.recurrence_id = meetings.calendar_event_recurrence_id
                 LEFT JOIN transcript_segments AS segments ON segments.meetingId = meetings.id
                 WHERE meetings.vaultId = ?
                 GROUP BY meetings.id

--- a/Sources/Dahlia/Views/CalendarEventOriginIcon.swift
+++ b/Sources/Dahlia/Views/CalendarEventOriginIcon.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+struct CalendarEventOriginIcon: View {
+    let event: CalendarEventDisplayInfo
+
+    var body: some View {
+        Image(systemName: "calendar.badge.checkmark")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize()
+            .help(tooltipText)
+            .accessibilityLabel(L10n.calendarEventOrigin(eventTitle))
+    }
+
+    private var tooltipText: String {
+        [
+            L10n.calendarEventOriginTitle,
+            eventTitle,
+            dateText,
+            event.description.nilIfBlank,
+        ]
+        .compactMap(\.self)
+        .joined(separator: "\n")
+    }
+
+    private var eventTitle: String {
+        event.title.nilIfBlank ?? L10n.newMeeting
+    }
+
+    private var dateText: String {
+        if event.isAllDay {
+            return allDayDateText
+        }
+
+        let startDate = event.startDate.formatted(date: .abbreviated, time: .shortened)
+        let endDate = if Calendar.autoupdatingCurrent.isDate(event.startDate, inSameDayAs: event.endDate) {
+            event.endDate.formatted(date: .omitted, time: .shortened)
+        } else {
+            event.endDate.formatted(date: .abbreviated, time: .shortened)
+        }
+        return "\(startDate) – \(endDate)"
+    }
+
+    private var allDayDateText: String {
+        let startDate = event.startDate.formatted(date: .abbreviated, time: .omitted)
+        let inclusiveEndDate = if event.endDate > event.startDate {
+            event.endDate.addingTimeInterval(-1)
+        } else {
+            event.endDate
+        }
+        if Calendar.autoupdatingCurrent.isDate(event.startDate, inSameDayAs: inclusiveEndDate) {
+            return "\(startDate) · \(L10n.calendarAllDay)"
+        }
+        let endDate = inclusiveEndDate.formatted(date: .abbreviated, time: .omitted)
+        return "\(startDate) – \(endDate) · \(L10n.calendarAllDay)"
+    }
+}

--- a/Sources/Dahlia/Views/CalendarEventOriginIcon.swift
+++ b/Sources/Dahlia/Views/CalendarEventOriginIcon.swift
@@ -10,17 +10,20 @@ struct CalendarEventOriginIcon: View {
             .fixedSize()
             .help(tooltipText)
             .accessibilityLabel(L10n.calendarEventOrigin(event.resolvedTitle))
+            .accessibilityValue(detailLines.joined(separator: ", "))
     }
 
     private var tooltipText: String {
-        [
+        ([
             L10n.calendarEventOriginTitle,
             event.resolvedTitle,
-            dateText,
-            event.description.nilIfBlank,
-        ]
-        .compactMap(\.self)
-        .joined(separator: "\n")
+        ] + detailLines)
+            .joined(separator: "\n")
+    }
+
+    private var detailLines: [String] {
+        [dateText, event.description.nilIfBlank]
+            .compactMap(\.self)
     }
 
     private var dateText: String {

--- a/Sources/Dahlia/Views/CalendarEventOriginIcon.swift
+++ b/Sources/Dahlia/Views/CalendarEventOriginIcon.swift
@@ -9,22 +9,18 @@ struct CalendarEventOriginIcon: View {
             .foregroundStyle(.secondary)
             .fixedSize()
             .help(tooltipText)
-            .accessibilityLabel(L10n.calendarEventOrigin(eventTitle))
+            .accessibilityLabel(L10n.calendarEventOrigin(event.resolvedTitle))
     }
 
     private var tooltipText: String {
         [
             L10n.calendarEventOriginTitle,
-            eventTitle,
+            event.resolvedTitle,
             dateText,
             event.description.nilIfBlank,
         ]
         .compactMap(\.self)
         .joined(separator: "\n")
-    }
-
-    private var eventTitle: String {
-        event.title.nilIfBlank ?? L10n.newMeeting
     }
 
     private var dateText: String {

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -295,6 +295,7 @@ private struct MeetingDetailHeader: View {
     var sidebarViewModel: SidebarViewModel
     let title: String
     let metadataText: String
+    let calendarEvent: CalendarEventDisplayInfo?
     @Binding var isEditing: Bool
     @Binding var editingName: String
     @FocusState.Binding var isFocused: Bool
@@ -336,6 +337,10 @@ private struct MeetingDetailHeader: View {
         VStack(alignment: .leading, spacing: 8) {
             FlowLayout(spacing: 8, rowSpacing: 8) {
                 MeetingMetadataPill(systemImage: "calendar", text: metadataText)
+
+                if let calendarEvent {
+                    CalendarEventOriginIcon(event: calendarEvent)
+                }
 
                 MeetingProjectPicker(
                     viewModel: viewModel,
@@ -412,6 +417,7 @@ struct ControlPanelView: View {
                     sidebarViewModel: sidebarViewModel,
                     title: meetingTitle,
                     metadataText: meetingMetadataText,
+                    calendarEvent: displayedCalendarEvent,
                     isEditing: $isEditingMeetingName,
                     editingName: $editingMeetingName,
                     isFocused: $isMeetingNameFieldFocused,
@@ -682,6 +688,11 @@ struct ControlPanelView: View {
     private var currentMeetingItem: MeetingOverviewItem? {
         guard let meetingId = viewModel.currentMeetingId else { return nil }
         return sidebarViewModel.allMeetings.first(where: { $0.meetingId == meetingId })
+    }
+
+    private var displayedCalendarEvent: CalendarEventDisplayInfo? {
+        currentMeetingItem?.calendarEvent
+            ?? viewModel.draftMeeting?.linkedCalendarEvent.map { CalendarEventDisplayInfo(event: $0) }
     }
 
     private var screenshotTimeBase: Date {

--- a/Sources/Dahlia/Views/MeetingListSidebarView.swift
+++ b/Sources/Dahlia/Views/MeetingListSidebarView.swift
@@ -600,8 +600,14 @@ private struct MeetingSidebarRow: View {
                         .onSubmit(onCommitRename)
                         .onExitCommand(perform: onCancelRename)
                 } else {
-                    Text(displayTitle)
-                        .lineLimit(1)
+                    HStack(spacing: 4) {
+                        Text(displayTitle)
+                            .lineLimit(1)
+
+                        if let calendarEvent = item.calendarEvent {
+                            CalendarEventOriginIcon(event: calendarEvent)
+                        }
+                    }
                 }
 
                 HStack(spacing: 6) {
@@ -667,10 +673,15 @@ private struct MeetingSidebarRow: View {
     }
 
     private var accessibilityLabel: String {
+        var components = [displayTitle]
         if isActiveRecording {
-            return "\(displayTitle), \(L10n.recordingNow)"
+            components.append(L10n.recordingNow)
         }
-        return displayTitle
+        if let calendarEvent = item.calendarEvent {
+            let eventTitle = calendarEvent.title.nilIfBlank ?? L10n.newMeeting
+            components.append(L10n.calendarEventOrigin(eventTitle))
+        }
+        return components.joined(separator: ", ")
     }
 }
 

--- a/Sources/Dahlia/Views/MeetingListSidebarView.swift
+++ b/Sources/Dahlia/Views/MeetingListSidebarView.swift
@@ -678,8 +678,7 @@ private struct MeetingSidebarRow: View {
             components.append(L10n.recordingNow)
         }
         if let calendarEvent = item.calendarEvent {
-            let eventTitle = calendarEvent.title.nilIfBlank ?? L10n.newMeeting
-            components.append(L10n.calendarEventOrigin(eventTitle))
+            components.append(L10n.calendarEventOrigin(calendarEvent.resolvedTitle))
         }
         return components.joined(separator: ", ")
     }

--- a/Tests/DahliaTests/MeetingOverviewItemTests.swift
+++ b/Tests/DahliaTests/MeetingOverviewItemTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct MeetingOverviewItemTests {
+        @Test
+        func decodesLinkedCalendarEventFromOverviewRow() throws {
+            let meetingId = UUID.v7()
+            let vaultId = UUID.v7()
+            let createdAt = Date(timeIntervalSince1970: 1_700_000_000)
+            let eventStart = Date(timeIntervalSince1970: 1_700_003_600)
+            let eventEnd = eventStart.addingTimeInterval(3600)
+            let dbQueue = try DatabaseQueue(path: ":memory:")
+
+            let item = try dbQueue.read { db in
+                let fetchedRow = try Row.fetchOne(
+                    db,
+                    sql: """
+                    SELECT
+                        ? AS meetingId,
+                        ? AS vaultId,
+                        NULL AS projectId,
+                        NULL AS projectName,
+                        'Weekly sync' AS meetingName,
+                        'READY' AS status,
+                        NULL AS duration,
+                        ? AS createdAt,
+                        'Calendar title' AS calendarEventTitle,
+                        'Calendar description' AS calendarEventDescription,
+                        ? AS calendarEventStart,
+                        ? AS calendarEventEnd,
+                        0 AS calendarEventIsAllDay,
+                        0 AS hasSummary,
+                        0 AS segmentCount,
+                        NULL AS latestSegmentText,
+                        NULL AS tags
+                    """,
+                    arguments: [meetingId, vaultId, createdAt, eventStart, eventEnd]
+                )
+                let row = try #require(fetchedRow)
+                return try MeetingOverviewItem(row: row)
+            }
+
+            #expect(item.calendarEvent == CalendarEventDisplayInfo(
+                title: "Calendar title",
+                description: "Calendar description",
+                startDate: eventStart,
+                endDate: eventEnd,
+                isAllDay: false
+            ))
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary

- カレンダーイベント由来のミーティングにカレンダーバッジを表示
- バッジのホバーでイベント名、日時、終日状態、説明を確認可能に変更
- 下書き中と保存済みのミーティング詳細、サイドバーの両方に対応
- VoiceOver ラベルと日本語・英語ローカライズを追加

## Why

カレンダーから作成したミーティングと通常のミーティングを一覧上で判別できず、元イベントの情報も画面を移動せず確認できませんでした。

## Impact

既存のカレンダーイベント関連データを一覧取得に含めるだけで、DB スキーマや録音・文字起こし処理は変更しません。

## Validation

- Xcode toolchain で Debug ビルド成功
- `swift test --filter MeetingOverviewItemTests`（1 test / 1 suite passed）
- SwiftFormat（Sources と追加テスト）
- 変更対象の SwiftLint
- 日英 `Localizable.strings` の `plutil -lint`

リポジトリ全体の SwiftLint には、今回の変更と無関係な既存違反が残っています。
