### PR TITLE
Fix settings sidebar layout

### DIFF
--- a/Sources/Dahlia/Views/SettingsView.swift
+++ b/Sources/Dahlia/Views/SettingsView.swift
@@ -9,16 +9,22 @@ struct SettingsView: View {
     private var selection: SettingsCategory = .general
 
     var body: some View {
-        NavigationSplitView {
-            SettingsSidebarView(selection: $selection)
-        } detail: {
-            SettingsDetailView(
-                selection: selection,
-                sidebarViewModel: sidebarViewModel,
-                onSelectVault: onSelectVault
-            )
+        NavigationStack {
+            HStack(spacing: 0) {
+                SettingsSidebarView(selection: $selection)
+                    .frame(width: 180)
+
+                Divider()
+
+                SettingsDetailView(
+                    selection: selection,
+                    sidebarViewModel: sidebarViewModel,
+                    onSelectVault: onSelectVault
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            .navigationTitle(selection.label)
         }
-        .navigationSplitViewStyle(.balanced)
         .frame(minWidth: 860, minHeight: 560)
     }
 }


### PR DESCRIPTION
## Summary

- keep the settings sidebar permanently visible
- remove the collapsible split-view behavior and sidebar toggle
- fix the settings sidebar width at 180 points
- preserve the existing 860-point minimum settings window width

## Why

The system-managed `NavigationSplitView` allowed the settings sidebar to collapse or retain an unsuitable saved width. A fixed sidebar layout keeps the navigation consistently visible and sized appropriately.

## User impact

The settings sidebar remains visible at a stable 180-point width while the settings window is resized.

## Validation

- `swift build`
- `CI=true ./scripts/lint.sh` (SwiftFormat passed; SwiftLint reported pre-existing repository violations)
- `git diff --check`