### PR TITLE
Reorder CI test and build checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,6 @@ jobs:
           xcodebuild -version
           swift --version
 
-      - name: Resolve dependencies
-        run: swift package resolve
-
-      - name: Build
-        run: swift build
-
       - name: Run unit tests
         run: |
           set -o pipefail
@@ -62,3 +56,6 @@ jobs:
 
       - name: Verify tests executed
         run: grep -Eq "Test run with [1-9][0-9]* tests" test-output.log
+
+      - name: Build executable
+        run: swift build


### PR DESCRIPTION
## Summary

- run unit tests before the standalone executable build
- verify that the test suite executed before continuing
- remove the redundant explicit dependency resolution step

## Why

This surfaces compilation and unit-test failures earlier while retaining an explicit check that the normal executable build succeeds without the test configuration.

## Impact

CI stops before the standalone build when tests fail or no tests execute. Successful test runs continue to validate the executable build.

## Validation

- `git diff --check`
- YAML parsed successfully with Ruby Psych
- `actionlint` was unavailable locally
