### PR TITLE
Add menu bar calendar agenda

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundleVersion</key>
     <string>14</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.3.5</string>
+    <string>0.4.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/DahliaApp.swift
+++ b/Sources/Dahlia/DahliaApp.swift
@@ -23,6 +23,7 @@ struct DahliaApp: App {
     @StateObject private var liveSubtitleOverlayService: LiveSubtitleOverlayService
     @State private var liveSubtitleOverlayCoordinator: LiveSubtitleOverlayCoordinator
     @State private var recordingCoordinator: RecordingCoordinator
+    @State private var menuBarCalendarViewModel: MenuBarCalendarViewModel
     @State private var appDatabase: AppDatabaseManager?
     @State private var showVaultPicker = true
 
@@ -35,6 +36,7 @@ struct DahliaApp: App {
             viewModel: viewModel,
             sidebarViewModel: sidebarViewModel
         )
+        let menuBarCalendarViewModel = MenuBarCalendarViewModel()
         let liveSubtitleOverlayCoordinator = LiveSubtitleOverlayCoordinator(
             viewModel: viewModel,
             liveSubtitleOverlayService: liveSubtitleOverlayService
@@ -44,6 +46,7 @@ struct DahliaApp: App {
         _sidebarViewModel = State(initialValue: sidebarViewModel)
         _liveSubtitleOverlayService = StateObject(wrappedValue: liveSubtitleOverlayService)
         _recordingCoordinator = State(initialValue: recordingCoordinator)
+        _menuBarCalendarViewModel = State(initialValue: menuBarCalendarViewModel)
         _liveSubtitleOverlayCoordinator = State(initialValue: liveSubtitleOverlayCoordinator)
     }
 
@@ -118,10 +121,14 @@ struct DahliaApp: App {
         MenuBarExtra {
             MenuBarMenuView(
                 viewModel: viewModel,
-                recordingCoordinator: recordingCoordinator
+                recordingCoordinator: recordingCoordinator,
+                calendarViewModel: menuBarCalendarViewModel
             )
         } label: {
-            MenuBarLabel(viewModel: viewModel)
+            MenuBarLabel(
+                viewModel: viewModel,
+                calendarViewModel: menuBarCalendarViewModel
+            )
         }
         .menuBarExtraStyle(.menu)
     }

--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -291,6 +291,9 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     @AppStorage("excludeCalendarEventsWithoutConferenceURI") var excludeCalendarEventsWithoutConferenceURI = false
     @AppStorage("excludeDeclinedCalendarEvents") var excludeDeclinedCalendarEvents = true
     @AppStorage("excludeOutOfOfficeCalendarEvents") var excludeOutOfOfficeCalendarEvents = true
+    @AppStorage("menuBarCalendarEnabled") var menuBarCalendarEnabled = true
+    @AppStorage("menuBarCalendarShowsEventTitle") var menuBarCalendarShowsEventTitle = true
+    @AppStorage("menuBarCalendarShowsCountdown") var menuBarCalendarShowsCountdown = true
     nonisolated static let googleOAuthClientIDOverrideUserDefaultsKey = "googleOAuthClientIDOverride"
     nonisolated static let googleOAuthClientSecretOverrideKey = "googleOAuthClientSecretOverride"
     @AppStorage(AppSettings.googleOAuthClientIDOverrideUserDefaultsKey) var googleOAuthClientIDOverride = ""

--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -99,6 +99,10 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     fileprivate nonisolated static let defaultAutomaticScreenshotChangeThresholdPercent = 20
     nonisolated static let defaultLLMMaxTokens = 16000
 
+    init() {
+        Self.migrateCalendarEventFilterSettings(in: .standard)
+    }
+
     // MARK: - 表示言語
 
     @AppStorage(AppLanguage.userDefaultsKey) var appLanguageRawValue: String = AppLanguage.system.rawValue
@@ -287,8 +291,8 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     @AppStorage("calendarSource") var calendarSourceRawValue = CalendarSource.google.rawValue
     @AppStorage(CalendarSource.enabledSourcesUserDefaultsKey) var enabledCalendarSourcesJSON = CalendarSource.defaultEnabledSourcesJSON
     @AppStorage("includesAllDayCalendarEvents") var includesAllDayCalendarEvents = false
-    @AppStorage("includesCalendarEventsWithoutOtherAttendees") var includesCalendarEventsWithoutOtherAttendees = false
-    @AppStorage("includesCalendarEventsWithoutConferenceURI") var includesCalendarEventsWithoutConferenceURI = false
+    @AppStorage("includesCalendarEventsWithoutOtherAttendees") var includesCalendarEventsWithoutOtherAttendees = true
+    @AppStorage("includesCalendarEventsWithoutConferenceURI") var includesCalendarEventsWithoutConferenceURI = true
     @AppStorage("includesDeclinedCalendarEvents") var includesDeclinedCalendarEvents = false
     @AppStorage("includesOutOfOfficeCalendarEvents") var includesOutOfOfficeCalendarEvents = false
     @AppStorage("menuBarCalendarEnabled") var menuBarCalendarEnabled = true
@@ -311,6 +315,21 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
             includesDeclinedEvents: includesDeclinedCalendarEvents,
             includesOutOfOfficeEvents: includesOutOfOfficeCalendarEvents
         )
+    }
+
+    nonisolated static func migrateCalendarEventFilterSettings(in userDefaults: UserDefaults) {
+        let keyPairs = [
+            (legacy: "excludeAllDayCalendarEvents", current: "includesAllDayCalendarEvents"),
+            (legacy: "excludeCalendarEventsWithoutOtherAttendees", current: "includesCalendarEventsWithoutOtherAttendees"),
+            (legacy: "excludeCalendarEventsWithoutConferenceURI", current: "includesCalendarEventsWithoutConferenceURI"),
+            (legacy: "excludeDeclinedCalendarEvents", current: "includesDeclinedCalendarEvents"),
+            (legacy: "excludeOutOfOfficeCalendarEvents", current: "includesOutOfOfficeCalendarEvents"),
+        ]
+
+        for keyPair in keyPairs where userDefaults.object(forKey: keyPair.current) == nil {
+            guard userDefaults.object(forKey: keyPair.legacy) != nil else { continue }
+            userDefaults.set(!userDefaults.bool(forKey: keyPair.legacy), forKey: keyPair.current)
+        }
     }
 
     var enabledCalendarSources: Set<CalendarSource> {

--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -286,11 +286,11 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
 
     @AppStorage("calendarSource") var calendarSourceRawValue = CalendarSource.google.rawValue
     @AppStorage(CalendarSource.enabledSourcesUserDefaultsKey) var enabledCalendarSourcesJSON = CalendarSource.defaultEnabledSourcesJSON
-    @AppStorage("excludeAllDayCalendarEvents") var excludeAllDayCalendarEvents = true
-    @AppStorage("excludeCalendarEventsWithoutOtherAttendees") var excludeCalendarEventsWithoutOtherAttendees = false
-    @AppStorage("excludeCalendarEventsWithoutConferenceURI") var excludeCalendarEventsWithoutConferenceURI = false
-    @AppStorage("excludeDeclinedCalendarEvents") var excludeDeclinedCalendarEvents = true
-    @AppStorage("excludeOutOfOfficeCalendarEvents") var excludeOutOfOfficeCalendarEvents = true
+    @AppStorage("includesAllDayCalendarEvents") var includesAllDayCalendarEvents = false
+    @AppStorage("includesCalendarEventsWithoutOtherAttendees") var includesCalendarEventsWithoutOtherAttendees = false
+    @AppStorage("includesCalendarEventsWithoutConferenceURI") var includesCalendarEventsWithoutConferenceURI = false
+    @AppStorage("includesDeclinedCalendarEvents") var includesDeclinedCalendarEvents = false
+    @AppStorage("includesOutOfOfficeCalendarEvents") var includesOutOfOfficeCalendarEvents = false
     @AppStorage("menuBarCalendarEnabled") var menuBarCalendarEnabled = true
     @AppStorage("menuBarCalendarShowsEventTitle") var menuBarCalendarShowsEventTitle = true
     @AppStorage("menuBarCalendarShowsCountdown") var menuBarCalendarShowsCountdown = true
@@ -305,11 +305,11 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
 
     var calendarEventFilter: CalendarEventFilter {
         CalendarEventFilter(
-            excludesAllDayEvents: excludeAllDayCalendarEvents,
-            excludesEventsWithoutOtherAttendees: excludeCalendarEventsWithoutOtherAttendees,
-            excludesEventsWithoutConferenceURI: excludeCalendarEventsWithoutConferenceURI,
-            excludesDeclinedEvents: excludeDeclinedCalendarEvents,
-            excludesOutOfOfficeEvents: excludeOutOfOfficeCalendarEvents
+            includesAllDayEvents: includesAllDayCalendarEvents,
+            includesEventsWithoutOtherAttendees: includesCalendarEventsWithoutOtherAttendees,
+            includesEventsWithoutConferenceURI: includesCalendarEventsWithoutConferenceURI,
+            includesDeclinedEvents: includesDeclinedCalendarEvents,
+            includesOutOfOfficeEvents: includesOutOfOfficeCalendarEvents
         )
     }
 

--- a/Sources/Dahlia/Models/CalendarEvent.swift
+++ b/Sources/Dahlia/Models/CalendarEvent.swift
@@ -21,6 +21,7 @@ struct CalendarEvent: Identifiable, Equatable, Codable {
     let isAllDay: Bool
     let hasOtherAttendees: Bool
     let isDeclined: Bool
+    let isAttending: Bool
     let isOutOfOffice: Bool
     let conferenceURI: URL?
     let url: URL?
@@ -41,6 +42,7 @@ struct CalendarEvent: Identifiable, Equatable, Codable {
         isAllDay: Bool,
         hasOtherAttendees: Bool = false,
         isDeclined: Bool = false,
+        isAttending: Bool = false,
         isOutOfOffice: Bool = false,
         conferenceURI: URL?,
         url: URL? = nil
@@ -60,6 +62,7 @@ struct CalendarEvent: Identifiable, Equatable, Codable {
         self.isAllDay = isAllDay
         self.hasOtherAttendees = hasOtherAttendees
         self.isDeclined = isDeclined
+        self.isAttending = isAttending && !isDeclined
         self.isOutOfOffice = isOutOfOffice || Self.titleIndicatesOutOfOffice(title)
         self.conferenceURI = conferenceURI
         self.url = url
@@ -136,6 +139,7 @@ private extension CalendarEvent {
             isAllDay: isAllDay,
             hasOtherAttendees: hasOtherAttendees || fallback.hasOtherAttendees,
             isDeclined: isDeclined || fallback.isDeclined,
+            isAttending: isAttending || fallback.isAttending,
             isOutOfOffice: isOutOfOffice || fallback.isOutOfOffice,
             conferenceURI: conferenceURI ?? fallback.conferenceURI,
             url: url ?? fallback.url
@@ -160,6 +164,7 @@ extension CalendarEvent {
         case isAllDay
         case hasOtherAttendees
         case isDeclined
+        case isAttending
         case isOutOfOffice
         case conferenceURI
         case url
@@ -188,6 +193,8 @@ extension CalendarEvent {
         isAllDay = try container.decode(Bool.self, forKey: .isAllDay)
         hasOtherAttendees = try container.decodeIfPresent(Bool.self, forKey: .hasOtherAttendees) ?? false
         isDeclined = try container.decodeIfPresent(Bool.self, forKey: .isDeclined) ?? false
+        let decodedIsAttending = try container.decodeIfPresent(Bool.self, forKey: .isAttending) ?? false
+        isAttending = decodedIsAttending && !isDeclined
         let decodedIsOutOfOffice = try container.decodeIfPresent(Bool.self, forKey: .isOutOfOffice) ?? false
         isOutOfOffice = decodedIsOutOfOffice || Self.titleIndicatesOutOfOffice(title)
         conferenceURI = try container.decodeIfPresent(URL.self, forKey: .conferenceURI)

--- a/Sources/Dahlia/Models/CalendarEventFilter.swift
+++ b/Sources/Dahlia/Models/CalendarEventFilter.swift
@@ -1,38 +1,38 @@
 struct CalendarEventFilter: Equatable {
-    let excludesAllDayEvents: Bool
-    let excludesEventsWithoutOtherAttendees: Bool
-    let excludesEventsWithoutConferenceURI: Bool
-    let excludesDeclinedEvents: Bool
-    let excludesOutOfOfficeEvents: Bool
+    let includesAllDayEvents: Bool
+    let includesEventsWithoutOtherAttendees: Bool
+    let includesEventsWithoutConferenceURI: Bool
+    let includesDeclinedEvents: Bool
+    let includesOutOfOfficeEvents: Bool
 
     init(
-        excludesAllDayEvents: Bool = false,
-        excludesEventsWithoutOtherAttendees: Bool = false,
-        excludesEventsWithoutConferenceURI: Bool = false,
-        excludesDeclinedEvents: Bool = false,
-        excludesOutOfOfficeEvents: Bool = false
+        includesAllDayEvents: Bool = false,
+        includesEventsWithoutOtherAttendees: Bool = false,
+        includesEventsWithoutConferenceURI: Bool = false,
+        includesDeclinedEvents: Bool = false,
+        includesOutOfOfficeEvents: Bool = false
     ) {
-        self.excludesAllDayEvents = excludesAllDayEvents
-        self.excludesEventsWithoutOtherAttendees = excludesEventsWithoutOtherAttendees
-        self.excludesEventsWithoutConferenceURI = excludesEventsWithoutConferenceURI
-        self.excludesDeclinedEvents = excludesDeclinedEvents
-        self.excludesOutOfOfficeEvents = excludesOutOfOfficeEvents
+        self.includesAllDayEvents = includesAllDayEvents
+        self.includesEventsWithoutOtherAttendees = includesEventsWithoutOtherAttendees
+        self.includesEventsWithoutConferenceURI = includesEventsWithoutConferenceURI
+        self.includesDeclinedEvents = includesDeclinedEvents
+        self.includesOutOfOfficeEvents = includesOutOfOfficeEvents
     }
 
     func includes(_ event: CalendarEvent) -> Bool {
-        if excludesAllDayEvents, event.isAllDay {
+        if !includesAllDayEvents, event.isAllDay {
             return false
         }
-        if excludesEventsWithoutOtherAttendees, !event.hasOtherAttendees {
+        if !includesEventsWithoutOtherAttendees, !event.hasOtherAttendees {
             return false
         }
-        if excludesEventsWithoutConferenceURI, event.conferenceURI == nil {
+        if !includesEventsWithoutConferenceURI, event.conferenceURI == nil {
             return false
         }
-        if excludesDeclinedEvents, event.isDeclined {
+        if !includesDeclinedEvents, event.isDeclined {
             return false
         }
-        if excludesOutOfOfficeEvents, event.isOutOfOffice {
+        if !includesOutOfOfficeEvents, event.isOutOfOffice {
             return false
         }
         return true

--- a/Sources/Dahlia/Models/CalendarEventFilter.swift
+++ b/Sources/Dahlia/Models/CalendarEventFilter.swift
@@ -7,8 +7,8 @@ struct CalendarEventFilter: Equatable {
 
     init(
         includesAllDayEvents: Bool = false,
-        includesEventsWithoutOtherAttendees: Bool = false,
-        includesEventsWithoutConferenceURI: Bool = false,
+        includesEventsWithoutOtherAttendees: Bool = true,
+        includesEventsWithoutConferenceURI: Bool = true,
         includesDeclinedEvents: Bool = false,
         includesOutOfOfficeEvents: Bool = false
     ) {

--- a/Sources/Dahlia/Models/MenuBarCalendarAgenda.swift
+++ b/Sources/Dahlia/Models/MenuBarCalendarAgenda.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+struct MenuBarCalendarAgenda: Equatable {
+    let events: [CalendarEvent]
+    let featuredEvent: CalendarEvent?
+    let featuredEventIsOngoing: Bool
+
+    init(
+        googleEvents: [CalendarEvent],
+        macEvents: [CalendarEvent],
+        enabledSources: Set<CalendarSource>,
+        filter: CalendarEventFilter,
+        now: Date,
+        calendar: Calendar = .autoupdatingCurrent
+    ) {
+        var sourceEvents: [CalendarEvent] = []
+        if enabledSources.contains(.google) {
+            sourceEvents.append(contentsOf: googleEvents)
+        }
+        if enabledSources.contains(.macOS) {
+            sourceEvents.append(contentsOf: macEvents)
+        }
+
+        let tomorrow = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now)) ?? now
+        events = sourceEvents
+            .deduplicatedAcrossSources()
+            .filter(filter.includes)
+            .filter { $0.endDate > now && $0.startDate < tomorrow }
+            .sorted(by: Self.sortEvents)
+
+        let timedEvents = events.filter { !$0.isAllDay }
+        if let ongoingEvent = timedEvents
+            .filter({ $0.startDate <= now && $0.endDate > now })
+            .max(by: Self.compareOngoingEvents) {
+            featuredEvent = ongoingEvent
+            featuredEventIsOngoing = true
+        } else {
+            featuredEvent = timedEvents.first(where: { $0.startDate > now })
+            featuredEventIsOngoing = false
+        }
+    }
+
+    func labelText(showsTitle: Bool, showsCountdown: Bool, now: Date) -> String? {
+        guard let featuredEvent else { return nil }
+
+        var components: [String] = []
+        if showsTitle {
+            components.append(featuredEvent.resolvedMeetingTitle)
+        }
+        if showsCountdown {
+            components.append(countdownText(now: now))
+        }
+        return components.isEmpty ? nil : components.joined(separator: " · ")
+    }
+
+    func accessibilityLabel(now: Date) -> String? {
+        guard let featuredEvent else { return nil }
+        return "\(featuredEvent.resolvedMeetingTitle), \(countdownText(now: now))"
+    }
+
+    func countdownText(now: Date) -> String {
+        guard let featuredEvent else { return "" }
+        let targetDate = featuredEventIsOngoing ? featuredEvent.endDate : featuredEvent.startDate
+
+        if targetDate.timeIntervalSince(now) < 60 {
+            return featuredEventIsOngoing ? L10n.menuBarEndingSoon : L10n.menuBarStartingSoon
+        }
+
+        let remainingMinutes = Self.remainingMinutes(from: now, to: targetDate)
+        let duration = Self.durationText(minutes: remainingMinutes)
+        return featuredEventIsOngoing ? L10n.menuBarEndsIn(duration) : L10n.menuBarStartsIn(duration)
+    }
+
+    static func remainingMinutes(from now: Date, to targetDate: Date) -> Int {
+        max(0, Int(ceil(targetDate.timeIntervalSince(now) / 60)))
+    }
+
+    static func durationText(minutes: Int) -> String {
+        let hours = minutes / 60
+        let remainingMinutes = minutes % 60
+
+        if hours > 0, remainingMinutes > 0 {
+            return L10n.menuBarHoursAndMinutes(hours, remainingMinutes)
+        }
+        if hours > 0 {
+            return L10n.menuBarHours(hours)
+        }
+        return L10n.menuBarMinutes(remainingMinutes)
+    }
+
+    private static func sortEvents(_ lhs: CalendarEvent, _ rhs: CalendarEvent) -> Bool {
+        if lhs.isAllDay != rhs.isAllDay {
+            return lhs.isAllDay
+        }
+        if lhs.startDate != rhs.startDate {
+            return lhs.startDate < rhs.startDate
+        }
+        if lhs.endDate != rhs.endDate {
+            return lhs.endDate < rhs.endDate
+        }
+        if lhs.title != rhs.title {
+            return lhs.title.localizedStandardCompare(rhs.title) == .orderedAscending
+        }
+        return lhs.id < rhs.id
+    }
+
+    private static func compareOngoingEvents(_ lhs: CalendarEvent, _ rhs: CalendarEvent) -> Bool {
+        if lhs.startDate != rhs.startDate {
+            return lhs.startDate < rhs.startDate
+        }
+        if lhs.endDate != rhs.endDate {
+            return lhs.endDate > rhs.endDate
+        }
+        return lhs.id < rhs.id
+    }
+}

--- a/Sources/Dahlia/Models/MenuBarCalendarAgenda.swift
+++ b/Sources/Dahlia/Models/MenuBarCalendarAgenda.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 struct MenuBarCalendarAgenda: Equatable {
+    private static let menuBarTitleLimit = 24
+
     let events: [CalendarEvent]
     let featuredEvent: CalendarEvent?
     let featuredEventIsOngoing: Bool
@@ -45,7 +47,7 @@ struct MenuBarCalendarAgenda: Equatable {
 
         var components: [String] = []
         if showsTitle {
-            components.append(featuredEvent.resolvedMeetingTitle)
+            components.append(Self.truncatedTitle(featuredEvent.resolvedMeetingTitle))
         }
         if showsCountdown {
             components.append(countdownText(now: now))
@@ -55,7 +57,8 @@ struct MenuBarCalendarAgenda: Equatable {
 
     func accessibilityLabel(now: Date) -> String? {
         guard let featuredEvent else { return nil }
-        return "\(featuredEvent.resolvedMeetingTitle), \(countdownText(now: now))"
+        let participation = featuredEvent.isAttending ? ", \(L10n.calendarAttending)" : ""
+        return "\(featuredEvent.resolvedMeetingTitle), \(countdownText(now: now))\(participation)"
     }
 
     func countdownText(now: Date) -> String {
@@ -86,6 +89,11 @@ struct MenuBarCalendarAgenda: Equatable {
             return L10n.menuBarHours(hours)
         }
         return L10n.menuBarMinutes(remainingMinutes)
+    }
+
+    private static func truncatedTitle(_ title: String) -> String {
+        guard title.count > menuBarTitleLimit else { return title }
+        return "\(title.prefix(menuBarTitleLimit))…"
     }
 
     private static func sortEvents(_ lhs: CalendarEvent, _ rhs: CalendarEvent) -> Bool {

--- a/Sources/Dahlia/Models/MenuBarCalendarAgenda.swift
+++ b/Sources/Dahlia/Models/MenuBarCalendarAgenda.swift
@@ -6,6 +6,7 @@ struct MenuBarCalendarAgenda: Equatable {
     let events: [CalendarEvent]
     let featuredEvent: CalendarEvent?
     let featuredEventIsOngoing: Bool
+    let hasEventsExcludedByFilter: Bool
 
     init(
         googleEvents: [CalendarEvent],
@@ -24,11 +25,14 @@ struct MenuBarCalendarAgenda: Equatable {
         }
 
         let tomorrow = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now)) ?? now
-        events = sourceEvents
+        let currentEvents = sourceEvents
             .deduplicatedAcrossSources()
-            .filter(filter.includes)
             .filter { $0.endDate > now && $0.startDate < tomorrow }
+
+        events = currentEvents
+            .filter(filter.includes)
             .sorted(by: Self.sortEvents)
+        hasEventsExcludedByFilter = events.isEmpty && !currentEvents.isEmpty
 
         let timedEvents = events.filter { !$0.isAllDay }
         if let ongoingEvent = timedEvents

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -256,18 +256,18 @@
 "Choose which calendar service provides upcoming events." = "Choose which calendar service provides upcoming events.";
 "Calendar Sources" = "Calendar Sources";
 "Choose which calendar services provide upcoming events." = "Choose which calendar services provide upcoming events.";
-"Event Filters" = "Event Filters";
-"Hide events from Home and calendar notifications when they match any selected condition." = "Hide events from Home and calendar notifications when they match any selected condition.";
+"Events to Include" = "Events to Include";
+"Turn on the event types to show in Home, the menu bar, and calendar notifications." = "Turn on the event types to show in Home, the menu bar, and calendar notifications.";
 "All-day events" = "All-day events";
-"Hide events marked as all-day." = "Hide events marked as all-day.";
-"Events with only you" = "Events with only you";
-"Hide events with no attendees other than you." = "Hide events with no attendees other than you.";
+"Include events marked as all-day." = "Include events marked as all-day.";
+"Events without other attendees" = "Events without other attendees";
+"Include events with no attendees other than you." = "Include events with no attendees other than you.";
 "Events without a meeting URL" = "Events without a meeting URL";
-"Hide events that do not include a supported meeting URL." = "Hide events that do not include a supported meeting URL.";
+"Include events that do not have a supported meeting URL." = "Include events that do not have a supported meeting URL.";
 "Declined events" = "Declined events";
-"Hide events you declined." = "Hide events you declined.";
+"Include events you declined." = "Include events you declined.";
 "OOO / OOTO events" = "OOO / OOTO events";
-"Hide out-of-office events and events whose title includes OOO or OOTO." = "Hide out-of-office events and events whose title includes OOO or OOTO.";
+"Include out-of-office events and events whose title includes OOO or OOTO." = "Include out-of-office events and events whose title includes OOO or OOTO.";
 "Show events from Google Calendar." = "Show events from Google Calendar.";
 "Show events from the Calendar app on this Mac." = "Show events from the Calendar app on this Mac.";
 "Upcoming schedule" = "Upcoming schedule";
@@ -305,8 +305,8 @@
 "Enable at least one calendar source in Settings to show upcoming events." = "Enable at least one calendar source in Settings to show upcoming events.";
 "No upcoming events" = "No upcoming events";
 "There are no events in the next 7 days for the selected calendars." = "There are no events in the next 7 days for the selected calendars.";
-"No events match your filters" = "No events match your filters";
-"Upcoming events were found, but all of them are hidden by your event filters." = "Upcoming events were found, but all of them are hidden by your event filters.";
+"No events match your inclusion settings" = "No events match your inclusion settings";
+"Upcoming events were found, but none match the event types you chose to include." = "Upcoming events were found, but none match the event types you chose to include.";
 "Could not load Google Calendar" = "Could not load Google Calendar";
 "Could not load macOS Calendar" = "Could not load macOS Calendar";
 "Allow macOS Calendar access" = "Allow macOS Calendar access";
@@ -483,6 +483,10 @@
 "%lld hr %lld min" = "%lld hr %lld min";
 "%lld hr" = "%lld hr";
 "%lld min" = "%lld min";
+"Join Meeting (with recording)" = "Join Meeting (with recording)";
+"Join Meeting" = "Join Meeting";
+"Show Event in Calendar" = "Show Event in Calendar";
+"Attending" = "Attending";
 
 /* Meeting Detection */
 "Meeting Notifications" = "Meeting Notifications";

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -463,6 +463,26 @@
 "Live Subtitles" = "Live Subtitles";
 "Settings..." = "Settings...";
 "Quit Dahlia" = "Quit Dahlia";
+"Menu Bar Calendar" = "Menu Bar Calendar";
+"Choose which event details appear in the menu bar. Calendar selection and event filters above are shared." = "Choose which event details appear in the menu bar. Calendar selection and event filters above are shared.";
+"Show today's events" = "Show today's events";
+"Show ongoing and upcoming events in the menu bar popover." = "Show ongoing and upcoming events in the menu bar popover.";
+"Event title" = "Event title";
+"Show the current or next event title in the menu bar." = "Show the current or next event title in the menu bar.";
+"Time remaining" = "Time remaining";
+"Show the time until the event starts or ends." = "Show the time until the event starts or ends.";
+"No more events today" = "No more events today";
+"There are no ongoing or upcoming events today." = "There are no ongoing or upcoming events today.";
+"Open Calendar Settings" = "Open Calendar Settings";
+"In progress" = "In progress";
+"Starting soon" = "Starting soon";
+"Ending soon" = "Ending soon";
+"Open %@ in Dahlia" = "Open %@ in Dahlia";
+"Starts in %@" = "Starts in %@";
+"Ends in %@" = "Ends in %@";
+"%lld hr %lld min" = "%lld hr %lld min";
+"%lld hr" = "%lld hr";
+"%lld min" = "%lld min";
 
 /* Meeting Detection */
 "Meeting Notifications" = "Meeting Notifications";

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -466,7 +466,7 @@
 "Menu Bar Calendar" = "Menu Bar Calendar";
 "Choose which event details appear in the menu bar. Calendar selection and event filters above are shared." = "Choose which event details appear in the menu bar. Calendar selection and event filters above are shared.";
 "Show today's events" = "Show today's events";
-"Show ongoing and upcoming events in the menu bar popover." = "Show ongoing and upcoming events in the menu bar popover.";
+"Show ongoing and upcoming events in the menu bar menu." = "Show ongoing and upcoming events in the menu bar menu.";
 "Event title" = "Event title";
 "Show the current or next event title in the menu bar." = "Show the current or next event title in the menu bar.";
 "Time remaining" = "Time remaining";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -466,7 +466,7 @@
 "Menu Bar Calendar" = "メニューバーのカレンダー";
 "Choose which event details appear in the menu bar. Calendar selection and event filters above are shared." = "メニューバーに表示する予定の詳細を選びます。表示するカレンダーと予定のフィルタは上の設定を共有します。";
 "Show today's events" = "今日の予定を表示";
-"Show ongoing and upcoming events in the menu bar popover." = "進行中と今後の予定をメニューバーのポップオーバーに表示します。";
+"Show ongoing and upcoming events in the menu bar menu." = "進行中と今後の予定をメニューバーのメニューに表示します。";
 "Event title" = "予定のタイトル";
 "Show the current or next event title in the menu bar." = "進行中または次の予定のタイトルをメニューバーに表示します。";
 "Time remaining" = "開始・終了までの時間";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -256,18 +256,18 @@
 "Choose which calendar service provides upcoming events." = "今後の予定を取得するカレンダーサービスを選びます。";
 "Calendar Sources" = "カレンダーソース";
 "Choose which calendar services provide upcoming events." = "今後の予定を取得するカレンダーサービスを選びます。";
-"Event Filters" = "予定のフィルタ";
-"Hide events from Home and calendar notifications when they match any selected condition." = "選択した条件のいずれかに該当する予定を Home とカレンダー通知から除外します。";
+"Events to Include" = "イベントを含める";
+"Turn on the event types to show in Home, the menu bar, and calendar notifications." = "Home、メニューバー、カレンダー通知に表示するイベントの種類をオンにします。";
 "All-day events" = "終日イベント";
-"Hide events marked as all-day." = "終日として設定された予定を非表示にします。";
-"Events with only you" = "参加者が自分だけのイベント";
-"Hide events with no attendees other than you." = "自分以外の参加者がいない予定を非表示にします。";
+"Include events marked as all-day." = "終日として設定されたイベントを含めます。";
+"Events without other attendees" = "参加者のいないイベント";
+"Include events with no attendees other than you." = "自分以外の参加者がいないイベントを含めます。";
 "Events without a meeting URL" = "会議 URL がないイベント";
-"Hide events that do not include a supported meeting URL." = "対応している会議 URL が含まれていない予定を非表示にします。";
+"Include events that do not have a supported meeting URL." = "対応している会議 URL がないイベントを含めます。";
 "Declined events" = "辞退済みのイベント";
-"Hide events you declined." = "自分が辞退した予定を非表示にします。";
+"Include events you declined." = "自分が辞退したイベントを含めます。";
 "OOO / OOTO events" = "OOO / OOTO のイベント";
-"Hide out-of-office events and events whose title includes OOO or OOTO." = "不在として設定された予定と、タイトルに OOO または OOTO を含む予定を除外します。";
+"Include out-of-office events and events whose title includes OOO or OOTO." = "不在として設定されたイベントと、タイトルに OOO または OOTO を含むイベントを含めます。";
 "Show events from Google Calendar." = "Google カレンダーの予定を表示します。";
 "Show events from the Calendar app on this Mac." = "この Mac のカレンダーアプリの予定を表示します。";
 "Upcoming schedule" = "今後の予定";
@@ -305,8 +305,8 @@
 "Enable at least one calendar source in Settings to show upcoming events." = "今後の予定を表示するには設定画面で少なくとも 1 つのカレンダーソースを有効にしてください。";
 "No upcoming events" = "今後の予定はありません";
 "There are no events in the next 7 days for the selected calendars." = "選択したカレンダーには今後 7 日間の予定がありません。";
-"No events match your filters" = "フィルタに一致する予定がありません";
-"Upcoming events were found, but all of them are hidden by your event filters." = "今後の予定はありますが、すべて予定のフィルタで非表示になっています。";
+"No events match your inclusion settings" = "含めるイベントがありません";
+"Upcoming events were found, but none match the event types you chose to include." = "今後の予定はありますが、「イベントを含める」の設定に一致しません。";
 "Could not load Google Calendar" = "Google カレンダーを読み込めませんでした";
 "Could not load macOS Calendar" = "macOS カレンダーを読み込めませんでした";
 "Allow macOS Calendar access" = "macOS カレンダーへのアクセスを許可";
@@ -483,6 +483,10 @@
 "%lld hr %lld min" = "%lld時間%lld分";
 "%lld hr" = "%lld時間";
 "%lld min" = "%lld分";
+"Join Meeting (with recording)" = "ミーティングに参加する（録音あり）";
+"Join Meeting" = "ミーティングに参加する";
+"Show Event in Calendar" = "イベントをカレンダーで表示する";
+"Attending" = "参加予定";
 
 /* Meeting Detection */
 "Meeting Notifications" = "ミーティング通知";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -463,6 +463,26 @@
 "Live Subtitles" = "ライブ字幕";
 "Settings..." = "設定...";
 "Quit Dahlia" = "Dahlia を終了";
+"Menu Bar Calendar" = "メニューバーのカレンダー";
+"Choose which event details appear in the menu bar. Calendar selection and event filters above are shared." = "メニューバーに表示する予定の詳細を選びます。表示するカレンダーと予定のフィルタは上の設定を共有します。";
+"Show today's events" = "今日の予定を表示";
+"Show ongoing and upcoming events in the menu bar popover." = "進行中と今後の予定をメニューバーのポップオーバーに表示します。";
+"Event title" = "予定のタイトル";
+"Show the current or next event title in the menu bar." = "進行中または次の予定のタイトルをメニューバーに表示します。";
+"Time remaining" = "開始・終了までの時間";
+"Show the time until the event starts or ends." = "予定が開始または終了するまでの時間を表示します。";
+"No more events today" = "今日の予定はもうありません";
+"There are no ongoing or upcoming events today." = "今日の進行中または今後の予定はありません。";
+"Open Calendar Settings" = "カレンダー設定を開く";
+"In progress" = "進行中";
+"Starting soon" = "まもなく開始";
+"Ending soon" = "まもなく終了";
+"Open %@ in Dahlia" = "「%@」を Dahlia で開く";
+"Starts in %@" = "開始まで %@";
+"Ends in %@" = "終了まで %@";
+"%lld hr %lld min" = "%lld時間%lld分";
+"%lld hr" = "%lld時間";
+"%lld min" = "%lld分";
 
 /* Meeting Detection */
 "Meeting Notifications" = "ミーティング通知";

--- a/Sources/Dahlia/Services/GoogleCalendarAPIClient.swift
+++ b/Sources/Dahlia/Services/GoogleCalendarAPIClient.swift
@@ -147,7 +147,7 @@ final class GoogleCalendarAPIClient: GoogleCalendarAPIClientProviding {
             isAllDay: item.start.date != nil,
             hasOtherAttendees: item.hasOtherAttendees,
             isDeclined: item.isDeclinedByCurrentUser,
-            isAttending: item.isAcceptedByCurrentUser,
+            isAttending: item.isCurrentUserAttending,
             isOutOfOffice: item.eventType == "outOfOffice",
             conferenceURI: conferenceURI(for: item),
             url: absoluteURL(from: item.htmlLink)
@@ -416,6 +416,7 @@ extension GoogleCalendarAPIClient {
         let conferenceData: ConferenceData?
         let eventType: String?
         let attendees: [GoogleCalendarAttendee]?
+        let organizer: GoogleCalendarAttendee?
 
         init(
             id: String,
@@ -430,7 +431,8 @@ extension GoogleCalendarAPIClient {
             recurringEventId: String? = nil,
             conferenceData: ConferenceData?,
             eventType: String?,
-            attendees: [GoogleCalendarAttendee]? = nil
+            attendees: [GoogleCalendarAttendee]? = nil,
+            organizer: GoogleCalendarAttendee? = nil
         ) {
             self.id = id
             self.summary = summary
@@ -445,6 +447,7 @@ extension GoogleCalendarAPIClient {
             self.conferenceData = conferenceData
             self.eventType = eventType
             self.attendees = attendees
+            self.organizer = organizer
         }
 
         var hasOtherAttendees: Bool {
@@ -455,8 +458,10 @@ extension GoogleCalendarAPIClient {
             attendees?.first(where: \.isCurrentUser)?.responseStatus == "declined"
         }
 
-        var isAcceptedByCurrentUser: Bool {
-            attendees?.first(where: \.isCurrentUser)?.responseStatus == "accepted"
+        var isCurrentUserAttending: Bool {
+            attendees == nil
+                || organizer?.isCurrentUser == true
+                || attendees?.first(where: \.isCurrentUser)?.responseStatus == "accepted"
         }
     }
 }

--- a/Sources/Dahlia/Services/GoogleCalendarAPIClient.swift
+++ b/Sources/Dahlia/Services/GoogleCalendarAPIClient.swift
@@ -147,6 +147,7 @@ final class GoogleCalendarAPIClient: GoogleCalendarAPIClientProviding {
             isAllDay: item.start.date != nil,
             hasOtherAttendees: item.hasOtherAttendees,
             isDeclined: item.isDeclinedByCurrentUser,
+            isAttending: item.isAcceptedByCurrentUser,
             isOutOfOffice: item.eventType == "outOfOffice",
             conferenceURI: conferenceURI(for: item),
             url: absoluteURL(from: item.htmlLink)
@@ -452,6 +453,10 @@ extension GoogleCalendarAPIClient {
 
         var isDeclinedByCurrentUser: Bool {
             attendees?.first(where: \.isCurrentUser)?.responseStatus == "declined"
+        }
+
+        var isAcceptedByCurrentUser: Bool {
+            attendees?.first(where: \.isCurrentUser)?.responseStatus == "accepted"
         }
     }
 }

--- a/Sources/Dahlia/Services/MacCalendarStore.swift
+++ b/Sources/Dahlia/Services/MacCalendarStore.swift
@@ -392,6 +392,7 @@ actor EventKitMacCalendarEventStore: MacCalendarEventStoreProviding {
             isAllDay: event.isAllDay,
             hasOtherAttendees: event.attendees?.contains { !$0.isCurrentUser } == true,
             isDeclined: event.attendees?.first(where: \.isCurrentUser)?.participantStatus == .declined,
+            isAttending: event.attendees?.first(where: \.isCurrentUser)?.participantStatus == .accepted,
             isOutOfOffice: event.availability == .unavailable,
             conferenceURI: CalendarConferenceURIExtractor.conferenceURI(
                 url: event.url,

--- a/Sources/Dahlia/Services/MacCalendarStore.swift
+++ b/Sources/Dahlia/Services/MacCalendarStore.swift
@@ -392,7 +392,9 @@ actor EventKitMacCalendarEventStore: MacCalendarEventStoreProviding {
             isAllDay: event.isAllDay,
             hasOtherAttendees: event.attendees?.contains { !$0.isCurrentUser } == true,
             isDeclined: event.attendees?.first(where: \.isCurrentUser)?.participantStatus == .declined,
-            isAttending: event.attendees?.first(where: \.isCurrentUser)?.participantStatus == .accepted,
+            isAttending: event.attendees == nil
+                || event.organizer?.isCurrentUser == true
+                || event.attendees?.first(where: \.isCurrentUser)?.participantStatus == .accepted,
             isOutOfOffice: event.availability == .unavailable,
             conferenceURI: CalendarConferenceURIExtractor.conferenceURI(
                 url: event.url,

--- a/Sources/Dahlia/Services/MeetingDetectionService.swift
+++ b/Sources/Dahlia/Services/MeetingDetectionService.swift
@@ -139,11 +139,11 @@ final class MeetingDetectionService: ObservableObject {
             settings.microphoneMeetingNotificationsEnabled.description,
             settings.calendarEventMeetingNotificationsEnabled.description,
             settings.enabledCalendarSourcesJSON,
-            settings.excludeAllDayCalendarEvents.description,
-            settings.excludeCalendarEventsWithoutOtherAttendees.description,
-            settings.excludeCalendarEventsWithoutConferenceURI.description,
-            settings.excludeDeclinedCalendarEvents.description,
-            settings.excludeOutOfOfficeCalendarEvents.description,
+            settings.includesAllDayCalendarEvents.description,
+            settings.includesCalendarEventsWithoutOtherAttendees.description,
+            settings.includesCalendarEventsWithoutConferenceURI.description,
+            settings.includesDeclinedCalendarEvents.description,
+            settings.includesOutOfOfficeCalendarEvents.description,
             settings.appLanguageRawValue,
         ].joined(separator: "|")
         guard notificationSettingsSignature != settingsSignature else { return }

--- a/Sources/Dahlia/Services/RecordingCoordinator.swift
+++ b/Sources/Dahlia/Services/RecordingCoordinator.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import GRDB
 
@@ -96,6 +97,13 @@ final class RecordingCoordinator {
         )
     }
 
+    func joinCalendarEventAndStartRecording(_ event: CalendarEvent) {
+        startRecording(forCalendarEvent: event)
+        if let conferenceURI = event.conferenceURI {
+            NSWorkspace.shared.open(conferenceURI)
+        }
+    }
+
     func startRecording(appendingTo meetingId: UUID) {
         guard canStartNewMeeting,
               let dbQueue = sidebarViewModel.dbQueue,
@@ -128,5 +136,35 @@ final class RecordingCoordinator {
 
     func stopRecording() {
         viewModel.stopListening()
+    }
+
+    private func startRecording(forCalendarEvent event: CalendarEvent) {
+        guard canStartNewMeeting,
+              let dbQueue = sidebarViewModel.dbQueue,
+              let vault = sidebarViewModel.currentVault else {
+            MainWindowOpener.shared.openMainWindow()
+            return
+        }
+
+        let repository = MeetingRepository(dbQueue: dbQueue)
+        do {
+            if let existingMeetingId = try repository.resolveMeetingIdForCalendarEvent(event, vaultId: vault.id) {
+                sidebarViewModel.selectMeeting(existingMeetingId)
+                startRecording(appendingTo: existingMeetingId)
+                return
+            }
+        } catch {
+            viewModel.errorMessage = error.localizedDescription
+            ErrorReportingService.capture(error, context: ["source": "calendarEventRecording"])
+            return
+        }
+
+        sidebarViewModel.clearMeetingSelection()
+        viewModel.beginDraftMeeting(
+            from: event,
+            dbQueue: dbQueue,
+            vaultURL: vault.url
+        )
+        startNewMeeting()
     }
 }

--- a/Sources/Dahlia/Services/RecordingCoordinator.swift
+++ b/Sources/Dahlia/Services/RecordingCoordinator.swift
@@ -89,6 +89,8 @@ final class RecordingCoordinator {
             return
         }
 
+        guard !viewModel.isListening else { return }
+
         sidebarViewModel.clearMeetingSelection()
         viewModel.beginDraftMeeting(
             from: event,
@@ -98,24 +100,24 @@ final class RecordingCoordinator {
     }
 
     func joinCalendarEventAndStartRecording(_ event: CalendarEvent) {
-        startRecording(forCalendarEvent: event)
-        if let conferenceURI = event.conferenceURI {
-            NSWorkspace.shared.open(conferenceURI)
-        }
+        guard startRecording(forCalendarEvent: event),
+              let conferenceURI = event.conferenceURI else { return }
+        NSWorkspace.shared.open(conferenceURI)
     }
 
-    func startRecording(appendingTo meetingId: UUID) {
+    @discardableResult
+    func startRecording(appendingTo meetingId: UUID) -> Bool {
         guard canStartNewMeeting,
               let dbQueue = sidebarViewModel.dbQueue,
               let vault = sidebarViewModel.currentVault else {
             MainWindowOpener.shared.openMainWindow()
-            return
+            return false
         }
 
         let item = sidebarViewModel.allMeetings.first(where: { $0.meetingId == meetingId })
         guard item != nil || viewModel.currentMeetingId == meetingId else {
             MainWindowOpener.shared.openMainWindow()
-            return
+            return false
         }
         let projectName = item?.projectName ?? viewModel.currentProjectName
         let projectId = item?.projectId ?? viewModel.currentProjectId
@@ -132,31 +134,32 @@ final class RecordingCoordinator {
             )
             sidebarViewModel.selectMeeting(meetingId)
         }
+        return true
     }
 
     func stopRecording() {
         viewModel.stopListening()
     }
 
-    private func startRecording(forCalendarEvent event: CalendarEvent) {
+    @discardableResult
+    private func startRecording(forCalendarEvent event: CalendarEvent) -> Bool {
         guard canStartNewMeeting,
               let dbQueue = sidebarViewModel.dbQueue,
               let vault = sidebarViewModel.currentVault else {
             MainWindowOpener.shared.openMainWindow()
-            return
+            return false
         }
 
         let repository = MeetingRepository(dbQueue: dbQueue)
         do {
             if let existingMeetingId = try repository.resolveMeetingIdForCalendarEvent(event, vaultId: vault.id) {
                 sidebarViewModel.selectMeeting(existingMeetingId)
-                startRecording(appendingTo: existingMeetingId)
-                return
+                return startRecording(appendingTo: existingMeetingId)
             }
         } catch {
             viewModel.errorMessage = error.localizedDescription
             ErrorReportingService.capture(error, context: ["source": "calendarEventRecording"])
-            return
+            return false
         }
 
         sidebarViewModel.clearMeetingSelection()
@@ -166,5 +169,6 @@ final class RecordingCoordinator {
             vaultURL: vault.url
         )
         startNewMeeting()
+        return true
     }
 }

--- a/Sources/Dahlia/Services/RecordingCoordinator.swift
+++ b/Sources/Dahlia/Services/RecordingCoordinator.swift
@@ -71,6 +71,31 @@ final class RecordingCoordinator {
         }
     }
 
+    func openCalendarEvent(_ event: CalendarEvent) {
+        MainWindowOpener.shared.openMainWindow()
+        guard let dbQueue = sidebarViewModel.dbQueue,
+              let vault = sidebarViewModel.currentVault else { return }
+
+        let repository = MeetingRepository(dbQueue: dbQueue)
+        do {
+            if let existingMeetingId = try repository.resolveMeetingIdForCalendarEvent(event, vaultId: vault.id) {
+                sidebarViewModel.selectMeeting(existingMeetingId)
+                return
+            }
+        } catch {
+            viewModel.errorMessage = error.localizedDescription
+            ErrorReportingService.capture(error, context: ["source": "calendarEventSelection"])
+            return
+        }
+
+        sidebarViewModel.clearMeetingSelection()
+        viewModel.beginDraftMeeting(
+            from: event,
+            dbQueue: dbQueue,
+            vaultURL: vault.url
+        )
+    }
+
     func startRecording(appendingTo meetingId: UUID) {
         guard canStartNewMeeting,
               let dbQueue = sidebarViewModel.dbQueue,

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -519,45 +519,45 @@ enum L10n {
         localized: "Choose which calendar services provide upcoming events.",
         bundle: bundle
     ) }
-    static var calendarEventFilters: String { String(localized: "Event Filters", bundle: bundle) }
-    static var calendarEventFiltersDescription: String { String(
-        localized: "Hide events from Home and calendar notifications when they match any selected condition.",
+    static var calendarEventsToInclude: String { String(localized: "Events to Include", bundle: bundle) }
+    static var calendarEventsToIncludeDescription: String { String(
+        localized: "Turn on the event types to show in Home, the menu bar, and calendar notifications.",
         bundle: bundle
     ) }
     static var calendarFilterAllDayEvents: String { String(localized: "All-day events", bundle: bundle) }
-    static var calendarFilterAllDayEventsDescription: String { String(
-        localized: "Hide events marked as all-day.",
+    static var calendarIncludeAllDayEventsDescription: String { String(
+        localized: "Include events marked as all-day.",
         bundle: bundle
     ) }
-    static var calendarFilterUserOnlyEvents: String { String(localized: "Events with only you", bundle: bundle) }
-    static var calendarFilterUserOnlyEventsDescription: String { String(
-        localized: "Hide events with no attendees other than you.",
+    static var calendarFilterUserOnlyEvents: String { String(localized: "Events without other attendees", bundle: bundle) }
+    static var calendarIncludeUserOnlyEventsDescription: String { String(
+        localized: "Include events with no attendees other than you.",
         bundle: bundle
     ) }
     static var calendarFilterEventsWithoutMeetingURL: String { String(
         localized: "Events without a meeting URL",
         bundle: bundle
     ) }
-    static var calendarFilterEventsWithoutMeetingURLDescription: String { String(
-        localized: "Hide events that do not include a supported meeting URL.",
+    static var calendarIncludeEventsWithoutMeetingURLDescription: String { String(
+        localized: "Include events that do not have a supported meeting URL.",
         bundle: bundle
     ) }
     static var calendarFilterDeclinedEvents: String { String(localized: "Declined events", bundle: bundle) }
-    static var calendarFilterDeclinedEventsDescription: String { String(
-        localized: "Hide events you declined.",
+    static var calendarIncludeDeclinedEventsDescription: String { String(
+        localized: "Include events you declined.",
         bundle: bundle
     ) }
     static var calendarFilterOutOfOfficeEvents: String { String(localized: "OOO / OOTO events", bundle: bundle) }
-    static var calendarFilterOutOfOfficeEventsDescription: String { String(
-        localized: "Hide out-of-office events and events whose title includes OOO or OOTO.",
+    static var calendarIncludeOutOfOfficeEventsDescription: String { String(
+        localized: "Include out-of-office events and events whose title includes OOO or OOTO.",
         bundle: bundle
     ) }
     static var calendarNoEventsMatchFiltersTitle: String { String(
-        localized: "No events match your filters",
+        localized: "No events match your inclusion settings",
         bundle: bundle
     ) }
     static var calendarNoEventsMatchFiltersMessage: String { String(
-        localized: "Upcoming events were found, but all of them are hidden by your event filters.",
+        localized: "Upcoming events were found, but none match the event types you chose to include.",
         bundle: bundle
     ) }
     static var googleCalendarSourceDescription: String { String(
@@ -1097,6 +1097,11 @@ enum L10n {
     static func menuBarMinutes(_ minutes: Int) -> String {
         String(localized: "\(minutes) min", bundle: bundle)
     }
+
+    static var menuBarJoinMeetingWithRecording: String { String(localized: "Join Meeting (with recording)", bundle: bundle) }
+    static var menuBarJoinMeeting: String { String(localized: "Join Meeting", bundle: bundle) }
+    static var menuBarShowEventInCalendar: String { String(localized: "Show Event in Calendar", bundle: bundle) }
+    static var calendarAttending: String { String(localized: "Attending", bundle: bundle) }
 
     // MARK: - Meeting Detection
 

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1051,7 +1051,7 @@ enum L10n {
     ) }
     static var menuBarCalendarDisplay: String { String(localized: "Show today's events", bundle: bundle) }
     static var menuBarCalendarDisplayDescription: String { String(
-        localized: "Show ongoing and upcoming events in the menu bar popover.",
+        localized: "Show ongoing and upcoming events in the menu bar menu.",
         bundle: bundle
     ) }
     static var menuBarCalendarEventTitle: String { String(localized: "Event title", bundle: bundle) }

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1044,6 +1044,59 @@ enum L10n {
     static var menuBarShowLiveSubtitles: String { String(localized: "Live Subtitles", bundle: bundle) }
     static var settingsMenuItem: String { String(localized: "Settings...", bundle: bundle) }
     static var menuBarQuitDahlia: String { String(localized: "Quit Dahlia", bundle: bundle) }
+    static var menuBarCalendar: String { String(localized: "Menu Bar Calendar", bundle: bundle) }
+    static var menuBarCalendarDescription: String { String(
+        localized: "Choose which event details appear in the menu bar. Calendar selection and event filters above are shared.",
+        bundle: bundle
+    ) }
+    static var menuBarCalendarDisplay: String { String(localized: "Show today's events", bundle: bundle) }
+    static var menuBarCalendarDisplayDescription: String { String(
+        localized: "Show ongoing and upcoming events in the menu bar popover.",
+        bundle: bundle
+    ) }
+    static var menuBarCalendarEventTitle: String { String(localized: "Event title", bundle: bundle) }
+    static var menuBarCalendarEventTitleDescription: String { String(
+        localized: "Show the current or next event title in the menu bar.",
+        bundle: bundle
+    ) }
+    static var menuBarCalendarCountdown: String { String(localized: "Time remaining", bundle: bundle) }
+    static var menuBarCalendarCountdownDescription: String { String(
+        localized: "Show the time until the event starts or ends.",
+        bundle: bundle
+    ) }
+    static var menuBarNoMoreEventsToday: String { String(localized: "No more events today", bundle: bundle) }
+    static var menuBarNoMoreEventsTodayDescription: String { String(
+        localized: "There are no ongoing or upcoming events today.",
+        bundle: bundle
+    ) }
+    static var menuBarOpenCalendarSettings: String { String(localized: "Open Calendar Settings", bundle: bundle) }
+    static var menuBarInProgress: String { String(localized: "In progress", bundle: bundle) }
+    static var menuBarStartingSoon: String { String(localized: "Starting soon", bundle: bundle) }
+    static var menuBarEndingSoon: String { String(localized: "Ending soon", bundle: bundle) }
+
+    static func menuBarOpenEventInDahlia(_ title: String) -> String {
+        String(localized: "Open \(title) in Dahlia", bundle: bundle)
+    }
+
+    static func menuBarStartsIn(_ duration: String) -> String {
+        String(localized: "Starts in \(duration)", bundle: bundle)
+    }
+
+    static func menuBarEndsIn(_ duration: String) -> String {
+        String(localized: "Ends in \(duration)", bundle: bundle)
+    }
+
+    static func menuBarHoursAndMinutes(_ hours: Int, _ minutes: Int) -> String {
+        String(localized: "\(hours) hr \(minutes) min", bundle: bundle)
+    }
+
+    static func menuBarHours(_ hours: Int) -> String {
+        String(localized: "\(hours) hr", bundle: bundle)
+    }
+
+    static func menuBarMinutes(_ minutes: Int) -> String {
+        String(localized: "\(minutes) min", bundle: bundle)
+    }
 
     // MARK: - Meeting Detection
 

--- a/Sources/Dahlia/ViewModels/MenuBarCalendarViewModel.swift
+++ b/Sources/Dahlia/ViewModels/MenuBarCalendarViewModel.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class MenuBarCalendarViewModel {
+    private(set) var currentDate = Date.now
+
+    private let settings: AppSettings
+    private let googleCalendarStore: GoogleCalendarStore
+    private let macCalendarStore: MacCalendarStore
+    private var isRefreshLoopRunning = false
+
+    init(
+        settings: AppSettings = .shared,
+        googleCalendarStore: GoogleCalendarStore = .shared,
+        macCalendarStore: MacCalendarStore = .shared
+    ) {
+        self.settings = settings
+        self.googleCalendarStore = googleCalendarStore
+        self.macCalendarStore = macCalendarStore
+    }
+
+    func runRefreshLoop() async {
+        guard !isRefreshLoopRunning else { return }
+        isRefreshLoopRunning = true
+        defer { isRefreshLoopRunning = false }
+
+        while !Task.isCancelled {
+            currentDate = .now
+            if settings.menuBarCalendarEnabled {
+                await refreshEnabledSources()
+            }
+
+            do {
+                try await Task.sleep(for: .seconds(60))
+            } catch {
+                return
+            }
+        }
+    }
+
+    private func refreshEnabledSources() async {
+        if settings.isCalendarSourceEnabled(.google) {
+            await googleCalendarStore.refreshIfNeeded()
+        }
+        if settings.isCalendarSourceEnabled(.macOS) {
+            await macCalendarStore.refreshIfNeeded()
+        }
+    }
+}

--- a/Sources/Dahlia/ViewModels/MenuBarCalendarViewModel.swift
+++ b/Sources/Dahlia/ViewModels/MenuBarCalendarViewModel.swift
@@ -1,43 +1,105 @@
+import Combine
 import Foundation
 import Observation
 
 @MainActor
 @Observable
 final class MenuBarCalendarViewModel {
-    private(set) var currentDate = Date.now
+    private(set) var currentDate: Date
+    private(set) var agenda: MenuBarCalendarAgenda
 
     private let settings: AppSettings
     private let googleCalendarStore: GoogleCalendarStore
     private let macCalendarStore: MacCalendarStore
-    private var isRefreshLoopRunning = false
+    private var cancellables: Set<AnyCancellable> = []
 
     init(
         settings: AppSettings = .shared,
         googleCalendarStore: GoogleCalendarStore = .shared,
         macCalendarStore: MacCalendarStore = .shared
     ) {
+        let now = Date.now
         self.settings = settings
         self.googleCalendarStore = googleCalendarStore
         self.macCalendarStore = macCalendarStore
+        self.currentDate = now
+        self.agenda = Self.makeAgenda(
+            settings: settings,
+            googleEvents: googleCalendarStore.upcomingEvents,
+            macEvents: macCalendarStore.upcomingEvents,
+            now: now
+        )
+        observeCalendarInputs()
     }
 
     func runRefreshLoop() async {
-        guard !isRefreshLoopRunning else { return }
-        isRefreshLoopRunning = true
-        defer { isRefreshLoopRunning = false }
-
         while !Task.isCancelled {
             currentDate = .now
+            rebuildAgenda()
             if settings.menuBarCalendarEnabled {
                 await refreshEnabledSources()
             }
 
             do {
-                try await Task.sleep(for: .seconds(60))
+                try await Task.sleep(for: refreshDelay(from: currentDate))
             } catch {
                 return
             }
         }
+    }
+
+    private func observeCalendarInputs() {
+        googleCalendarStore.$upcomingEvents
+            .dropFirst()
+            .sink { [weak self] _ in self?.scheduleAgendaRebuild() }
+            .store(in: &cancellables)
+        macCalendarStore.$upcomingEvents
+            .dropFirst()
+            .sink { [weak self] _ in self?.scheduleAgendaRebuild() }
+            .store(in: &cancellables)
+        settings.objectWillChange
+            .sink { [weak self] _ in self?.scheduleAgendaRebuild() }
+            .store(in: &cancellables)
+    }
+
+    private func scheduleAgendaRebuild() {
+        Task { @MainActor [weak self] in
+            await Task.yield()
+            self?.rebuildAgenda()
+        }
+    }
+
+    private func rebuildAgenda() {
+        agenda = Self.makeAgenda(
+            settings: settings,
+            googleEvents: googleCalendarStore.upcomingEvents,
+            macEvents: macCalendarStore.upcomingEvents,
+            now: currentDate
+        )
+    }
+
+    private func refreshDelay(from now: Date) -> Duration {
+        let nextMinute = Date(timeIntervalSinceReferenceDate: (floor(now.timeIntervalSinceReferenceDate / 60) + 1) * 60)
+        let eventTransitions = [agenda.featuredEvent?.startDate, agenda.featuredEvent?.endDate]
+            .compactMap(\.self)
+            .filter { $0 > now }
+        let nextUpdate = eventTransitions.min().map { min($0, nextMinute) } ?? nextMinute
+        return .seconds(max(0.1, nextUpdate.timeIntervalSince(now)))
+    }
+
+    private static func makeAgenda(
+        settings: AppSettings,
+        googleEvents: [CalendarEvent],
+        macEvents: [CalendarEvent],
+        now: Date
+    ) -> MenuBarCalendarAgenda {
+        MenuBarCalendarAgenda(
+            googleEvents: googleEvents,
+            macEvents: macEvents,
+            enabledSources: settings.enabledCalendarSources,
+            filter: settings.calendarEventFilter,
+            now: now
+        )
     }
 
     private func refreshEnabledSources() async {

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -94,7 +94,7 @@ struct ContentView: View {
             )
         } else {
             CalendarScheduleView(
-                onSelectEvent: handleCalendarEventSelection,
+                onSelectEvent: recordingCoordinator.openCalendarEvent,
                 onCreateMeeting: recordingCoordinator.createEmptyMeeting
             )
         }
@@ -115,29 +115,6 @@ struct ContentView: View {
             viewModel.clearCurrentMeeting()
         }
         sidebarViewModel.clearMeetingSelection()
-    }
-
-    private func handleCalendarEventSelection(_ event: CalendarEvent) {
-        guard let dbQueue = sidebarViewModel.dbQueue,
-              let vault = sidebarViewModel.currentVault else { return }
-
-        let repository = MeetingRepository(dbQueue: dbQueue)
-        do {
-            if let existingMeetingId = try repository.resolveMeetingIdForCalendarEvent(event, vaultId: vault.id) {
-                sidebarViewModel.selectMeeting(existingMeetingId)
-                return
-            }
-        } catch {
-            viewModel.errorMessage = error.localizedDescription
-            return
-        }
-
-        sidebarViewModel.clearMeetingSelection()
-        viewModel.beginDraftMeeting(
-            from: event,
-            dbQueue: dbQueue,
-            vaultURL: vault.url
-        )
     }
 
     private func handleMeetingSelection(_ meetingId: UUID) {

--- a/Sources/Dahlia/Views/MenuBarAppActionsView.swift
+++ b/Sources/Dahlia/Views/MenuBarAppActionsView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct MenuBarAppActionsView: View {
+    @Environment(\.openWindow) private var openWindow
+    @Environment(\.openSettings) private var openSettings
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button(L10n.menuBarOpenDahlia, systemImage: "macwindow", action: openDahlia)
+            Button(L10n.manageProjects, systemImage: "folder", action: openProjectManager)
+            Button(L10n.settingsMenuItem, systemImage: "gearshape", action: showSettings)
+                .keyboardShortcut(",", modifiers: .command)
+            Button(L10n.menuBarQuitDahlia, systemImage: "power", action: quit)
+                .keyboardShortcut("q", modifiers: .command)
+        }
+        .buttonStyle(.borderless)
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .onAppear {
+            MainWindowOpener.shared.register(openWindow: openWindow)
+        }
+    }
+
+    private func openDahlia() {
+        MainWindowOpener.shared.openMainWindow()
+    }
+
+    private func openProjectManager() {
+        NSApp.activate(ignoringOtherApps: true)
+        openWindow(id: WindowID.projectManager)
+    }
+
+    private func showSettings() {
+        NSApp.activate(ignoringOtherApps: true)
+        openSettings()
+    }
+
+    private func quit() {
+        NSApplication.shared.terminate(nil)
+    }
+}

--- a/Sources/Dahlia/Views/MenuBarCalendarEventRow.swift
+++ b/Sources/Dahlia/Views/MenuBarCalendarEventRow.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct MenuBarCalendarEventRow: View {
     let event: CalendarEvent
     let now: Date
+    let canJoinAndRecord: Bool
     let canJoin: Bool
     let canShowInCalendar: Bool
     let onJoinAndRecord: () -> Void
@@ -12,7 +13,7 @@ struct MenuBarCalendarEventRow: View {
     var body: some View {
         Menu {
             Button(L10n.menuBarJoinMeetingWithRecording, systemImage: "record.circle", action: onJoinAndRecord)
-                .disabled(!canJoin)
+                .disabled(!canJoinAndRecord)
 
             Button(L10n.menuBarJoinMeeting, systemImage: "video.fill", action: onJoin)
                 .disabled(!canJoin)

--- a/Sources/Dahlia/Views/MenuBarCalendarEventRow.swift
+++ b/Sources/Dahlia/Views/MenuBarCalendarEventRow.swift
@@ -3,65 +3,53 @@ import SwiftUI
 struct MenuBarCalendarEventRow: View {
     let event: CalendarEvent
     let now: Date
-    let onOpen: () -> Void
-    let onJoin: (() -> Void)?
+    let canJoin: Bool
+    let canShowInCalendar: Bool
+    let onJoinAndRecord: () -> Void
+    let onJoin: () -> Void
+    let onShowInCalendar: () -> Void
+
+    var body: some View {
+        Menu {
+            Button(L10n.menuBarJoinMeetingWithRecording, systemImage: "record.circle", action: onJoinAndRecord)
+                .disabled(!canJoin)
+
+            Button(L10n.menuBarJoinMeeting, systemImage: "video.fill", action: onJoin)
+                .disabled(!canJoin)
+
+            Divider()
+
+            Button(L10n.menuBarShowEventInCalendar, systemImage: "calendar", action: onShowInCalendar)
+                .disabled(!canShowInCalendar)
+        } label: {
+            Label {
+                Text(menuTitle)
+            } icon: {
+                MenuBarCalendarParticipationIndicator(isAttending: event.isAttending)
+            }
+        }
+        .accessibilityLabel(accessibilityLabel)
+    }
 
     private var isOngoing: Bool {
         !event.isAllDay && event.startDate <= now && event.endDate > now
     }
 
-    var body: some View {
-        HStack(spacing: 10) {
-            Button(action: onOpen) {
-                HStack(spacing: 10) {
-                    Circle()
-                        .fill(event.calendarColorHex.map(Color.init(hex:)) ?? Color.accentColor)
-                        .frame(width: 9, height: 9)
-                        .accessibilityHidden(true)
+    private var menuTitle: String {
+        let progress = isOngoing ? " · \(L10n.menuBarInProgress)" : ""
+        return "\(timeText)  \(event.resolvedMeetingTitle)\(progress)"
+    }
 
-                    VStack(alignment: .leading, spacing: 3) {
-                        HStack(spacing: 6) {
-                            Text(event.resolvedMeetingTitle)
-                                .font(.headline)
-                                .lineLimit(1)
-
-                            if isOngoing {
-                                Text(L10n.menuBarInProgress)
-                                    .font(.caption)
-                                    .bold()
-                                    .foregroundStyle(.tint)
-                            }
-                        }
-
-                        Text("\(timeText) · \(event.calendarName)")
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                    }
-
-                    Spacer(minLength: 0)
-                }
-                .contentShape(.rect)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel(L10n.menuBarOpenEventInDahlia(event.resolvedMeetingTitle))
-
-            if let onJoin {
-                Button(L10n.join, systemImage: "video.fill", action: onJoin)
-                    .labelStyle(.iconOnly)
-                    .buttonStyle(.bordered)
-                    .help(L10n.join)
-            }
-        }
-        .padding(10)
-        .background(isOngoing ? Color.accentColor.opacity(0.1) : Color.clear, in: .rect(cornerRadius: 8))
+    private var accessibilityLabel: String {
+        let participation = event.isAttending ? ", \(L10n.calendarAttending)" : ""
+        return "\(event.resolvedMeetingTitle), \(timeText), \(event.calendarName)\(participation)"
     }
 
     private var timeText: String {
         if event.isAllDay {
             L10n.calendarAllDay
         } else {
-            "\(event.startDate.formatted(date: .omitted, time: .shortened))–\(event.endDate.formatted(date: .omitted, time: .shortened))"
+            event.startDate.formatted(date: .omitted, time: .shortened)
         }
     }
 }

--- a/Sources/Dahlia/Views/MenuBarCalendarEventRow.swift
+++ b/Sources/Dahlia/Views/MenuBarCalendarEventRow.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct MenuBarCalendarEventRow: View {
+    let event: CalendarEvent
+    let now: Date
+    let onOpen: () -> Void
+    let onJoin: (() -> Void)?
+
+    private var isOngoing: Bool {
+        !event.isAllDay && event.startDate <= now && event.endDate > now
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Button(action: onOpen) {
+                HStack(spacing: 10) {
+                    Circle()
+                        .fill(event.calendarColorHex.map(Color.init(hex:)) ?? Color.accentColor)
+                        .frame(width: 9, height: 9)
+                        .accessibilityHidden(true)
+
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(spacing: 6) {
+                            Text(event.resolvedMeetingTitle)
+                                .font(.headline)
+                                .lineLimit(1)
+
+                            if isOngoing {
+                                Text(L10n.menuBarInProgress)
+                                    .font(.caption)
+                                    .bold()
+                                    .foregroundStyle(.tint)
+                            }
+                        }
+
+                        Text("\(timeText) · \(event.calendarName)")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+
+                    Spacer(minLength: 0)
+                }
+                .contentShape(.rect)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(L10n.menuBarOpenEventInDahlia(event.resolvedMeetingTitle))
+
+            if let onJoin {
+                Button(L10n.join, systemImage: "video.fill", action: onJoin)
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.bordered)
+                    .help(L10n.join)
+            }
+        }
+        .padding(10)
+        .background(isOngoing ? Color.accentColor.opacity(0.1) : Color.clear, in: .rect(cornerRadius: 8))
+    }
+
+    private var timeText: String {
+        if event.isAllDay {
+            L10n.calendarAllDay
+        } else {
+            "\(event.startDate.formatted(date: .omitted, time: .shortened))–\(event.endDate.formatted(date: .omitted, time: .shortened))"
+        }
+    }
+}

--- a/Sources/Dahlia/Views/MenuBarCalendarParticipationIndicator.swift
+++ b/Sources/Dahlia/Views/MenuBarCalendarParticipationIndicator.swift
@@ -1,0 +1,35 @@
+import AppKit
+import SwiftUI
+
+struct MenuBarCalendarParticipationIndicator: View {
+    let isAttending: Bool
+
+    var body: some View {
+        Image(nsImage: isAttending ? Self.solidIndicator : Self.dottedIndicator)
+            .renderingMode(.template)
+            .accessibilityHidden(true)
+    }
+
+    private static let solidIndicator = makeIndicator(isSolid: true)
+    private static let dottedIndicator = makeIndicator(isSolid: false)
+
+    private static func makeIndicator(isSolid: Bool) -> NSImage {
+        let image = NSImage(size: NSSize(width: 6, height: 14), flipped: true) { _ in
+            NSColor.black.setFill()
+            if isSolid {
+                NSBezierPath(
+                    roundedRect: NSRect(x: 2, y: 1, width: 2, height: 12),
+                    xRadius: 1,
+                    yRadius: 1
+                ).fill()
+            } else {
+                for y in [1.5, 6, 10.5] {
+                    NSBezierPath(ovalIn: NSRect(x: 2, y: y, width: 2, height: 2)).fill()
+                }
+            }
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }
+}

--- a/Sources/Dahlia/Views/MenuBarCalendarSectionView.swift
+++ b/Sources/Dahlia/Views/MenuBarCalendarSectionView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct MenuBarCalendarSectionView: View {
     let agenda: MenuBarCalendarAgenda
     let now: Date
+    let canStartRecording: Bool
     let onJoinAndRecordEvent: (CalendarEvent) -> Void
     let onJoinEvent: (CalendarEvent) -> Void
     let onShowEventInCalendar: (CalendarEvent) -> Void
@@ -19,6 +20,7 @@ struct MenuBarCalendarSectionView: View {
                     MenuBarCalendarEventRow(
                         event: event,
                         now: now,
+                        canJoinAndRecord: event.conferenceURI != nil && canStartRecording,
                         canJoin: event.conferenceURI != nil,
                         canShowInCalendar: event.url != nil,
                         onJoinAndRecord: { onJoinAndRecordEvent(event) },
@@ -33,6 +35,9 @@ struct MenuBarCalendarSectionView: View {
                 statusLabel(L10n.calendarLoading, systemImage: "arrow.triangle.2.circlepath")
             } else if let issueTitle = sourceIssueTitle {
                 statusLabel(issueTitle, systemImage: "calendar.badge.exclamationmark")
+                calendarSettingsButton
+            } else if agenda.hasEventsExcludedByFilter {
+                statusLabel(L10n.calendarNoEventsMatchFiltersTitle, systemImage: "line.3.horizontal.decrease.circle")
                 calendarSettingsButton
             } else {
                 statusLabel(L10n.menuBarNoMoreEventsToday, systemImage: "calendar.badge.checkmark")

--- a/Sources/Dahlia/Views/MenuBarCalendarSectionView.swift
+++ b/Sources/Dahlia/Views/MenuBarCalendarSectionView.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+struct MenuBarCalendarSectionView: View {
+    let agenda: MenuBarCalendarAgenda
+    let now: Date
+    let onOpenEvent: (CalendarEvent) -> Void
+    let onJoinEvent: (CalendarEvent) -> Void
+    let onOpenCalendarSettings: () -> Void
+
+    @ObservedObject private var settings = AppSettings.shared
+    @ObservedObject private var googleCalendarStore = GoogleCalendarStore.shared
+    @ObservedObject private var macCalendarStore = MacCalendarStore.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(L10n.today, systemImage: "calendar")
+                .font(.headline)
+
+            if !settings.enabledCalendarSources.isEmpty, !agenda.events.isEmpty {
+                ScrollView {
+                    LazyVStack(spacing: 6) {
+                        ForEach(agenda.events) { event in
+                            MenuBarCalendarEventRow(
+                                event: event,
+                                now: now,
+                                onOpen: { onOpenEvent(event) },
+                                onJoin: event.conferenceURI == nil ? nil : { onJoinEvent(event) }
+                            )
+                        }
+                    }
+                }
+                .frame(maxHeight: 300)
+            } else {
+                emptyContent
+            }
+        }
+        .padding()
+    }
+
+    @ViewBuilder
+    private var emptyContent: some View {
+        if settings.enabledCalendarSources.isEmpty {
+            unavailableView(
+                title: L10n.calendarNoSourcesEnabledTitle,
+                message: L10n.calendarNoSourcesEnabledMessage
+            )
+        } else if isLoading {
+            ProgressView(L10n.calendarLoading)
+                .frame(maxWidth: .infinity, minHeight: 120)
+        } else if let issue = sourceIssue {
+            unavailableView(title: issue.title, message: issue.message)
+        } else {
+            ContentUnavailableView(
+                L10n.menuBarNoMoreEventsToday,
+                systemImage: "calendar.badge.checkmark",
+                description: Text(L10n.menuBarNoMoreEventsTodayDescription)
+            )
+            .frame(minHeight: 120)
+        }
+    }
+
+    private func unavailableView(title: String, message: String) -> some View {
+        ContentUnavailableView {
+            Label(title, systemImage: "calendar.badge.exclamationmark")
+        } description: {
+            Text(message)
+        } actions: {
+            Button(L10n.menuBarOpenCalendarSettings, action: onOpenCalendarSettings)
+        }
+        .frame(minHeight: 140)
+    }
+
+    private var isLoading: Bool {
+        (settings.isCalendarSourceEnabled(.google) && googleCalendarStore.state == .loading)
+            || (settings.isCalendarSourceEnabled(.macOS) && macCalendarStore.state == .loading)
+    }
+
+    private var sourceIssue: (title: String, message: String)? {
+        if settings.isCalendarSourceEnabled(.google) {
+            switch googleCalendarStore.state {
+            case .unconfigured:
+                return (L10n.googleCalendarClientIDMissingTitle, L10n.googleCalendarClientIDMissingMessage)
+            case .signedOut:
+                return (L10n.googleCalendarSignInRequiredTitle, L10n.googleCalendarScheduleSignInRequiredMessage)
+            case .needsCalendarSelection:
+                return (L10n.calendarSelectionRequiredTitle, L10n.calendarScheduleSelectionRequiredMessage)
+            case .failed:
+                return (
+                    L10n.googleCalendarLoadFailedTitle,
+                    googleCalendarStore.lastErrorMessage ?? L10n.googleCalendarUnexpectedResponse
+                )
+            case .loading, .loaded:
+                break
+            }
+        }
+
+        if settings.isCalendarSourceEnabled(.macOS) {
+            switch macCalendarStore.state {
+            case .notDetermined:
+                return (L10n.macOSCalendarAccessRequiredTitle, L10n.macOSCalendarAccessRequiredMessage)
+            case .accessDenied:
+                return (L10n.macOSCalendarAccessDeniedTitle, L10n.macOSCalendarAccessDeniedMessage)
+            case .needsCalendarSelection:
+                return (L10n.calendarSelectionRequiredTitle, L10n.calendarScheduleSelectionRequiredMessage)
+            case .failed:
+                return (
+                    L10n.macOSCalendarLoadFailedTitle,
+                    macCalendarStore.lastErrorMessage ?? L10n.macOSCalendarUnexpectedError
+                )
+            case .loading, .loaded:
+                break
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/Dahlia/Views/MenuBarCalendarSectionView.swift
+++ b/Sources/Dahlia/Views/MenuBarCalendarSectionView.swift
@@ -3,8 +3,9 @@ import SwiftUI
 struct MenuBarCalendarSectionView: View {
     let agenda: MenuBarCalendarAgenda
     let now: Date
-    let onOpenEvent: (CalendarEvent) -> Void
+    let onJoinAndRecordEvent: (CalendarEvent) -> Void
     let onJoinEvent: (CalendarEvent) -> Void
+    let onShowEventInCalendar: (CalendarEvent) -> Void
     let onOpenCalendarSettings: () -> Void
 
     @ObservedObject private var settings = AppSettings.shared
@@ -12,62 +13,40 @@ struct MenuBarCalendarSectionView: View {
     @ObservedObject private var macCalendarStore = MacCalendarStore.shared
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Label(L10n.today, systemImage: "calendar")
-                .font(.headline)
-
+        Section(L10n.today) {
             if !settings.enabledCalendarSources.isEmpty, !agenda.events.isEmpty {
-                ScrollView {
-                    LazyVStack(spacing: 6) {
-                        ForEach(agenda.events) { event in
-                            MenuBarCalendarEventRow(
-                                event: event,
-                                now: now,
-                                onOpen: { onOpenEvent(event) },
-                                onJoin: event.conferenceURI == nil ? nil : { onJoinEvent(event) }
-                            )
-                        }
-                    }
+                ForEach(agenda.events) { event in
+                    MenuBarCalendarEventRow(
+                        event: event,
+                        now: now,
+                        canJoin: event.conferenceURI != nil,
+                        canShowInCalendar: event.url != nil,
+                        onJoinAndRecord: { onJoinAndRecordEvent(event) },
+                        onJoin: { onJoinEvent(event) },
+                        onShowInCalendar: { onShowEventInCalendar(event) }
+                    )
                 }
-                .frame(maxHeight: 300)
+            } else if settings.enabledCalendarSources.isEmpty {
+                statusLabel(L10n.calendarNoSourcesEnabledTitle, systemImage: "calendar.badge.exclamationmark")
+                calendarSettingsButton
+            } else if isLoading {
+                statusLabel(L10n.calendarLoading, systemImage: "arrow.triangle.2.circlepath")
+            } else if let issueTitle = sourceIssueTitle {
+                statusLabel(issueTitle, systemImage: "calendar.badge.exclamationmark")
+                calendarSettingsButton
             } else {
-                emptyContent
+                statusLabel(L10n.menuBarNoMoreEventsToday, systemImage: "calendar.badge.checkmark")
             }
         }
-        .padding()
     }
 
-    @ViewBuilder
-    private var emptyContent: some View {
-        if settings.enabledCalendarSources.isEmpty {
-            unavailableView(
-                title: L10n.calendarNoSourcesEnabledTitle,
-                message: L10n.calendarNoSourcesEnabledMessage
-            )
-        } else if isLoading {
-            ProgressView(L10n.calendarLoading)
-                .frame(maxWidth: .infinity, minHeight: 120)
-        } else if let issue = sourceIssue {
-            unavailableView(title: issue.title, message: issue.message)
-        } else {
-            ContentUnavailableView(
-                L10n.menuBarNoMoreEventsToday,
-                systemImage: "calendar.badge.checkmark",
-                description: Text(L10n.menuBarNoMoreEventsTodayDescription)
-            )
-            .frame(minHeight: 120)
-        }
+    private func statusLabel(_ title: String, systemImage: String) -> some View {
+        Label(title, systemImage: systemImage)
+            .disabled(true)
     }
 
-    private func unavailableView(title: String, message: String) -> some View {
-        ContentUnavailableView {
-            Label(title, systemImage: "calendar.badge.exclamationmark")
-        } description: {
-            Text(message)
-        } actions: {
-            Button(L10n.menuBarOpenCalendarSettings, action: onOpenCalendarSettings)
-        }
-        .frame(minHeight: 140)
+    private var calendarSettingsButton: some View {
+        Button(L10n.menuBarOpenCalendarSettings, systemImage: "gearshape", action: onOpenCalendarSettings)
     }
 
     private var isLoading: Bool {
@@ -75,20 +54,17 @@ struct MenuBarCalendarSectionView: View {
             || (settings.isCalendarSourceEnabled(.macOS) && macCalendarStore.state == .loading)
     }
 
-    private var sourceIssue: (title: String, message: String)? {
+    private var sourceIssueTitle: String? {
         if settings.isCalendarSourceEnabled(.google) {
             switch googleCalendarStore.state {
             case .unconfigured:
-                return (L10n.googleCalendarClientIDMissingTitle, L10n.googleCalendarClientIDMissingMessage)
+                return L10n.googleCalendarClientIDMissingTitle
             case .signedOut:
-                return (L10n.googleCalendarSignInRequiredTitle, L10n.googleCalendarScheduleSignInRequiredMessage)
+                return L10n.googleCalendarSignInRequiredTitle
             case .needsCalendarSelection:
-                return (L10n.calendarSelectionRequiredTitle, L10n.calendarScheduleSelectionRequiredMessage)
+                return L10n.calendarSelectionRequiredTitle
             case .failed:
-                return (
-                    L10n.googleCalendarLoadFailedTitle,
-                    googleCalendarStore.lastErrorMessage ?? L10n.googleCalendarUnexpectedResponse
-                )
+                return L10n.googleCalendarLoadFailedTitle
             case .loading, .loaded:
                 break
             }
@@ -97,16 +73,13 @@ struct MenuBarCalendarSectionView: View {
         if settings.isCalendarSourceEnabled(.macOS) {
             switch macCalendarStore.state {
             case .notDetermined:
-                return (L10n.macOSCalendarAccessRequiredTitle, L10n.macOSCalendarAccessRequiredMessage)
+                return L10n.macOSCalendarAccessRequiredTitle
             case .accessDenied:
-                return (L10n.macOSCalendarAccessDeniedTitle, L10n.macOSCalendarAccessDeniedMessage)
+                return L10n.macOSCalendarAccessDeniedTitle
             case .needsCalendarSelection:
-                return (L10n.calendarSelectionRequiredTitle, L10n.calendarScheduleSelectionRequiredMessage)
+                return L10n.calendarSelectionRequiredTitle
             case .failed:
-                return (
-                    L10n.macOSCalendarLoadFailedTitle,
-                    macCalendarStore.lastErrorMessage ?? L10n.macOSCalendarUnexpectedError
-                )
+                return L10n.macOSCalendarLoadFailedTitle
             case .loading, .loaded:
                 break
             }

--- a/Sources/Dahlia/Views/MenuBarLabel.swift
+++ b/Sources/Dahlia/Views/MenuBarLabel.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct MenuBarLabel: View {
+    @ObservedObject var viewModel: CaptionViewModel
+    let calendarViewModel: MenuBarCalendarViewModel
+
+    @ObservedObject private var settings = AppSettings.shared
+    @ObservedObject private var googleCalendarStore = GoogleCalendarStore.shared
+    @ObservedObject private var macCalendarStore = MacCalendarStore.shared
+
+    var body: some View {
+        let agenda = MenuBarCalendarAgenda(
+            googleEvents: googleCalendarStore.upcomingEvents,
+            macEvents: macCalendarStore.upcomingEvents,
+            enabledSources: settings.enabledCalendarSources,
+            filter: settings.calendarEventFilter,
+            now: calendarViewModel.currentDate
+        )
+        let calendarText = settings.menuBarCalendarEnabled
+            ? agenda.labelText(
+                showsTitle: settings.menuBarCalendarShowsEventTitle,
+                showsCountdown: settings.menuBarCalendarShowsCountdown,
+                now: calendarViewModel.currentDate
+            )
+            : nil
+
+        Label {
+            Text(calendarText ?? L10n.dahlia)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: 320)
+        } icon: {
+            Image(systemName: viewModel.isListening ? "record.circle.fill" : "waveform")
+        }
+        .accessibilityLabel(
+            calendarText == nil
+                ? L10n.dahlia
+                : agenda.accessibilityLabel(now: calendarViewModel.currentDate) ?? L10n.dahlia
+        )
+        .task {
+            await calendarViewModel.runRefreshLoop()
+        }
+    }
+}

--- a/Sources/Dahlia/Views/MenuBarLabel.swift
+++ b/Sources/Dahlia/Views/MenuBarLabel.swift
@@ -23,20 +23,43 @@ struct MenuBarLabel: View {
                 now: calendarViewModel.currentDate
             )
             : nil
+        let calendarAccessibilityLabel = calendarText == nil
+            ? L10n.dahlia
+            : agenda.accessibilityLabel(now: calendarViewModel.currentDate) ?? L10n.dahlia
+        let accessibilityLabel = viewModel.isListening
+            ? "\(calendarAccessibilityLabel), \(L10n.recordingNow)"
+            : calendarAccessibilityLabel
 
-        Label {
-            Text(calendarText ?? L10n.dahlia)
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .frame(maxWidth: 320)
-        } icon: {
-            Image(systemName: viewModel.isListening ? "record.circle.fill" : "waveform")
+        Group {
+            if settings.menuBarCalendarEnabled,
+               let featuredEvent = agenda.featuredEvent,
+               let calendarText {
+                Label {
+                    Text(calendarText)
+                } icon: {
+                    if viewModel.isListening {
+                        Image(systemName: "record.circle.fill")
+                    } else {
+                        MenuBarCalendarParticipationIndicator(isAttending: featuredEvent.isAttending)
+                    }
+                }
+            } else if settings.menuBarCalendarEnabled {
+                if viewModel.isListening {
+                    Label(L10n.dahlia, systemImage: "record.circle.fill")
+                } else {
+                    Text(calendarText ?? L10n.dahlia)
+                }
+            } else {
+                Label(
+                    L10n.dahlia,
+                    systemImage: viewModel.isListening ? "record.circle.fill" : "waveform"
+                )
+            }
         }
-        .accessibilityLabel(
-            calendarText == nil
-                ? L10n.dahlia
-                : agenda.accessibilityLabel(now: calendarViewModel.currentDate) ?? L10n.dahlia
-        )
+        .labelStyle(.titleAndIcon)
+        .lineLimit(1)
+        .truncationMode(.tail)
+        .accessibilityLabel(accessibilityLabel)
         .task {
             await calendarViewModel.runRefreshLoop()
         }

--- a/Sources/Dahlia/Views/MenuBarLabel.swift
+++ b/Sources/Dahlia/Views/MenuBarLabel.swift
@@ -1,21 +1,14 @@
 import SwiftUI
 
 struct MenuBarLabel: View {
-    @ObservedObject var viewModel: CaptionViewModel
+    let viewModel: CaptionViewModel
     let calendarViewModel: MenuBarCalendarViewModel
 
     @ObservedObject private var settings = AppSettings.shared
-    @ObservedObject private var googleCalendarStore = GoogleCalendarStore.shared
-    @ObservedObject private var macCalendarStore = MacCalendarStore.shared
+    @State private var isListening = false
 
     var body: some View {
-        let agenda = MenuBarCalendarAgenda(
-            googleEvents: googleCalendarStore.upcomingEvents,
-            macEvents: macCalendarStore.upcomingEvents,
-            enabledSources: settings.enabledCalendarSources,
-            filter: settings.calendarEventFilter,
-            now: calendarViewModel.currentDate
-        )
+        let agenda = calendarViewModel.agenda
         let calendarText = settings.menuBarCalendarEnabled
             ? agenda.labelText(
                 showsTitle: settings.menuBarCalendarShowsEventTitle,
@@ -26,7 +19,7 @@ struct MenuBarLabel: View {
         let calendarAccessibilityLabel = calendarText == nil
             ? L10n.dahlia
             : agenda.accessibilityLabel(now: calendarViewModel.currentDate) ?? L10n.dahlia
-        let accessibilityLabel = viewModel.isListening
+        let accessibilityLabel = isListening
             ? "\(calendarAccessibilityLabel), \(L10n.recordingNow)"
             : calendarAccessibilityLabel
 
@@ -37,22 +30,21 @@ struct MenuBarLabel: View {
                 Label {
                     Text(calendarText)
                 } icon: {
-                    if viewModel.isListening {
+                    if isListening {
                         Image(systemName: "record.circle.fill")
                     } else {
                         MenuBarCalendarParticipationIndicator(isAttending: featuredEvent.isAttending)
                     }
                 }
             } else if settings.menuBarCalendarEnabled {
-                if viewModel.isListening {
-                    Label(L10n.dahlia, systemImage: "record.circle.fill")
-                } else {
-                    Text(calendarText ?? L10n.dahlia)
-                }
+                Label(
+                    L10n.dahlia,
+                    systemImage: isListening ? "record.circle.fill" : "waveform"
+                )
             } else {
                 Label(
                     L10n.dahlia,
-                    systemImage: viewModel.isListening ? "record.circle.fill" : "waveform"
+                    systemImage: isListening ? "record.circle.fill" : "waveform"
                 )
             }
         }
@@ -60,7 +52,9 @@ struct MenuBarLabel: View {
         .lineLimit(1)
         .truncationMode(.tail)
         .accessibilityLabel(accessibilityLabel)
+        .onReceive(viewModel.$isListening) { isListening = $0 }
         .task {
+            isListening = viewModel.isListening
             await calendarViewModel.runRefreshLoop()
         }
     }

--- a/Sources/Dahlia/Views/MenuBarMenuView.swift
+++ b/Sources/Dahlia/Views/MenuBarMenuView.swift
@@ -6,24 +6,15 @@ struct MenuBarMenuView: View {
     let calendarViewModel: MenuBarCalendarViewModel
 
     @ObservedObject private var settings = AppSettings.shared
-    @ObservedObject private var googleCalendarStore = GoogleCalendarStore.shared
-    @ObservedObject private var macCalendarStore = MacCalendarStore.shared
     @Environment(\.openSettings) private var openSettings
 
     var body: some View {
-        let agenda = MenuBarCalendarAgenda(
-            googleEvents: googleCalendarStore.upcomingEvents,
-            macEvents: macCalendarStore.upcomingEvents,
-            enabledSources: settings.enabledCalendarSources,
-            filter: settings.calendarEventFilter,
-            now: calendarViewModel.currentDate
-        )
-
-        VStack(spacing: 0) {
+        VStack {
             if settings.menuBarCalendarEnabled {
                 MenuBarCalendarSectionView(
-                    agenda: agenda,
+                    agenda: calendarViewModel.agenda,
                     now: calendarViewModel.currentDate,
+                    canStartRecording: recordingCoordinator.canStartNewMeeting,
                     onJoinAndRecordEvent: joinAndRecordEvent,
                     onJoinEvent: joinEvent,
                     onShowEventInCalendar: showEventInCalendar,
@@ -42,7 +33,6 @@ struct MenuBarMenuView: View {
 
             MenuBarAppActionsView()
         }
-        .frame(minWidth: 380, idealWidth: 420, maxWidth: 460)
     }
 
     private func joinAndRecordEvent(_ event: CalendarEvent) {

--- a/Sources/Dahlia/Views/MenuBarMenuView.swift
+++ b/Sources/Dahlia/Views/MenuBarMenuView.swift
@@ -1,195 +1,64 @@
-import AppKit
 import SwiftUI
 
 struct MenuBarMenuView: View {
     @ObservedObject var viewModel: CaptionViewModel
     let recordingCoordinator: RecordingCoordinator
+    let calendarViewModel: MenuBarCalendarViewModel
 
-    @Environment(\.openWindow) private var openWindow
+    @ObservedObject private var settings = AppSettings.shared
+    @ObservedObject private var googleCalendarStore = GoogleCalendarStore.shared
+    @ObservedObject private var macCalendarStore = MacCalendarStore.shared
     @Environment(\.openSettings) private var openSettings
-    @AppStorage("liveSubtitleOverlayEnabled") private var liveSubtitleOverlayEnabled = false
 
     var body: some View {
-        VStack {
-            if viewModel.isListening {
-                Button {
-                    recordingCoordinator.stopRecording()
-                } label: {
-                    Label(L10n.menuBarStopRecording, systemImage: "stop.fill")
-                }
-            } else {
-                Button {
-                    startRecording()
-                } label: {
-                    Label(L10n.menuBarStartRecording, systemImage: "record.circle")
-                }
-                .disabled(!recordingCoordinator.canStartNewMeeting && AppSettings.shared.currentVault != nil)
-            }
+        let agenda = MenuBarCalendarAgenda(
+            googleEvents: googleCalendarStore.upcomingEvents,
+            macEvents: macCalendarStore.upcomingEvents,
+            enabledSources: settings.enabledCalendarSources,
+            filter: settings.calendarEventFilter,
+            now: calendarViewModel.currentDate
+        )
 
-            Toggle(isOn: $liveSubtitleOverlayEnabled) {
-                Label(L10n.menuBarShowLiveSubtitles, systemImage: "text.bubble")
-            }
-
-            Divider()
-
-            recordingSettingsMenus
-
-            Divider()
-
-            Button {
-                MainWindowOpener.shared.openMainWindow()
-            } label: {
-                Label(L10n.menuBarOpenDahlia, systemImage: "macwindow")
-            }
-
-            Button {
-                NSApp.activate(ignoringOtherApps: true)
-                openWindow(id: WindowID.projectManager)
-            } label: {
-                Label(L10n.manageProjects, systemImage: "folder")
-            }
-
-            Divider()
-
-            Button {
-                NSApp.activate(ignoringOtherApps: true)
-                openSettings()
-            } label: {
-                Label(L10n.settingsMenuItem, systemImage: "gearshape")
-            }
-            .keyboardShortcut(",", modifiers: .command)
-
-            Button {
-                NSApplication.shared.terminate(nil)
-            } label: {
-                Label(L10n.menuBarQuitDahlia, systemImage: "power")
-            }
-            .keyboardShortcut("q", modifiers: .command)
-        }
-        .onAppear {
-            MainWindowOpener.shared.register(openWindow: openWindow)
-            viewModel.refreshAvailableWindows()
-        }
-        .task {
-            await viewModel.refreshAvailableMicrophones()
-        }
-    }
-
-    @ViewBuilder
-    private var recordingSettingsMenus: some View {
-        Menu {
-            Picker(selection: $viewModel.microphoneSelection) {
-                Text(L10n.none).tag(MicrophoneSelection.none)
+        VStack(spacing: 0) {
+            if settings.menuBarCalendarEnabled {
+                MenuBarCalendarSectionView(
+                    agenda: agenda,
+                    now: calendarViewModel.currentDate,
+                    onOpenEvent: openEvent,
+                    onJoinEvent: joinEvent,
+                    onOpenCalendarSettings: openCalendarSettings
+                )
 
                 Divider()
-
-                Text(viewModel.systemDefaultMicrophoneTitle).tag(MicrophoneSelection.systemDefault)
-
-                if !viewModel.availableMicrophones.isEmpty {
-                    Divider()
-                }
-
-                ForEach(viewModel.availableMicrophones) { microphone in
-                    Text(microphone.name).tag(MicrophoneSelection.device(microphone.id))
-                }
-            } label: {
-                EmptyView()
             }
-            .pickerStyle(.inline)
-            .labelsHidden()
-            .onChange(of: viewModel.microphoneSelection) { oldValue, newValue in
-                viewModel.handleMicrophoneSelectionChange(from: oldValue, to: newValue)
-            }
-        } label: {
-            Label(L10n.microphone, systemImage: "mic.fill")
+
+            MenuBarRecordingControls(
+                viewModel: viewModel,
+                recordingCoordinator: recordingCoordinator
+            )
+
+            Divider()
+
+            MenuBarAppActionsView()
         }
-        .task {
-            await viewModel.refreshAvailableMicrophones()
-        }
-
-        Menu {
-            Picker(selection: $viewModel.isSystemAudioEnabled) {
-                Text(L10n.noComputerAudio).tag(false)
-                Text(L10n.recordComputerAudio).tag(true)
-            } label: {
-                EmptyView()
-            }
-            .pickerStyle(.inline)
-            .labelsHidden()
-            .onChange(of: viewModel.isSystemAudioEnabled) { oldValue, newValue in
-                viewModel.handleSystemAudioSelectionChange(from: oldValue, to: newValue)
-            }
-        } label: {
-            Label(L10n.systemAudio, systemImage: "speaker.wave.2.fill")
-        }
-
-        Menu {
-            Picker(selection: $viewModel.selectedLocale) {
-                if viewModel.filteredLocales.isEmpty {
-                    let id = viewModel.selectedLocale
-                    let name = Locale.current.localizedString(forIdentifier: id) ?? id
-                    Text(name).tag(id)
-                } else {
-                    ForEach(viewModel.filteredLocales, id: \.identifier) { locale in
-                        let id = locale.identifier
-                        let name = locale.localizedString(forIdentifier: id) ?? id
-                        Text(name).tag(id)
-                    }
-                }
-            } label: {
-                EmptyView()
-            }
-            .pickerStyle(.inline)
-            .labelsHidden()
-        } label: {
-            Label(L10n.language, systemImage: "globe")
-        }
-
-        Menu {
-            Picker(selection: $viewModel.screenshotCaptureSource) {
-                Text(L10n.notSelected).tag(ScreenshotCaptureSource.none)
-
-                Divider()
-
-                Text(L10n.entireDesktop).tag(ScreenshotCaptureSource.entireDesktop)
-
-                if !viewModel.availableWindows.isEmpty {
-                    Divider()
-                }
-
-                ForEach(viewModel.availableWindows) { window in
-                    Text(window.displayName).tag(ScreenshotCaptureSource.window(window.id))
-                }
-            } label: {
-                EmptyView()
-            }
-            .pickerStyle(.inline)
-            .labelsHidden()
-        } label: {
-            Label(L10n.source, systemImage: "rectangle.on.rectangle")
-        }
-        .onAppear {
-            viewModel.refreshAvailableWindows()
-        }
+        .frame(minWidth: 380, idealWidth: 420, maxWidth: 460)
     }
 
-    private func startRecording() {
-        if AppSettings.shared.currentVault == nil {
-            MainWindowOpener.shared.openMainWindow()
-        } else {
-            recordingCoordinator.startNewMeeting()
-        }
+    private func openEvent(_ event: CalendarEvent) {
+        recordingCoordinator.openCalendarEvent(event)
     }
-}
 
-struct MenuBarLabel: View {
-    @ObservedObject var viewModel: CaptionViewModel
+    private func joinEvent(_ event: CalendarEvent) {
+        guard let conferenceURI = event.conferenceURI else { return }
+        NSWorkspace.shared.open(conferenceURI)
+    }
 
-    var body: some View {
-        Label {
-            Text("Dahlia")
-        } icon: {
-            Image(systemName: viewModel.isListening ? "record.circle.fill" : "waveform")
-        }
+    private func openCalendarSettings() {
+        UserDefaults.standard.set(
+            SettingsCategory.calendar.rawValue,
+            forKey: SettingsNavigation.selectedCategoryDefaultsKey
+        )
+        NSApp.activate(ignoringOtherApps: true)
+        openSettings()
     }
 }

--- a/Sources/Dahlia/Views/MenuBarMenuView.swift
+++ b/Sources/Dahlia/Views/MenuBarMenuView.swift
@@ -24,8 +24,9 @@ struct MenuBarMenuView: View {
                 MenuBarCalendarSectionView(
                     agenda: agenda,
                     now: calendarViewModel.currentDate,
-                    onOpenEvent: openEvent,
+                    onJoinAndRecordEvent: joinAndRecordEvent,
                     onJoinEvent: joinEvent,
+                    onShowEventInCalendar: showEventInCalendar,
                     onOpenCalendarSettings: openCalendarSettings
                 )
 
@@ -44,13 +45,18 @@ struct MenuBarMenuView: View {
         .frame(minWidth: 380, idealWidth: 420, maxWidth: 460)
     }
 
-    private func openEvent(_ event: CalendarEvent) {
-        recordingCoordinator.openCalendarEvent(event)
+    private func joinAndRecordEvent(_ event: CalendarEvent) {
+        recordingCoordinator.joinCalendarEventAndStartRecording(event)
     }
 
     private func joinEvent(_ event: CalendarEvent) {
         guard let conferenceURI = event.conferenceURI else { return }
         NSWorkspace.shared.open(conferenceURI)
+    }
+
+    private func showEventInCalendar(_ event: CalendarEvent) {
+        guard let eventURL = event.url else { return }
+        NSWorkspace.shared.open(eventURL)
     }
 
     private func openCalendarSettings() {

--- a/Sources/Dahlia/Views/MenuBarRecordingControls.swift
+++ b/Sources/Dahlia/Views/MenuBarRecordingControls.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+
+struct MenuBarRecordingControls: View {
+    @ObservedObject var viewModel: CaptionViewModel
+    let recordingCoordinator: RecordingCoordinator
+
+    @AppStorage("liveSubtitleOverlayEnabled") private var liveSubtitleOverlayEnabled = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Button(action: toggleRecording) {
+                Label(
+                    viewModel.isListening ? L10n.menuBarStopRecording : L10n.menuBarStartRecording,
+                    systemImage: viewModel.isListening ? "stop.fill" : "record.circle"
+                )
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(viewModel.isListening ? .red : .accentColor)
+            .disabled(!viewModel.isListening && !recordingCoordinator.canStartNewMeeting && AppSettings.shared.currentVault != nil)
+
+            Toggle(isOn: $liveSubtitleOverlayEnabled) {
+                Label(L10n.menuBarShowLiveSubtitles, systemImage: "text.bubble")
+            }
+            .toggleStyle(.switch)
+
+            recordingSettingsMenus
+        }
+        .padding()
+        .onAppear {
+            viewModel.refreshAvailableWindows()
+        }
+        .task {
+            await viewModel.refreshAvailableMicrophones()
+        }
+    }
+
+    @ViewBuilder
+    private var recordingSettingsMenus: some View {
+        Menu {
+            Picker(selection: $viewModel.microphoneSelection) {
+                Text(L10n.none).tag(MicrophoneSelection.none)
+                Divider()
+                Text(viewModel.systemDefaultMicrophoneTitle).tag(MicrophoneSelection.systemDefault)
+
+                if !viewModel.availableMicrophones.isEmpty {
+                    Divider()
+                }
+
+                ForEach(viewModel.availableMicrophones) { microphone in
+                    Text(microphone.name).tag(MicrophoneSelection.device(microphone.id))
+                }
+            } label: {
+                EmptyView()
+            }
+            .pickerStyle(.inline)
+            .labelsHidden()
+            .onChange(of: viewModel.microphoneSelection) { oldValue, newValue in
+                viewModel.handleMicrophoneSelectionChange(from: oldValue, to: newValue)
+            }
+        } label: {
+            Label(L10n.microphone, systemImage: "mic.fill")
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        Menu {
+            Picker(selection: $viewModel.isSystemAudioEnabled) {
+                Text(L10n.noComputerAudio).tag(false)
+                Text(L10n.recordComputerAudio).tag(true)
+            } label: {
+                EmptyView()
+            }
+            .pickerStyle(.inline)
+            .labelsHidden()
+            .onChange(of: viewModel.isSystemAudioEnabled) { oldValue, newValue in
+                viewModel.handleSystemAudioSelectionChange(from: oldValue, to: newValue)
+            }
+        } label: {
+            Label(L10n.systemAudio, systemImage: "speaker.wave.2.fill")
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        Menu {
+            Picker(selection: $viewModel.selectedLocale) {
+                if viewModel.filteredLocales.isEmpty {
+                    let id = viewModel.selectedLocale
+                    let name = Locale.current.localizedString(forIdentifier: id) ?? id
+                    Text(name).tag(id)
+                } else {
+                    ForEach(viewModel.filteredLocales, id: \.identifier) { locale in
+                        let id = locale.identifier
+                        let name = locale.localizedString(forIdentifier: id) ?? id
+                        Text(name).tag(id)
+                    }
+                }
+            } label: {
+                EmptyView()
+            }
+            .pickerStyle(.inline)
+            .labelsHidden()
+        } label: {
+            Label(L10n.language, systemImage: "globe")
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        Menu {
+            Picker(selection: $viewModel.screenshotCaptureSource) {
+                Text(L10n.notSelected).tag(ScreenshotCaptureSource.none)
+                Divider()
+                Text(L10n.entireDesktop).tag(ScreenshotCaptureSource.entireDesktop)
+
+                if !viewModel.availableWindows.isEmpty {
+                    Divider()
+                }
+
+                ForEach(viewModel.availableWindows) { window in
+                    Text(window.displayName).tag(ScreenshotCaptureSource.window(window.id))
+                }
+            } label: {
+                EmptyView()
+            }
+            .pickerStyle(.inline)
+            .labelsHidden()
+        } label: {
+            Label(L10n.source, systemImage: "rectangle.on.rectangle")
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func toggleRecording() {
+        if viewModel.isListening {
+            recordingCoordinator.stopRecording()
+        } else if AppSettings.shared.currentVault == nil {
+            MainWindowOpener.shared.openMainWindow()
+        } else {
+            recordingCoordinator.startNewMeeting()
+        }
+    }
+}

--- a/Sources/Dahlia/Views/MenuBarRecordingControls.swift
+++ b/Sources/Dahlia/Views/MenuBarRecordingControls.swift
@@ -7,26 +7,20 @@ struct MenuBarRecordingControls: View {
     @AppStorage("liveSubtitleOverlayEnabled") private var liveSubtitleOverlayEnabled = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack {
             Button(action: toggleRecording) {
                 Label(
                     viewModel.isListening ? L10n.menuBarStopRecording : L10n.menuBarStartRecording,
                     systemImage: viewModel.isListening ? "stop.fill" : "record.circle"
                 )
-                .frame(maxWidth: .infinity)
             }
-            .buttonStyle(.borderedProminent)
-            .tint(viewModel.isListening ? .red : .accentColor)
             .disabled(!viewModel.isListening && !recordingCoordinator.canStartNewMeeting && AppSettings.shared.currentVault != nil)
 
             Toggle(isOn: $liveSubtitleOverlayEnabled) {
                 Label(L10n.menuBarShowLiveSubtitles, systemImage: "text.bubble")
             }
-            .toggleStyle(.switch)
-
             recordingSettingsMenus
         }
-        .padding()
         .onAppear {
             viewModel.refreshAvailableWindows()
         }
@@ -60,7 +54,6 @@ struct MenuBarRecordingControls: View {
             }
         } label: {
             Label(L10n.microphone, systemImage: "mic.fill")
-                .frame(maxWidth: .infinity, alignment: .leading)
         }
 
         Menu {
@@ -77,7 +70,6 @@ struct MenuBarRecordingControls: View {
             }
         } label: {
             Label(L10n.systemAudio, systemImage: "speaker.wave.2.fill")
-                .frame(maxWidth: .infinity, alignment: .leading)
         }
 
         Menu {
@@ -100,7 +92,6 @@ struct MenuBarRecordingControls: View {
             .labelsHidden()
         } label: {
             Label(L10n.language, systemImage: "globe")
-                .frame(maxWidth: .infinity, alignment: .leading)
         }
 
         Menu {
@@ -123,7 +114,6 @@ struct MenuBarRecordingControls: View {
             .labelsHidden()
         } label: {
             Label(L10n.source, systemImage: "rectangle.on.rectangle")
-                .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 

--- a/Sources/Dahlia/Views/Settings/CalendarEventFilterSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/CalendarEventFilterSettingsView.swift
@@ -5,39 +5,39 @@ struct CalendarEventFilterSettingsView: View {
 
     var body: some View {
         Section {
-            Toggle(isOn: $settings.excludeAllDayCalendarEvents) {
+            Toggle(isOn: $settings.includesAllDayCalendarEvents) {
                 Text(L10n.calendarFilterAllDayEvents)
-                Text(L10n.calendarFilterAllDayEventsDescription)
+                Text(L10n.calendarIncludeAllDayEventsDescription)
             }
             .toggleStyle(.checkbox)
 
-            Toggle(isOn: $settings.excludeCalendarEventsWithoutOtherAttendees) {
+            Toggle(isOn: $settings.includesCalendarEventsWithoutOtherAttendees) {
                 Text(L10n.calendarFilterUserOnlyEvents)
-                Text(L10n.calendarFilterUserOnlyEventsDescription)
+                Text(L10n.calendarIncludeUserOnlyEventsDescription)
             }
             .toggleStyle(.checkbox)
 
-            Toggle(isOn: $settings.excludeCalendarEventsWithoutConferenceURI) {
+            Toggle(isOn: $settings.includesCalendarEventsWithoutConferenceURI) {
                 Text(L10n.calendarFilterEventsWithoutMeetingURL)
-                Text(L10n.calendarFilterEventsWithoutMeetingURLDescription)
+                Text(L10n.calendarIncludeEventsWithoutMeetingURLDescription)
             }
             .toggleStyle(.checkbox)
 
-            Toggle(isOn: $settings.excludeDeclinedCalendarEvents) {
+            Toggle(isOn: $settings.includesDeclinedCalendarEvents) {
                 Text(L10n.calendarFilterDeclinedEvents)
-                Text(L10n.calendarFilterDeclinedEventsDescription)
+                Text(L10n.calendarIncludeDeclinedEventsDescription)
             }
             .toggleStyle(.checkbox)
 
-            Toggle(isOn: $settings.excludeOutOfOfficeCalendarEvents) {
+            Toggle(isOn: $settings.includesOutOfOfficeCalendarEvents) {
                 Text(L10n.calendarFilterOutOfOfficeEvents)
-                Text(L10n.calendarFilterOutOfOfficeEventsDescription)
+                Text(L10n.calendarIncludeOutOfOfficeEventsDescription)
             }
             .toggleStyle(.checkbox)
         } header: {
-            Text(L10n.calendarEventFilters)
+            Text(L10n.calendarEventsToInclude)
         } footer: {
-            Text(L10n.calendarEventFiltersDescription)
+            Text(L10n.calendarEventsToIncludeDescription)
         }
     }
 }

--- a/Sources/Dahlia/Views/Settings/CalendarSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/CalendarSettingsView.swift
@@ -8,6 +8,32 @@ struct CalendarSettingsView: View {
     var body: some View {
         Form {
             Section {
+                Toggle(isOn: $settings.menuBarCalendarEnabled) {
+                    Text(L10n.menuBarCalendarDisplay)
+                    Text(L10n.menuBarCalendarDisplayDescription)
+                }
+                .toggleStyle(.switch)
+
+                Toggle(isOn: $settings.menuBarCalendarShowsEventTitle) {
+                    Text(L10n.menuBarCalendarEventTitle)
+                    Text(L10n.menuBarCalendarEventTitleDescription)
+                }
+                .toggleStyle(.switch)
+                .disabled(!settings.menuBarCalendarEnabled)
+
+                Toggle(isOn: $settings.menuBarCalendarShowsCountdown) {
+                    Text(L10n.menuBarCalendarCountdown)
+                    Text(L10n.menuBarCalendarCountdownDescription)
+                }
+                .toggleStyle(.switch)
+                .disabled(!settings.menuBarCalendarEnabled)
+            } header: {
+                Text(L10n.menuBarCalendar)
+            } footer: {
+                Text(L10n.menuBarCalendarDescription)
+            }
+
+            Section {
                 ForEach(CalendarSource.allCases) { source in
                     Toggle(isOn: calendarSourceBinding(for: source)) {
                         Text(source.displayName)

--- a/Sources/Dahlia/Views/Settings/CalendarSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/CalendarSettingsView.swift
@@ -33,8 +33,10 @@ struct CalendarSettingsView: View {
                 Text(L10n.menuBarCalendarDescription)
             }
 
+            CalendarEventFilterSettingsView(settings: settings)
+
             Section {
-                ForEach(CalendarSource.allCases) { source in
+                ForEach(displayedCalendarSources) { source in
                     Toggle(isOn: calendarSourceBinding(for: source)) {
                         Text(source.displayName)
                         Text(calendarSourceDescription(for: source))
@@ -47,14 +49,12 @@ struct CalendarSettingsView: View {
                 Text(L10n.calendarSourcesDescription)
             }
 
-            CalendarEventFilterSettingsView(settings: settings)
+            if settings.isCalendarSourceEnabled(.macOS) {
+                macCalendarSettings
+            }
 
             if settings.isCalendarSourceEnabled(.google) {
                 googleCalendarSettings
-            }
-
-            if settings.isCalendarSourceEnabled(.macOS) {
-                macCalendarSettings
             }
         }
         .task {
@@ -66,6 +66,10 @@ struct CalendarSettingsView: View {
             }
         }
         .formStyle(.grouped)
+    }
+
+    private var displayedCalendarSources: [CalendarSource] {
+        [.macOS, .google]
     }
 
     @ViewBuilder

--- a/Tests/DahliaTests/CalendarEventFilterTests.swift
+++ b/Tests/DahliaTests/CalendarEventFilterTests.swift
@@ -6,56 +6,54 @@ import Foundation
 
     struct CalendarEventFilterTests {
         @Test
-        func includesEventWhenNoFiltersAreEnabled() {
-            let event = makeEvent(
-                isAllDay: true,
-                hasOtherAttendees: false,
-                isDeclined: true,
-                isOutOfOffice: true,
-                conferenceURI: nil
-            )
-
-            #expect(CalendarEventFilter().includes(event))
+        func includesRegularEventsByDefault() {
+            #expect(CalendarEventFilter().includes(makeEvent()))
         }
 
         @Test
-        func excludesAllDayEvents() {
-            let filter = CalendarEventFilter(excludesAllDayEvents: true)
+        func excludesOptionalEventTypesByDefault() {
+            let filter = CalendarEventFilter()
 
             #expect(!filter.includes(makeEvent(isAllDay: true)))
-            #expect(filter.includes(makeEvent()))
-        }
-
-        @Test
-        func excludesEventsWithoutOtherAttendees() {
-            let filter = CalendarEventFilter(excludesEventsWithoutOtherAttendees: true)
-
             #expect(!filter.includes(makeEvent(hasOtherAttendees: false)))
-            #expect(filter.includes(makeEvent(hasOtherAttendees: true)))
-        }
-
-        @Test
-        func excludesEventsWithoutConferenceURI() {
-            let filter = CalendarEventFilter(excludesEventsWithoutConferenceURI: true)
-
             #expect(!filter.includes(makeEvent(conferenceURI: nil)))
-            #expect(filter.includes(makeEvent(conferenceURI: URL(string: "https://meet.example.com/room"))))
-        }
-
-        @Test
-        func excludesDeclinedEvents() {
-            let filter = CalendarEventFilter(excludesDeclinedEvents: true)
-
             #expect(!filter.includes(makeEvent(isDeclined: true)))
-            #expect(filter.includes(makeEvent(isDeclined: false)))
+            #expect(!filter.includes(makeEvent(isOutOfOffice: true)))
         }
 
         @Test
-        func excludesOutOfOfficeEvents() {
-            let filter = CalendarEventFilter(excludesOutOfOfficeEvents: true)
+        func includesAllDayEventsWhenEnabled() {
+            let filter = CalendarEventFilter(includesAllDayEvents: true)
 
-            #expect(!filter.includes(makeEvent(isOutOfOffice: true)))
-            #expect(filter.includes(makeEvent(isOutOfOffice: false)))
+            #expect(filter.includes(makeEvent(isAllDay: true)))
+        }
+
+        @Test
+        func includesEventsWithoutOtherAttendeesWhenEnabled() {
+            let filter = CalendarEventFilter(includesEventsWithoutOtherAttendees: true)
+
+            #expect(filter.includes(makeEvent(hasOtherAttendees: false)))
+        }
+
+        @Test
+        func includesEventsWithoutConferenceURIWhenEnabled() {
+            let filter = CalendarEventFilter(includesEventsWithoutConferenceURI: true)
+
+            #expect(filter.includes(makeEvent(conferenceURI: nil)))
+        }
+
+        @Test
+        func includesDeclinedEventsWhenEnabled() {
+            let filter = CalendarEventFilter(includesDeclinedEvents: true)
+
+            #expect(filter.includes(makeEvent(isDeclined: true)))
+        }
+
+        @Test
+        func includesOutOfOfficeEventsWhenEnabled() {
+            let filter = CalendarEventFilter(includesOutOfOfficeEvents: true)
+
+            #expect(filter.includes(makeEvent(isOutOfOffice: true)))
         }
 
         @Test(arguments: [

--- a/Tests/DahliaTests/CalendarEventFilterTests.swift
+++ b/Tests/DahliaTests/CalendarEventFilterTests.swift
@@ -15,10 +15,27 @@ import Foundation
             let filter = CalendarEventFilter()
 
             #expect(!filter.includes(makeEvent(isAllDay: true)))
-            #expect(!filter.includes(makeEvent(hasOtherAttendees: false)))
-            #expect(!filter.includes(makeEvent(conferenceURI: nil)))
+            #expect(filter.includes(makeEvent(hasOtherAttendees: false)))
+            #expect(filter.includes(makeEvent(conferenceURI: nil)))
             #expect(!filter.includes(makeEvent(isDeclined: true)))
             #expect(!filter.includes(makeEvent(isOutOfOffice: true)))
+        }
+
+        @Test
+        func migratesLegacyExclusionSettingsWithoutOverwritingCurrentValues() throws {
+            let suiteName = "CalendarEventFilterTests.\(UUID().uuidString)"
+            let defaults = try #require(UserDefaults(suiteName: suiteName))
+            defer { defaults.removePersistentDomain(forName: suiteName) }
+
+            defaults.set(false, forKey: "excludeAllDayCalendarEvents")
+            defaults.set(true, forKey: "excludeCalendarEventsWithoutOtherAttendees")
+            defaults.set(false, forKey: "includesCalendarEventsWithoutConferenceURI")
+
+            AppSettings.migrateCalendarEventFilterSettings(in: defaults)
+
+            #expect(defaults.bool(forKey: "includesAllDayCalendarEvents"))
+            #expect(!defaults.bool(forKey: "includesCalendarEventsWithoutOtherAttendees"))
+            #expect(!defaults.bool(forKey: "includesCalendarEventsWithoutConferenceURI"))
         }
 
         @Test

--- a/Tests/DahliaTests/CalendarMeetingNotificationPlannerTests.swift
+++ b/Tests/DahliaTests/CalendarMeetingNotificationPlannerTests.swift
@@ -58,7 +58,7 @@ import Foundation
                 title: "Alex - OOTO",
                 startDate: now.addingTimeInterval(300)
             )
-            let filter = CalendarEventFilter(excludesOutOfOfficeEvents: true)
+            let filter = CalendarEventFilter(includesOutOfOfficeEvents: false)
 
             let schedule = CalendarMeetingNotificationPlanner.schedule(
                 for: [outOfOffice, included],
@@ -90,6 +90,7 @@ private func calendarEvent(
         startDate: startDate,
         endDate: startDate.addingTimeInterval(3600),
         isAllDay: isAllDay,
+        hasOtherAttendees: true,
         conferenceURI: URL(string: "https://meet.example.com/planning")
     )
 }

--- a/Tests/DahliaTests/DetectedMeetingCodableTests.swift
+++ b/Tests/DahliaTests/DetectedMeetingCodableTests.swift
@@ -66,6 +66,7 @@ import Foundation
             legacyObject.removeValue(forKey: "recurrenceId")
             legacyObject.removeValue(forKey: "hasOtherAttendees")
             legacyObject.removeValue(forKey: "isDeclined")
+            legacyObject.removeValue(forKey: "isAttending")
             legacyObject.removeValue(forKey: "isOutOfOffice")
             let legacyData = try JSONSerialization.data(withJSONObject: legacyObject)
 
@@ -76,6 +77,7 @@ import Foundation
             #expect(decoded.recurrenceId.isEmpty)
             #expect(!decoded.hasOtherAttendees)
             #expect(!decoded.isDeclined)
+            #expect(!decoded.isAttending)
             #expect(!decoded.isOutOfOffice)
         }
     }

--- a/Tests/DahliaTests/GoogleCalendarAPIClientTests.swift
+++ b/Tests/DahliaTests/GoogleCalendarAPIClientTests.swift
@@ -162,6 +162,35 @@ struct GoogleCalendarAPIClientTests {
 
         #expect(event.hasOtherAttendees)
         #expect(event.isDeclined)
+        #expect(!event.isAttending)
+    }
+
+    @Test
+    func eventPayloadMarksAcceptedCurrentUserAsAttending() throws {
+        let data = Data("""
+        {
+          "items": [
+            {
+              "id": "accepted-meeting",
+              "start": { "dateTime": "2026-04-17T01:00:00Z" },
+              "end": { "dateTime": "2026-04-17T02:00:00Z" },
+              "attendees": [
+                { "email": "me@example.com", "self": true, "responseStatus": "accepted" },
+                { "email": "colleague@example.com", "responseStatus": "accepted" }
+              ]
+            }
+          ]
+        }
+        """.utf8)
+
+        let response = try JSONDecoder().decode(GoogleCalendarAPIClient.EventListResponse.self, from: data)
+        let item = try #require(response.items.first)
+        let transformed = try GoogleCalendarAPIClient.makeEvent(
+            from: item,
+            calendarItem: GoogleCalendarListItem(id: "primary", title: "Primary", colorHex: nil, isPrimary: true)
+        )
+
+        #expect(transformed?.isAttending == true)
     }
 
     @Test

--- a/Tests/DahliaTests/GoogleCalendarAPIClientTests.swift
+++ b/Tests/DahliaTests/GoogleCalendarAPIClientTests.swift
@@ -193,6 +193,34 @@ struct GoogleCalendarAPIClientTests {
         #expect(transformed?.isAttending == true)
     }
 
+    @Test(arguments: [
+        ", \"organizer\": { \"self\": true }",
+        "",
+    ])
+    func eventPayloadTreatsOrganizerOrMissingAttendeesAsAttending(_ participationJSON: String) throws {
+        let data = Data("""
+        {
+          "items": [
+            {
+              "id": "owned-meeting",
+              "start": { "dateTime": "2026-04-17T01:00:00Z" },
+              "end": { "dateTime": "2026-04-17T02:00:00Z" }
+              \(participationJSON)
+            }
+          ]
+        }
+        """.utf8)
+
+        let response = try JSONDecoder().decode(GoogleCalendarAPIClient.EventListResponse.self, from: data)
+        let item = try #require(response.items.first)
+        let transformed = try GoogleCalendarAPIClient.makeEvent(
+            from: item,
+            calendarItem: GoogleCalendarListItem(id: "primary", title: "Primary", colorHex: nil, isPrimary: true)
+        )
+
+        #expect(transformed?.isAttending == true)
+    }
+
     @Test
     func originalStartTimeUsesItsIANATimeZoneWhenOffsetIsOmitted() throws {
         let data = Data("""

--- a/Tests/DahliaTests/MenuBarCalendarAgendaTests.swift
+++ b/Tests/DahliaTests/MenuBarCalendarAgendaTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct MenuBarCalendarAgendaTests {
+        private let now = Date(timeIntervalSince1970: 1_773_576_000) // 2026-03-15 12:00:00 UTC
+        private var calendar: Calendar {
+            var calendar = Calendar(identifier: .gregorian)
+            calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+            return calendar
+        }
+
+        @Test
+        func includesOnlyOngoingAndUpcomingEventsToday() {
+            let ended = event(id: "ended", start: -7_200, end: -3_600)
+            let overnight = event(id: "overnight", start: -46_800, end: 1_800)
+            let upcoming = event(id: "upcoming", start: 3_600, end: 7_200)
+            let tomorrow = event(id: "tomorrow", start: 46_800, end: 50_400)
+
+            let agenda = agenda(googleEvents: [ended, overnight, upcoming, tomorrow])
+
+            #expect(agenda.events.map(\.id) == [overnight.id, upcoming.id])
+            #expect(agenda.featuredEvent?.id == overnight.id)
+            #expect(agenda.featuredEventIsOngoing)
+        }
+
+        @Test
+        func appliesEnabledSourcesFiltersAndCrossSourceDeduplication() {
+            let googleEvent = event(
+                id: "google",
+                platform: CalendarEventPlatform.googleCalendar,
+                icalUid: "shared",
+                start: 3_600,
+                end: 7_200
+            )
+            let duplicateMacEvent = event(
+                id: "mac-duplicate",
+                platform: CalendarEventPlatform.macOSCalendar,
+                icalUid: "shared",
+                start: 3_600,
+                end: 7_200
+            )
+            let declined = event(id: "declined", start: 7_200, end: 10_800, isDeclined: true)
+
+            let agenda = MenuBarCalendarAgenda(
+                googleEvents: [googleEvent, declined],
+                macEvents: [duplicateMacEvent],
+                enabledSources: [.google, .macOS],
+                filter: CalendarEventFilter(excludesDeclinedEvents: true),
+                now: now,
+                calendar: calendar
+            )
+
+            #expect(agenda.events.map(\.id) == [googleEvent.id])
+        }
+
+        @Test
+        func prioritizesMostRecentlyStartedOngoingEventThenNextEvent() {
+            let earlierOngoing = event(id: "earlier", start: -1_800, end: 3_600)
+            let laterOngoing = event(id: "later", start: -600, end: 1_800)
+            let next = event(id: "next", start: 3_600, end: 7_200)
+
+            let ongoingAgenda = agenda(googleEvents: [next, earlierOngoing, laterOngoing])
+            let upcomingAgenda = agenda(googleEvents: [next])
+
+            #expect(ongoingAgenda.featuredEvent?.id == laterOngoing.id)
+            #expect(ongoingAgenda.featuredEventIsOngoing)
+            #expect(upcomingAgenda.featuredEvent?.id == next.id)
+            #expect(!upcomingAgenda.featuredEventIsOngoing)
+        }
+
+        @Test
+        func keepsAllDayEventsInListButNotInMenuBarLabel() {
+            let startOfDay = calendar.startOfDay(for: now)
+            let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)
+                ?? startOfDay.addingTimeInterval(86_400)
+            let allDay = event(
+                id: "all-day",
+                startDate: startOfDay,
+                endDate: endOfDay,
+                isAllDay: true
+            )
+
+            let agenda = agenda(googleEvents: [allDay])
+
+            #expect(agenda.events == [allDay])
+            #expect(agenda.featuredEvent == nil)
+        }
+
+        @Test
+        func roundsCountdownUpAndHonorsLabelSettings() {
+            let upcoming = event(id: "upcoming", title: "Planning", start: 3_601, end: 7_200)
+            let agenda = agenda(googleEvents: [upcoming])
+
+            #expect(MenuBarCalendarAgenda.remainingMinutes(from: now, to: upcoming.startDate) == 61)
+            #expect(agenda.labelText(showsTitle: true, showsCountdown: false, now: now) == "Planning")
+            #expect(agenda.labelText(showsTitle: false, showsCountdown: false, now: now) == nil)
+            #expect(agenda.labelText(showsTitle: false, showsCountdown: true, now: now)?.isEmpty == false)
+            #expect(agenda.labelText(showsTitle: true, showsCountdown: true, now: now)?.contains("Planning") == true)
+        }
+
+        @Test
+        func usesSoonTextForEventsStartingOrEndingInLessThanOneMinute() {
+            let startingSoon = event(id: "starting", start: 59, end: 3_600)
+            let endingSoon = event(id: "ending", start: -3_600, end: 59)
+
+            #expect(agenda(googleEvents: [startingSoon]).countdownText(now: now) == L10n.menuBarStartingSoon)
+            #expect(agenda(googleEvents: [endingSoon]).countdownText(now: now) == L10n.menuBarEndingSoon)
+        }
+
+        private func agenda(googleEvents: [CalendarEvent]) -> MenuBarCalendarAgenda {
+            MenuBarCalendarAgenda(
+                googleEvents: googleEvents,
+                macEvents: [],
+                enabledSources: [.google],
+                filter: CalendarEventFilter(),
+                now: now,
+                calendar: calendar
+            )
+        }
+
+        private func event(
+            id: String,
+            title: String = "Event",
+            platform: String = CalendarEventPlatform.googleCalendar,
+            icalUid: String? = nil,
+            start: TimeInterval,
+            end: TimeInterval,
+            isAllDay: Bool = false,
+            isDeclined: Bool = false
+        ) -> CalendarEvent {
+            event(
+                id: id,
+                title: title,
+                platform: platform,
+                icalUid: icalUid,
+                startDate: now.addingTimeInterval(start),
+                endDate: now.addingTimeInterval(end),
+                isAllDay: isAllDay,
+                isDeclined: isDeclined
+            )
+        }
+
+        private func event(
+            id: String,
+            title: String = "Event",
+            platform: String = CalendarEventPlatform.googleCalendar,
+            icalUid: String? = nil,
+            startDate: Date,
+            endDate: Date,
+            isAllDay: Bool = false,
+            isDeclined: Bool = false
+        ) -> CalendarEvent {
+            CalendarEvent(
+                id: id,
+                calendarID: "calendar-\(platform)",
+                calendarName: "Calendar",
+                calendarColorHex: nil,
+                platform: platform,
+                platformId: id,
+                title: title,
+                description: "",
+                icalUid: icalUid,
+                startDate: startDate,
+                endDate: endDate,
+                isAllDay: isAllDay,
+                isDeclined: isDeclined,
+                conferenceURI: URL(string: "https://meet.example.com/\(id)")
+            )
+        }
+    }
+#endif

--- a/Tests/DahliaTests/MenuBarCalendarAgendaTests.swift
+++ b/Tests/DahliaTests/MenuBarCalendarAgendaTests.swift
@@ -57,6 +57,25 @@ import Foundation
         }
 
         @Test
+        func distinguishesEventsExcludedByFiltersFromAnEmptyCalendar() {
+            let declined = event(id: "declined", start: 3_600, end: 7_200, isDeclined: true)
+
+            let filteredAgenda = MenuBarCalendarAgenda(
+                googleEvents: [declined],
+                macEvents: [],
+                enabledSources: [.google],
+                filter: CalendarEventFilter(includesDeclinedEvents: false),
+                now: now,
+                calendar: calendar
+            )
+            let emptyAgenda = agenda(googleEvents: [])
+
+            #expect(filteredAgenda.events.isEmpty)
+            #expect(filteredAgenda.hasEventsExcludedByFilter)
+            #expect(!emptyAgenda.hasEventsExcludedByFilter)
+        }
+
+        @Test
         func prioritizesMostRecentlyStartedOngoingEventThenNextEvent() {
             let earlierOngoing = event(id: "earlier", start: -1_800, end: 3_600)
             let laterOngoing = event(id: "later", start: -600, end: 1_800)

--- a/Tests/DahliaTests/MenuBarCalendarAgendaTests.swift
+++ b/Tests/DahliaTests/MenuBarCalendarAgendaTests.swift
@@ -48,7 +48,7 @@ import Foundation
                 googleEvents: [googleEvent, declined],
                 macEvents: [duplicateMacEvent],
                 enabledSources: [.google, .macOS],
-                filter: CalendarEventFilter(excludesDeclinedEvents: true),
+                filter: CalendarEventFilter(includesDeclinedEvents: false),
                 now: now,
                 calendar: calendar
             )
@@ -102,6 +102,16 @@ import Foundation
         }
 
         @Test
+        func truncatesLongMenuBarTitlesWithoutTruncatingAccessibilityText() {
+            let title = "Office Hours for Japan PS/DSA/Training [Weekly]"
+            let upcoming = event(id: "upcoming", title: title, start: 3_600, end: 7_200)
+            let agenda = agenda(googleEvents: [upcoming])
+
+            #expect(agenda.labelText(showsTitle: true, showsCountdown: false, now: now) == "Office Hours for Japan P…")
+            #expect(agenda.accessibilityLabel(now: now)?.hasPrefix(title) == true)
+        }
+
+        @Test
         func usesSoonTextForEventsStartingOrEndingInLessThanOneMinute() {
             let startingSoon = event(id: "starting", start: 59, end: 3_600)
             let endingSoon = event(id: "ending", start: -3_600, end: 59)
@@ -115,7 +125,7 @@ import Foundation
                 googleEvents: googleEvents,
                 macEvents: [],
                 enabledSources: [.google],
-                filter: CalendarEventFilter(),
+                filter: CalendarEventFilter(includesAllDayEvents: true),
                 now: now,
                 calendar: calendar
             )
@@ -166,6 +176,7 @@ import Foundation
                 startDate: startDate,
                 endDate: endDate,
                 isAllDay: isAllDay,
+                hasOtherAttendees: true,
                 isDeclined: isDeclined,
                 conferenceURI: URL(string: "https://meet.example.com/\(id)")
             )


### PR DESCRIPTION
## 概要

- メニューバーに今日の進行中・今後のカレンダー予定を表示
- 進行中または次の予定のタイトルと開始・終了までの時間をメニューバーラベルに表示
- Google Calendar と macOS Calendar の予定を結合し、既存フィルターとカレンダー選択を適用
- 予定を Dahlia で開く操作と、会議URLへの参加操作を追加
- カレンダー設定ページ最上部にメニューバー表示設定を追加
- アプリバージョンを `0.4.0` に更新

## 影響

- 既存の録音、ライブ字幕、音源、言語、画面ソース、アプリ操作は維持
- `MenuBarExtra` は既存の `.menu` スタイルを使用
- DBスキーマ、外部依存、カレンダーAPIの取得期間に変更なし

## 検証

- `swift build`
- `swift test --filter MenuBarCalendar`（6件成功）
- `swift test`（Swift Testing 403件、XCTest 3件成功）
- `CI=true ./scripts/lint.sh`（SwiftFormat成功。SwiftLintは既存のリポジトリ全体違反を報告）
- 日英 `Localizable.strings` の `plutil -lint`
