### PR TITLE
Fix calendar event popover crash and bump version to 0.5.1

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>16</string>
+    <string>17</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.5.0</string>
+    <string>0.5.1</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/Views/CalendarEventMetadataButton.swift
+++ b/Sources/Dahlia/Views/CalendarEventMetadataButton.swift
@@ -37,20 +37,11 @@ struct CalendarEventMetadataButton: View {
         .accessibilityLabel(L10n.calendarEventOrigin(event.resolvedTitle))
         .accessibilityValue(detailLines.joined(separator: ", "))
         .popover(isPresented: $isPresented, arrowEdge: .bottom) {
-            VStack(alignment: .leading, spacing: 8) {
-                Label(event.resolvedTitle, systemImage: "calendar")
-                    .font(.headline)
-
-                Text(dateText)
-                    .foregroundStyle(.secondary)
-
-                if let attributedDescription {
-                    Text(attributedDescription)
-                        .textSelection(.enabled)
-                }
-            }
-            .frame(minWidth: 260, idealWidth: 300, maxWidth: 360, alignment: .leading)
-            .padding()
+            CalendarEventPopoverContent(
+                title: event.resolvedTitle,
+                dateText: dateText,
+                attributedDescription: attributedDescription
+            )
         }
     }
 

--- a/Sources/Dahlia/Views/CalendarEventPopoverContent.swift
+++ b/Sources/Dahlia/Views/CalendarEventPopoverContent.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct CalendarEventPopoverContent: View {
+    // Keep the popover's root size stable while presented. Content-driven window resizing can re-enter AppKit's display cycle.
+    private static let contentWidth = 360.0
+    private static let heightWithDescription = 280.0
+    private static let heightWithoutDescription = 120.0
+
+    let title: String
+    let dateText: String
+    let attributedDescription: AttributedString?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                Label(title, systemImage: "calendar")
+                    .font(.headline)
+
+                Text(dateText)
+                    .foregroundStyle(.secondary)
+
+                if let attributedDescription {
+                    Divider()
+
+                    Text(attributedDescription)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(width: Self.contentWidth, height: contentHeight, alignment: .topLeading)
+        .padding()
+    }
+
+    private var contentHeight: Double {
+        attributedDescription == nil ? Self.heightWithoutDescription : Self.heightWithDescription
+    }
+}

--- a/Tests/DahliaTests/CalendarEventDescriptionFormatterTests.swift
+++ b/Tests/DahliaTests/CalendarEventDescriptionFormatterTests.swift
@@ -1,4 +1,4 @@
-import Foundation
+@preconcurrency import AppKit
 @testable import Dahlia
 
 #if canImport(Testing)
@@ -18,13 +18,49 @@ import Foundation
         }
 
         @Test
+        func rendersComplexCalendarDescription() throws {
+            let url = try #require(URL(
+                string: "https://example.com/documents/long-calendar-event-link-for-wrapping-tests/edit#section=agenda"
+            ))
+            let urlString = url.absoluteString
+            let description = [
+                #"<b>Meeting Agenda</b><br><a href="\#(urlString)" target="_blank">\#(urlString)</a><br><br>"#,
+                "【週次定例】毎週月曜日10:00-10:30   (*毎月1回は全体会議に変更)<br>",
+                "【内　容】プロジェクトの進捗確認<br>",
+                "【対象者】プロジェクトメンバー<br>",
+                "【備　考】会議室で実施します。オンラインからも参加できます",
+            ].joined()
+
+            let attributed = CalendarEventDescriptionFormatter.attributedString(from: description)
+
+            #expect(String(attributed.characters) == """
+            Meeting Agenda
+            \(urlString)
+
+            【週次定例】毎週月曜日10:00-10:30   (*毎月1回は全体会議に変更)
+            【内　容】プロジェクトの進捗確認
+            【対象者】プロジェクトメンバー
+            【備　考】会議室で実施します。オンラインからも参加できます
+            """)
+            let rendered = NSAttributedString(attributed)
+            let agendaFont = rendered.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+            let hasAgendaFont = agendaFont != nil
+            #expect(hasAgendaFont)
+            guard let agendaFont else { return }
+            let isAgendaBold = agendaFont.fontDescriptor.symbolicTraits.contains(.bold)
+            #expect(isAgendaBold)
+            let link = try #require(attributed.runs.compactMap(\.link).first)
+            #expect(link == url)
+        }
+
+        @Test
         func detectsBareURLInHTML() throws {
-            let description = #"Google Meet に参加:<br>https://meet.google.com/zun-tfvn-pcr"#
+            let description = #"Online meeting:<br>https://example.com/meet/abc-defg-hij"#
 
             let attributed = CalendarEventDescriptionFormatter.attributedString(from: description)
 
             let link = try #require(attributed.runs.compactMap(\.link).first)
-            #expect(link == URL(string: "https://meet.google.com/zun-tfvn-pcr"))
+            #expect(link == URL(string: "https://example.com/meet/abc-defg-hij"))
         }
 
         @Test

--- a/Tests/DahliaTests/CalendarEventPopoverContentTests.swift
+++ b/Tests/DahliaTests/CalendarEventPopoverContentTests.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct CalendarEventPopoverContentTests {
+        @Test
+        func longContentRendersAtStableSize() throws {
+            let description = AttributedString(String(repeating: "Long calendar description https://example.com/agenda ", count: 100))
+            let view = CalendarEventPopoverContent(
+                title: String(repeating: "Long meeting title ", count: 20),
+                dateText: "Jul 15, 2026 at 10:00 AM – 10:30 AM",
+                attributedDescription: description
+            )
+
+            let image = try #require(ImageRenderer(content: view).nsImage)
+
+            #expect(image.size == CGSize(width: 392, height: 312))
+        }
+
+        @Test
+        func contentWithoutDescriptionRendersAtStableSize() throws {
+            let view = CalendarEventPopoverContent(
+                title: String(repeating: "Long meeting title ", count: 20),
+                dateText: "Jul 15, 2026 at 10:00 AM – 10:30 AM",
+                attributedDescription: nil
+            )
+
+            let image = try #require(ImageRenderer(content: view).nsImage)
+
+            #expect(image.size == CGSize(width: 392, height: 152))
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary

- stabilize the calendar event detail popover with a fixed root size and scrolling content
- preserve long titles and render HTML descriptions, links, and formatting correctly
- add formatter and rendered-size regression coverage with anonymized fixture data
- bump Dahlia to version 0.5.1 (build 17)

## Root cause

Long HTML calendar descriptions could cause SwiftUI to resize the popover during AppKit's display cycle. That constraint invalidation could re-enter popover layout and abort the app.

## Validation

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build`
- 8 targeted tests across `CalendarEventDescriptionFormatterTests` and `CalendarEventPopoverContentTests`
- SwiftFormat: clean
- SwiftLint on changed Swift files: clean
- `plutil -lint Resources/Info.plist`
- secret scan hooks on commit and push

The repository-wide SwiftLint run still reports existing unrelated violations.