### PR TITLE
Add batch summary export destinations

### DIFF
--- a/Sources/Dahlia/Database/AppDatabaseManager.swift
+++ b/Sources/Dahlia/Database/AppDatabaseManager.swift
@@ -107,6 +107,10 @@ final class AppDatabaseManager: Sendable {
             try addSegmentedRecordingAudioSchema(in: db)
         }
 
+        migrator.registerMigration("v19_summaryExports") { db in
+            try SummaryExportsMigration.migrate(in: db)
+        }
+
         return migrator
     }()
 

--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -284,11 +284,14 @@ final class MeetingRepository {
                 title: trimmedTitle.isEmpty ? (existingSummary?.title ?? "") : trimmedTitle,
                 summary: renderedBody,
                 document: document.databaseJSONString(),
-                vaultRelativePath: existingSummary?.vaultRelativePath,
-                googleFileId: existingSummary?.googleFileId,
+                vaultRelativePath: nil,
+                googleFileId: nil,
                 createdAt: existingSummary?.createdAt ?? Date()
             )
             try record.save(db)
+            _ = try SummaryExportRecord
+                .filter(Column("meetingId") == meetingId)
+                .deleteAll(db)
 
             let tagNames = tags.filter { !$0.isEmpty }
             if !tagNames.isEmpty {
@@ -460,19 +463,52 @@ final class MeetingRepository {
 
     func updateSummaryGoogleFileId(forMeetingId meetingId: UUID, googleFileId: String?) throws {
         try dbQueue.write { db in
+            guard try SummaryRecord.fetchOne(db, key: meetingId) != nil else { return }
+            let googleDocsURL = googleFileId?.nilIfBlank.flatMap { fileId in
+                SummaryExportRecord.googleDocsURL(fileId: fileId)
+            }
             try db.execute(
                 sql: "UPDATE summaries SET googleFileId = ? WHERE meetingId = ?",
                 arguments: [googleFileId?.nilIfBlank, meetingId]
+            )
+            try SummaryExportRecord.setURL(
+                googleDocsURL,
+                meetingId: meetingId,
+                type: .googleDocs,
+                in: db
             )
         }
     }
 
     nonisolated func updateSummaryVaultRelativePath(forMeetingId meetingId: UUID, relativePath: String?) throws {
         try dbQueue.write { db in
+            guard try SummaryRecord.fetchOne(db, key: meetingId) != nil else { return }
             try db.execute(
                 sql: "UPDATE summaries SET vaultRelativePath = ? WHERE meetingId = ?",
                 arguments: [relativePath?.nilIfBlank, meetingId]
             )
+            try SummaryExportRecord.setURL(
+                relativePath?.nilIfBlank.flatMap(SummaryExportRecord.vaultURL(relativePath:)),
+                meetingId: meetingId,
+                type: .vault,
+                in: db
+            )
+        }
+    }
+
+    func fetchSummaryVaultRelativePath(forMeetingId meetingId: UUID) throws -> String? {
+        try dbQueue.read { db in
+            try SummaryExportRecord.fetchOne(meetingId: meetingId, type: .vault, in: db)?.vaultRelativePath
+                ?? SummaryRecord.fetchOne(db, key: meetingId)?.vaultRelativePath
+        }
+    }
+
+    func fetchSummaryExport(
+        forMeetingId meetingId: UUID,
+        type: SummaryExportType
+    ) throws -> SummaryExportRecord? {
+        try dbQueue.read { db in
+            try SummaryExportRecord.fetchOne(meetingId: meetingId, type: type, in: db)
         }
     }
 
@@ -486,7 +522,22 @@ final class MeetingRepository {
     /// サマリーを保存する（insert or update）。
     nonisolated func upsertSummary(_ summary: SummaryRecord) throws {
         try dbQueue.write { db in
+            let googleDocsURL = summary.googleFileId?.nilIfBlank.flatMap { fileId in
+                SummaryExportRecord.googleDocsURL(fileId: fileId)
+            }
             try summary.save(db)
+            try SummaryExportRecord.setURL(
+                summary.vaultRelativePath?.nilIfBlank.flatMap(SummaryExportRecord.vaultURL(relativePath:)),
+                meetingId: summary.meetingId,
+                type: .vault,
+                in: db
+            )
+            try SummaryExportRecord.setURL(
+                googleDocsURL,
+                meetingId: summary.meetingId,
+                type: .googleDocs,
+                in: db
+            )
         }
     }
 
@@ -501,6 +552,7 @@ final class MeetingRepository {
         let screenshots: [MeetingScreenshotRecord]
         let note: MeetingNoteRecord?
         let summary: SummaryRecord?
+        let summaryExports: [SummaryExportRecord]
     }
 
     nonisolated func fetchMeetingDetail(id meetingId: UUID) throws -> MeetingDetail {
@@ -521,6 +573,9 @@ final class MeetingRepository {
                 .fetchAll(db)
             let note = try MeetingNoteRecord.fetchOne(db, key: meetingId)
             let summary = try SummaryRecord.fetchOne(db, key: meetingId)
+            let summaryExports = try SummaryExportRecord
+                .filter(Column("meetingId") == meetingId)
+                .fetchAll(db)
             return MeetingDetail(
                 meeting: meeting,
                 calendarEvent: calendarEvent,
@@ -528,7 +583,8 @@ final class MeetingRepository {
                 recordingSessions: recordingSessions,
                 screenshots: screenshots,
                 note: note,
-                summary: summary
+                summary: summary,
+                summaryExports: summaryExports
             )
         }
     }
@@ -624,6 +680,12 @@ extension MeetingRepository {
                 vaultId: vaultId,
                 in: db
             )
+            try SummaryExportRecord.renameVaultPathsByPrefix(
+                oldPrefix: oldPrefix,
+                newPrefix: newPrefix,
+                vaultId: vaultId,
+                in: db
+            )
         }
     }
 
@@ -698,6 +760,11 @@ extension MeetingRepository {
                         .filter(meetingIds.contains(Column("id")))
                         .updateAll(db, Column("projectId").set(to: destinationId))
                     try SummaryRecord.clearVaultRelativePaths(
+                        meetingIds: meetingIds,
+                        underProjectPrefix: name,
+                        in: db
+                    )
+                    try SummaryExportRecord.clearVaultPaths(
                         meetingIds: meetingIds,
                         underProjectPrefix: name,
                         in: db

--- a/Sources/Dahlia/Database/SummaryExportRecord.swift
+++ b/Sources/Dahlia/Database/SummaryExportRecord.swift
@@ -1,0 +1,162 @@
+import Foundation
+import GRDB
+
+struct SummaryExportRecord: Codable, FetchableRecord, PersistableRecord, Equatable {
+    static let databaseTableName = "summary_exports"
+
+    var meetingId: UUID
+    var type: SummaryExportType
+    /// `vault` は Vault 相対 URL、`google_docs` は完全な URL。
+    var url: String
+    var createdAt: Date
+    var updatedAt: Date
+
+    var googleDocumentID: String? {
+        guard type == .googleDocs,
+              let url = URL(string: url)
+        else { return nil }
+        let components = url.pathComponents
+        guard let documentMarkerIndex = components.firstIndex(of: "d"),
+              components.indices.contains(components.index(after: documentMarkerIndex))
+        else { return nil }
+        return components[components.index(after: documentMarkerIndex)].nilIfBlank
+    }
+
+    var vaultRelativePath: String? {
+        guard type == .vault,
+              let components = URLComponents(string: url),
+              components.scheme?.lowercased() == SummaryExportType.vault.rawValue,
+              components.host?.nilIfBlank == nil
+        else { return nil }
+        return String(components.path.drop(while: { $0 == "/" })).nilIfBlank
+    }
+
+    static func vaultURL(relativePath: String) -> String? {
+        guard let relativePath = relativePath.nilIfBlank else { return nil }
+        let normalizedPath = String(relativePath.drop(while: { $0 == "/" }))
+        guard !normalizedPath.isEmpty else { return nil }
+
+        var components = URLComponents()
+        components.scheme = SummaryExportType.vault.rawValue
+        components.host = ""
+        components.path = "/" + normalizedPath
+        return components.string
+    }
+
+    static func googleDocsURL(fileId: String) -> String? {
+        URL(string: "https://docs.google.com/document/d")?
+            .appending(path: fileId)
+            .appending(path: "edit")
+            .absoluteString
+    }
+
+    static func fetchOne(
+        meetingId: UUID,
+        type: SummaryExportType,
+        in db: Database
+    ) throws -> Self? {
+        try filter(Column("meetingId") == meetingId)
+            .filter(Column("type") == type)
+            .fetchOne(db)
+    }
+
+    static func setURL(
+        _ url: String?,
+        meetingId: UUID,
+        type: SummaryExportType,
+        updatedAt: Date = .now,
+        in db: Database
+    ) throws {
+        guard let url = url?.nilIfBlank else {
+            _ = try filter(Column("meetingId") == meetingId)
+                .filter(Column("type") == type)
+                .deleteAll(db)
+            return
+        }
+        let existing = try fetchOne(meetingId: meetingId, type: type, in: db)
+        try Self(
+            meetingId: meetingId,
+            type: type,
+            url: url,
+            createdAt: existing?.createdAt ?? updatedAt,
+            updatedAt: updatedAt
+        ).save(db)
+    }
+
+    static func renameVaultPathsByPrefix(
+        oldPrefix: String,
+        newPrefix: String,
+        vaultId: UUID,
+        in db: Database
+    ) throws {
+        let records = try fetchAll(
+            db,
+            sql: """
+            SELECT summary_exports.*
+            FROM summary_exports
+            JOIN meetings ON meetings.id = summary_exports.meetingId
+            WHERE summary_exports.type = ? AND meetings.vaultId = ?
+            """,
+            arguments: [SummaryExportType.vault, vaultId]
+        )
+
+        for var record in records {
+            guard let relativePath = record.vaultRelativePath,
+                  relativePath == oldPrefix || relativePath.hasPrefix(oldPrefix + "/"),
+                  let newURL = vaultURL(relativePath: newPrefix + relativePath.dropFirst(oldPrefix.count))
+            else { continue }
+            record.url = newURL
+            record.updatedAt = Date.now
+            try record.update(db)
+        }
+    }
+
+    static func renameVaultPath(
+        from oldPath: String,
+        to newPath: String,
+        vaultId: UUID,
+        in db: Database
+    ) throws {
+        guard let oldURL = vaultURL(relativePath: oldPath),
+              let newURL = vaultURL(relativePath: newPath) else { return }
+        try db.execute(
+            sql: """
+            UPDATE summary_exports
+            SET url = ?, updatedAt = ?
+            WHERE type = ?
+              AND url = ?
+              AND meetingId IN (SELECT id FROM meetings WHERE vaultId = ?)
+            """,
+            arguments: [newURL, Date.now, SummaryExportType.vault, oldURL, vaultId]
+        )
+    }
+
+    static func clearVaultPath(_ relativePath: String, vaultId: UUID, in db: Database) throws {
+        guard let url = vaultURL(relativePath: relativePath) else { return }
+        try db.execute(
+            sql: """
+            DELETE FROM summary_exports
+            WHERE type = ?
+              AND url = ?
+              AND meetingId IN (SELECT id FROM meetings WHERE vaultId = ?)
+            """,
+            arguments: [SummaryExportType.vault, url, vaultId]
+        )
+    }
+
+    static func clearVaultPaths(
+        meetingIds: Set<UUID>,
+        underProjectPrefix projectPrefix: String,
+        in db: Database
+    ) throws {
+        guard !meetingIds.isEmpty else { return }
+        let records = try filter(meetingIds.contains(Column("meetingId")))
+            .filter(Column("type") == SummaryExportType.vault)
+            .fetchAll(db)
+        for record in records where record.vaultRelativePath.map({
+            ProjectRecord.belongsToHierarchy($0, prefix: projectPrefix)
+        }) == true {
+            _ = try record.delete(db)
+        }
+    }
+}

--- a/Sources/Dahlia/Database/SummaryExportsMigration.swift
+++ b/Sources/Dahlia/Database/SummaryExportsMigration.swift
@@ -1,0 +1,83 @@
+import Foundation
+import GRDB
+
+enum SummaryExportsMigration {
+    static func migrate(in db: Database) throws {
+        guard try db.tableExists("summaries") else { return }
+
+        try createTableIfNeeded(in: db)
+        try backfillLegacyVaultExports(in: db)
+        try backfillLegacyGoogleDocsExports(in: db)
+    }
+
+    private static func createTableIfNeeded(in db: Database) throws {
+        if try !db.tableExists("summary_exports") {
+            try db.create(table: "summary_exports") { table in
+                table.column("meetingId", .blob).notNull()
+                    .references("summaries", column: "meetingId", onDelete: .cascade)
+                table.column("type", .text).notNull()
+                table.column("url", .text).notNull()
+                table.column("createdAt", .datetime).notNull()
+                table.column("updatedAt", .datetime).notNull()
+                table.primaryKey(["meetingId", "type"])
+            }
+        }
+        try db.create(
+            index: "summary_exports_on_type",
+            on: "summary_exports",
+            columns: ["type"],
+            ifNotExists: true
+        )
+    }
+
+    private static func backfillLegacyVaultExports(in db: Database) throws {
+        guard try db.columns(in: "summaries").contains(where: { $0.name == "vaultRelativePath" }) else { return }
+        let rows = try Row.fetchAll(
+            db,
+            sql: """
+            SELECT meetingId, vaultRelativePath, createdAt
+            FROM summaries
+            WHERE vaultRelativePath IS NOT NULL AND TRIM(vaultRelativePath) <> ''
+            """
+        )
+        for row in rows {
+            let relativePath: String = row["vaultRelativePath"]
+            guard let url = SummaryExportRecord.vaultURL(relativePath: relativePath) else { continue }
+            try insertExport(type: .vault, url: url, from: row, in: db)
+        }
+    }
+
+    private static func backfillLegacyGoogleDocsExports(in db: Database) throws {
+        guard try db.columns(in: "summaries").contains(where: { $0.name == "googleFileId" }) else { return }
+        let rows = try Row.fetchAll(
+            db,
+            sql: """
+            SELECT meetingId, googleFileId, createdAt
+            FROM summaries
+            WHERE googleFileId IS NOT NULL AND TRIM(googleFileId) <> ''
+            """
+        )
+        for row in rows {
+            let fileId: String = row["googleFileId"]
+            guard let url = SummaryExportRecord.googleDocsURL(fileId: fileId) else { continue }
+            try insertExport(type: .googleDocs, url: url, from: row, in: db)
+        }
+    }
+
+    private static func insertExport(
+        type: SummaryExportType,
+        url: String,
+        from row: Row,
+        in db: Database
+    ) throws {
+        let meetingId: UUID = row["meetingId"]
+        let createdAt: Date = row["createdAt"]
+        try db.execute(
+            sql: """
+            INSERT OR IGNORE INTO summary_exports (meetingId, type, url, createdAt, updatedAt)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            arguments: [meetingId, type, url, createdAt, createdAt]
+        )
+    }
+}

--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -80,6 +80,8 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     nonisolated static let automaticScreenshotIntervalSecondsUserDefaultsKey = "automaticScreenshotIntervalSeconds"
     nonisolated static let automaticScreenshotChangeThresholdPercentUserDefaultsKey = "automaticScreenshotChangeThresholdPercent"
     nonisolated static let generateSummaryAfterBatchTranscriptionUserDefaultsKey = "generateSummaryAfterBatchTranscription"
+    nonisolated static let exportBatchSummaryToVaultUserDefaultsKey = "exportBatchSummaryToVault"
+    nonisolated static let exportBatchSummaryToGoogleDocsUserDefaultsKey = "exportBatchSummaryToGoogleDocs"
     nonisolated static let defaultGoogleDriveExportFolderName = "Meeting Notes"
     fileprivate nonisolated static let defaultAutomaticScreenshotIntervalSeconds = 30
     fileprivate nonisolated static let defaultAutomaticScreenshotChangeThresholdPercent = 20
@@ -141,6 +143,8 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     @AppStorage(TranscriptionMode.userDefaultsKey) var transcriptionModeRawValue = TranscriptionMode.defaultMode.rawValue
     @AppStorage("retainAudioAfterBatchTranscription") var retainAudioAfterBatchTranscription = false
     @AppStorage(AppSettings.generateSummaryAfterBatchTranscriptionUserDefaultsKey) var generateSummaryAfterBatchTranscription = false
+    @AppStorage(AppSettings.exportBatchSummaryToVaultUserDefaultsKey) var exportBatchSummaryToVault = true
+    @AppStorage(AppSettings.exportBatchSummaryToGoogleDocsUserDefaultsKey) var exportBatchSummaryToGoogleDocs = false
     @AppStorage("transcriptTranslationEnabled") var transcriptTranslationEnabled = true
     @AppStorage("transcriptTranslationTargetLanguage") var transcriptTranslationTargetLanguage = TranscriptTranslationLanguage.defaultIdentifier
     @AppStorage("liveSubtitleOverlayEnabled") var liveSubtitleOverlayEnabled = false
@@ -160,6 +164,13 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     var isRealtimeTranscriptionEnabled: Bool {
         get { transcriptionMode == .realtime }
         set { transcriptionMode = newValue ? .realtime : .batch }
+    }
+
+    var batchSummaryExportOptions: SummaryExportOptions {
+        SummaryExportOptions(
+            exportsToVault: exportBatchSummaryToVault,
+            exportsToGoogleDocs: exportBatchSummaryToGoogleDocs
+        )
     }
 
     var automaticScreenshotIntervalSeconds: Int {

--- a/Sources/Dahlia/Models/SummaryExportOptions.swift
+++ b/Sources/Dahlia/Models/SummaryExportOptions.swift
@@ -1,0 +1,16 @@
+struct SummaryExportOptions: Equatable {
+    let exportsToVault: Bool
+    let exportsToGoogleDocs: Bool
+
+    static let manual = Self(
+        exportsToVault: true,
+        exportsToGoogleDocs: false
+    )
+
+    static func merging(_ options: [Self]) -> Self {
+        Self(
+            exportsToVault: options.contains(where: \.exportsToVault),
+            exportsToGoogleDocs: options.contains(where: \.exportsToGoogleDocs)
+        )
+    }
+}

--- a/Sources/Dahlia/Models/SummaryExportType.swift
+++ b/Sources/Dahlia/Models/SummaryExportType.swift
@@ -1,0 +1,6 @@
+import GRDB
+
+enum SummaryExportType: String, Codable, DatabaseValueConvertible {
+    case vault
+    case googleDocs = "google_docs"
+}

--- a/Sources/Dahlia/Models/SummaryProgressState.swift
+++ b/Sources/Dahlia/Models/SummaryProgressState.swift
@@ -16,20 +16,41 @@ final class SummaryProgressState {
             default: false
             }
         }
+
+        var isSkipped: Bool {
+            if case .skipped = self {
+                true
+            } else {
+                false
+            }
+        }
+
+        var accessibilityDescription: String {
+            switch self {
+            case .pending: L10n.waiting
+            case .running: L10n.inProgress
+            case .completed: L10n.completed
+            case .skipped: L10n.skipped
+            case let .failed(message): message
+            }
+        }
     }
 
     var isVisible = false
     var vaultExport: StepStatus = .pending
+    var googleDocsExport: StepStatus = .pending
     var summaryGeneration: StepStatus = .pending
 
     /// 全ステップが完了またはスキップ済みか。
     var isAllDone: Bool {
         vaultExport.isTerminal
+            && googleDocsExport.isTerminal
             && summaryGeneration.isTerminal
     }
 
     func reset() {
         vaultExport = .pending
+        googleDocsExport = .pending
         summaryGeneration = .pending
     }
 

--- a/Sources/Dahlia/Models/SummaryProgressState.swift
+++ b/Sources/Dahlia/Models/SummaryProgressState.swift
@@ -40,6 +40,7 @@ final class SummaryProgressState {
     var vaultExport: StepStatus = .pending
     var googleDocsExport: StepStatus = .pending
     var summaryGeneration: StepStatus = .pending
+    private var presentationID: UUID?
 
     /// 全ステップが完了またはスキップ済みか。
     var isAllDone: Bool {
@@ -54,12 +55,22 @@ final class SummaryProgressState {
         summaryGeneration = .pending
     }
 
-    func show() {
+    @discardableResult
+    func show() -> UUID {
+        let presentationID = UUID()
         reset()
+        self.presentationID = presentationID
         isVisible = true
+        return presentationID
     }
 
     func dismiss() {
+        presentationID = nil
         isVisible = false
+    }
+
+    func dismiss(ifCurrent presentationID: UUID) {
+        guard self.presentationID == presentationID else { return }
+        dismiss()
     }
 }

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -76,6 +76,8 @@
 "Tags" = "Tags";
 "Assigned to me" = "Assigned to me";
 "Completed" = "Completed";
+"Waiting" = "Waiting";
+"Skipped" = "Skipped";
 "Project is" = "Project is";
 "Tag is" = "Tag is";
 "Add tag" = "Add tag";
@@ -522,6 +524,11 @@
 "Delete the recording files after batch transcription succeeds. They are kept if transcription fails." = "Delete the recording files after batch transcription succeeds. They are kept if transcription fails.";
 "Generate Summary After Transcription" = "Generate Summary After Transcription";
 "Automatically generate a summary when batch transcription succeeds." = "Automatically generate a summary when batch transcription succeeds.";
+"Summary and Export" = "Summary and Export";
+"Export Summary to Vault" = "Export Summary to Vault";
+"Write the generated summary and related files to the current Vault." = "Write the generated summary and related files to the current Vault.";
+"Export Summary to Google Docs" = "Export Summary to Google Docs";
+"Export the generated summary to the configured Google Docs folder." = "Export the generated summary to the configured Google Docs folder.";
 "Later" = "Later";
 "Discard Failed Recording" = "Discard Failed Recording";
 "Discard this failed recording?" = "Discard this failed recording?";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -76,6 +76,8 @@
 "Tags" = "タグ";
 "Assigned to me" = "自分担当";
 "Completed" = "完了";
+"Waiting" = "待機中";
+"Skipped" = "スキップ";
 "Project is" = "プロジェクト";
 "Tag is" = "タグ";
 "Add tag" = "タグを追加";
@@ -522,6 +524,11 @@
 "Delete the recording files after batch transcription succeeds. They are kept if transcription fails." = "バッチ文字起こしが成功したら録音ファイルを削除します。失敗した場合は再試行のため保持されます。";
 "Generate Summary After Transcription" = "文字起こし後に要約を生成";
 "Automatically generate a summary when batch transcription succeeds." = "バッチ文字起こしが成功したら、自動的に要約を生成します。";
+"Summary and Export" = "要約と書き出し";
+"Export Summary to Vault" = "要約を Vault へ書き出す";
+"Write the generated summary and related files to the current Vault." = "生成した要約と関連ファイルを現在の Vault へ書き出します。";
+"Export Summary to Google Docs" = "要約を Google Docs へ書き出す";
+"Export the generated summary to the configured Google Docs folder." = "生成した要約を設定済みの Google Docs フォルダへ書き出します。";
 "Later" = "あとで";
 "Discard Failed Recording" = "失敗した録音を破棄";
 "Discard this failed recording?" = "失敗した録音を破棄しますか？";

--- a/Sources/Dahlia/Services/VaultSummaryPathSynchronizer.swift
+++ b/Sources/Dahlia/Services/VaultSummaryPathSynchronizer.swift
@@ -13,11 +13,23 @@ struct VaultSummaryPathSynchronizer {
                 vaultId: vaultId,
                 in: db
             )
+            try SummaryExportRecord.renameVaultPath(
+                from: oldPath,
+                to: newPath,
+                vaultId: vaultId,
+                in: db
+            )
         }
     }
 
     func renamePathsByPrefix(oldPrefix: String, newPrefix: String, in db: Database) throws {
         try SummaryRecord.renameVaultRelativePathsByPrefix(
+            oldPrefix: oldPrefix,
+            newPrefix: newPrefix,
+            vaultId: vaultId,
+            in: db
+        )
+        try SummaryExportRecord.renameVaultPathsByPrefix(
             oldPrefix: oldPrefix,
             newPrefix: newPrefix,
             vaultId: vaultId,
@@ -30,6 +42,7 @@ struct VaultSummaryPathSynchronizer {
         try? dbQueue.write { db in
             for relativePath in relativePaths {
                 try SummaryRecord.clearVaultRelativePath(relativePath, vaultId: vaultId, in: db)
+                try SummaryExportRecord.clearVaultPath(relativePath, vaultId: vaultId, in: db)
             }
         }
     }

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -168,6 +168,8 @@ enum L10n {
     static var tags: String { String(localized: "Tags", bundle: bundle) }
     static var assignedToMe: String { String(localized: "Assigned to me", bundle: bundle) }
     static var completed: String { String(localized: "Completed", bundle: bundle) }
+    static var waiting: String { String(localized: "Waiting", bundle: bundle) }
+    static var skipped: String { String(localized: "Skipped", bundle: bundle) }
     static var projectIs: String { String(localized: "Project is", bundle: bundle) }
     static var tagIs: String { String(localized: "Tag is", bundle: bundle) }
     static var today: String { String(localized: "Today", bundle: bundle) }
@@ -439,6 +441,23 @@ enum L10n {
     ) }
     static var generateSummaryAfterBatchTranscriptionDescription: String { String(
         localized: "Automatically generate a summary when batch transcription succeeds.",
+        bundle: bundle
+    ) }
+    static var summaryAndExport: String { String(localized: "Summary and Export", bundle: bundle) }
+    static var exportBatchSummaryToVault: String { String(
+        localized: "Export Summary to Vault",
+        bundle: bundle
+    ) }
+    static var exportBatchSummaryToVaultDescription: String { String(
+        localized: "Write the generated summary and related files to the current Vault.",
+        bundle: bundle
+    ) }
+    static var exportBatchSummaryToGoogleDocs: String { String(
+        localized: "Export Summary to Google Docs",
+        bundle: bundle
+    ) }
+    static var exportBatchSummaryToGoogleDocsDescription: String { String(
+        localized: "Export the generated summary to the configured Google Docs folder.",
         bundle: bundle
     ) }
     static var later: String { String(localized: "Later", bundle: bundle) }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -137,10 +137,12 @@ final class CaptionViewModel: ObservableObject {
 
     @Published var summaryGeneratingMeetingId: UUID?
     var isSummaryGenerating: Bool { summaryGeneratingMeetingId != nil }
-    private var pendingBatchSummaryMeetingIdsBySessionId: [UUID: UUID] = [:]
+    private var pendingBatchSummaryRequestsBySessionId: [UUID: (meetingId: UUID, exportOptions: SummaryExportOptions)] = [:]
     @Published var summaryError: String?
     @Published private(set) var googleDocsExportError: String?
     private var isExportingCurrentSummaryToGoogleDocs = false
+    private var isGoogleDocsExportBusy = false
+    private var googleDocsExportWaiters: [CheckedContinuation<Void, Never>] = []
     @Published var lastSummaryURL: URL?
     @Published var currentSummaryGoogleFileId: String?
     @Published var currentSummaryDocument: SummaryDocument?
@@ -229,24 +231,15 @@ final class CaptionViewModel: ObservableObject {
         )
         let fileName = lastSummaryURL?.lastPathComponent
             ?? "\(document.title.nilIfBlank ?? L10n.summary).rtf"
+        let dbQueue = currentDbQueue
 
         do {
-            let fileId = try await GoogleDocsSummaryExportService.exportSummary(
+            let fileId = try await exportSummaryToGoogleDocs(
                 document: document,
                 context: context,
                 fileName: fileName
             )
-            if let currentDbQueue {
-                do {
-                    try MeetingRepository(dbQueue: currentDbQueue)
-                        .updateSummaryGoogleFileId(forMeetingId: meetingId, googleFileId: fileId)
-                } catch {
-                    ErrorReportingService.capture(error, context: ["source": "persistGoogleDocsFileId"])
-                }
-            }
-            if currentMeetingId == meetingId {
-                currentSummaryGoogleFileId = fileId
-            }
+            try persistGoogleDocsFileId(fileId, meetingId: meetingId, dbQueue: dbQueue)
             if let url = URL(string: "https://docs.google.com/document/d/\(fileId)/edit") {
                 NSWorkspace.shared.open(url)
             }
@@ -515,10 +508,14 @@ final class CaptionViewModel: ObservableObject {
             suggestedLocaleIdentifier: localeIdentifier,
             retainAudioAfterBatch: retainAudioAfterBatch
         )
-        if AppSettings.shared.generateSummaryAfterBatchTranscription {
-            pendingBatchSummaryMeetingIdsBySessionId[confirmation.sessionId] = confirmation.meetingId
+        let settings = AppSettings.shared
+        if settings.generateSummaryAfterBatchTranscription {
+            pendingBatchSummaryRequestsBySessionId[confirmation.sessionId] = (
+                meetingId: confirmation.meetingId,
+                exportOptions: settings.batchSummaryExportOptions
+            )
         } else {
-            pendingBatchSummaryMeetingIdsBySessionId.removeValue(forKey: confirmation.sessionId)
+            pendingBatchSummaryRequestsBySessionId.removeValue(forKey: confirmation.sessionId)
         }
         pendingBatchTranscriptionConfirmation = nil
         if currentMeetingId == confirmation.meetingId {
@@ -551,7 +548,7 @@ final class CaptionViewModel: ObservableObject {
             do {
                 let repository = MeetingRepository(dbQueue: dbQueue)
                 guard try await repository.discardFailedBatchSessionSafely(id: sessionId) else { return }
-                pendingBatchSummaryMeetingIdsBySessionId.removeValue(forKey: sessionId)
+                pendingBatchSummaryRequestsBySessionId.removeValue(forKey: sessionId)
                 try refreshBatchTranscriptionState(meetingId: meetingId, dbQueue: dbQueue)
             } catch {
                 errorMessage = error.localizedDescription
@@ -762,10 +759,12 @@ final class CaptionViewModel: ObservableObject {
         let detail = try repo.fetchMeetingDetail(id: meetingId)
         let recordingSessions = detail.recordingSessions.map(RecordingSessionTimeline.init)
         let segments = detail.segments.map(TranscriptSegment.init(from:))
+        let vaultExport = detail.summaryExports.first(where: { $0.type == .vault })
+        let googleDocsExport = detail.summaryExports.first(where: { $0.type == .googleDocs })
 
         let lastSummaryURL: URL? = if let summary = detail.summary {
             SummaryService.findSummaryFile(
-                storedRelativePath: summary.vaultRelativePath,
+                storedRelativePath: vaultExport?.vaultRelativePath ?? summary.vaultRelativePath,
                 vaultURL: vaultURL
             )
         } else {
@@ -779,7 +778,7 @@ final class CaptionViewModel: ObservableObject {
             segments: segments,
             screenshots: detail.screenshots,
             summaryDocument: detail.summary?.loadDocument(),
-            googleFileId: detail.summary?.googleFileId,
+            googleFileId: googleDocsExport?.googleDocumentID ?? detail.summary?.googleFileId,
             lastSummaryURL: lastSummaryURL,
             note: detail.note
         )
@@ -1945,6 +1944,7 @@ final class CaptionViewModel: ObservableObject {
     var canGenerateSummary: Bool {
         guard !isListening,
               !isFinalizingRecording,
+              !isSummaryGenerating,
               currentMeetingId != nil,
               currentVaultURL != nil,
               batchTranscriptionState?.blocksSummaryGeneration != true else { return false }
@@ -1953,6 +1953,10 @@ final class CaptionViewModel: ObservableObject {
 
     /// プルダウンメニューから手動で要約を実行する。
     func triggerManualSummary() {
+        triggerSummary(exportOptions: .manual)
+    }
+
+    private func triggerSummary(exportOptions: SummaryExportOptions) {
         guard canGenerateSummary,
               let meetingId = currentMeetingId,
               let vaultURL = currentVaultURL else { return }
@@ -1972,22 +1976,26 @@ final class CaptionViewModel: ObservableObject {
                 vaultURL: vaultURL,
                 projectName: projectName,
                 segments: segments,
-                recordingSessions: recordingSessions
+                recordingSessions: recordingSessions,
+                exportOptions: exportOptions
             )
         }
     }
 
     private func generatePendingBatchSummaryIfReady(meetingId: UUID) {
-        let pendingSessionIds = pendingBatchSummaryMeetingIdsBySessionId.compactMap { sessionId, pendingMeetingId in
-            pendingMeetingId == meetingId ? sessionId : nil
+        let pendingRequests = pendingBatchSummaryRequestsBySessionId.compactMap { sessionId, request in
+            request.meetingId == meetingId
+                ? (sessionId: sessionId, exportOptions: request.exportOptions)
+                : nil
         }
         guard currentMeetingId == meetingId,
               canGenerateSummary,
-              !pendingSessionIds.isEmpty else { return }
-        for sessionId in pendingSessionIds {
-            pendingBatchSummaryMeetingIdsBySessionId.removeValue(forKey: sessionId)
+              !pendingRequests.isEmpty else { return }
+        for request in pendingRequests {
+            pendingBatchSummaryRequestsBySessionId.removeValue(forKey: request.sessionId)
         }
-        triggerManualSummary()
+        let exportOptions = SummaryExportOptions.merging(pendingRequests.map(\.exportOptions))
+        triggerSummary(exportOptions: exportOptions)
     }
 
     func generateSummary(
@@ -1998,7 +2006,8 @@ final class CaptionViewModel: ObservableObject {
         vaultURL: URL,
         projectName: String,
         segments: [TranscriptSegment],
-        recordingSessions: [RecordingSessionTimeline]
+        recordingSessions: [RecordingSessionTimeline],
+        exportOptions: SummaryExportOptions
     ) async {
         guard !transcriptText.isEmpty else { return }
 
@@ -2028,6 +2037,8 @@ final class CaptionViewModel: ObservableObject {
             }
 
             summaryProgress.show()
+            summaryProgress.vaultExport = exportOptions.exportsToVault ? .pending : .skipped
+            summaryProgress.googleDocsExport = exportOptions.exportsToGoogleDocs ? .pending : .skipped
 
             // LLM 要約
             summaryProgress.summaryGeneration = .running
@@ -2044,6 +2055,10 @@ final class CaptionViewModel: ObservableObject {
                 repository: repo
             )
 
+            // Regeneration invalidates the previous export locations. Keep the old
+            // Vault path only long enough to overwrite the existing file when selected.
+            let storedSummaryRelativePath = try repo?.fetchSummaryVaultRelativePath(forMeetingId: meetingId)
+
             if let repo {
                 try repo.applyGeneratedSummary(
                     toMeetingId: meetingId,
@@ -2056,39 +2071,64 @@ final class CaptionViewModel: ObservableObject {
             if currentMeetingId == meetingId {
                 currentSummaryDocument = generatedSummary.document
             }
-            let storedSummaryRelativePath = try repo?.fetchSummary(forMeetingId: meetingId)?.vaultRelativePath
 
-            summaryProgress.vaultExport = .running
+            if exportOptions.exportsToVault {
+                summaryProgress.vaultExport = .running
+                do {
+                    let fileURL = try await VaultSummaryExportService.exportSummaryBundle(
+                        projectURL: projectURL,
+                        vaultURL: vaultURL,
+                        storedSummaryRelativePath: storedSummaryRelativePath,
+                        meetingId: meetingId,
+                        createdAt: createdAt,
+                        projectName: projectName,
+                        segments: segments,
+                        recordingSessions: recordingSessions,
+                        screenshots: screenshots,
+                        summaryFileName: generatedSummary.fileName,
+                        summaryMarkdown: generatedSummary.markdown
+                    )
+                    if let relativePath = VaultSummaryFileLocator.relativePath(for: fileURL, vaultURL: vaultURL) {
+                        try repo?.updateSummaryVaultRelativePath(forMeetingId: meetingId, relativePath: relativePath)
+                    }
+                    summaryProgress.vaultExport = .completed
+                    if currentMeetingId == meetingId {
+                        lastSummaryURL = fileURL
+                    }
+                } catch {
+                    summaryProgress.vaultExport = .failed(error.localizedDescription)
+                    if currentMeetingId == meetingId {
+                        summaryError = error.localizedDescription
+                    }
+                    ErrorReportingService.capture(error, context: ["source": "vaultSummaryExport"])
+                }
+            }
 
-            async let vaultExport: URL = VaultSummaryExportService.exportSummaryBundle(
-                projectURL: projectURL,
-                vaultURL: vaultURL,
-                storedSummaryRelativePath: storedSummaryRelativePath,
-                meetingId: meetingId,
-                createdAt: createdAt,
-                projectName: projectName,
-                segments: segments,
-                recordingSessions: recordingSessions,
-                screenshots: screenshots,
-                summaryFileName: generatedSummary.fileName,
-                summaryMarkdown: generatedSummary.markdown
-            )
-
-            do {
-                let fileURL = try await vaultExport
-                if let relativePath = VaultSummaryFileLocator.relativePath(for: fileURL, vaultURL: vaultURL) {
-                    try repo?.updateSummaryVaultRelativePath(forMeetingId: meetingId, relativePath: relativePath)
+            if exportOptions.exportsToGoogleDocs {
+                summaryProgress.googleDocsExport = .running
+                do {
+                    let fileId = try await exportSummaryToGoogleDocs(
+                        document: generatedSummary.document,
+                        context: SummaryRenderContext(
+                            meetingId: meetingId,
+                            createdAt: createdAt,
+                            screenshots: screenshots
+                        ),
+                        fileName: generatedSummary.fileName
+                    )
+                    try persistGoogleDocsFileId(fileId, meetingId: meetingId, dbQueue: dbQueue)
+                    summaryProgress.googleDocsExport = .completed
+                } catch {
+                    let message = GoogleAuthErrorFormatter.message(
+                        for: error,
+                        defaultMessage: L10n.googleDocsExportFailed
+                    )
+                    summaryProgress.googleDocsExport = .failed(message)
+                    if currentMeetingId == meetingId {
+                        googleDocsExportError = message
+                    }
+                    ErrorReportingService.capture(error, context: ["source": "batchGoogleDocsExport"])
                 }
-                summaryProgress.vaultExport = .completed
-                if currentMeetingId == meetingId {
-                    lastSummaryURL = fileURL
-                }
-            } catch {
-                summaryProgress.vaultExport = .failed(error.localizedDescription)
-                if currentMeetingId == meetingId {
-                    summaryError = error.localizedDescription
-                }
-                ErrorReportingService.capture(error, context: ["source": "vaultSummaryExport"])
             }
         } catch {
             if currentMeetingId == meetingId {
@@ -2097,6 +2137,7 @@ final class CaptionViewModel: ObservableObject {
             }
             summaryProgress.summaryGeneration = .failed(error.localizedDescription)
             summaryProgress.vaultExport = .skipped
+            summaryProgress.googleDocsExport = .skipped
             if Self.shouldCaptureSummaryGenerationError(error) {
                 ErrorReportingService.capture(error, context: ["source": "summaryGeneration"])
             }
@@ -2113,6 +2154,56 @@ final class CaptionViewModel: ObservableObject {
                 summaryProgress.dismiss()
             }
         }
+
+        if let currentMeetingId {
+            generatePendingBatchSummaryIfReady(meetingId: currentMeetingId)
+        }
+    }
+
+    private func persistGoogleDocsFileId(
+        _ fileId: String,
+        meetingId: UUID,
+        dbQueue: DatabaseQueue?
+    ) throws {
+        if let dbQueue {
+            try MeetingRepository(dbQueue: dbQueue)
+                .updateSummaryGoogleFileId(forMeetingId: meetingId, googleFileId: fileId)
+        }
+        if currentMeetingId == meetingId {
+            currentSummaryGoogleFileId = fileId
+        }
+    }
+
+    private func exportSummaryToGoogleDocs(
+        document: SummaryDocument,
+        context: SummaryRenderContext,
+        fileName: String
+    ) async throws -> String {
+        await acquireGoogleDocsExport()
+        defer { releaseGoogleDocsExport() }
+        return try await GoogleDocsSummaryExportService.exportSummary(
+            document: document,
+            context: context,
+            fileName: fileName
+        )
+    }
+
+    private func acquireGoogleDocsExport() async {
+        if !isGoogleDocsExportBusy {
+            isGoogleDocsExportBusy = true
+            return
+        }
+        await withCheckedContinuation { continuation in
+            googleDocsExportWaiters.append(continuation)
+        }
+    }
+
+    private func releaseGoogleDocsExport() {
+        guard !googleDocsExportWaiters.isEmpty else {
+            isGoogleDocsExportBusy = false
+            return
+        }
+        googleDocsExportWaiters.removeFirst().resume()
     }
 
     nonisolated static func shouldCaptureSummaryGenerationError(_ error: any Error) -> Bool {

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -2019,6 +2019,7 @@ final class CaptionViewModel: ObservableObject {
         summaryError = nil
         googleDocsExportError = nil
         lastSummaryURL = nil
+        var progressPresentationID: UUID?
 
         do {
             let dbQueue = currentDbQueue
@@ -2036,7 +2037,7 @@ final class CaptionViewModel: ObservableObject {
                 }
             }
 
-            summaryProgress.show()
+            progressPresentationID = summaryProgress.show()
             summaryProgress.vaultExport = exportOptions.exportsToVault ? .pending : .skipped
             summaryProgress.googleDocsExport = exportOptions.exportsToGoogleDocs ? .pending : .skipped
 
@@ -2070,6 +2071,7 @@ final class CaptionViewModel: ObservableObject {
             summaryProgress.summaryGeneration = .completed
             if currentMeetingId == meetingId {
                 currentSummaryDocument = generatedSummary.document
+                currentSummaryGoogleFileId = nil
             }
 
             if exportOptions.exportsToVault {
@@ -2148,10 +2150,10 @@ final class CaptionViewModel: ObservableObject {
         }
 
         // 全完了後に自動で非表示
-        if summaryProgress.isAllDone {
+        if summaryProgress.isAllDone, let progressPresentationID {
             try? await Task.sleep(for: .seconds(2))
             withAnimation(.easeOut(duration: 0.3)) {
-                summaryProgress.dismiss()
+                summaryProgress.dismiss(ifCurrent: progressPresentationID)
             }
         }
 

--- a/Sources/Dahlia/Views/BatchTranscriptionConfirmationView.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionConfirmationView.swift
@@ -5,8 +5,6 @@ struct BatchTranscriptionConfirmationView: View {
     let onStart: (String, Bool) -> Void
     let onPostpone: () -> Void
 
-    @AppStorage(AppSettings.generateSummaryAfterBatchTranscriptionUserDefaultsKey)
-    private var generateSummaryAfterBatchTranscription = false
     @State private var selectedLocaleIdentifier: String
     @State private var deleteAudioAfterTranscription: Bool
 
@@ -25,40 +23,24 @@ struct BatchTranscriptionConfirmationView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text(L10n.batchTranscriptionConfirmationTitle)
-                .font(.headline)
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(L10n.batchTranscriptionConfirmationTitle)
+                    .font(.headline)
 
-            Text(L10n.batchTranscriptionConfirmationDescription)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            Picker(L10n.language, selection: $selectedLocaleIdentifier) {
-                ForEach(locales, id: \.identifier) { locale in
-                    Text(displayName(for: locale)).tag(locale.identifier)
-                }
+                Text(L10n.batchTranscriptionConfirmationDescription)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
-            .pickerStyle(.menu)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding([.horizontal, .top], 20)
+            .padding(.bottom, 8)
 
-            Toggle(isOn: $deleteAudioAfterTranscription) {
-                VStack(alignment: .leading) {
-                    Text(L10n.deleteBatchAudioAfterTranscription)
-                    Text(L10n.deleteBatchAudioAfterTranscriptionDescription)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .toggleStyle(.checkbox)
-
-            Toggle(isOn: $generateSummaryAfterBatchTranscription) {
-                VStack(alignment: .leading) {
-                    Text(L10n.generateSummaryAfterBatchTranscription)
-                    Text(L10n.generateSummaryAfterBatchTranscriptionDescription)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .toggleStyle(.checkbox)
+            BatchTranscriptionOptionsForm(
+                locales: locales,
+                selectedLocaleIdentifier: $selectedLocaleIdentifier,
+                deleteAudioAfterTranscription: $deleteAudioAfterTranscription
+            )
 
             Divider()
 
@@ -69,15 +51,9 @@ struct BatchTranscriptionConfirmationView: View {
                 Button(L10n.startTranscription, action: startTranscription)
                     .keyboardShortcut(.defaultAction)
             }
+            .padding(20)
         }
-        .padding(20)
-        .frame(minWidth: 420)
-    }
-
-    private func displayName(for locale: Locale) -> String {
-        locale.localizedString(forIdentifier: locale.identifier)
-            ?? Locale.current.localizedString(forIdentifier: locale.identifier)
-            ?? locale.identifier
+        .frame(minWidth: 500, idealWidth: 520, minHeight: 440, idealHeight: 500)
     }
 
     private func startTranscription() {

--- a/Sources/Dahlia/Views/BatchTranscriptionOptionsForm.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionOptionsForm.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+struct BatchTranscriptionOptionsForm: View {
+    let locales: [Locale]
+    @Binding var selectedLocaleIdentifier: String
+    @Binding var deleteAudioAfterTranscription: Bool
+
+    @AppStorage(AppSettings.generateSummaryAfterBatchTranscriptionUserDefaultsKey)
+    private var generateSummaryAfterBatchTranscription = false
+    @AppStorage(AppSettings.exportBatchSummaryToVaultUserDefaultsKey)
+    private var exportBatchSummaryToVault = true
+    @AppStorage(AppSettings.exportBatchSummaryToGoogleDocsUserDefaultsKey)
+    private var exportBatchSummaryToGoogleDocs = false
+
+    var body: some View {
+        Form {
+            Section(L10n.transcription) {
+                Picker(L10n.language, selection: $selectedLocaleIdentifier) {
+                    ForEach(locales, id: \.identifier) { locale in
+                        Text(displayName(for: locale)).tag(locale.identifier)
+                    }
+                }
+                .pickerStyle(.menu)
+
+                Toggle(isOn: $deleteAudioAfterTranscription) {
+                    Text(L10n.deleteBatchAudioAfterTranscription)
+                    Text(L10n.deleteBatchAudioAfterTranscriptionDescription)
+                }
+                .toggleStyle(.checkbox)
+            }
+
+            Section(L10n.summaryAndExport) {
+                Toggle(isOn: $generateSummaryAfterBatchTranscription) {
+                    Text(L10n.generateSummaryAfterBatchTranscription)
+                    Text(L10n.generateSummaryAfterBatchTranscriptionDescription)
+                }
+                .toggleStyle(.checkbox)
+
+                Toggle(isOn: $exportBatchSummaryToVault) {
+                    Text(L10n.exportBatchSummaryToVault)
+                    Text(L10n.exportBatchSummaryToVaultDescription)
+                }
+                .toggleStyle(.checkbox)
+                .disabled(!generateSummaryAfterBatchTranscription)
+
+                Toggle(isOn: $exportBatchSummaryToGoogleDocs) {
+                    Text(L10n.exportBatchSummaryToGoogleDocs)
+                    Text(L10n.exportBatchSummaryToGoogleDocsDescription)
+                }
+                .toggleStyle(.checkbox)
+                .disabled(!generateSummaryAfterBatchTranscription)
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private func displayName(for locale: Locale) -> String {
+        locale.localizedString(forIdentifier: locale.identifier)
+            ?? Locale.current.localizedString(forIdentifier: locale.identifier)
+            ?? locale.identifier
+    }
+}

--- a/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
@@ -6,6 +6,10 @@ struct TranscriptionSettingsView: View {
     @ObservedObject private var settings = AppSettings.shared
     @AppStorage(AppSettings.generateSummaryAfterBatchTranscriptionUserDefaultsKey)
     private var generateSummaryAfterBatchTranscription = false
+    @AppStorage(AppSettings.exportBatchSummaryToVaultUserDefaultsKey)
+    private var exportBatchSummaryToVault = true
+    @AppStorage(AppSettings.exportBatchSummaryToGoogleDocsUserDefaultsKey)
+    private var exportBatchSummaryToGoogleDocs = false
     @State private var supportedLocales: [Locale] = []
     @State private var isLoadingLocales = false
     @State private var localeSearchText = ""
@@ -31,6 +35,20 @@ struct TranscriptionSettingsView: View {
                         Text(L10n.generateSummaryAfterBatchTranscriptionDescription)
                     }
                     .toggleStyle(.switch)
+
+                    Toggle(isOn: $exportBatchSummaryToVault) {
+                        Text(L10n.exportBatchSummaryToVault)
+                        Text(L10n.exportBatchSummaryToVaultDescription)
+                    }
+                    .toggleStyle(.switch)
+                    .disabled(!generateSummaryAfterBatchTranscription)
+
+                    Toggle(isOn: $exportBatchSummaryToGoogleDocs) {
+                        Text(L10n.exportBatchSummaryToGoogleDocs)
+                        Text(L10n.exportBatchSummaryToGoogleDocsDescription)
+                    }
+                    .toggleStyle(.switch)
+                    .disabled(!generateSummaryAfterBatchTranscription)
                 }
             } header: {
                 Text(L10n.transcriptionMethod)

--- a/Sources/Dahlia/Views/SummaryProgressStepRow.swift
+++ b/Sources/Dahlia/Views/SummaryProgressStepRow.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct SummaryProgressStepRow: View {
+    let label: String
+    let status: SummaryProgressState.StepStatus
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Group {
+                switch status {
+                case .pending:
+                    Image(systemName: "circle")
+                        .foregroundStyle(.tertiary)
+                case .running:
+                    ProgressView()
+                        .controlSize(.mini)
+                case .completed:
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                case .skipped:
+                    Image(systemName: "minus.circle")
+                        .foregroundStyle(.tertiary)
+                case .failed:
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.red)
+                }
+            }
+            .frame(width: 14, height: 14)
+            .accessibilityHidden(true)
+
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(textColor)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(label)
+        .accessibilityValue(status.accessibilityDescription)
+    }
+
+    private var textColor: Color {
+        switch status {
+        case .pending: .secondary
+        case .running: .primary
+        case .completed, .skipped: .secondary
+        case .failed: .red
+        }
+    }
+}

--- a/Sources/Dahlia/Views/SummaryProgressToastView.swift
+++ b/Sources/Dahlia/Views/SummaryProgressToastView.swift
@@ -6,67 +6,23 @@ struct SummaryProgressToastView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("要約を生成中")
-                .font(.system(size: 12, weight: .semibold))
+            Text(L10n.generatingSummary)
+                .font(.callout)
+                .bold()
                 .foregroundStyle(.primary)
 
-            StepRow(label: "要約の生成", status: state.summaryGeneration)
-            StepRow(label: "Vault へ書き出し", status: state.vaultExport)
+            SummaryProgressStepRow(label: L10n.generateSummary, status: state.summaryGeneration)
+            if !state.vaultExport.isSkipped {
+                SummaryProgressStepRow(label: L10n.exportBatchSummaryToVault, status: state.vaultExport)
+            }
+            if !state.googleDocsExport.isSkipped {
+                SummaryProgressStepRow(label: L10n.exportBatchSummaryToGoogleDocs, status: state.googleDocsExport)
+            }
         }
         .padding(12)
-        .frame(width: 220)
+        .frame(minWidth: 220)
         .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 10))
         .shadow(color: .black.opacity(0.12), radius: 12, y: 4)
         .shadow(color: .black.opacity(0.06), radius: 3, y: 1)
-    }
-}
-
-private struct StepRow: View {
-    let label: String
-    let status: SummaryProgressState.StepStatus
-
-    var body: some View {
-        HStack(spacing: 8) {
-            statusIcon
-                .frame(width: 14, height: 14)
-            Text(label)
-                .font(.system(size: 11))
-                .foregroundStyle(textColor)
-        }
-    }
-
-    @ViewBuilder
-    private var statusIcon: some View {
-        switch status {
-        case .pending:
-            Image(systemName: "circle")
-                .font(.system(size: 10))
-                .foregroundStyle(.tertiary)
-        case .running:
-            ProgressView()
-                .controlSize(.mini)
-                .scaleEffect(0.7)
-        case .completed:
-            Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 12))
-                .foregroundStyle(.green)
-        case .skipped:
-            Image(systemName: "minus.circle")
-                .font(.system(size: 12))
-                .foregroundStyle(.tertiary)
-        case .failed:
-            Image(systemName: "xmark.circle.fill")
-                .font(.system(size: 12))
-                .foregroundStyle(.red)
-        }
-    }
-
-    private var textColor: Color {
-        switch status {
-        case .pending: .secondary
-        case .running: .primary
-        case .completed, .skipped: .secondary
-        case .failed: .red
-        }
     }
 }

--- a/Tests/DahliaTests/BatchAudioRecordingSessionTests.swift
+++ b/Tests/DahliaTests/BatchAudioRecordingSessionTests.swift
@@ -305,8 +305,13 @@ import GRDB
             #expect(delayed.pendingByteCount == 320)
             #expect(delayed.oldestFinalizationStartedAt != nil)
 
-            try await Task.sleep(for: .milliseconds(600))
-            let recovered = await writer.backlogSnapshot()
+            let clock = ContinuousClock()
+            let deadline = clock.now + .seconds(2)
+            var recovered = await writer.backlogSnapshot()
+            while recovered.segmentCount > 0, clock.now < deadline {
+                try await Task.sleep(for: .milliseconds(10))
+                recovered = await writer.backlogSnapshot()
+            }
             #expect(recovered.segmentCount == 0)
             try writer.appendBuffer(makeBuffer(
                 format: recorder.targetFormat,

--- a/Tests/DahliaTests/CaptionViewModelTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelTests.swift
@@ -209,6 +209,17 @@ import GRDB
         }
 
         @Test
+        func canGenerateSummaryIsDisabledWhileAnotherSummaryIsGenerating() {
+            let viewModel = summaryReadyViewModel()
+
+            #expect(viewModel.canGenerateSummary)
+
+            viewModel.summaryGeneratingMeetingId = UUID.v7()
+
+            #expect(!viewModel.canGenerateSummary)
+        }
+
+        @Test
         func manualSummaryDoesNotStartWhileFinalizingRecording() {
             let viewModel = summaryReadyViewModel()
             viewModel.isFinalizingRecording = true

--- a/Tests/DahliaTests/MeetingRepositorySummaryTests.swift
+++ b/Tests/DahliaTests/MeetingRepositorySummaryTests.swift
@@ -79,7 +79,7 @@ import GRDB
         }
 
         @Test
-        func regeneratingSummaryPreservesStoredVaultRelativePath() throws {
+        func regeneratingSummaryClearsStaleExportLocations() throws {
             let context = try makeRepositoryContext()
             try context.repo.upsertSummary(
                 SummaryRecord(
@@ -87,7 +87,7 @@ import GRDB
                     title: "Old",
                     summary: "Old body",
                     vaultRelativePath: "Acme/Existing.md",
-                    googleFileId: nil,
+                    googleFileId: "old-google-file",
                     createdAt: .now
                 )
             )
@@ -106,7 +106,67 @@ import GRDB
 
             let fetchedSummary = try context.repo.fetchSummary(forMeetingId: context.meeting.id)
             let summary = try #require(fetchedSummary)
-            #expect(summary.vaultRelativePath == "Acme/Existing.md")
+            #expect(summary.vaultRelativePath == nil)
+            #expect(summary.googleFileId == nil)
+            #expect(try context.repo.fetchSummaryExport(
+                forMeetingId: context.meeting.id,
+                type: .vault
+            ) == nil)
+            #expect(try context.repo.fetchSummaryExport(
+                forMeetingId: context.meeting.id,
+                type: .googleDocs
+            ) == nil)
+        }
+
+        @Test
+        func storesVaultAndGoogleDocsExportsIndependently() throws {
+            let context = try makeRepositoryContext()
+            try context.repo.upsertSummary(
+                SummaryRecord(
+                    meetingId: context.meeting.id,
+                    title: "Summary",
+                    summary: "Body",
+                    vaultRelativePath: nil,
+                    googleFileId: nil,
+                    createdAt: .now
+                )
+            )
+
+            try context.repo.updateSummaryVaultRelativePath(
+                forMeetingId: context.meeting.id,
+                relativePath: "Acme/Summary.md"
+            )
+            try context.repo.updateSummaryGoogleFileId(
+                forMeetingId: context.meeting.id,
+                googleFileId: "google-123"
+            )
+
+            let vault = try context.repo.fetchSummaryExport(
+                forMeetingId: context.meeting.id,
+                type: .vault
+            )
+            let googleDocs = try context.repo.fetchSummaryExport(
+                forMeetingId: context.meeting.id,
+                type: .googleDocs
+            )
+
+            #expect(vault?.url == "vault:///Acme/Summary.md")
+            #expect(vault?.vaultRelativePath == "Acme/Summary.md")
+            #expect(googleDocs?.url == "https://docs.google.com/document/d/google-123/edit")
+
+            try context.repo.updateSummaryVaultRelativePath(
+                forMeetingId: context.meeting.id,
+                relativePath: nil
+            )
+
+            #expect(try context.repo.fetchSummaryExport(
+                forMeetingId: context.meeting.id,
+                type: .vault
+            ) == nil)
+            #expect(try context.repo.fetchSummaryExport(
+                forMeetingId: context.meeting.id,
+                type: .googleDocs
+            )?.googleDocumentID == "google-123")
         }
 
         private func makeRepositoryContext() throws -> RepositoryContext {

--- a/Tests/DahliaTests/ProjectWorkspaceServiceTests.swift
+++ b/Tests/DahliaTests/ProjectWorkspaceServiceTests.swift
@@ -112,12 +112,18 @@ import GRDB
 
             let fetchedChildRecord = try context.repository.fetchProject(id: child.id)
             let fetchedSummary = try context.repository.fetchSummary(forMeetingId: meeting.id)
+            let vaultExport = try context.repository.fetchSummaryExport(
+                forMeetingId: meeting.id,
+                type: .vault
+            )
             let fetchedChild = try #require(fetchedChildRecord)
             let summary = try #require(fetchedSummary)
             #expect(renamed.name == "Renamed")
             #expect(fetchedChild.name == "Renamed/Child")
             #expect(fetchedChild.description == "Keep me")
             #expect(summary.vaultRelativePath == "Renamed/Child/Summary.md")
+            #expect(vaultExport?.url == "vault:///Renamed/Child/Summary.md")
+            #expect(vaultExport?.vaultRelativePath == "Renamed/Child/Summary.md")
             #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Renamed/Child").path))
             #expect(!FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Original").path))
         }
@@ -179,9 +185,14 @@ import GRDB
                 try MeetingRecord.fetchOne(db, key: meeting.id)
             }
             let fetchedSummary = try context.repository.fetchSummary(forMeetingId: meeting.id)
+            let vaultExport = try context.repository.fetchSummaryExport(
+                forMeetingId: meeting.id,
+                type: .vault
+            )
             let summary = try #require(fetchedSummary)
             #expect(fetchedMeeting?.projectId == destination.id)
             #expect(summary.vaultRelativePath == nil)
+            #expect(vaultExport == nil)
             #expect(summary.summary == "Body")
             #expect(try context.repository.fetchSegments(forMeetingId: meeting.id).count == 1)
             #expect(try context.repository.fetchTagsForMeeting(id: meeting.id).map(\.name) == ["important"])
@@ -321,15 +332,15 @@ import GRDB
             path: String,
             context: ProjectWorkspaceTestContext
         ) throws {
-            try context.database.dbQueue.write { db in
-                try SummaryRecord(
+            try context.repository.upsertSummary(
+                SummaryRecord(
                     meetingId: meetingId,
                     title: "Summary",
                     summary: "Body",
                     vaultRelativePath: path,
                     createdAt: .now
-                ).insert(db)
-            }
+                )
+            )
         }
 
         private func insertSegment(

--- a/Tests/DahliaTests/SummaryExportOptionsTests.swift
+++ b/Tests/DahliaTests/SummaryExportOptionsTests.swift
@@ -1,0 +1,24 @@
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct SummaryExportOptionsTests {
+        @Test
+        func mergesVaultAndGoogleDocsIndependently() {
+            let merged = SummaryExportOptions.merging([
+                SummaryExportOptions(exportsToVault: true, exportsToGoogleDocs: false),
+                SummaryExportOptions(exportsToVault: false, exportsToGoogleDocs: true),
+            ])
+
+            #expect(merged.exportsToVault)
+            #expect(merged.exportsToGoogleDocs)
+        }
+
+        @Test
+        func manualSummaryKeepsExistingVaultExportBehavior() {
+            #expect(SummaryExportOptions.manual.exportsToVault)
+            #expect(!SummaryExportOptions.manual.exportsToGoogleDocs)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/SummaryExportsMigrationTests.swift
+++ b/Tests/DahliaTests/SummaryExportsMigrationTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct SummaryExportsMigrationTests {
+        @Test
+        func initializesDatabaseWithSummaryExportsTable() throws {
+            let database = try AppDatabaseManager(path: ":memory:")
+
+            let columns = try database.dbQueue.read { db in
+                try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summary_exports')")
+            }
+
+            #expect(columns == ["meetingId", "type", "url", "createdAt", "updatedAt"])
+        }
+
+        @Test
+        func migratesLegacyExportLocationsWithoutRemovingLegacyValues() throws {
+            let databaseURL = URL.temporaryDirectory
+                .appending(path: UUID.v7().uuidString)
+                .appendingPathExtension("sqlite")
+            let meetingId = UUID.v7()
+            let createdAt = Date(timeIntervalSince1970: 1_700_000_000)
+            defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+            let legacyQueue = try DatabaseQueue(path: databaseURL.path)
+            try createV18SummaryDatabase(
+                in: legacyQueue,
+                meetingId: meetingId,
+                createdAt: createdAt
+            )
+
+            let migrated = try AppDatabaseManager(path: databaseURL.path)
+            let result = try migrated.dbQueue.read { db in
+                let exports = try SummaryExportRecord
+                    .filter(Column("meetingId") == meetingId)
+                    .order(Column("type"))
+                    .fetchAll(db)
+                let legacy = try Row.fetchOne(
+                    db,
+                    sql: "SELECT vaultRelativePath, googleFileId FROM summaries WHERE meetingId = ?",
+                    arguments: [meetingId]
+                )
+                return try (exports, #require(legacy))
+            }
+
+            #expect(result.0 == [
+                SummaryExportRecord(
+                    meetingId: meetingId,
+                    type: .googleDocs,
+                    url: "https://docs.google.com/document/d/google-123/edit",
+                    createdAt: createdAt,
+                    updatedAt: createdAt
+                ),
+                SummaryExportRecord(
+                    meetingId: meetingId,
+                    type: .vault,
+                    url: "vault:///Project/Summary.md",
+                    createdAt: createdAt,
+                    updatedAt: createdAt
+                ),
+            ])
+            #expect(result.1["vaultRelativePath"] == "Project/Summary.md" as String?)
+            #expect(result.1["googleFileId"] == "google-123" as String?)
+        }
+
+        @Test
+        func vaultURLRoundTripsRelativePathsWithReservedCharacters() throws {
+            let url = try #require(SummaryExportRecord.vaultURL(relativePath: "Project/My Summary #1.md"))
+            let record = SummaryExportRecord(
+                meetingId: .v7(),
+                type: .vault,
+                url: url,
+                createdAt: .now,
+                updatedAt: .now
+            )
+
+            #expect(url == "vault:///Project/My%20Summary%20%231.md")
+            #expect(record.vaultRelativePath == "Project/My Summary #1.md")
+        }
+
+        private func createV18SummaryDatabase(
+            in dbQueue: DatabaseQueue,
+            meetingId: UUID,
+            createdAt: Date
+        ) throws {
+            try dbQueue.write { db in
+                try db.execute(
+                    sql: """
+                    CREATE TABLE summaries (
+                        meetingId BLOB PRIMARY KEY,
+                        title TEXT NOT NULL DEFAULT '',
+                        summary TEXT NOT NULL,
+                        document TEXT,
+                        vaultRelativePath TEXT,
+                        googleFileId TEXT,
+                        createdAt DATETIME NOT NULL
+                    )
+                    """
+                )
+                try db.create(table: "grdb_migrations") { table in
+                    table.column("identifier", .text).primaryKey()
+                }
+                for migration in Self.v18MigrationIdentifiers {
+                    try db.execute(
+                        sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
+                        arguments: [migration]
+                    )
+                }
+                try db.execute(
+                    sql: """
+                    INSERT INTO summaries (
+                        meetingId, title, summary, document, vaultRelativePath, googleFileId, createdAt
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    arguments: [
+                        meetingId,
+                        "Legacy",
+                        "Body",
+                        nil,
+                        "Project/Summary.md",
+                        "google-123",
+                        createdAt,
+                    ]
+                )
+            }
+        }
+
+        private static let v18MigrationIdentifiers = [
+            "v3_googleDriveFolderSchema",
+            "v4_instructionsSchema",
+            "v5_summaryGoogleFileId",
+            "v6_transcriptSegmentTranslation",
+            "v7_normalizeLegacyMeetingStatus",
+            "v8_recordingSessions",
+            "v9_summaryDocument",
+            "v10_batchTranscription",
+            "v11_batchAudioStorageLocation",
+            "v12_batchTranscriptionDiscard",
+            "v13_summaryVaultRelativePath",
+            "v14_projectDescription",
+            "v15_calendarEventIdentity",
+            "v16_calendarEventURL",
+            "v17_calendarEventIntegrity",
+            "v18_segmentedRecordingAudio",
+        ]
+    }
+#endif

--- a/Tests/DahliaTests/SummaryProgressStateTests.swift
+++ b/Tests/DahliaTests/SummaryProgressStateTests.swift
@@ -1,0 +1,31 @@
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct SummaryProgressStateTests {
+        @Test
+        func waitsForGoogleDocsExportToReachTerminalState() {
+            let state = SummaryProgressState()
+            state.summaryGeneration = .completed
+            state.vaultExport = .skipped
+
+            #expect(!state.isAllDone)
+
+            state.googleDocsExport = .completed
+
+            #expect(state.isAllDone)
+        }
+
+        @Test
+        func resetRestoresGoogleDocsExportToPending() {
+            let state = SummaryProgressState()
+            state.googleDocsExport = .failed("offline")
+
+            state.reset()
+
+            #expect(!state.googleDocsExport.isTerminal)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/SummaryProgressStateTests.swift
+++ b/Tests/DahliaTests/SummaryProgressStateTests.swift
@@ -27,5 +27,20 @@
 
             #expect(!state.googleDocsExport.isTerminal)
         }
+
+        @Test
+        func delayedDismissDoesNotHideNewerProgress() {
+            let state = SummaryProgressState()
+            let firstPresentationID = state.show()
+            let secondPresentationID = state.show()
+
+            state.dismiss(ifCurrent: firstPresentationID)
+
+            #expect(state.isVisible)
+
+            state.dismiss(ifCurrent: secondPresentationID)
+
+            #expect(!state.isVisible)
+        }
     }
 #endif

--- a/Tests/DahliaTests/VaultSyncSummaryPathTests.swift
+++ b/Tests/DahliaTests/VaultSyncSummaryPathTests.swift
@@ -26,8 +26,14 @@ import GRDB
             )
 
             let fetchedSummary = try context.repository.fetchSummary(forMeetingId: context.meeting.id)
+            let vaultExport = try context.repository.fetchSummaryExport(
+                forMeetingId: context.meeting.id,
+                type: .vault
+            )
             let summary = try #require(fetchedSummary)
             #expect(summary.vaultRelativePath == "Project/Renamed.md")
+            #expect(vaultExport?.url == "vault:///Project/Renamed.md")
+            #expect(vaultExport?.vaultRelativePath == "Project/Renamed.md")
         }
 
         @Test
@@ -48,10 +54,16 @@ import GRDB
 
             let fetchedProject = try context.repository.fetchProject(id: context.project.id)
             let fetchedSummary = try context.repository.fetchSummary(forMeetingId: context.meeting.id)
+            let vaultExport = try context.repository.fetchSummaryExport(
+                forMeetingId: context.meeting.id,
+                type: .vault
+            )
             let project = try #require(fetchedProject)
             let summary = try #require(fetchedSummary)
             #expect(project.name == "Renamed")
             #expect(summary.vaultRelativePath == "Renamed/Summary.md")
+            #expect(vaultExport?.url == "vault:///Renamed/Summary.md")
+            #expect(vaultExport?.vaultRelativePath == "Renamed/Summary.md")
         }
 
         @Test
@@ -101,15 +113,17 @@ import GRDB
             )
             try manager.dbQueue.write { db in
                 try meeting.insert(db)
-                try SummaryRecord(
+            }
+            try repository.upsertSummary(
+                SummaryRecord(
                     meetingId: meeting.id,
                     title: "Summary",
                     summary: "Body",
                     vaultRelativePath: summaryRelativePath,
                     googleFileId: nil,
                     createdAt: .now
-                ).insert(db)
-            }
+                )
+            )
 
             return TestContext(
                 vaultURL: vaultURL,


### PR DESCRIPTION
## Summary

- Reorganize the batch transcription confirmation popup into grouped transcription and summary/export settings.
- Add independent Vault and Google Docs export options after automatic summary generation.
- Add a generic `summary_exports` table with `vault:///...` and Google Docs URLs while retaining legacy-column compatibility.
- Track Vault and Google Docs progress independently and keep failures isolated.
- Prevent stale export metadata, overlapping summary progress, and duplicate Google Docs exports.

## Why

Batch transcription settings had grown beyond the original flat confirmation layout, and summary exports were tied to destination-specific columns. This change makes the popup easier to scan and introduces an extensible export record model for additional destinations.

Vault locations use Vault-relative custom URLs instead of absolute `file://` URLs so records remain valid when a Vault moves or is opened on another Mac.

## Validation

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build`
- Full test suite: 499 Swift Testing tests and 3 XCTest tests, 0 failures
- Final focused test run: 47 tests across export migration, repository, Vault sync, project workspace, view-model, options, and progress suites
- SwiftFormat: 0 of 319 files require formatting
- English and Japanese localization files pass `plutil -lint`
- New files pass focused SwiftLint; repository-wide SwiftLint still reports pre-existing non-blocking violations