### PR TITLE
Improve Codex chat UI and MCP settings

### DIFF
--- a/Sources/Dahlia/Models/CodexChatMessage.swift
+++ b/Sources/Dahlia/Models/CodexChatMessage.swift
@@ -9,17 +9,20 @@ struct CodexChatMessage: Identifiable, Equatable {
     let id: String
     let role: Role
     var text: String
+    var reasoning: String
     var isStreaming: Bool
 
     init(
         id: String = UUID.v7().uuidString,
         role: Role,
         text: String,
+        reasoning: String = "",
         isStreaming: Bool = false
     ) {
         self.id = id
         self.role = role
         self.text = text
+        self.reasoning = reasoning
         self.isStreaming = isStreaming
     }
 }

--- a/Sources/Dahlia/Models/CodexChatTurnAccumulator.swift
+++ b/Sources/Dahlia/Models/CodexChatTurnAccumulator.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+struct CodexChatTurnAccumulator {
+    private var responseItemIDs: [String] = []
+    private var responseTexts: [String: String] = [:]
+    private var reasoningItemIDs: [String] = []
+    private var reasoningSections: [String: [Int: String]] = [:]
+
+    var responseText: String {
+        responseItemIDs.compactMap { responseTexts[$0]?.nilIfBlank }.joined(separator: "\n\n")
+    }
+
+    var reasoningText: String {
+        reasoningItemIDs.compactMap { itemID in
+            reasoningSections[itemID]?
+                .sorted { $0.key < $1.key }
+                .compactMap(\.value.nilIfBlank)
+                .joined(separator: "\n\n")
+                .nilIfBlank
+        }
+        .joined(separator: "\n\n")
+    }
+
+    mutating func appendResponseDelta(itemID: String, text: String) {
+        registerResponseItem(itemID)
+        responseTexts[itemID, default: ""] += text
+    }
+
+    mutating func completeResponse(itemID: String, text: String?) {
+        registerResponseItem(itemID)
+        if let text {
+            responseTexts[itemID] = text
+        }
+    }
+
+    mutating func appendReasoningDelta(itemID: String, summaryIndex: Int, text: String) {
+        registerReasoningItem(itemID)
+        reasoningSections[itemID, default: [:]][summaryIndex, default: ""] += text
+    }
+
+    mutating func completeReasoning(itemID: String, text: String) {
+        registerReasoningItem(itemID)
+        if let text = text.nilIfBlank {
+            reasoningSections[itemID] = [0: text]
+        }
+    }
+
+    private mutating func registerResponseItem(_ itemID: String) {
+        guard responseTexts[itemID] == nil else { return }
+        responseItemIDs.append(itemID)
+        responseTexts[itemID] = ""
+    }
+
+    private mutating func registerReasoningItem(_ itemID: String) {
+        guard reasoningSections[itemID] == nil else { return }
+        reasoningItemIDs.append(itemID)
+        reasoningSections[itemID] = [:]
+    }
+}

--- a/Sources/Dahlia/Models/CodexChatTurnEvent.swift
+++ b/Sources/Dahlia/Models/CodexChatTurnEvent.swift
@@ -4,6 +4,8 @@ enum CodexChatTurnEvent: Equatable {
     case started(turnID: String)
     case delta(itemID: String, text: String)
     case completed(itemID: String?, text: String?)
+    case reasoningDelta(itemID: String, summaryIndex: Int, text: String)
+    case reasoningCompleted(itemID: String, text: String)
     case interrupted
     case failed(message: String?)
 }

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -671,17 +671,18 @@
 "Resize" = "Resize";
 "Show all chats" = "Show all";
 "Copy message" = "Copy message";
+"Thought process" = "Thought process";
 "Selected" = "Selected";
 "Response performance" = "Response performance";
 
-/* Meeting Data Access */
-"Meeting Data Access" = "Meeting Data Access";
+/* MCP */
+"MCP" = "MCP";
 "Vault Name" = "Vault Name";
 "Vault ID" = "Vault ID";
 "Copy Command" = "Copy Command";
 "Codex CLI" = "Codex CLI";
 "Claude Code" = "Claude Code";
-"The meeting access helper is not available in this app build." = "The meeting access helper is not available in this app build.";
-"Select a vault before configuring meeting data access." = "Select a vault before configuring meeting data access.";
+"The MCP helper is not available in this app build." = "The MCP helper is not available in this app build.";
+"Select a vault before configuring MCP." = "Select a vault before configuring MCP.";
 "Each command registers read-only access to only the selected vault. Run it again after switching vaults." = "Each command registers read-only access to only the selected vault. Run it again after switching vaults.";
 "%@ registration command" = "%@ registration command";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -671,17 +671,18 @@
 "Resize" = "サイズを変更";
 "Show all chats" = "すべて表示";
 "Copy message" = "メッセージをコピー";
+"Thought process" = "思考プロセス";
 "Selected" = "選択中";
 "Response performance" = "応答性能";
 
-/* Meeting Data Access */
-"Meeting Data Access" = "議事録データアクセス";
+/* MCP */
+"MCP" = "MCP";
 "Vault Name" = "保管庫名";
 "Vault ID" = "保管庫 ID";
 "Copy Command" = "コマンドをコピー";
 "Codex CLI" = "Codex CLI";
 "Claude Code" = "Claude Code";
-"The meeting access helper is not available in this app build." = "このアプリビルドでは議事録アクセス用ヘルパーを利用できません。";
-"Select a vault before configuring meeting data access." = "議事録データアクセスを設定する前に保管庫を選択してください。";
+"The MCP helper is not available in this app build." = "このアプリビルドではMCPヘルパーを利用できません。";
+"Select a vault before configuring MCP." = "MCPを設定する前に保管庫を選択してください。";
 "Each command registers read-only access to only the selected vault. Run it again after switching vaults." = "各コマンドは、選択中の保管庫だけへの読み取り専用アクセスを登録します。保管庫を切り替えた後は再実行してください。";
 "%@ registration command" = "%@ 登録コマンド";

--- a/Sources/Dahlia/Services/CodexChatService.swift
+++ b/Sources/Dahlia/Services/CodexChatService.swift
@@ -257,6 +257,7 @@ private extension CodexChatService {
         var messages: [CodexChatMessage] = []
         var assistantItemID: String?
         var assistantTexts: [String] = []
+        var reasoningItemID: String?
         var reasoningTexts: [String] = []
 
         for item in items {
@@ -273,18 +274,17 @@ private extension CodexChatService {
                 assistantItemID = assistantItemID ?? id
                 assistantTexts.append(text)
             case "reasoning":
-                let summaries = object["summary"]?.arrayValue?
-                    .compactMap(\.stringValue)
-                    .compactMap(\.nilIfBlank)
-                reasoningTexts.append(contentsOf: summaries ?? [])
+                reasoningItemID = reasoningItemID ?? id
+                reasoningTexts.append(contentsOf: parseReasoningSummaries(object["summary"]))
             default:
                 continue
             }
         }
 
-        if let assistantItemID, !assistantTexts.isEmpty {
+        if let messageID = assistantItemID ?? reasoningItemID,
+           !assistantTexts.isEmpty || !reasoningTexts.isEmpty {
             messages.append(CodexChatMessage(
-                id: assistantItemID,
+                id: messageID,
                 role: .assistant,
                 text: assistantTexts.joined(separator: "\n\n"),
                 reasoning: reasoningTexts.joined(separator: "\n\n")
@@ -349,26 +349,30 @@ private extension CodexChatService {
         guard let item = params["item"]?.objectValue else {
             throw CodexAppServerError.invalidProtocolResponse
         }
-        guard let itemID = item["id"]?.stringValue,
-              let type = item["type"]?.stringValue
-        else {
-            throw CodexAppServerError.invalidProtocolResponse
-        }
+        guard let type = item["type"]?.stringValue else { return nil }
         switch type {
         case "agentMessage":
-            guard let text = item["text"]?.stringValue else {
+            guard let itemID = item["id"]?.stringValue,
+                  let text = item["text"]?.stringValue
+            else {
                 throw CodexAppServerError.invalidProtocolResponse
             }
             return .completed(itemID: itemID, text: text)
         case "reasoning":
-            let text = item["summary"]?.arrayValue?
-                .compactMap(\.stringValue)
-                .compactMap(\.nilIfBlank)
-                .joined(separator: "\n\n") ?? ""
+            guard let itemID = item["id"]?.stringValue else {
+                throw CodexAppServerError.invalidProtocolResponse
+            }
+            let text = parseReasoningSummaries(item["summary"]).joined(separator: "\n\n")
             return .reasoningCompleted(itemID: itemID, text: text)
         default:
             return nil
         }
+    }
+
+    nonisolated static func parseReasoningSummaries(_ value: JSONValue?) -> [String] {
+        value?.arrayValue?.compactMap { summary in
+            (summary.objectValue?["text"]?.stringValue ?? summary.stringValue)?.nilIfBlank
+        } ?? []
     }
 
     nonisolated static func parseTurnCompletion(_ params: [String: JSONValue]) throws -> CodexChatTurnEvent {

--- a/Sources/Dahlia/Services/CodexChatService.swift
+++ b/Sources/Dahlia/Services/CodexChatService.swift
@@ -156,6 +156,7 @@ actor CodexChatService: CodexChatServicing {
                     "text": .string(text),
                 ]),
             ]),
+            "summary": .string("auto"),
             "threadId": .string(threadID),
         ]
         if let model = model?.nilIfBlank {
@@ -253,29 +254,54 @@ private extension CodexChatService {
 
     nonisolated static func parseMessages(_ turn: JSONValue) -> [CodexChatMessage] {
         guard let items = turn.objectValue?["items"]?.arrayValue else { return [] }
-        return items.compactMap { item in
+        var messages: [CodexChatMessage] = []
+        var assistantItemID: String?
+        var assistantTexts: [String] = []
+        var reasoningTexts: [String] = []
+
+        for item in items {
             guard let object = item.objectValue,
                   let id = object["id"]?.stringValue,
                   let type = object["type"]?.stringValue
-            else { return nil }
+            else { continue }
 
             switch type {
             case "userMessage":
-                let text = object["content"]?.arrayValue?
-                    .compactMap { input -> String? in
-                        guard input.objectValue?["type"]?.stringValue == "text" else { return nil }
-                        return input.objectValue?["text"]?.stringValue
-                    }
-                    .joined(separator: "\n")
-                guard let text = text?.nilIfBlank else { return nil }
-                return CodexChatMessage(id: id, role: .user, text: text)
+                messages.append(contentsOf: parseUserMessages(object, id: id))
             case "agentMessage":
-                guard let text = object["text"]?.stringValue?.nilIfBlank else { return nil }
-                return CodexChatMessage(id: id, role: .assistant, text: text)
+                guard let text = object["text"]?.stringValue?.nilIfBlank else { continue }
+                assistantItemID = assistantItemID ?? id
+                assistantTexts.append(text)
+            case "reasoning":
+                let summaries = object["summary"]?.arrayValue?
+                    .compactMap(\.stringValue)
+                    .compactMap(\.nilIfBlank)
+                reasoningTexts.append(contentsOf: summaries ?? [])
             default:
-                return nil
+                continue
             }
         }
+
+        if let assistantItemID, !assistantTexts.isEmpty {
+            messages.append(CodexChatMessage(
+                id: assistantItemID,
+                role: .assistant,
+                text: assistantTexts.joined(separator: "\n\n"),
+                reasoning: reasoningTexts.joined(separator: "\n\n")
+            ))
+        }
+        return messages
+    }
+
+    nonisolated static func parseUserMessages(_ object: [String: JSONValue], id: String) -> [CodexChatMessage] {
+        let text = object["content"]?.arrayValue?
+            .compactMap { input -> String? in
+                guard input.objectValue?["type"]?.stringValue == "text" else { return nil }
+                return input.objectValue?["text"]?.stringValue
+            }
+            .joined(separator: "\n")
+        guard let text = text?.nilIfBlank else { return [] }
+        return [CodexChatMessage(id: id, role: .user, text: text)]
     }
 
     nonisolated static func parseTurnEvent(_ value: JSONValue) throws -> CodexChatTurnEvent? {
@@ -289,6 +315,8 @@ private extension CodexChatService {
         switch method {
         case "item/agentMessage/delta":
             return try parseDelta(params)
+        case "item/reasoning/summaryTextDelta":
+            return try parseReasoningDelta(params)
         case "item/completed":
             return try parseCompletedItem(params)
         case "turn/completed":
@@ -296,6 +324,16 @@ private extension CodexChatService {
         default:
             return nil
         }
+    }
+
+    nonisolated static func parseReasoningDelta(_ params: [String: JSONValue]) throws -> CodexChatTurnEvent {
+        guard let itemID = params["itemId"]?.stringValue,
+              let summaryIndex = params["summaryIndex"]?.intValue,
+              let delta = params["delta"]?.stringValue
+        else {
+            throw CodexAppServerError.invalidProtocolResponse
+        }
+        return .reasoningDelta(itemID: itemID, summaryIndex: summaryIndex, text: delta)
     }
 
     nonisolated static func parseDelta(_ params: [String: JSONValue]) throws -> CodexChatTurnEvent {
@@ -311,13 +349,26 @@ private extension CodexChatService {
         guard let item = params["item"]?.objectValue else {
             throw CodexAppServerError.invalidProtocolResponse
         }
-        guard item["type"]?.stringValue == "agentMessage" else { return nil }
         guard let itemID = item["id"]?.stringValue,
-              let text = item["text"]?.stringValue
+              let type = item["type"]?.stringValue
         else {
             throw CodexAppServerError.invalidProtocolResponse
         }
-        return .completed(itemID: itemID, text: text)
+        switch type {
+        case "agentMessage":
+            guard let text = item["text"]?.stringValue else {
+                throw CodexAppServerError.invalidProtocolResponse
+            }
+            return .completed(itemID: itemID, text: text)
+        case "reasoning":
+            let text = item["summary"]?.arrayValue?
+                .compactMap(\.stringValue)
+                .compactMap(\.nilIfBlank)
+                .joined(separator: "\n\n") ?? ""
+            return .reasoningCompleted(itemID: itemID, text: text)
+        default:
+            return nil
+        }
     }
 
     nonisolated static func parseTurnCompletion(_ params: [String: JSONValue]) throws -> CodexChatTurnEvent {

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -519,17 +519,17 @@ enum L10n {
     static var developerSettings: String { String(localized: "Developer Settings", bundle: bundle) }
     static var vault: String { String(localized: "Vault", bundle: bundle) }
     static var currentVault: String { String(localized: "Current Vault", bundle: bundle) }
-    static var meetingDataAccess: String { String(localized: "Meeting Data Access", bundle: bundle) }
+    static var mcp: String { String(localized: "MCP", bundle: bundle) }
     static var vaultID: String { String(localized: "Vault ID", bundle: bundle) }
     static var copyCommand: String { String(localized: "Copy Command", bundle: bundle) }
     static var codexCLI: String { String(localized: "Codex CLI", bundle: bundle) }
     static var claudeCode: String { String(localized: "Claude Code", bundle: bundle) }
-    static var meetingDataAccessHelperUnavailable: String { String(
-        localized: "The meeting access helper is not available in this app build.",
+    static var mcpHelperUnavailable: String { String(
+        localized: "The MCP helper is not available in this app build.",
         bundle: bundle
     ) }
-    static var selectVaultForMeetingDataAccess: String { String(localized: "Select a vault before configuring meeting data access.", bundle: bundle) }
-    static var meetingDataAccessFooter: String { String(
+    static var selectVaultForMCP: String { String(localized: "Select a vault before configuring MCP.", bundle: bundle) }
+    static var mcpFooter: String { String(
         localized: "Each command registers read-only access to only the selected vault. Run it again after switching vaults.",
         bundle: bundle
     ) }
@@ -1289,6 +1289,7 @@ enum L10n {
     static var resize: String { String(localized: "Resize", bundle: bundle) }
     static var chatShowAll: String { String(localized: "Show all chats", bundle: bundle) }
     static var copyChatMessage: String { String(localized: "Copy message", bundle: bundle) }
+    static var chatReasoning: String { String(localized: "Thought process", bundle: bundle) }
     static var selected: String { String(localized: "Selected", bundle: bundle) }
     static var responsePerformance: String { String(localized: "Response performance", bundle: bundle) }
 }

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -179,7 +179,7 @@ final class CodexChatSessionModel: Identifiable {
                 }
             }
             if turnCompleted {
-                await reconcileFromRollout()
+                await reconcileFromRollout(preservingReasoningFrom: responseID)
             }
         } catch is CancellationError {
             completeTurnResponse(responseID: responseID)
@@ -251,11 +251,28 @@ final class CodexChatSessionModel: Identifiable {
         messages[index].reasoning = accumulator.reasoningText
     }
 
-    private func reconcileFromRollout() async {
+    private func reconcileFromRollout(preservingReasoningFrom responseID: String) async {
         guard let backendThreadID,
               let thread = try? await service.loadThread(id: backendThreadID)
         else { return }
-        apply(thread, preservingPendingMessages: thread.messages.count < messages.count)
+        let streamedReasoning = messages
+            .first(where: { $0.id == responseID })?
+            .reasoning
+            .nilIfBlank
+        var reconciledMessages = thread.messages
+        if let streamedReasoning,
+           let index = reconciledMessages.lastIndex(where: { $0.role == .assistant }),
+           reconciledMessages[index].reasoning.nilIfBlank == nil {
+            reconciledMessages[index].reasoning = streamedReasoning
+        }
+        let reconciledThread = CodexChatThread(
+            id: thread.id,
+            title: thread.title,
+            messages: reconciledMessages,
+            model: thread.model,
+            reasoningEffort: thread.reasoningEffort
+        )
+        apply(reconciledThread, preservingPendingMessages: thread.messages.count < messages.count)
     }
 
     private func finishGeneration() {

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -144,7 +144,7 @@ final class CodexChatSessionModel: Identifiable {
     }
 
     private func runTurn(text: String, responseID: String) async {
-        var responseIDsByItemID: [String: String] = [:]
+        var accumulator = CodexChatTurnAccumulator()
         do {
             if models.isEmpty {
                 await prepare()
@@ -173,7 +173,7 @@ final class CodexChatSessionModel: Identifiable {
             )
             var turnCompleted = false
             for try await event in stream {
-                apply(event, responseID: responseID, responseIDsByItemID: &responseIDsByItemID)
+                apply(event, responseID: responseID, accumulator: &accumulator)
                 if case .completed(itemID: nil, text: nil) = event {
                     turnCompleted = true
                 }
@@ -182,10 +182,10 @@ final class CodexChatSessionModel: Identifiable {
                 await reconcileFromRollout()
             }
         } catch is CancellationError {
-            completeTurnResponses(responseID: responseID, responseIDsByItemID: responseIDsByItemID)
+            completeTurnResponse(responseID: responseID)
         } catch {
             errorMessage = error.localizedDescription
-            completeTurnResponses(responseID: responseID, responseIDsByItemID: responseIDsByItemID)
+            completeTurnResponse(responseID: responseID)
         }
         finishGeneration()
     }
@@ -193,7 +193,7 @@ final class CodexChatSessionModel: Identifiable {
     private func apply(
         _ event: CodexChatTurnEvent,
         responseID: String,
-        responseIDsByItemID: inout [String: String]
+        accumulator: inout CodexChatTurnAccumulator
     ) {
         switch event {
         case let .started(turnID):
@@ -202,30 +202,24 @@ final class CodexChatSessionModel: Identifiable {
                 Task { await service.interrupt(threadID: backendThreadID, turnID: turnID) }
             }
         case let .delta(itemID, text):
-            let messageID = responseMessageID(
-                for: itemID,
-                pendingResponseID: responseID,
-                responseIDsByItemID: &responseIDsByItemID
-            )
-            guard let index = messages.firstIndex(where: { $0.id == messageID }) else { return }
-            messages[index].text += text
+            accumulator.appendResponseDelta(itemID: itemID, text: text)
+            updateTurnResponse(id: responseID, from: accumulator)
         case let .completed(itemID?, text):
-            let messageID = responseMessageID(
-                for: itemID,
-                pendingResponseID: responseID,
-                responseIDsByItemID: &responseIDsByItemID
-            )
-            if let text, let index = messages.firstIndex(where: { $0.id == messageID }) {
-                messages[index].text = text
-                messages[index].isStreaming = false
-            }
+            accumulator.completeResponse(itemID: itemID, text: text)
+            updateTurnResponse(id: responseID, from: accumulator)
         case .completed(itemID: nil, text: _):
-            completeTurnResponses(responseID: responseID, responseIDsByItemID: responseIDsByItemID)
+            completeTurnResponse(responseID: responseID)
+        case let .reasoningDelta(itemID, summaryIndex, text):
+            accumulator.appendReasoningDelta(itemID: itemID, summaryIndex: summaryIndex, text: text)
+            updateTurnResponse(id: responseID, from: accumulator)
+        case let .reasoningCompleted(itemID, text):
+            accumulator.completeReasoning(itemID: itemID, text: text)
+            updateTurnResponse(id: responseID, from: accumulator)
         case .interrupted:
-            completeTurnResponses(responseID: responseID, responseIDsByItemID: responseIDsByItemID)
+            completeTurnResponse(responseID: responseID)
         case let .failed(message):
             errorMessage = CodexAppServerError.turnFailed(message).localizedDescription
-            completeTurnResponses(responseID: responseID, responseIDsByItemID: responseIDsByItemID)
+            completeTurnResponse(responseID: responseID)
         }
     }
 
@@ -243,40 +237,18 @@ final class CodexChatSessionModel: Identifiable {
         }
     }
 
-    private func markResponseComplete(id: String) {
-        guard let index = messages.firstIndex(where: { $0.id == id }) else { return }
+    private func completeTurnResponse(responseID: String) {
+        guard let index = messages.firstIndex(where: { $0.id == responseID }) else { return }
         messages[index].isStreaming = false
+        if messages[index].text.isEmpty, messages[index].reasoning.isEmpty {
+            messages.remove(at: index)
+        }
     }
 
-    private func responseMessageID(
-        for itemID: String,
-        pendingResponseID: String,
-        responseIDsByItemID: inout [String: String]
-    ) -> String {
-        if let existingID = responseIDsByItemID[itemID] {
-            return existingID
-        }
-
-        if responseIDsByItemID.isEmpty {
-            responseIDsByItemID[itemID] = pendingResponseID
-            return pendingResponseID
-        }
-
-        let messageID = "response-\(itemID)"
-        responseIDsByItemID[itemID] = messageID
-        messages.append(CodexChatMessage(id: messageID, role: .assistant, text: "", isStreaming: true))
-        return messageID
-    }
-
-    private func completeTurnResponses(
-        responseID: String,
-        responseIDsByItemID: [String: String]
-    ) {
-        markResponseComplete(id: responseID)
-        for messageID in responseIDsByItemID.values where messageID != responseID {
-            markResponseComplete(id: messageID)
-        }
-        messages.removeAll { $0.id == responseID && $0.text.isEmpty }
+    private func updateTurnResponse(id: String, from accumulator: CodexChatTurnAccumulator) {
+        guard let index = messages.firstIndex(where: { $0.id == id }) else { return }
+        messages[index].text = accumulator.responseText
+        messages[index].reasoning = accumulator.reasoningText
     }
 
     private func reconcileFromRollout() async {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatCopyButton.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatCopyButton.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct CodexChatCopyButton: View {
+    let text: String
+
+    var body: some View {
+        Button(L10n.copyChatMessage, systemImage: "square.on.square", action: copyMessage)
+            .labelStyle(.iconOnly)
+            .buttonStyle(.plain)
+            .font(.caption)
+            .foregroundStyle(.tertiary)
+            .frame(width: 24, height: 24)
+            .contentShape(Rectangle())
+            .help(L10n.copyChatMessage)
+    }
+
+    private func copyMessage() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownBlock.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownBlock.swift
@@ -2,7 +2,7 @@ enum CodexChatMarkdownBlock: Equatable {
     case paragraph(String)
     case heading(level: Int, text: String)
     case unorderedList([String])
-    case orderedList([String])
+    case orderedList([CodexChatMarkdownOrderedItem])
     case blockquote(String)
     case code(language: String?, text: String)
     case divider

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownBlock.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownBlock.swift
@@ -1,0 +1,9 @@
+enum CodexChatMarkdownBlock: Equatable {
+    case paragraph(String)
+    case heading(level: Int, text: String)
+    case unorderedList([String])
+    case orderedList([String])
+    case blockquote(String)
+    case code(language: String?, text: String)
+    case divider
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownBlockView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownBlockView.swift
@@ -12,9 +12,17 @@ struct CodexChatMarkdownBlockView: View {
                 .font(headingFont(for: level))
                 .fontWeight(.semibold)
         case let .unorderedList(items):
-            list(items: items, ordered: false)
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                    CodexChatMarkdownListRow(marker: "•", text: item)
+                }
+            }
         case let .orderedList(items):
-            list(items: items, ordered: true)
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                    CodexChatMarkdownListRow(marker: item.marker, text: item.text)
+                }
+            }
         case let .blockquote(text):
             HStack(alignment: .top, spacing: 10) {
                 RoundedRectangle(cornerRadius: 1)
@@ -40,19 +48,6 @@ struct CodexChatMarkdownBlockView: View {
             }
         case .divider:
             Divider()
-        }
-    }
-
-    private func list(items: [String], ordered: Bool) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            ForEach(Array(items.enumerated()), id: \.offset) { index, item in
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Text(ordered ? "\(index + 1)." : "•")
-                        .frame(minWidth: 14, alignment: .trailing)
-                    markdownText(item)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-            }
         }
     }
 

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownBlockView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownBlockView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+struct CodexChatMarkdownBlockView: View {
+    let block: CodexChatMarkdownBlock
+
+    var body: some View {
+        switch block {
+        case let .paragraph(text):
+            markdownText(text)
+        case let .heading(level, text):
+            markdownText(text)
+                .font(headingFont(for: level))
+                .fontWeight(.semibold)
+        case let .unorderedList(items):
+            list(items: items, ordered: false)
+        case let .orderedList(items):
+            list(items: items, ordered: true)
+        case let .blockquote(text):
+            HStack(alignment: .top, spacing: 10) {
+                RoundedRectangle(cornerRadius: 1)
+                    .fill(.tertiary)
+                    .frame(width: 3)
+                markdownText(text)
+                    .foregroundStyle(.secondary)
+            }
+        case let .code(language, text):
+            VStack(alignment: .leading, spacing: 6) {
+                if let language {
+                    Text(language)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                ScrollView(.horizontal) {
+                    Text(text)
+                        .font(.system(.body, design: .monospaced))
+                        .textSelection(.enabled)
+                        .padding(10)
+                }
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: 8))
+            }
+        case .divider:
+            Divider()
+        }
+    }
+
+    private func list(items: [String], ordered: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(ordered ? "\(index + 1)." : "•")
+                        .frame(minWidth: 14, alignment: .trailing)
+                    markdownText(item)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    private func markdownText(_ value: String) -> some View {
+        Text(attributedMarkdown(value))
+            .textSelection(.enabled)
+    }
+
+    private func attributedMarkdown(_ value: String) -> AttributedString {
+        (try? AttributedString(
+            markdown: value,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )) ?? AttributedString(value)
+    }
+
+    private func headingFont(for level: Int) -> Font {
+        switch level {
+        case 1: .title
+        case 2: .title2
+        case 3: .title3
+        default: .headline
+        }
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownCache.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownCache.swift
@@ -1,0 +1,21 @@
+@MainActor
+enum CodexChatMarkdownCache {
+    private static let capacity = 32
+    private static var blocksByMarkdown: [String: [CodexChatMarkdownBlock]] = [:]
+    private static var insertionOrder: [String] = []
+
+    static func blocks(for markdown: String) -> [CodexChatMarkdownBlock] {
+        if let blocks = blocksByMarkdown[markdown] {
+            return blocks
+        }
+
+        let blocks = CodexChatMarkdownParser.parse(markdown)
+        if insertionOrder.count == capacity, let oldest = insertionOrder.first {
+            blocksByMarkdown.removeValue(forKey: oldest)
+            insertionOrder.removeFirst()
+        }
+        blocksByMarkdown[markdown] = blocks
+        insertionOrder.append(markdown)
+        return blocks
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownListRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownListRow.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct CodexChatMarkdownListRow: View {
+    let marker: String
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(marker)
+                .frame(minWidth: 14, alignment: .trailing)
+            Text(attributedMarkdown)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var attributedMarkdown: AttributedString {
+        (try? AttributedString(
+            markdown: text,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )) ?? AttributedString(text)
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownOrderedItem.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownOrderedItem.swift
@@ -1,0 +1,4 @@
+struct CodexChatMarkdownOrderedItem: Equatable {
+    let marker: String
+    let text: String
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownParser.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownParser.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 enum CodexChatMarkdownParser {
     static func parse(_ markdown: String) -> [CodexChatMarkdownBlock] {
         let normalized = markdown
@@ -40,6 +42,7 @@ enum CodexChatMarkdownParser {
 
     private struct ListMarker {
         let kind: ListKind
+        let orderedMarker: String?
         let content: String
     }
 
@@ -100,6 +103,7 @@ enum CodexChatMarkdownParser {
         kind: ListKind
     ) -> CodexChatMarkdownBlock {
         var items: [String] = []
+        var orderedItems: [CodexChatMarkdownOrderedItem] = []
 
         while index < lines.count {
             guard let marker = listMarker(in: lines[index]), marker.kind == kind else { break }
@@ -123,14 +127,19 @@ enum CodexChatMarkdownParser {
                 index += 1
             }
 
-            items.append(joinedText(itemLines))
+            let text = joinedText(itemLines)
+            if let orderedMarker = marker.orderedMarker {
+                orderedItems.append(CodexChatMarkdownOrderedItem(marker: orderedMarker, text: text))
+            } else {
+                items.append(text)
+            }
         }
 
         switch kind {
         case .unordered:
             return .unorderedList(items)
         case .ordered:
-            return .orderedList(items)
+            return .orderedList(orderedItems)
         }
     }
 
@@ -166,7 +175,11 @@ enum CodexChatMarkdownParser {
         if let first = trimmed.first,
            ["-", "*", "+"].contains(first),
            trimmed.dropFirst().first == " " {
-            return ListMarker(kind: .unordered, content: String(trimmed.dropFirst(2)))
+            return ListMarker(
+                kind: .unordered,
+                orderedMarker: nil,
+                content: String(trimmed.dropFirst(2))
+            )
         }
 
         let number = trimmed.prefix(while: { $0.isNumber })
@@ -176,7 +189,11 @@ enum CodexChatMarkdownParser {
               punctuation == "." || punctuation == ")",
               suffix.dropFirst().first == " "
         else { return nil }
-        return ListMarker(kind: .ordered, content: String(suffix.dropFirst(2)))
+        return ListMarker(
+            kind: .ordered,
+            orderedMarker: String(number) + String(punctuation),
+            content: String(suffix.dropFirst(2))
+        )
     }
 
     private static func nextNonemptyLine(in lines: [String], after index: Int) -> Int? {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownParser.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownParser.swift
@@ -1,0 +1,214 @@
+enum CodexChatMarkdownParser {
+    static func parse(_ markdown: String) -> [CodexChatMarkdownBlock] {
+        let normalized = markdown
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        let lines = normalized.components(separatedBy: "\n")
+        var blocks: [CodexChatMarkdownBlock] = []
+        var index = 0
+
+        while index < lines.count {
+            if lines[index].trimmingCharacters(in: .whitespaces).isEmpty {
+                index += 1
+                continue
+            }
+
+            if let block = parseFence(lines, index: &index) {
+                blocks.append(block)
+            } else if let block = parseHeading(lines[index]) {
+                blocks.append(block)
+                index += 1
+            } else if isDivider(lines[index]) {
+                blocks.append(.divider)
+                index += 1
+            } else if isBlockquote(lines[index]) {
+                blocks.append(parseBlockquote(lines, index: &index))
+            } else if let marker = listMarker(in: lines[index]) {
+                blocks.append(parseList(lines, index: &index, kind: marker.kind))
+            } else {
+                blocks.append(parseParagraph(lines, index: &index))
+            }
+        }
+
+        return blocks
+    }
+
+    private enum ListKind: Equatable {
+        case unordered
+        case ordered
+    }
+
+    private struct ListMarker {
+        let kind: ListKind
+        let content: String
+    }
+
+    private static func parseFence(
+        _ lines: [String],
+        index: inout Int
+    ) -> CodexChatMarkdownBlock? {
+        let opening = lines[index].trimmingCharacters(in: .whitespaces)
+        guard opening.hasPrefix("```") else { return nil }
+
+        let language = String(opening.dropFirst(3)).trimmingCharacters(in: .whitespaces)
+        index += 1
+        var codeLines: [String] = []
+        while index < lines.count,
+              !lines[index].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
+            codeLines.append(lines[index])
+            index += 1
+        }
+        if index < lines.count {
+            index += 1
+        }
+
+        return .code(
+            language: language.isEmpty ? nil : language,
+            text: codeLines.joined(separator: "\n")
+        )
+    }
+
+    private static func parseHeading(_ line: String) -> CodexChatMarkdownBlock? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        let level = trimmed.prefix(while: { $0 == "#" }).count
+        guard (1 ... 6).contains(level),
+              trimmed.dropFirst(level).first == " "
+        else { return nil }
+
+        return .heading(
+            level: level,
+            text: String(trimmed.dropFirst(level + 1))
+        )
+    }
+
+    private static func parseBlockquote(
+        _ lines: [String],
+        index: inout Int
+    ) -> CodexChatMarkdownBlock {
+        var quoteLines: [String] = []
+        while index < lines.count, isBlockquote(lines[index]) {
+            let trimmed = removingLeadingWhitespace(from: lines[index])
+            quoteLines.append(removingLeadingWhitespace(from: String(trimmed.dropFirst())))
+            index += 1
+        }
+        return .blockquote(joinedText(quoteLines))
+    }
+
+    private static func parseList(
+        _ lines: [String],
+        index: inout Int,
+        kind: ListKind
+    ) -> CodexChatMarkdownBlock {
+        var items: [String] = []
+
+        while index < lines.count {
+            guard let marker = listMarker(in: lines[index]), marker.kind == kind else { break }
+            var itemLines = [marker.content]
+            index += 1
+
+            while index < lines.count {
+                if lines[index].trimmingCharacters(in: .whitespaces).isEmpty {
+                    let next = nextNonemptyLine(in: lines, after: index)
+                    if let next,
+                       let nextMarker = listMarker(in: lines[next]),
+                       nextMarker.kind == kind {
+                        index = next
+                    }
+                    break
+                }
+                if listMarker(in: lines[index]) != nil || isBlockStart(lines[index]) {
+                    break
+                }
+                itemLines.append(removingLeadingWhitespace(from: lines[index]))
+                index += 1
+            }
+
+            items.append(joinedText(itemLines))
+        }
+
+        switch kind {
+        case .unordered:
+            return .unorderedList(items)
+        case .ordered:
+            return .orderedList(items)
+        }
+    }
+
+    private static func parseParagraph(
+        _ lines: [String],
+        index: inout Int
+    ) -> CodexChatMarkdownBlock {
+        var paragraphLines: [String] = []
+        while index < lines.count,
+              !lines[index].trimmingCharacters(in: .whitespaces).isEmpty {
+            if !paragraphLines.isEmpty, isBlockStart(lines[index]) {
+                break
+            }
+            paragraphLines.append(lines[index])
+            index += 1
+        }
+        return .paragraph(joinedText(paragraphLines))
+    }
+
+    private static func joinedText(_ lines: [String]) -> String {
+        lines.enumerated().reduce(into: "") { result, element in
+            let (offset, line) = element
+            let hasHardBreak = line.hasSuffix("  ")
+            result += hasHardBreak ? String(line.dropLast(2)) : line
+            if offset < lines.count - 1 {
+                result += hasHardBreak ? "\n" : " "
+            }
+        }
+    }
+
+    private static func listMarker(in line: String) -> ListMarker? {
+        let trimmed = removingLeadingWhitespace(from: line)
+        if let first = trimmed.first,
+           ["-", "*", "+"].contains(first),
+           trimmed.dropFirst().first == " " {
+            return ListMarker(kind: .unordered, content: String(trimmed.dropFirst(2)))
+        }
+
+        let number = trimmed.prefix(while: { $0.isNumber })
+        guard !number.isEmpty else { return nil }
+        let suffix = trimmed.dropFirst(number.count)
+        guard let punctuation = suffix.first,
+              punctuation == "." || punctuation == ")",
+              suffix.dropFirst().first == " "
+        else { return nil }
+        return ListMarker(kind: .ordered, content: String(suffix.dropFirst(2)))
+    }
+
+    private static func nextNonemptyLine(in lines: [String], after index: Int) -> Int? {
+        var candidate = index + 1
+        while candidate < lines.count {
+            if !lines[candidate].trimmingCharacters(in: .whitespaces).isEmpty {
+                return candidate
+            }
+            candidate += 1
+        }
+        return nil
+    }
+
+    private static func removingLeadingWhitespace(from line: String) -> String {
+        String(line.drop(while: { $0 == " " || $0 == "\t" }))
+    }
+
+    private static func isBlockStart(_ line: String) -> Bool {
+        parseHeading(line) != nil ||
+            isDivider(line) ||
+            isBlockquote(line) ||
+            line.trimmingCharacters(in: .whitespaces).hasPrefix("```") ||
+            listMarker(in: line) != nil
+    }
+
+    private static func isBlockquote(_ line: String) -> Bool {
+        line.trimmingCharacters(in: .whitespaces).hasPrefix(">")
+    }
+
+    private static func isDivider(_ line: String) -> Bool {
+        let compact = line.filter { !$0.isWhitespace }
+        guard compact.count >= 3, let marker = compact.first else { return false }
+        return ["-", "*", "_"].contains(marker) && compact.allSatisfy { $0 == marker }
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownView.swift
@@ -12,6 +12,6 @@ struct CodexChatMarkdownView: View {
     }
 
     private var blocks: [CodexChatMarkdownBlock] {
-        CodexChatMarkdownParser.parse(markdown)
+        CodexChatMarkdownCache.blocks(for: markdown)
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownView.swift
@@ -5,35 +5,13 @@ struct CodexChatMarkdownView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
-                if segment.isCode {
-                    ScrollView(.horizontal) {
-                        Text(segment.text)
-                            .font(.system(.body, design: .monospaced))
-                            .textSelection(.enabled)
-                            .padding(10)
-                    }
-                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 8))
-                } else if !segment.text.isEmpty {
-                    Text(attributedMarkdown(segment.text))
-                        .textSelection(.enabled)
-                }
+            ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
+                CodexChatMarkdownBlockView(block: block)
             }
         }
     }
 
-    private var segments: [(text: String, isCode: Bool)] {
-        markdown.components(separatedBy: "```").enumerated().map { index, text in
-            let isCode = index.isMultiple(of: 2) == false
-            let cleaned = isCode ? text.replacing(/^\w*\n/, with: "") : text
-            return (cleaned.trimmingCharacters(in: isCode ? .newlines : []), isCode)
-        }
-    }
-
-    private func attributedMarkdown(_ value: String) -> AttributedString {
-        (try? AttributedString(
-            markdown: value,
-            options: .init(interpretedSyntax: .full)
-        )) ?? AttributedString(value)
+    private var blocks: [CodexChatMarkdownBlock] {
+        CodexChatMarkdownParser.parse(markdown)
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
@@ -19,14 +19,22 @@ struct CodexChatMessageRow: View {
             } else {
                 VStack(alignment: .leading, spacing: 10) {
                     if !message.reasoning.isEmpty {
-                        CodexChatReasoningView(reasoning: message.reasoning)
+                        CodexChatReasoningView(
+                            reasoning: message.reasoning,
+                            isStreaming: message.isStreaming
+                        )
                     }
 
                     if message.text.isEmpty, message.isStreaming {
                         ProgressView()
                             .controlSize(.small)
                     } else if !message.text.isEmpty {
-                        CodexChatMarkdownView(markdown: message.text)
+                        if message.isStreaming {
+                            Text(message.text)
+                                .textSelection(.enabled)
+                        } else {
+                            CodexChatMarkdownView(markdown: message.text)
+                        }
                     }
 
                     if !message.text.isEmpty, !message.isStreaming {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
@@ -1,4 +1,3 @@
-import AppKit
 import SwiftUI
 
 struct CodexChatMessageRow: View {
@@ -8,38 +7,35 @@ struct CodexChatMessageRow: View {
         HStack(alignment: .top) {
             if message.role == .user {
                 Spacer(minLength: 72)
-                Text(message.text)
-                    .textSelection(.enabled)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 14))
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text(message.text)
+                        .textSelection(.enabled)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(.quaternary, in: RoundedRectangle(cornerRadius: 14))
+
+                    CodexChatCopyButton(text: message.text)
+                }
             } else {
                 VStack(alignment: .leading, spacing: 10) {
+                    if !message.reasoning.isEmpty {
+                        CodexChatReasoningView(reasoning: message.reasoning)
+                    }
+
                     if message.text.isEmpty, message.isStreaming {
                         ProgressView()
                             .controlSize(.small)
-                    } else {
+                    } else if !message.text.isEmpty {
                         CodexChatMarkdownView(markdown: message.text)
                     }
 
                     if !message.text.isEmpty, !message.isStreaming {
-                        Button(L10n.copyChatMessage, systemImage: "document.on.document", action: copyMessage)
-                            .labelStyle(.iconOnly)
-                            .buttonStyle(.plain)
-                            .foregroundStyle(.tertiary)
-                            .frame(width: 28, height: 28)
-                            .contentShape(Rectangle())
-                            .help(L10n.copyChatMessage)
+                        CodexChatCopyButton(text: message.text)
                     }
                 }
                 Spacer(minLength: 40)
             }
         }
         .frame(maxWidth: .infinity, alignment: message.role == .user ? .trailing : .leading)
-    }
-
-    private func copyMessage() {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(message.text, forType: .string)
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatReasoningView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatReasoningView.swift
@@ -2,13 +2,20 @@ import SwiftUI
 
 struct CodexChatReasoningView: View {
     let reasoning: String
+    let isStreaming: Bool
 
     @State private var isExpanded = false
 
     var body: some View {
         DisclosureGroup(isExpanded: $isExpanded) {
-            CodexChatMarkdownView(markdown: reasoning)
-                .padding(.top, 8)
+            Group {
+                if isStreaming {
+                    Text(reasoning)
+                } else {
+                    CodexChatMarkdownView(markdown: reasoning)
+                }
+            }
+            .padding(.top, 8)
         } label: {
             Text(L10n.chatReasoning)
                 .foregroundStyle(.secondary)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatReasoningView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatReasoningView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct CodexChatReasoningView: View {
+    let reasoning: String
+
+    @State private var isExpanded = false
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            CodexChatMarkdownView(markdown: reasoning)
+                .padding(.top, 8)
+        } label: {
+            Text(L10n.chatReasoning)
+                .foregroundStyle(.secondary)
+        }
+        .textSelection(.enabled)
+    }
+}

--- a/Sources/Dahlia/Views/Settings/MCPSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/MCPSettingsView.swift
@@ -1,7 +1,7 @@
 import AppKit
 import SwiftUI
 
-struct MeetingDataAccessSettingsView: View {
+struct MCPSettingsView: View {
     @ObservedObject private var settings = AppSettings.shared
 
     var body: some View {
@@ -22,20 +22,20 @@ struct MeetingDataAccessSettingsView: View {
                             command: commands.claude
                         )
                     } else {
-                        Text(L10n.meetingDataAccessHelperUnavailable)
+                        Text(L10n.mcpHelperUnavailable)
                             .foregroundStyle(.secondary)
                     }
                 } else {
                     ContentUnavailableView(
                         L10n.noVaultSelected,
                         systemImage: "externaldrive.badge.questionmark",
-                        description: Text(L10n.selectVaultForMeetingDataAccess)
+                        description: Text(L10n.selectVaultForMCP)
                     )
                 }
             } header: {
-                Text(L10n.meetingDataAccess)
+                Text(L10n.mcp)
             } footer: {
-                Text(L10n.meetingDataAccessFooter)
+                Text(L10n.mcpFooter)
             }
         }
         .formStyle(.grouped)

--- a/Sources/Dahlia/Views/Settings/SettingsCategory.swift
+++ b/Sources/Dahlia/Views/Settings/SettingsCategory.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// 設定項目。rawValue は保存済みの選択状態との互換性のため維持する。
+/// 設定画面のカテゴリ。
 enum SettingsCategory: String, CaseIterable, Identifiable {
     case general
     case transcription
@@ -9,7 +9,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
     case cloudStorage
     case modelProvider = "accounts"
     case aiSummary
-    case meetingDataAccess
+    case mcp
     case instructions
     case developer
     case audioDiagnostics
@@ -25,7 +25,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .cloudStorage: L10n.export
         case .modelProvider: L10n.aiConnection
         case .aiSummary: L10n.aiSummary
-        case .meetingDataAccess: L10n.meetingDataAccess
+        case .mcp: L10n.mcp
         case .instructions: L10n.instructions
         case .developer: L10n.developerSettings
         case .audioDiagnostics: L10n.diagnostics
@@ -41,7 +41,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .cloudStorage: "square.and.arrow.up"
         case .modelProvider: "link"
         case .aiSummary: "sparkles"
-        case .meetingDataAccess: "server.rack"
+        case .mcp: "network"
         case .instructions: "list.bullet.clipboard"
         case .developer: "wrench.and.screwdriver"
         case .audioDiagnostics: "stethoscope"

--- a/Sources/Dahlia/Views/Settings/SettingsDetailView.swift
+++ b/Sources/Dahlia/Views/Settings/SettingsDetailView.swift
@@ -22,8 +22,8 @@ struct SettingsDetailView: View {
                 AccountSettingsView()
             case .aiSummary:
                 AISummarySettingsView()
-            case .meetingDataAccess:
-                MeetingDataAccessSettingsView()
+            case .mcp:
+                MCPSettingsView()
             case .instructions:
                 InstructionsSettingsView(sidebarViewModel: sidebarViewModel)
             case .developer:

--- a/Sources/Dahlia/Views/Settings/SettingsGroup.swift
+++ b/Sources/Dahlia/Views/Settings/SettingsGroup.swift
@@ -25,7 +25,7 @@ enum SettingsGroup: CaseIterable, Identifiable {
         case .app: [.general]
         case .recording: [.transcription, .screenshots]
         case .integrations: [.calendar, .cloudStorage]
-        case .ai: [.modelProvider, .aiSummary, .meetingDataAccess, .instructions]
+        case .ai: [.modelProvider, .aiSummary, .mcp, .instructions]
         case .advanced: [.developer, .audioDiagnostics]
         }
     }

--- a/Tests/DahliaTests/CodexChatMarkdownParserTests.swift
+++ b/Tests/DahliaTests/CodexChatMarkdownParserTests.swift
@@ -43,8 +43,8 @@
                 "line  ",
                 "hard",
                 "",
-                "1. First",
-                "2. Second",
+                "3. First",
+                "7) Second",
                 "",
                 "> Quoted text",
                 "",
@@ -58,7 +58,10 @@
             #expect(CodexChatMarkdownParser.parse(markdown) == [
                 .heading(level: 2, text: "Heading"),
                 .paragraph("soft line\nhard"),
-                .orderedList(["First", "Second"]),
+                .orderedList([
+                    CodexChatMarkdownOrderedItem(marker: "3.", text: "First"),
+                    CodexChatMarkdownOrderedItem(marker: "7)", text: "Second"),
+                ]),
                 .blockquote("Quoted text"),
                 .code(language: "swift", text: "let value = 1"),
                 .divider,

--- a/Tests/DahliaTests/CodexChatMarkdownParserTests.swift
+++ b/Tests/DahliaTests/CodexChatMarkdownParserTests.swift
@@ -1,0 +1,68 @@
+#if canImport(Testing)
+    import Testing
+    @testable import Dahlia
+
+    struct CodexChatMarkdownParserTests {
+        @Test func preservesParagraphsAndUnorderedListItems() {
+            let authenticationDescription =
+                "GCP環境でログインがループする問題を調査。`.com`エイリアスとGoogle Workspaceの`.jp` IDの不一致が原因候補となり、" +
+                "過去事例を確認のうえ必要なら`.jp`で環境を作り直す方針です。"
+            let pocDescription =
+                "Salesforce上でJさんのContactとPOC用Business Subscriptionを作成。発行は承認・バックエンド処理待ちで、" +
+                "招待メール到着後にJさんがログイン・初期設定を進める予定です。POCはPremium Tier、終了希望は8月末です。"
+            let markdown = [
+                "昨日（7月15日）の予定を確認します。",
+                "",
+                "昨日（7月15日）は、DeNA／Databricks関連で3件ありました。",
+                "",
+                "- **DeNA/Databricks DAIS Recap**（約1時間48分）  ",
+                "  要約は未作成です。",
+                "",
+                "- **Databricks GCP環境のアカウント認証トラブル対応**（約46分）  ",
+                "  \(authenticationDescription)",
+                "",
+                "- **DeNA向けE2アカウント／POC発行設定**（約14分）  ",
+                "  \(pocDescription)",
+            ].joined(separator: "\n")
+
+            #expect(CodexChatMarkdownParser.parse(markdown) == [
+                .paragraph("昨日（7月15日）の予定を確認します。"),
+                .paragraph("昨日（7月15日）は、DeNA／Databricks関連で3件ありました。"),
+                .unorderedList([
+                    "**DeNA/Databricks DAIS Recap**（約1時間48分）\n要約は未作成です。",
+                    "**Databricks GCP環境のアカウント認証トラブル対応**（約46分）\n\(authenticationDescription)",
+                    "**DeNA向けE2アカウント／POC発行設定**（約14分）\n\(pocDescription)",
+                ]),
+            ])
+        }
+
+        @Test func parsesCommonBlockMarkdownAndLineBreaks() {
+            let markdown = [
+                "## Heading",
+                "soft",
+                "line  ",
+                "hard",
+                "",
+                "1. First",
+                "2. Second",
+                "",
+                "> Quoted text",
+                "",
+                "```swift",
+                "let value = 1",
+                "```",
+                "",
+                "---",
+            ].joined(separator: "\n")
+
+            #expect(CodexChatMarkdownParser.parse(markdown) == [
+                .heading(level: 2, text: "Heading"),
+                .paragraph("soft line\nhard"),
+                .orderedList(["First", "Second"]),
+                .blockquote("Quoted text"),
+                .code(language: "swift", text: "let value = 1"),
+                .divider,
+            ])
+        }
+    }
+#endif

--- a/Tests/DahliaTests/CodexChatServiceTests.swift
+++ b/Tests/DahliaTests/CodexChatServiceTests.swift
@@ -49,23 +49,7 @@ import Foundation
             #expect(threadParams["sandbox"] == .string("read-only"))
             #expect(threadParams["cwd"] == .string(workspace.appending(path: vaultID.uuidString.lowercased()).path))
             let config = try #require(threadParams["config"]?.objectValue)
-            #expect(config["features.apps"] == .bool(false))
-            #expect(config["features.codex_hooks"] == .bool(false))
-            #expect(config["features.memory_tool"] == .bool(false))
-            #expect(config["features.plugins"] == .bool(false))
-            #expect(config["include_apps_instructions"] == .bool(false))
-            #expect(config["memories.dedicated_tools"] == .bool(false))
-            #expect(config["memories.use_memories"] == .bool(false))
-            #expect(config["orchestrator.mcp.enabled"] == .bool(false))
-            #expect(config["skills.include_instructions"] == .bool(false))
-            #expect(config["mcp_servers"] == .object([
-                "dahlia": .object([
-                    "args": .array([.string("--vault-id"), .string(vaultID.uuidString)]),
-                    "command": .string("/tmp/dahlia-mcp"),
-                    "enabled": .bool(true),
-                ]),
-                "docs": .object(["enabled": .bool(false)]),
-            ]))
+            expectChatConfiguration(config, vaultID: vaultID)
             #expect(threadParams["developerInstructions"]?.stringValue?.contains("query_meetings") == true)
 
             let turnParams = try #require(messages.first {
@@ -137,8 +121,9 @@ import Foundation
 
             #expect(page.threads.map(\.id) == ["thread-history"])
             #expect(page.nextCursor == "next-page")
-            #expect(loaded.messages.map(\.text) == ["Question", "Answer"])
-            #expect(loaded.messages.last?.reasoning == "Reviewed the question\n\nPrepared the answer")
+            #expect(loaded.messages.map(\.text) == ["Question", "Answer", ""])
+            #expect(loaded.messages[1].reasoning == "Reviewed the question\n\nPrepared the answer")
+            #expect(loaded.messages[2].reasoning == "Reasoning without an answer")
             #expect(resumed.model == "default-model")
             #expect(resumed.reasoningEffort == "high")
 
@@ -177,6 +162,26 @@ import Foundation
             }
             await appServer.shutdown()
             return events
+        }
+
+        private func expectChatConfiguration(_ config: [String: JSONValue], vaultID: UUID) {
+            #expect(config["features.apps"] == .bool(false))
+            #expect(config["features.codex_hooks"] == .bool(false))
+            #expect(config["features.memory_tool"] == .bool(false))
+            #expect(config["features.plugins"] == .bool(false))
+            #expect(config["include_apps_instructions"] == .bool(false))
+            #expect(config["memories.dedicated_tools"] == .bool(false))
+            #expect(config["memories.use_memories"] == .bool(false))
+            #expect(config["orchestrator.mcp.enabled"] == .bool(false))
+            #expect(config["skills.include_instructions"] == .bool(false))
+            #expect(config["mcp_servers"] == .object([
+                "dahlia": .object([
+                    "args": .array([.string("--vault-id"), .string(vaultID.uuidString)]),
+                    "command": .string("/tmp/dahlia-mcp"),
+                    "enabled": .bool(true),
+                ]),
+                "docs": .object(["enabled": .bool(false)]),
+            ]))
         }
     }
 

--- a/Tests/DahliaTests/CodexChatServiceTests.swift
+++ b/Tests/DahliaTests/CodexChatServiceTests.swift
@@ -33,7 +33,9 @@ import Foundation
             #expect(thread.id == "thread-1")
             #expect(events == [
                 .started(turnID: "turn-1"),
+                .reasoningDelta(itemID: "reasoning-1", summaryIndex: 0, text: "Checked the request"),
                 .delta(itemID: "item-1", text: "Hello"),
+                .reasoningCompleted(itemID: "reasoning-1", text: "Checked the request"),
                 .completed(itemID: "item-1", text: "Hello"),
                 .completed(itemID: nil, text: nil),
             ])
@@ -71,6 +73,7 @@ import Foundation
             }?.objectValue?["params"]?.objectValue)
             #expect(turnParams["outputSchema"] == nil)
             #expect(turnParams["effort"] == .string("high"))
+            #expect(turnParams["summary"] == .string("auto"))
             await appServer.shutdown()
         }
 
@@ -135,6 +138,7 @@ import Foundation
             #expect(page.threads.map(\.id) == ["thread-history"])
             #expect(page.nextCursor == "next-page")
             #expect(loaded.messages.map(\.text) == ["Question", "Answer"])
+            #expect(loaded.messages.last?.reasoning == "Reviewed the question\n\nPrepared the answer")
             #expect(resumed.model == "default-model")
             #expect(resumed.reasoningEffort == "high")
 

--- a/Tests/DahliaTests/CodexChatSessionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatSessionModelTests.swift
@@ -79,6 +79,26 @@ import Foundation
         }
 
         @Test
+        func rolloutWithoutReasoningPreservesStreamedSummary() async {
+            let service = TestCodexChatService(mode: .rolloutWithoutReasoning)
+            let settings = AppSettings()
+            settings.currentVault = Self.testVault()
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings
+            )
+
+            session.draft = "Question"
+            session.sendDraft()
+            await waitUntil { !session.isGenerating }
+
+            #expect(session.messages.last?.text == "Final answer")
+            #expect(session.messages.last?.reasoning == "Considered the question")
+        }
+
+        @Test
         func multipleAgentMessageItemsAreCombinedIntoOneResponse() async {
             let service = TestCodexChatService(mode: .multipleMessages)
             let settings = AppSettings()
@@ -175,6 +195,7 @@ import Foundation
             case complete
             case block
             case staleRollout
+            case rolloutWithoutReasoning
             case multipleMessages
         }
 
@@ -204,6 +225,8 @@ import Foundation
             let assistantMessages: [CodexChatMessage] = switch mode {
             case .complete, .block:
                 [CodexChatMessage(role: .assistant, text: "Final answer", reasoning: "Considered the question")]
+            case .rolloutWithoutReasoning:
+                [CodexChatMessage(role: .assistant, text: "Final answer")]
             case .staleRollout, .multipleMessages:
                 []
             }
@@ -240,7 +263,7 @@ import Foundation
             let (stream, continuation) = AsyncThrowingStream<CodexChatTurnEvent, any Error>.makeStream()
             continuation.yield(.started(turnID: "turn-1"))
             switch mode {
-            case .complete, .staleRollout:
+            case .complete, .staleRollout, .rolloutWithoutReasoning:
                 continuation.yield(.reasoningDelta(
                     itemID: "reasoning-1",
                     summaryIndex: 0,

--- a/Tests/DahliaTests/CodexChatSessionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatSessionModelTests.swift
@@ -31,6 +31,7 @@ import Foundation
 
             #expect(session.backendThreadID == "thread-1")
             #expect(session.messages.map(\.text) == ["Question", "Final answer"])
+            #expect(session.messages.last?.reasoning == "Considered the question")
             #expect(session.title == "Question")
             #expect(await service.sentTexts == ["Question"])
         }
@@ -78,7 +79,7 @@ import Foundation
         }
 
         @Test
-        func multipleAgentMessageItemsUseSeparateBubbles() async {
+        func multipleAgentMessageItemsAreCombinedIntoOneResponse() async {
             let service = TestCodexChatService(mode: .multipleMessages)
             let settings = AppSettings()
             settings.currentVault = Self.testVault()
@@ -93,7 +94,7 @@ import Foundation
             session.sendDraft()
             await waitUntil { !session.isGenerating }
 
-            #expect(session.messages.map(\.text) == ["Question", "First answer", "Second answer"])
+            #expect(session.messages.map(\.text) == ["Question", "First answer\n\nSecond answer"])
             #expect(session.messages.allSatisfy { !$0.isStreaming })
         }
 
@@ -202,7 +203,7 @@ import Foundation
         func loadThread(id: String) async throws -> CodexChatThread {
             let assistantMessages: [CodexChatMessage] = switch mode {
             case .complete, .block:
-                [CodexChatMessage(role: .assistant, text: "Final answer")]
+                [CodexChatMessage(role: .assistant, text: "Final answer", reasoning: "Considered the question")]
             case .staleRollout, .multipleMessages:
                 []
             }
@@ -240,6 +241,12 @@ import Foundation
             continuation.yield(.started(turnID: "turn-1"))
             switch mode {
             case .complete, .staleRollout:
+                continuation.yield(.reasoningDelta(
+                    itemID: "reasoning-1",
+                    summaryIndex: 0,
+                    text: "Considered the question"
+                ))
+                continuation.yield(.reasoningCompleted(itemID: "reasoning-1", text: "Considered the question"))
                 continuation.yield(.delta(itemID: "item-1", text: "Final "))
                 continuation.yield(.completed(itemID: "item-1", text: "Final answer"))
                 continuation.yield(.completed(itemID: nil, text: nil))

--- a/Tests/DahliaTests/SettingsCategoryTests.swift
+++ b/Tests/DahliaTests/SettingsCategoryTests.swift
@@ -14,7 +14,7 @@
                 .cloudStorage,
                 .modelProvider,
                 .aiSummary,
-                .meetingDataAccess,
+                .mcp,
                 .instructions,
                 .developer,
                 .audioDiagnostics,
@@ -28,11 +28,14 @@
         }
 
         @Test
-        func technicalCategoriesUseUserFacingLabelsWithoutChangingStoredValues() {
+        func technicalCategoriesUseUserFacingLabelsAndIdentifiers() {
             #expect(SettingsCategory.modelProvider.rawValue == "accounts")
             #expect(SettingsCategory.modelProvider.label == L10n.aiConnection)
             #expect(SettingsCategory.cloudStorage.rawValue == "cloudStorage")
             #expect(SettingsCategory.cloudStorage.label == L10n.export)
+            #expect(SettingsCategory.mcp.rawValue == "mcp")
+            #expect(SettingsCategory.mcp.label == "MCP")
+            #expect(SettingsCategory.mcp.systemImage == "network")
             #expect(SettingsCategory.audioDiagnostics.rawValue == "audioDiagnostics")
             #expect(SettingsCategory.audioDiagnostics.label == L10n.diagnostics)
         }

--- a/Tests/DahliaTests/TestCodexChatAppServerTransport.swift
+++ b/Tests/DahliaTests/TestCodexChatAppServerTransport.swift
@@ -58,7 +58,7 @@ actor TestCodexChatAppServerTransport: CodexAppServerTransport {
                 "requiresOpenaiAuth": .bool(true),
             ]))
         case "model/list":
-            enqueueResponse(requestID, result: modelList)
+            enqueueResponse(requestID, result: TestCodexChatFixtures.modelList)
         case "config/read":
             enqueueResponse(requestID, result: .object([
                 "config": .object([
@@ -88,11 +88,11 @@ actor TestCodexChatAppServerTransport: CodexAppServerTransport {
             ]))
         case "thread/read":
             enqueueResponse(requestID, result: .object([
-                "thread": Self.chatThread(id: "thread-history"),
+                "thread": TestCodexChatFixtures.chatThread(id: "thread-history"),
             ]))
         case "thread/resume":
             enqueueResponse(requestID, result: .object([
-                "thread": Self.chatThread(id: "thread-history"),
+                "thread": TestCodexChatFixtures.chatThread(id: "thread-history"),
                 "model": .string("default-model"),
                 "reasoningEffort": .string("high"),
             ]))
@@ -182,9 +182,22 @@ actor TestCodexChatAppServerTransport: CodexAppServerTransport {
             "method": .string("item/completed"),
             "params": turnParams([
                 "item": .object([
+                    "type": .string("commandExecution"),
+                ]),
+            ]),
+        ]))
+        enqueue(.object([
+            "method": .string("item/completed"),
+            "params": turnParams([
+                "item": .object([
                     "id": .string("reasoning-1"),
                     "type": .string("reasoning"),
-                    "summary": .array([.string("Checked the request")]),
+                    "summary": .array([
+                        .object([
+                            "type": .string("summary_text"),
+                            "text": .string("Checked the request"),
+                        ]),
+                    ]),
                     "content": .array([]),
                 ]),
             ]),
@@ -243,34 +256,6 @@ actor TestCodexChatAppServerTransport: CodexAppServerTransport {
         }
     }
 
-    private var modelList: JSONValue {
-        .object([
-            "data": .array([
-                .object([
-                    "id": .string("default"),
-                    "model": .string("default-model"),
-                    "displayName": .string("Default"),
-                    "description": .string("Default model"),
-                    "hidden": .bool(false),
-                    "isDefault": .bool(true),
-                    "supportedReasoningEfforts": .array([
-                        .object([
-                            "reasoningEffort": .string("medium"),
-                            "description": .string("Balanced"),
-                        ]),
-                        .object([
-                            "reasoningEffort": .string("high"),
-                            "description": .string("Deep"),
-                        ]),
-                    ]),
-                    "defaultReasoningEffort": .string("medium"),
-                    "inputModalities": .array([.string("text")]),
-                ]),
-            ]),
-            "nextCursor": .null,
-        ])
-    }
-
     private var inProgressTurn: JSONValue {
         .object([
             "turn": .object([
@@ -280,40 +265,4 @@ actor TestCodexChatAppServerTransport: CodexAppServerTransport {
         ])
     }
 
-    // swiftformat:disable:next modifierOrder
-    nonisolated private static func chatThread(id: String) -> JSONValue {
-        .object([
-            "id": .string(id),
-            "preview": .string("Previous chat"),
-            "turns": .array([
-                .object([
-                    "id": .string("turn-history"),
-                    "status": .string("completed"),
-                    "items": .array([
-                        .object([
-                            "id": .string("user-1"),
-                            "type": .string("userMessage"),
-                            "content": .array([
-                                .object(["type": .string("text"), "text": .string("Question")]),
-                            ]),
-                        ]),
-                        .object([
-                            "id": .string("agent-1"),
-                            "type": .string("agentMessage"),
-                            "text": .string("Answer"),
-                        ]),
-                        .object([
-                            "id": .string("reasoning-1"),
-                            "type": .string("reasoning"),
-                            "summary": .array([
-                                .string("Reviewed the question"),
-                                .string("Prepared the answer"),
-                            ]),
-                            "content": .array([]),
-                        ]),
-                    ]),
-                ]),
-            ]),
-        ])
-    }
 }

--- a/Tests/DahliaTests/TestCodexChatAppServerTransport.swift
+++ b/Tests/DahliaTests/TestCodexChatAppServerTransport.swift
@@ -156,6 +156,14 @@ actor TestCodexChatAppServerTransport: CodexAppServerTransport {
 
     private func enqueueCompletedTurn(requestID: Int) {
         enqueue(.object([
+            "method": .string("item/reasoning/summaryTextDelta"),
+            "params": turnParams([
+                "itemId": .string("reasoning-1"),
+                "summaryIndex": .number(0),
+                "delta": .string("Checked the request"),
+            ]),
+        ]))
+        enqueue(.object([
             "method": .string("item/agentMessage/delta"),
             "params": turnParams([
                 "itemId": .string("item-1"),
@@ -170,6 +178,17 @@ actor TestCodexChatAppServerTransport: CodexAppServerTransport {
             ]),
         ]))
         enqueueResponse(requestID, result: inProgressTurn)
+        enqueue(.object([
+            "method": .string("item/completed"),
+            "params": turnParams([
+                "item": .object([
+                    "id": .string("reasoning-1"),
+                    "type": .string("reasoning"),
+                    "summary": .array([.string("Checked the request")]),
+                    "content": .array([]),
+                ]),
+            ]),
+        ]))
         enqueue(.object([
             "method": .string("item/completed"),
             "params": turnParams([
@@ -282,6 +301,15 @@ actor TestCodexChatAppServerTransport: CodexAppServerTransport {
                             "id": .string("agent-1"),
                             "type": .string("agentMessage"),
                             "text": .string("Answer"),
+                        ]),
+                        .object([
+                            "id": .string("reasoning-1"),
+                            "type": .string("reasoning"),
+                            "summary": .array([
+                                .string("Reviewed the question"),
+                                .string("Prepared the answer"),
+                            ]),
+                            "content": .array([]),
                         ]),
                     ]),
                 ]),

--- a/Tests/DahliaTests/TestCodexChatFixtures.swift
+++ b/Tests/DahliaTests/TestCodexChatFixtures.swift
@@ -1,0 +1,90 @@
+@testable import Dahlia
+
+enum TestCodexChatFixtures {
+    nonisolated static var modelList: JSONValue {
+        .object([
+            "data": .array([
+                .object([
+                    "id": .string("default"),
+                    "model": .string("default-model"),
+                    "displayName": .string("Default"),
+                    "description": .string("Default model"),
+                    "hidden": .bool(false),
+                    "isDefault": .bool(true),
+                    "supportedReasoningEfforts": .array([
+                        .object([
+                            "reasoningEffort": .string("medium"),
+                            "description": .string("Balanced"),
+                        ]),
+                        .object([
+                            "reasoningEffort": .string("high"),
+                            "description": .string("Deep"),
+                        ]),
+                    ]),
+                    "defaultReasoningEffort": .string("medium"),
+                    "inputModalities": .array([.string("text")]),
+                ]),
+            ]),
+            "nextCursor": .null,
+        ])
+    }
+
+    nonisolated static func chatThread(id: String) -> JSONValue {
+        .object([
+            "id": .string(id),
+            "preview": .string("Previous chat"),
+            "turns": .array([
+                .object([
+                    "id": .string("turn-history"),
+                    "status": .string("completed"),
+                    "items": .array([
+                        .object([
+                            "id": .string("user-1"),
+                            "type": .string("userMessage"),
+                            "content": .array([
+                                .object(["type": .string("text"), "text": .string("Question")]),
+                            ]),
+                        ]),
+                        .object([
+                            "id": .string("agent-1"),
+                            "type": .string("agentMessage"),
+                            "text": .string("Answer"),
+                        ]),
+                        .object([
+                            "id": .string("reasoning-1"),
+                            "type": .string("reasoning"),
+                            "summary": .array([
+                                .object([
+                                    "type": .string("summary_text"),
+                                    "text": .string("Reviewed the question"),
+                                ]),
+                                .object([
+                                    "type": .string("summary_text"),
+                                    "text": .string("Prepared the answer"),
+                                ]),
+                            ]),
+                            "content": .array([]),
+                        ]),
+                    ]),
+                ]),
+                .object([
+                    "id": .string("turn-reasoning-only"),
+                    "status": .string("interrupted"),
+                    "items": .array([
+                        .object([
+                            "id": .string("reasoning-only-1"),
+                            "type": .string("reasoning"),
+                            "summary": .array([
+                                .object([
+                                    "type": .string("summary_text"),
+                                    "text": .string("Reasoning without an answer"),
+                                ]),
+                            ]),
+                            "content": .array([]),
+                        ]),
+                    ]),
+                ]),
+            ]),
+        ])
+    }
+}


### PR DESCRIPTION
## Summary

- consolidate all assistant message items from one Codex turn into a single response and copy action
- add compact copy buttons for both user and assistant messages while excluding reasoning summaries from copied text
- display Codex reasoning summaries in a collapsed, expandable section
- render Markdown block structure including paragraphs, lists, headings, quotes, dividers, and fenced code
- rename the Meeting Data Access settings category and its internal identifiers to MCP, with a new network icon

## Why

Codex app-server turns can emit multiple agent message items, which previously produced duplicate copy controls and fragmented responses. The chat also passed full Markdown documents through a single SwiftUI `Text`, so block-level formatting such as paragraphs and lists was lost. The settings category used a longer legacy name that no longer matched its MCP purpose.

## User impact

Chat responses now read and copy as one answer per turn, user messages can be copied, reasoning is available without cluttering the default view, and Markdown preserves its intended structure. The related settings page is consistently named MCP in both the UI and implementation.

## Validation

- `swift test --filter CodexChat` — 21 tests passed
- `swift test --filter CodexChatMarkdownParserTests` — 2 tests passed
- `swift test --filter SettingsCategoryTests` — 4 tests passed
- Debug build completed successfully
- SwiftFormat passed for all sources
- targeted SwiftLint passed for changed files; the repository-wide SwiftLint invocation still encounters the existing SourceKit loading failure
