### PR TITLE
Improve screenshot management

### DIFF
--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -464,9 +464,29 @@ final class MeetingRepository {
         }
     }
 
-    func deleteScreenshot(id: UUID) async throws {
-        try await dbQueue.write { db in
-            _ = try MeetingScreenshotRecord.deleteOne(db, key: id)
+    func deleteScreenshots(ids: Set<UUID>, meetingId: UUID) async throws -> SummaryDocument? {
+        guard !ids.isEmpty else { return nil }
+        return try await dbQueue.write { db in
+            let deletedIds = try Set(MeetingScreenshotRecord
+                .select(Column("id"))
+                .filter(ids.contains(Column("id")))
+                .filter(Column("meetingId") == meetingId)
+                .asRequest(of: UUID.self)
+                .fetchAll(db)
+            )
+            guard !deletedIds.isEmpty else { return nil }
+
+            _ = try MeetingScreenshotRecord
+                .filter(deletedIds.contains(Column("id")))
+                .deleteAll(db)
+
+            guard var summary = try SummaryRecord.fetchOne(db, key: meetingId) else { return nil }
+            let existingDocument = summary.loadDocument()
+            let updatedDocument = existingDocument.removingScreenshotReferences(deletedIds)
+            guard updatedDocument != existingDocument else { return nil }
+            summary.document = try updatedDocument.databaseJSONString()
+            try summary.update(db)
+            return updatedDocument
         }
     }
 

--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -464,29 +464,71 @@ final class MeetingRepository {
         }
     }
 
-    func deleteScreenshots(ids: Set<UUID>, meetingId: UUID) async throws -> SummaryDocument? {
+    struct ScreenshotDeletionResult {
+        let deletedScreenshots: [MeetingScreenshotRecord]
+        let updatedDocument: SummaryDocument?
+        let updatedSummaryMarkdown: String?
+        let storedSummaryRelativePath: String?
+    }
+
+    func deleteScreenshots(ids: Set<UUID>, meetingId: UUID) async throws -> ScreenshotDeletionResult? {
         guard !ids.isEmpty else { return nil }
         return try await dbQueue.write { db in
-            let deletedIds = try Set(MeetingScreenshotRecord
-                .select(Column("id"))
+            let deletedScreenshots = try MeetingScreenshotRecord
                 .filter(ids.contains(Column("id")))
                 .filter(Column("meetingId") == meetingId)
-                .asRequest(of: UUID.self)
                 .fetchAll(db)
-            )
-            guard !deletedIds.isEmpty else { return nil }
+            guard !deletedScreenshots.isEmpty else { return nil }
+            let deletedIds = Set(deletedScreenshots.map(\.id))
 
             _ = try MeetingScreenshotRecord
                 .filter(deletedIds.contains(Column("id")))
                 .deleteAll(db)
 
-            guard var summary = try SummaryRecord.fetchOne(db, key: meetingId) else { return nil }
+            guard var summary = try SummaryRecord.fetchOne(db, key: meetingId) else {
+                return ScreenshotDeletionResult(
+                    deletedScreenshots: deletedScreenshots,
+                    updatedDocument: nil,
+                    updatedSummaryMarkdown: nil,
+                    storedSummaryRelativePath: nil
+                )
+            }
+            let storedSummaryRelativePath = try SummaryExportRecord
+                .fetchOne(meetingId: meetingId, type: .vault, in: db)?.vaultRelativePath
+                ?? summary.vaultRelativePath
             let existingDocument = summary.loadDocument()
             let updatedDocument = existingDocument.removingScreenshotReferences(deletedIds)
-            guard updatedDocument != existingDocument else { return nil }
+            guard updatedDocument != existingDocument,
+                  let meeting = try MeetingRecord.fetchOne(db, key: meetingId)
+            else {
+                return ScreenshotDeletionResult(
+                    deletedScreenshots: deletedScreenshots,
+                    updatedDocument: nil,
+                    updatedSummaryMarkdown: nil,
+                    storedSummaryRelativePath: storedSummaryRelativePath
+                )
+            }
+            let remainingScreenshots = try MeetingScreenshotRecord
+                .filter(Column("meetingId") == meetingId)
+                .order(Column("capturedAt").asc)
+                .fetchAll(db)
+            let rendered = ObsidianMarkdownSummaryRenderer.render(
+                document: updatedDocument,
+                context: SummaryRenderContext(
+                    meetingId: meetingId,
+                    createdAt: meeting.createdAt,
+                    screenshots: remainingScreenshots
+                )
+            )
+            summary.summary = rendered.body
             summary.document = try updatedDocument.databaseJSONString()
             try summary.update(db)
-            return updatedDocument
+            return ScreenshotDeletionResult(
+                deletedScreenshots: deletedScreenshots,
+                updatedDocument: updatedDocument,
+                updatedSummaryMarkdown: rendered.markdown,
+                storedSummaryRelativePath: storedSummaryRelativePath
+            )
         }
     }
 

--- a/Sources/Dahlia/Models/SummaryDocument.swift
+++ b/Sources/Dahlia/Models/SummaryDocument.swift
@@ -48,6 +48,25 @@ struct SummaryDocument: Codable, Equatable {
         encoder.outputFormatting = [.sortedKeys]
         return try String(decoding: encoder.encode(self), as: UTF8.self)
     }
+
+    func removingScreenshotReferences(_ screenshotIds: Set<UUID>) -> SummaryDocument {
+        guard !screenshotIds.isEmpty else { return self }
+
+        var updated = self
+        updated.sections = sections.map { section in
+            var updatedSection = section
+            updatedSection.blocks = section.blocks.compactMap { block in
+                guard case let .image(screenshotId, caption) = block.content,
+                      screenshotIds.contains(screenshotId) else {
+                    return block
+                }
+                guard caption.text.nilIfBlank != nil || caption.transcriptRef != nil else { return nil }
+                return SummaryBlock(id: block.id, content: .paragraph(caption))
+            }
+            return updatedSection
+        }
+        return updated
+    }
 }
 
 struct SummarySection: Codable, Equatable, Identifiable {

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -6,6 +6,14 @@
 "Apply" = "Apply";
 "Clear" = "Clear";
 "Close" = "Close";
+"Done" = "Done";
+"Select" = "Select";
+"Select All" = "Select All";
+"Download" = "Download";
+"Layout" = "Layout";
+"Large" = "Large";
+"Small" = "Small";
+"The selected screenshots will be permanently deleted. Referenced captions will remain in the summary." = "The selected screenshots will be permanently deleted. Referenced captions will remain in the summary.";
 "Search" = "Search";
 "Actions" = "Actions";
 "Status" = "Status";
@@ -178,6 +186,7 @@
 "Take Screenshot" = "Take Screenshot";
 "Display not found" = "Display not found";
 "Screenshot image was unavailable" = "Screenshot image was unavailable";
+"Screenshot download failed: %@" = "Screenshot download failed: %@";
 "Screenshot encoding failed" = "Screenshot encoding failed";
 "Screenshot source is not selected or is unavailable" = "Screenshot source is not selected or is unavailable";
 "Screenshot capture failed: %@" = "Screenshot capture failed: %@";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -6,6 +6,14 @@
 "Apply" = "適用";
 "Clear" = "クリア";
 "Close" = "閉じる";
+"Done" = "完了";
+"Select" = "選択";
+"Select All" = "すべて選択";
+"Download" = "ダウンロード";
+"Layout" = "レイアウト";
+"Large" = "大";
+"Small" = "小";
+"The selected screenshots will be permanently deleted. Referenced captions will remain in the summary." = "選択したスクリーンショットは完全に削除されます。要約で参照されている画像の説明文は要約に残ります。";
 "Search" = "検索";
 "Actions" = "操作";
 "Status" = "状態";
@@ -178,6 +186,7 @@
 "Take Screenshot" = "スクリーンショットを撮影";
 "Display not found" = "ディスプレイが見つかりません";
 "Screenshot image was unavailable" = "スクリーンショット画像を取得できませんでした";
+"Screenshot download failed: %@" = "スクリーンショットのダウンロードに失敗しました: %@";
 "Screenshot encoding failed" = "スクリーンショットのエンコードに失敗しました";
 "Screenshot source is not selected or is unavailable" = "スクリーンショット対象が未設定、または利用できません";
 "Screenshot capture failed: %@" = "スクリーンショットの取得に失敗しました: %@";

--- a/Sources/Dahlia/Services/ScreenshotExportService.swift
+++ b/Sources/Dahlia/Services/ScreenshotExportService.swift
@@ -38,8 +38,6 @@ enum ScreenshotExportService {
     }
 
     private static func fileExtension(for screenshot: MeetingScreenshotRecord) -> String {
-        ImageEncoder.fileExtension(for: screenshot.mimeType)
-            ?? ImageEncoder.fileExtension(for: ImageEncoder.mimeType(for: screenshot.imageData) ?? "")
-            ?? ImageEncoder.preferredFileExtension
+        ImageEncoder.fileExtension(mimeType: screenshot.mimeType, data: screenshot.imageData)
     }
 }

--- a/Sources/Dahlia/Services/ScreenshotExportService.swift
+++ b/Sources/Dahlia/Services/ScreenshotExportService.swift
@@ -37,6 +37,18 @@ enum ScreenshotExportService {
         return relativePaths
     }
 
+    static func deleteExportedScreenshots(
+        vaultURL: URL,
+        screenshots: [MeetingScreenshotRecord]
+    ) throws {
+        let directoryURL = screenshotsDirectoryURL(in: vaultURL)
+        for screenshot in screenshots {
+            let fileURL = directoryURL.appending(path: filename(for: screenshot))
+            guard FileManager.default.fileExists(atPath: fileURL.path) else { continue }
+            try FileManager.default.removeItem(at: fileURL)
+        }
+    }
+
     private static func fileExtension(for screenshot: MeetingScreenshotRecord) -> String {
         ImageEncoder.fileExtension(mimeType: screenshot.mimeType, data: screenshot.imageData)
     }

--- a/Sources/Dahlia/Services/VaultSummaryExportService.swift
+++ b/Sources/Dahlia/Services/VaultSummaryExportService.swift
@@ -108,4 +108,23 @@ enum VaultSummaryExportService {
         try Data(markdown.utf8).write(to: fileURL, options: .atomic)
         return fileURL
     }
+
+    static func synchronizeScreenshotDeletion(
+        vaultURL: URL,
+        storedSummaryRelativePath: String?,
+        updatedSummaryMarkdown: String?,
+        deletedScreenshots: [MeetingScreenshotRecord]
+    ) throws {
+        if let updatedSummaryMarkdown,
+           let summaryURL = SummaryService.findSummaryFile(
+               storedRelativePath: storedSummaryRelativePath,
+               vaultURL: vaultURL
+           ) {
+            _ = try writeSummaryFile(fileURL: summaryURL, markdown: updatedSummaryMarkdown)
+        }
+        try ScreenshotExportService.deleteExportedScreenshots(
+            vaultURL: vaultURL,
+            screenshots: deletedScreenshots
+        )
+    }
 }

--- a/Sources/Dahlia/Utilities/ImageEncoder.swift
+++ b/Sources/Dahlia/Utilities/ImageEncoder.swift
@@ -57,6 +57,12 @@ enum ImageEncoder {
         }
     }
 
+    static func fileExtension(mimeType: String, data: Data) -> String {
+        fileExtension(for: mimeType)
+            ?? fileExtension(for: self.mimeType(for: data) ?? "")
+            ?? preferredFileExtension
+    }
+
     /// CGImage をエンコードする。WebP 優先、非対応時は JPEG フォールバック。
     static func encode(_ cgImage: CGImage, quality: CGFloat) -> Data? {
         let outputType = supportsWebP ? UTType.webP.identifier : UTType.jpeg.identifier

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -35,6 +35,18 @@ enum L10n {
     static var apply: String { String(localized: "Apply", bundle: bundle) }
     static var clear: String { String(localized: "Clear", bundle: bundle) }
     static var close: String { String(localized: "Close", bundle: bundle) }
+    static var done: String { String(localized: "Done", bundle: bundle) }
+    static var select: String { String(localized: "Select", bundle: bundle) }
+    static var selectAll: String { String(localized: "Select All", bundle: bundle) }
+    static var download: String { String(localized: "Download", bundle: bundle) }
+    static var layout: String { String(localized: "Layout", bundle: bundle) }
+    static var large: String { String(localized: "Large", bundle: bundle) }
+    static var medium: String { String(localized: "Medium", bundle: bundle) }
+    static var small: String { String(localized: "Small", bundle: bundle) }
+    static var deleteSelectedScreenshotsConfirmation: String { String(
+        localized: "The selected screenshots will be permanently deleted. Referenced captions will remain in the summary.",
+        bundle: bundle
+    ) }
     static var search: String { String(localized: "Search", bundle: bundle) }
     static var actions: String { String(localized: "Actions", bundle: bundle) }
     static var status: String { String(localized: "Status", bundle: bundle) }
@@ -344,6 +356,7 @@ enum L10n {
     static var screenshotEncodingFailed: String { String(localized: "Screenshot encoding failed", bundle: bundle) }
     static var screenshotSourceUnavailable: String { String(localized: "Screenshot source is not selected or is unavailable", bundle: bundle) }
     static func screenshotCaptureFailed(_ reason: String) -> String { String(localized: "Screenshot capture failed: \(reason)", bundle: bundle) }
+    static func screenshotDownloadFailed(_ reason: String) -> String { String(localized: "Screenshot download failed: \(reason)", bundle: bundle) }
     static var automaticScreenshots: String { String(localized: "Automatic Screenshots", bundle: bundle) }
     static var automaticScreenshotsDescription: String { String(
         localized: "Capture the screen during recording and save a new image when the display changes significantly.",

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -7,6 +7,7 @@ import os
 @preconcurrency import ScreenCaptureKit
 import Speech
 import SwiftUI
+import UniformTypeIdentifiers
 
 private let captionViewModelLogger = Logger(subsystem: "com.dahlia", category: "CaptionViewModel")
 
@@ -162,6 +163,7 @@ final class CaptionViewModel: ObservableObject {
     // MARK: - Screenshot State
 
     @Published var screenshots: [MeetingScreenshotRecord] = []
+    @Published private(set) var isDeletingScreenshots = false
     /// キャプチャ対象として選択可能なウィンドウ一覧。
     @Published var availableWindows: [ScreenshotWindowOption] = []
     /// スクリーンショット取得対象。未設定の場合はキャプチャしない。
@@ -1945,6 +1947,7 @@ final class CaptionViewModel: ObservableObject {
         guard !isListening,
               !isFinalizingRecording,
               !isSummaryGenerating,
+              !isDeletingScreenshots,
               currentMeetingId != nil,
               currentVaultURL != nil,
               batchTranscriptionState?.blocksSummaryGeneration != true else { return false }
@@ -2009,7 +2012,8 @@ final class CaptionViewModel: ObservableObject {
         recordingSessions: [RecordingSessionTimeline],
         exportOptions: SummaryExportOptions
     ) async {
-        guard !transcriptText.isEmpty else { return }
+        guard !transcriptText.isEmpty,
+              !isDeletingScreenshots else { return }
 
         // 要約前にノートを即座に保存してから取得
         saveNoteImmediately()
@@ -2589,16 +2593,58 @@ final class CaptionViewModel: ObservableObject {
     }
 
     func deleteScreenshot(_ screenshot: MeetingScreenshotRecord) {
-        guard let dbQueue = activeDbQueueForSessionControls else { return }
+        deleteScreenshots(ids: [screenshot.id], meetingId: screenshot.meetingId)
+    }
+
+    func deleteScreenshots(ids: Set<UUID>) {
+        guard let meetingId = currentMeetingId else { return }
+        deleteScreenshots(ids: ids, meetingId: meetingId)
+    }
+
+    private func deleteScreenshots(ids: Set<UUID>, meetingId: UUID) {
+        guard !ids.isEmpty,
+              !isSummaryGenerating,
+              !isDeletingScreenshots,
+              let dbQueue = activeDbQueueForSessionControls else { return }
+        let screenshotIds = ids
+        isDeletingScreenshots = true
         Task { [weak self] in
+            defer { self?.isDeletingScreenshots = false }
             do {
-                try await MeetingRepository(dbQueue: dbQueue).deleteScreenshot(id: screenshot.id)
-                await ScreenshotImageLoader.shared.remove(screenshotID: screenshot.id)
-                guard let self, self.currentMeetingId == screenshot.meetingId else { return }
-                self.screenshots.removeAll { $0.id == screenshot.id }
+                let document = try await MeetingRepository(dbQueue: dbQueue).deleteScreenshots(
+                    ids: screenshotIds,
+                    meetingId: meetingId
+                )
+                for screenshotId in screenshotIds {
+                    await ScreenshotImageLoader.shared.remove(screenshotID: screenshotId)
+                }
+                guard let self, self.currentMeetingId == meetingId else { return }
+                self.screenshots.removeAll { screenshotIds.contains($0.id) }
+                if let document {
+                    self.currentSummaryDocument = document
+                }
             } catch {
-                captionViewModelLogger.error("Failed to delete screenshot \(screenshot.id): \(error)")
-                ErrorReportingService.capture(error, context: ["source": "deleteScreenshot"])
+                captionViewModelLogger.error("Failed to delete screenshots: \(error)")
+                ErrorReportingService.capture(error, context: ["source": "deleteScreenshots"])
+            }
+        }
+    }
+
+    func downloadScreenshot(_ screenshot: MeetingScreenshotRecord) {
+        let fileExtension = ImageEncoder.fileExtension(mimeType: screenshot.mimeType, data: screenshot.imageData)
+        let panel = NSSavePanel()
+        if let contentType = UTType(filenameExtension: fileExtension) {
+            panel.allowedContentTypes = [contentType]
+        }
+        panel.nameFieldStringValue = "screenshot_\(Self.fileDateFormatter.string(from: screenshot.capturedAt)).\(fileExtension)"
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            do {
+                try screenshot.imageData.write(to: url, options: .atomic)
+            } catch {
+                captionViewModelLogger.error("Failed to download screenshot: \(error)")
+                ErrorReportingService.capture(error, context: ["source": "downloadScreenshot"])
+                self.errorMessage = L10n.screenshotDownloadFailed(error.localizedDescription)
             }
         }
     }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -2605,22 +2605,37 @@ final class CaptionViewModel: ObservableObject {
         guard !ids.isEmpty,
               !isSummaryGenerating,
               !isDeletingScreenshots,
-              let dbQueue = activeDbQueueForSessionControls else { return }
+              let dbQueue = activeDbQueueForSessionControls,
+              let vaultURL = currentVaultURL else { return }
         let screenshotIds = ids
         isDeletingScreenshots = true
         Task { [weak self] in
             defer { self?.isDeletingScreenshots = false }
             do {
-                let document = try await MeetingRepository(dbQueue: dbQueue).deleteScreenshots(
+                guard let result = try await MeetingRepository(dbQueue: dbQueue).deleteScreenshots(
                     ids: screenshotIds,
                     meetingId: meetingId
-                )
-                for screenshotId in screenshotIds {
-                    await ScreenshotImageLoader.shared.remove(screenshotID: screenshotId)
+                ) else { return }
+                for screenshot in result.deletedScreenshots {
+                    await ScreenshotImageLoader.shared.remove(screenshotID: screenshot.id)
+                }
+                do {
+                    try await Task.detached(priority: .utility) {
+                        try VaultSummaryExportService.synchronizeScreenshotDeletion(
+                            vaultURL: vaultURL,
+                            storedSummaryRelativePath: result.storedSummaryRelativePath,
+                            updatedSummaryMarkdown: result.updatedSummaryMarkdown,
+                            deletedScreenshots: result.deletedScreenshots
+                        )
+                    }.value
+                } catch {
+                    captionViewModelLogger.error("Failed to synchronize deleted screenshots with the Vault: \(error)")
+                    ErrorReportingService.capture(error, context: ["source": "synchronizeScreenshotDeletion"])
                 }
                 guard let self, self.currentMeetingId == meetingId else { return }
-                self.screenshots.removeAll { screenshotIds.contains($0.id) }
-                if let document {
+                let deletedIds = Set(result.deletedScreenshots.map(\.id))
+                self.screenshots.removeAll { deletedIds.contains($0.id) }
+                if let document = result.updatedDocument {
                     self.currentSummaryDocument = document
                 }
             } catch {
@@ -2637,14 +2652,14 @@ final class CaptionViewModel: ObservableObject {
             panel.allowedContentTypes = [contentType]
         }
         panel.nameFieldStringValue = "screenshot_\(Self.fileDateFormatter.string(from: screenshot.capturedAt)).\(fileExtension)"
-        panel.begin { response in
+        panel.begin { [weak self] response in
             guard response == .OK, let url = panel.url else { return }
             do {
                 try screenshot.imageData.write(to: url, options: .atomic)
             } catch {
                 captionViewModelLogger.error("Failed to download screenshot: \(error)")
                 ErrorReportingService.capture(error, context: ["source": "downloadScreenshot"])
-                self.errorMessage = L10n.screenshotDownloadFailed(error.localizedDescription)
+                self?.errorMessage = L10n.screenshotDownloadFailed(error.localizedDescription)
             }
         }
     }

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -116,7 +116,11 @@ private struct ScreenshotOverlayView: View {
 
             Button(L10n.close, systemImage: "xmark.circle.fill", action: onDismiss)
                 .labelStyle(.iconOnly)
-                .font(.title3)
+                .font(.title2)
+                .foregroundStyle(.black)
+                .padding(8)
+                .background(.white, in: Circle())
+                .shadow(color: .black.opacity(0.35), radius: 4, y: 2)
                 .padding(16)
                 .buttonStyle(.plain)
                 .pointerStyle(.link)
@@ -136,44 +140,69 @@ private struct ScreenshotThumbnailView: View {
     let screenshot: MeetingScreenshotRecord
     let timestamp: String
     let viewModel: CaptionViewModel
+    let isSelecting: Bool
     @Binding var expandedScreenshot: MeetingScreenshotRecord?
+    @Binding var selectedScreenshotIds: Set<UUID>
     @StateObject private var imageLoader = ScreenshotImageLoadModel()
+
+    private var isSelected: Bool {
+        selectedScreenshotIds.contains(screenshot.id)
+    }
 
     var body: some View {
         VStack(spacing: 4) {
-            if case let .loaded(thumbnailImage) = imageLoader.state {
-                Button {
-                    withAnimation(.easeOut(duration: 0.15)) {
-                        expandedScreenshot = screenshot
+            Button(action: handleImageAction) {
+                Group {
+                    if case let .loaded(thumbnailImage) = imageLoader.state {
+                        Image(decorative: thumbnailImage, scale: 1)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                            .shadow(color: .black.opacity(0.1), radius: 2, y: 1)
+                    } else {
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(Color.primary.opacity(0.05))
+                            .aspectRatio(16 / 9, contentMode: .fit)
                     }
-                } label: {
-                    Image(decorative: thumbnailImage, scale: 1)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .clipShape(RoundedRectangle(cornerRadius: 6))
-                        .shadow(color: .black.opacity(0.1), radius: 2, y: 1)
                 }
-                .buttonStyle(.plain)
-                .pointerStyle(.link)
-                .accessibilityLabel(L10n.open)
-            } else {
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(Color.primary.opacity(0.05))
-                    .aspectRatio(16 / 9, contentMode: .fit)
-                    .accessibilityHidden(true)
+                .overlay(alignment: .topTrailing) {
+                    if isSelecting {
+                        Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                            .font(.title2)
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(isSelected ? Color.accentColor : .white, .black.opacity(0.45))
+                            .padding(8)
+                    }
+                }
             }
+            .buttonStyle(.plain)
+            .pointerStyle(.link)
+            .accessibilityLabel(isSelecting ? L10n.select : L10n.open)
+            .accessibilityValue(isSelected ? L10n.selected : "")
             HStack {
                 Text(timestamp)
-                    .font(.caption2)
+                    .font(.caption)
                     .foregroundStyle(.secondary)
                 Spacer()
-                Button(L10n.delete, systemImage: "trash", role: .destructive) {
-                    viewModel.deleteScreenshot(screenshot)
+                if !isSelecting {
+                    Button(L10n.download, systemImage: "arrow.down.circle") {
+                        viewModel.downloadScreenshot(screenshot)
+                    }
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.plain)
+                    .pointerStyle(.link)
+                    .foregroundStyle(.secondary)
+                    .help(L10n.download)
+
+                    Button(L10n.delete, systemImage: "trash", role: .destructive) {
+                        viewModel.deleteScreenshot(screenshot)
+                    }
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.plain)
+                    .pointerStyle(.link)
+                    .foregroundStyle(.secondary)
+                    .disabled(viewModel.isSummaryGenerating || viewModel.isDeletingScreenshots)
                 }
-                .labelStyle(.iconOnly)
-                .buttonStyle(.plain)
-                .pointerStyle(.link)
-                .foregroundStyle(.secondary)
             }
         }
         .padding(6)
@@ -184,6 +213,20 @@ private struct ScreenshotThumbnailView: View {
                 data: screenshot.imageData,
                 targetSize: .maxPixelSize(600)
             )
+        }
+    }
+
+    private func handleImageAction() {
+        if isSelecting {
+            if isSelected {
+                selectedScreenshotIds.remove(screenshot.id)
+            } else {
+                selectedScreenshotIds.insert(screenshot.id)
+            }
+        } else {
+            withAnimation(.easeOut(duration: 0.15)) {
+                expandedScreenshot = screenshot
+            }
         }
     }
 }
@@ -400,6 +443,10 @@ struct ControlPanelView: View {
     @ObservedObject private var appSettings = AppSettings.shared
     @State private var selectedTab: DetailTab = .notes
     @State private var expandedScreenshot: MeetingScreenshotRecord?
+    @State private var screenshotGridLayout = ScreenshotGridLayout.large
+    @State private var isSelectingScreenshots = false
+    @State private var selectedScreenshotIds: Set<UUID> = []
+    @State private var isConfirmingScreenshotDeletion = false
     @State private var isEditingMeetingName = false
     @State private var editingMeetingName = ""
     @State private var didTapInsideMeetingNameEditor = false
@@ -509,12 +556,29 @@ struct ControlPanelView: View {
         .onChange(of: viewModel.requestShowSummaryTab) {
             updateSummaryTabSelection()
         }
+        .onChange(of: isSelectingScreenshots) { _, isSelecting in
+            if !isSelecting {
+                selectedScreenshotIds.removeAll()
+            }
+        }
         .onChange(of: displayedMeetingIdentity) { _, newIdentity in
             if newIdentity != nil {
                 selectedTab = initialTabSelection
             }
             viewModel.requestShowSummaryTab = false
             cancelMeetingRename()
+            isSelectingScreenshots = false
+            selectedScreenshotIds.removeAll()
+        }
+        .confirmationDialog(
+            L10n.deleteCount(selectedScreenshotIds.count),
+            isPresented: $isConfirmingScreenshotDeletion,
+            titleVisibility: .visible
+        ) {
+            Button(L10n.delete, role: .destructive, action: confirmDeleteSelectedScreenshots)
+            Button(L10n.cancel, role: .cancel) {}
+        } message: {
+            Text(L10n.deleteSelectedScreenshotsConfirmation)
         }
         .overlay(alignment: .bottomTrailing) {
             if viewModel.summaryProgress.isVisible {
@@ -664,27 +728,61 @@ struct ControlPanelView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
-            ScrollView {
-                LazyVGrid(columns: [GridItem(.adaptive(minimum: 200), spacing: 12)], spacing: 12) {
-                    let timeBase = screenshotTimeBase
-                    let recordingSessions = viewModel.store.recordingSessions
-                    ForEach(viewModel.screenshots, id: \.id) { screenshot in
-                        ScreenshotThumbnailView(
-                            screenshot: screenshot,
-                            timestamp: Formatters.elapsedHHmmss(
-                                at: screenshot.capturedAt,
-                                sessionId: screenshot.sessionId,
-                                sessions: recordingSessions,
-                                fallbackTimeBase: timeBase
-                            ),
-                            viewModel: viewModel,
-                            expandedScreenshot: $expandedScreenshot
-                        )
-                    }
-                }
+            VStack(spacing: 0) {
+                ScreenshotManagementToolbar(
+                    layout: $screenshotGridLayout,
+                    isSelecting: $isSelectingScreenshots,
+                    selectedCount: selectedScreenshotIds.count,
+                    canSelectAll: selectedScreenshotIds.count < viewModel.screenshots.count,
+                    isDeletionDisabled: viewModel.isSummaryGenerating || viewModel.isDeletingScreenshots,
+                    selectAll: selectAllScreenshots,
+                    deleteSelected: deleteSelectedScreenshots
+                )
                 .padding(12)
+
+                Divider()
+
+                ScrollView {
+                    LazyVGrid(
+                        columns: [GridItem(.adaptive(minimum: screenshotGridLayout.minimumWidth), spacing: 12)],
+                        spacing: 12
+                    ) {
+                        let timeBase = screenshotTimeBase
+                        let recordingSessions = viewModel.store.recordingSessions
+                        ForEach(viewModel.screenshots, id: \.id) { screenshot in
+                            ScreenshotThumbnailView(
+                                screenshot: screenshot,
+                                timestamp: Formatters.elapsedHHmmss(
+                                    at: screenshot.capturedAt,
+                                    sessionId: screenshot.sessionId,
+                                    sessions: recordingSessions,
+                                    fallbackTimeBase: timeBase
+                                ),
+                                viewModel: viewModel,
+                                isSelecting: isSelectingScreenshots,
+                                expandedScreenshot: $expandedScreenshot,
+                                selectedScreenshotIds: $selectedScreenshotIds
+                            )
+                        }
+                    }
+                    .padding(12)
+                }
             }
         }
+    }
+
+    private func selectAllScreenshots() {
+        selectedScreenshotIds = Set(viewModel.screenshots.map(\.id))
+    }
+
+    private func deleteSelectedScreenshots() {
+        isConfirmingScreenshotDeletion = true
+    }
+
+    private func confirmDeleteSelectedScreenshots() {
+        viewModel.deleteScreenshots(ids: selectedScreenshotIds)
+        selectedScreenshotIds.removeAll()
+        isSelectingScreenshots = false
     }
 
     // MARK: - Computed

--- a/Sources/Dahlia/Views/ScreenshotGridLayout.swift
+++ b/Sources/Dahlia/Views/ScreenshotGridLayout.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+enum ScreenshotGridLayout: String, CaseIterable, Identifiable {
+    case large
+    case medium
+    case small
+
+    var id: String { rawValue }
+
+    var minimumWidth: CGFloat {
+        switch self {
+        case .large: 200
+        case .medium: 150
+        case .small: 110
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .large: L10n.large
+        case .medium: L10n.medium
+        case .small: L10n.small
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .large: "rectangle.grid.1x2"
+        case .medium: "square.grid.2x2"
+        case .small: "square.grid.3x3"
+        }
+    }
+}

--- a/Sources/Dahlia/Views/ScreenshotManagementToolbar.swift
+++ b/Sources/Dahlia/Views/ScreenshotManagementToolbar.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct ScreenshotManagementToolbar: View {
+    @Binding var layout: ScreenshotGridLayout
+    @Binding var isSelecting: Bool
+    let selectedCount: Int
+    let canSelectAll: Bool
+    let isDeletionDisabled: Bool
+    let selectAll: () -> Void
+    let deleteSelected: () -> Void
+
+    var body: some View {
+        HStack {
+            Picker(L10n.layout, selection: $layout) {
+                ForEach(ScreenshotGridLayout.allCases) { layout in
+                    Label(layout.label, systemImage: layout.systemImage)
+                        .tag(layout)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .fixedSize()
+
+            Spacer()
+
+            if isSelecting {
+                Text(L10n.selectedCount(selectedCount))
+                    .foregroundStyle(.secondary)
+
+                Button(L10n.selectAll, action: selectAll)
+                    .disabled(!canSelectAll)
+
+                Button(L10n.delete, systemImage: "trash", role: .destructive, action: deleteSelected)
+                    .disabled(selectedCount == 0 || isDeletionDisabled)
+            }
+
+            Button(isSelecting ? L10n.done : L10n.select) {
+                isSelecting.toggle()
+            }
+            .disabled(!isSelecting && isDeletionDisabled)
+        }
+        .buttonStyle(.bordered)
+    }
+}

--- a/Tests/DahliaTests/CaptionViewModelBatchUpdateTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelBatchUpdateTests.swift
@@ -275,7 +275,7 @@ import GRDB
         }
 
         private func waitUntil(
-            timeout: Duration = .seconds(5),
+            timeout: Duration = .seconds(15),
             condition: () -> Bool
         ) async -> Bool {
             let clock = ContinuousClock()

--- a/Tests/DahliaTests/MeetingRepositorySummaryTests.swift
+++ b/Tests/DahliaTests/MeetingRepositorySummaryTests.swift
@@ -202,6 +202,81 @@ import GRDB
             #expect(meeting.description == "First description")
         }
 
+        @Test
+        func deletingScreenshotsAlsoRemovesPersistedSummaryImageReferences() async throws {
+            let context = try makeRepositoryContext()
+            let deletedScreenshot = MeetingScreenshotRecord(
+                id: .v7(),
+                meetingId: context.meeting.id,
+                capturedAt: .now,
+                imageData: Data([0x89, 0x50, 0x4E, 0x47]),
+                mimeType: "image/png"
+            )
+            try await context.manager.dbQueue.write { db in
+                try deletedScreenshot.insert(db)
+            }
+            let caption = SummaryText("Launch screen", transcriptRef: TranscriptReference(time: "00:00:42"))
+            let document = SummaryDocument(
+                title: "Summary",
+                sections: [
+                    SummarySection(
+                        id: .v7(),
+                        heading: "Launch",
+                        blocks: [.image(screenshotId: deletedScreenshot.id, caption: caption)]
+                    ),
+                ]
+            )
+            try context.repo.applyGeneratedSummary(
+                toMeetingId: context.meeting.id,
+                document: document,
+                renderedBody: "Launch screen",
+                tags: []
+            )
+
+            let updatedDocument = try await context.repo.deleteScreenshots(
+                ids: [deletedScreenshot.id],
+                meetingId: context.meeting.id
+            )
+
+            #expect(try context.repo.fetchScreenshots(forMeetingId: context.meeting.id).isEmpty)
+            #expect(updatedDocument?.sections[0].blocks == [.paragraph(caption)])
+            #expect(try context.repo.fetchSummary(forMeetingId: context.meeting.id)?.loadDocument() == updatedDocument)
+        }
+
+        @Test
+        func deletingUnreferencedScreenshotDoesNotConvertLegacySummaryDocument() async throws {
+            let context = try makeRepositoryContext()
+            let screenshot = MeetingScreenshotRecord(
+                id: .v7(),
+                meetingId: context.meeting.id,
+                capturedAt: .now,
+                imageData: Data([0x89, 0x50, 0x4E, 0x47]),
+                mimeType: "image/png"
+            )
+            try await context.manager.dbQueue.write { db in
+                try screenshot.insert(db)
+            }
+            try context.repo.upsertSummary(
+                SummaryRecord(
+                    meetingId: context.meeting.id,
+                    title: "Legacy",
+                    summary: "## Notes\n\nNo screenshot reference",
+                    document: nil,
+                    vaultRelativePath: nil,
+                    googleFileId: nil,
+                    createdAt: .now
+                )
+            )
+
+            let updatedDocument = try await context.repo.deleteScreenshots(
+                ids: [screenshot.id],
+                meetingId: context.meeting.id
+            )
+
+            #expect(updatedDocument == nil)
+            #expect(try context.repo.fetchSummary(forMeetingId: context.meeting.id)?.document == nil)
+        }
+
         private func makeRepositoryContext() throws -> RepositoryContext {
             let manager = try AppDatabaseManager(path: ":memory:")
             let repo = MeetingRepository(dbQueue: manager.dbQueue)

--- a/Tests/DahliaTests/MeetingRepositorySummaryTests.swift
+++ b/Tests/DahliaTests/MeetingRepositorySummaryTests.swift
@@ -233,14 +233,22 @@ import GRDB
                 tags: []
             )
 
-            let updatedDocument = try await context.repo.deleteScreenshots(
+            let result = try #require(try await context.repo.deleteScreenshots(
                 ids: [deletedScreenshot.id],
                 meetingId: context.meeting.id
-            )
+            ))
+            let updatedDocument = try #require(result.updatedDocument)
+            let updatedSummary = try #require(try context.repo.fetchSummary(forMeetingId: context.meeting.id))
 
             #expect(try context.repo.fetchScreenshots(forMeetingId: context.meeting.id).isEmpty)
-            #expect(updatedDocument?.sections[0].blocks == [.paragraph(caption)])
+            #expect(updatedDocument.sections[0].blocks == [.paragraph(caption)])
             #expect(try context.repo.fetchSummary(forMeetingId: context.meeting.id)?.loadDocument() == updatedDocument)
+            #expect(updatedSummary.summary == """
+            ## Launch
+
+            Launch screen ([[\(context.meeting.id.uuidString)#00:00:42|00:00:42]])
+            """)
+            #expect(result.updatedSummaryMarkdown?.contains("![[") == false)
         }
 
         @Test
@@ -268,12 +276,13 @@ import GRDB
                 )
             )
 
-            let updatedDocument = try await context.repo.deleteScreenshots(
+            let result = try #require(try await context.repo.deleteScreenshots(
                 ids: [screenshot.id],
                 meetingId: context.meeting.id
-            )
+            ))
 
-            #expect(updatedDocument == nil)
+            #expect(result.updatedDocument == nil)
+            #expect(result.deletedScreenshots.map(\.id) == [screenshot.id])
             #expect(try context.repo.fetchSummary(forMeetingId: context.meeting.id)?.document == nil)
         }
 

--- a/Tests/DahliaTests/SummaryDocumentCodableTests.swift
+++ b/Tests/DahliaTests/SummaryDocumentCodableTests.swift
@@ -105,6 +105,33 @@ import Foundation
         }
 
         @Test
+        func removingScreenshotReferencesPreservesCaptionsAsParagraphs() {
+            let removedImageId = UUID.v7()
+            let retainedImageId = UUID.v7()
+            let caption = SummaryText("Architecture diagram", transcriptRef: TranscriptReference(time: "00:01:23"))
+            let document = SummaryDocument(
+                title: "Summary",
+                sections: [
+                    SummarySection(
+                        id: .v7(),
+                        heading: "Design",
+                        blocks: [
+                            .image(screenshotId: removedImageId, caption: caption),
+                            .image(screenshotId: retainedImageId, caption: "Keep"),
+                            .image(screenshotId: UUID.v7(), caption: ""),
+                        ]
+                    ),
+                ]
+            )
+
+            let updated = document.removingScreenshotReferences([removedImageId])
+
+            #expect(updated.sections[0].blocks[0] == .paragraph(caption))
+            #expect(updated.sections[0].blocks[1] == .image(screenshotId: retainedImageId, caption: "Keep"))
+            #expect(updated.sections[0].blocks.count == 3)
+        }
+
+        @Test
         func decodesPersistedSummaryDocumentShape() throws {
             let imageId = UUID.v7()
             let json = """

--- a/Tests/DahliaTests/VaultSummaryExportServiceTests.swift
+++ b/Tests/DahliaTests/VaultSummaryExportServiceTests.swift
@@ -145,5 +145,40 @@ import Foundation
 
             #expect(didThrowExpectedError)
         }
+
+        @Test
+        func screenshotDeletionUpdatesStoredSummaryAndRemovesExportedImage() throws {
+            let vaultURL = FileManager.default.temporaryDirectory
+                .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+            defer { try? FileManager.default.removeItem(at: vaultURL) }
+
+            let summaryURL = vaultURL.appending(path: "Project/Summary.md")
+            try FileManager.default.createDirectory(
+                at: summaryURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data("Old summary".utf8).write(to: summaryURL)
+
+            let screenshot = MeetingScreenshotRecord(
+                id: .v7(),
+                meetingId: .v7(),
+                capturedAt: .now,
+                imageData: Data([0x89, 0x50, 0x4E, 0x47]),
+                mimeType: "image/png"
+            )
+            _ = try ScreenshotExportService.exportScreenshots(vaultURL: vaultURL, screenshots: [screenshot])
+            let screenshotURL = ScreenshotExportService.screenshotsDirectoryURL(in: vaultURL)
+                .appending(path: ScreenshotExportService.filename(for: screenshot))
+
+            try VaultSummaryExportService.synchronizeScreenshotDeletion(
+                vaultURL: vaultURL,
+                storedSummaryRelativePath: "Project/Summary.md",
+                updatedSummaryMarkdown: "Updated summary",
+                deletedScreenshots: [screenshot]
+            )
+
+            #expect(try String(contentsOf: summaryURL, encoding: .utf8) == "Updated summary")
+            #expect(!FileManager.default.fileExists(atPath: screenshotURL.path))
+        }
     }
 #endif


### PR DESCRIPTION
## Summary

- keep summaries readable when referenced screenshots are deleted by preserving their captions and transcript references
- add screenshot downloads, multi-select deletion with confirmation, and large/medium/small grid layouts
- improve the expanded-image close button and selection behavior for failed thumbnails
- prevent screenshot deletion from racing with summary generation

## Why

Deleting a screenshot previously left a dangling image block in the persisted summary, so the summary could no longer render cleanly. The screenshot manager also only supported one-at-a-time deletion and had no direct download or layout controls.

## User impact

Users can now download screenshots, select and delete multiple images safely, switch between three gallery densities, and more easily close the expanded preview. When a referenced image is removed, its useful caption remains in the summary instead of an unavailable-image placeholder.

## Validation

- `swift build`
- `swift test` — 516 tests in 93 suites passed
- `CI=true ./scripts/lint.sh` — SwiftFormat clean; SwiftLint reports existing repository-wide violations and remains non-blocking by script policy
- Claude Code secondary review (`high`, `sonnet`), with confirmed findings addressed
