### PR TITLE
Protect summary screenshots from deletion

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>19</string>
+    <string>20</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.5.3</string>
+    <string>0.5.4</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -464,71 +464,26 @@ final class MeetingRepository {
         }
     }
 
-    struct ScreenshotDeletionResult {
-        let deletedScreenshots: [MeetingScreenshotRecord]
-        let updatedDocument: SummaryDocument?
-        let updatedSummaryMarkdown: String?
-        let storedSummaryRelativePath: String?
-    }
-
-    func deleteScreenshots(ids: Set<UUID>, meetingId: UUID) async throws -> ScreenshotDeletionResult? {
-        guard !ids.isEmpty else { return nil }
+    func deleteScreenshots(ids: Set<UUID>, meetingId: UUID) async throws -> [MeetingScreenshotRecord] {
+        guard !ids.isEmpty else { return [] }
         return try await dbQueue.write { db in
+            let referencedScreenshotIds = try SummaryRecord.fetchOne(db, key: meetingId)?
+                .loadDocument()
+                .referencedScreenshotIds ?? []
+            let deletableIds = ids.subtracting(referencedScreenshotIds)
+            guard !deletableIds.isEmpty else { return [] }
+
             let deletedScreenshots = try MeetingScreenshotRecord
-                .filter(ids.contains(Column("id")))
+                .filter(deletableIds.contains(Column("id")))
                 .filter(Column("meetingId") == meetingId)
                 .fetchAll(db)
-            guard !deletedScreenshots.isEmpty else { return nil }
+            guard !deletedScreenshots.isEmpty else { return [] }
             let deletedIds = Set(deletedScreenshots.map(\.id))
 
             _ = try MeetingScreenshotRecord
                 .filter(deletedIds.contains(Column("id")))
                 .deleteAll(db)
-
-            guard var summary = try SummaryRecord.fetchOne(db, key: meetingId) else {
-                return ScreenshotDeletionResult(
-                    deletedScreenshots: deletedScreenshots,
-                    updatedDocument: nil,
-                    updatedSummaryMarkdown: nil,
-                    storedSummaryRelativePath: nil
-                )
-            }
-            let storedSummaryRelativePath = try SummaryExportRecord
-                .fetchOne(meetingId: meetingId, type: .vault, in: db)?.vaultRelativePath
-                ?? summary.vaultRelativePath
-            let existingDocument = summary.loadDocument()
-            let updatedDocument = existingDocument.removingScreenshotReferences(deletedIds)
-            guard updatedDocument != existingDocument,
-                  let meeting = try MeetingRecord.fetchOne(db, key: meetingId)
-            else {
-                return ScreenshotDeletionResult(
-                    deletedScreenshots: deletedScreenshots,
-                    updatedDocument: nil,
-                    updatedSummaryMarkdown: nil,
-                    storedSummaryRelativePath: storedSummaryRelativePath
-                )
-            }
-            let remainingScreenshots = try MeetingScreenshotRecord
-                .filter(Column("meetingId") == meetingId)
-                .order(Column("capturedAt").asc)
-                .fetchAll(db)
-            let rendered = ObsidianMarkdownSummaryRenderer.render(
-                document: updatedDocument,
-                context: SummaryRenderContext(
-                    meetingId: meetingId,
-                    createdAt: meeting.createdAt,
-                    screenshots: remainingScreenshots
-                )
-            )
-            summary.summary = rendered.body
-            summary.document = try updatedDocument.databaseJSONString()
-            try summary.update(db)
-            return ScreenshotDeletionResult(
-                deletedScreenshots: deletedScreenshots,
-                updatedDocument: updatedDocument,
-                updatedSummaryMarkdown: rendered.markdown,
-                storedSummaryRelativePath: storedSummaryRelativePath
-            )
+            return deletedScreenshots
         }
     }
 

--- a/Sources/Dahlia/Models/SummaryDocument.swift
+++ b/Sources/Dahlia/Models/SummaryDocument.swift
@@ -49,6 +49,13 @@ struct SummaryDocument: Codable, Equatable {
         return try String(decoding: encoder.encode(self), as: UTF8.self)
     }
 
+    var referencedScreenshotIds: Set<UUID> {
+        Set(sections.flatMap(\.blocks).compactMap { block in
+            guard case let .image(screenshotId, _) = block.content else { return nil }
+            return screenshotId
+        })
+    }
+
     func removingScreenshotReferences(_ screenshotIds: Set<UUID>) -> SummaryDocument {
         guard !screenshotIds.isEmpty else { return self }
 

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -13,7 +13,8 @@
 "Layout" = "Layout";
 "Large" = "Large";
 "Small" = "Small";
-"The selected screenshots will be permanently deleted. Referenced captions will remain in the summary." = "The selected screenshots will be permanently deleted. Referenced captions will remain in the summary.";
+"The selected screenshots will be permanently deleted. Screenshots used in the summary are protected." = "The selected screenshots will be permanently deleted. Screenshots used in the summary are protected.";
+"Used in summary" = "Used in summary";
 "Search" = "Search";
 "Actions" = "Actions";
 "Status" = "Status";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -13,7 +13,8 @@
 "Layout" = "レイアウト";
 "Large" = "大";
 "Small" = "小";
-"The selected screenshots will be permanently deleted. Referenced captions will remain in the summary." = "選択したスクリーンショットは完全に削除されます。要約で参照されている画像の説明文は要約に残ります。";
+"The selected screenshots will be permanently deleted. Screenshots used in the summary are protected." = "選択したスクリーンショットは完全に削除されます。要約で使用中のスクリーンショットは保護されます。";
+"Used in summary" = "要約で使用中";
 "Search" = "検索";
 "Actions" = "操作";
 "Status" = "状態";

--- a/Sources/Dahlia/Services/VaultSummaryExportService.swift
+++ b/Sources/Dahlia/Services/VaultSummaryExportService.swift
@@ -108,23 +108,4 @@ enum VaultSummaryExportService {
         try Data(markdown.utf8).write(to: fileURL, options: .atomic)
         return fileURL
     }
-
-    static func synchronizeScreenshotDeletion(
-        vaultURL: URL,
-        storedSummaryRelativePath: String?,
-        updatedSummaryMarkdown: String?,
-        deletedScreenshots: [MeetingScreenshotRecord]
-    ) throws {
-        if let updatedSummaryMarkdown,
-           let summaryURL = SummaryService.findSummaryFile(
-               storedRelativePath: storedSummaryRelativePath,
-               vaultURL: vaultURL
-           ) {
-            _ = try writeSummaryFile(fileURL: summaryURL, markdown: updatedSummaryMarkdown)
-        }
-        try ScreenshotExportService.deleteExportedScreenshots(
-            vaultURL: vaultURL,
-            screenshots: deletedScreenshots
-        )
-    }
 }

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -44,9 +44,10 @@ enum L10n {
     static var medium: String { String(localized: "Medium", bundle: bundle) }
     static var small: String { String(localized: "Small", bundle: bundle) }
     static var deleteSelectedScreenshotsConfirmation: String { String(
-        localized: "The selected screenshots will be permanently deleted. Referenced captions will remain in the summary.",
+        localized: "The selected screenshots will be permanently deleted. Screenshots used in the summary are protected.",
         bundle: bundle
     ) }
+    static var screenshotUsedInSummary: String { String(localized: "Used in summary", bundle: bundle) }
     static var search: String { String(localized: "Search", bundle: bundle) }
     static var actions: String { String(localized: "Actions", bundle: bundle) }
     static var status: String { String(localized: "Status", bundle: bundle) }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -2612,32 +2612,28 @@ final class CaptionViewModel: ObservableObject {
         Task { [weak self] in
             defer { self?.isDeletingScreenshots = false }
             do {
-                guard let result = try await MeetingRepository(dbQueue: dbQueue).deleteScreenshots(
+                let deletedScreenshots = try await MeetingRepository(dbQueue: dbQueue).deleteScreenshots(
                     ids: screenshotIds,
                     meetingId: meetingId
-                ) else { return }
-                for screenshot in result.deletedScreenshots {
+                )
+                guard !deletedScreenshots.isEmpty else { return }
+                for screenshot in deletedScreenshots {
                     await ScreenshotImageLoader.shared.remove(screenshotID: screenshot.id)
                 }
                 do {
                     try await Task.detached(priority: .utility) {
-                        try VaultSummaryExportService.synchronizeScreenshotDeletion(
+                        try ScreenshotExportService.deleteExportedScreenshots(
                             vaultURL: vaultURL,
-                            storedSummaryRelativePath: result.storedSummaryRelativePath,
-                            updatedSummaryMarkdown: result.updatedSummaryMarkdown,
-                            deletedScreenshots: result.deletedScreenshots
+                            screenshots: deletedScreenshots
                         )
                     }.value
                 } catch {
-                    captionViewModelLogger.error("Failed to synchronize deleted screenshots with the Vault: \(error)")
-                    ErrorReportingService.capture(error, context: ["source": "synchronizeScreenshotDeletion"])
+                    captionViewModelLogger.error("Failed to delete exported screenshots from the Vault: \(error)")
+                    ErrorReportingService.capture(error, context: ["source": "deleteExportedScreenshots"])
                 }
                 guard let self, self.currentMeetingId == meetingId else { return }
-                let deletedIds = Set(result.deletedScreenshots.map(\.id))
+                let deletedIds = Set(deletedScreenshots.map(\.id))
                 self.screenshots.removeAll { deletedIds.contains($0.id) }
-                if let document = result.updatedDocument {
-                    self.currentSummaryDocument = document
-                }
             } catch {
                 captionViewModelLogger.error("Failed to delete screenshots: \(error)")
                 ErrorReportingService.capture(error, context: ["source": "deleteScreenshots"])

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -141,6 +141,7 @@ private struct ScreenshotThumbnailView: View {
     let timestamp: String
     let viewModel: CaptionViewModel
     let isSelecting: Bool
+    let isReferencedBySummary: Bool
     @Binding var expandedScreenshot: MeetingScreenshotRecord?
     @Binding var selectedScreenshotIds: Set<UUID>
     @StateObject private var imageLoader = ScreenshotImageLoadModel()
@@ -167,23 +168,29 @@ private struct ScreenshotThumbnailView: View {
                 }
                 .overlay(alignment: .topTrailing) {
                     if isSelecting {
-                        Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        Image(systemName: selectionIndicatorSystemImage)
                             .font(.title2)
                             .symbolRenderingMode(.palette)
-                            .foregroundStyle(isSelected ? Color.accentColor : .white, .black.opacity(0.45))
+                            .foregroundStyle(selectionIndicatorColor, .black.opacity(0.45))
                             .padding(8)
                     }
                 }
             }
             .buttonStyle(.plain)
             .pointerStyle(.link)
-            .accessibilityLabel(isSelecting ? L10n.select : L10n.open)
+            .disabled(isSelecting && isReferencedBySummary)
+            .accessibilityLabel(imageActionAccessibilityLabel)
             .accessibilityValue(isSelected ? L10n.selected : "")
             HStack {
                 Text(timestamp)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Spacer()
+                if isReferencedBySummary {
+                    Image(systemName: "lock.fill")
+                        .foregroundStyle(.secondary)
+                        .help(L10n.screenshotUsedInSummary)
+                }
                 if !isSelecting {
                     Button(L10n.download, systemImage: "arrow.down.circle") {
                         viewModel.downloadScreenshot(screenshot)
@@ -201,7 +208,8 @@ private struct ScreenshotThumbnailView: View {
                     .buttonStyle(.plain)
                     .pointerStyle(.link)
                     .foregroundStyle(.secondary)
-                    .disabled(viewModel.isSummaryGenerating || viewModel.isDeletingScreenshots)
+                    .disabled(isReferencedBySummary || viewModel.isSummaryGenerating || viewModel.isDeletingScreenshots)
+                    .help(isReferencedBySummary ? L10n.screenshotUsedInSummary : L10n.delete)
                 }
             }
         }
@@ -218,6 +226,7 @@ private struct ScreenshotThumbnailView: View {
 
     private func handleImageAction() {
         if isSelecting {
+            guard !isReferencedBySummary else { return }
             if isSelected {
                 selectedScreenshotIds.remove(screenshot.id)
             } else {
@@ -227,6 +236,36 @@ private struct ScreenshotThumbnailView: View {
             withAnimation(.easeOut(duration: 0.15)) {
                 expandedScreenshot = screenshot
             }
+        }
+    }
+
+    private var imageActionAccessibilityLabel: String {
+        if isSelecting, isReferencedBySummary {
+            L10n.screenshotUsedInSummary
+        } else if isSelecting {
+            L10n.select
+        } else {
+            L10n.open
+        }
+    }
+
+    private var selectionIndicatorSystemImage: String {
+        if isReferencedBySummary {
+            "lock.circle.fill"
+        } else if isSelected {
+            "checkmark.circle.fill"
+        } else {
+            "circle"
+        }
+    }
+
+    private var selectionIndicatorColor: Color {
+        if isReferencedBySummary {
+            .secondary
+        } else if isSelected {
+            .accentColor
+        } else {
+            .white
         }
     }
 }
@@ -733,7 +772,7 @@ struct ControlPanelView: View {
                     layout: $screenshotGridLayout,
                     isSelecting: $isSelectingScreenshots,
                     selectedCount: selectedScreenshotIds.count,
-                    canSelectAll: selectedScreenshotIds.count < viewModel.screenshots.count,
+                    canSelectAll: selectedScreenshotIds.count < deletableScreenshotIds.count,
                     isDeletionDisabled: viewModel.isSummaryGenerating || viewModel.isDeletingScreenshots,
                     selectAll: selectAllScreenshots,
                     deleteSelected: deleteSelectedScreenshots
@@ -760,6 +799,7 @@ struct ControlPanelView: View {
                                 ),
                                 viewModel: viewModel,
                                 isSelecting: isSelectingScreenshots,
+                                isReferencedBySummary: referencedScreenshotIds.contains(screenshot.id),
                                 expandedScreenshot: $expandedScreenshot,
                                 selectedScreenshotIds: $selectedScreenshotIds
                             )
@@ -772,7 +812,7 @@ struct ControlPanelView: View {
     }
 
     private func selectAllScreenshots() {
-        selectedScreenshotIds = Set(viewModel.screenshots.map(\.id))
+        selectedScreenshotIds = deletableScreenshotIds
     }
 
     private func deleteSelectedScreenshots() {
@@ -799,6 +839,14 @@ struct ControlPanelView: View {
 
     private var screenshotTimeBase: Date {
         viewModel.store.timeBase
+    }
+
+    private var referencedScreenshotIds: Set<UUID> {
+        viewModel.currentSummaryDocument?.referencedScreenshotIds ?? []
+    }
+
+    private var deletableScreenshotIds: Set<UUID> {
+        Set(viewModel.screenshots.map(\.id)).subtracting(referencedScreenshotIds)
     }
 
     private func summaryTranscriptText(for reference: TranscriptReference) -> String? {

--- a/Tests/DahliaTests/MeetingRepositorySummaryTests.swift
+++ b/Tests/DahliaTests/MeetingRepositorySummaryTests.swift
@@ -203,17 +203,25 @@ import GRDB
         }
 
         @Test
-        func deletingScreenshotsAlsoRemovesPersistedSummaryImageReferences() async throws {
+        func deletingScreenshotsPreservesImagesReferencedBySummary() async throws {
             let context = try makeRepositoryContext()
-            let deletedScreenshot = MeetingScreenshotRecord(
+            let referencedScreenshot = MeetingScreenshotRecord(
                 id: .v7(),
                 meetingId: context.meeting.id,
                 capturedAt: .now,
                 imageData: Data([0x89, 0x50, 0x4E, 0x47]),
                 mimeType: "image/png"
             )
+            let unreferencedScreenshot = MeetingScreenshotRecord(
+                id: .v7(),
+                meetingId: context.meeting.id,
+                capturedAt: .now.addingTimeInterval(1),
+                imageData: Data([0x89, 0x50, 0x4E, 0x47]),
+                mimeType: "image/png"
+            )
             try await context.manager.dbQueue.write { db in
-                try deletedScreenshot.insert(db)
+                try referencedScreenshot.insert(db)
+                try unreferencedScreenshot.insert(db)
             }
             let caption = SummaryText("Launch screen", transcriptRef: TranscriptReference(time: "00:00:42"))
             let document = SummaryDocument(
@@ -222,7 +230,7 @@ import GRDB
                     SummarySection(
                         id: .v7(),
                         heading: "Launch",
-                        blocks: [.image(screenshotId: deletedScreenshot.id, caption: caption)]
+                        blocks: [.image(screenshotId: referencedScreenshot.id, caption: caption)]
                     ),
                 ]
             )
@@ -233,22 +241,14 @@ import GRDB
                 tags: []
             )
 
-            let result = try #require(try await context.repo.deleteScreenshots(
-                ids: [deletedScreenshot.id],
+            let deletedScreenshots = try await context.repo.deleteScreenshots(
+                ids: [referencedScreenshot.id, unreferencedScreenshot.id],
                 meetingId: context.meeting.id
-            ))
-            let updatedDocument = try #require(result.updatedDocument)
-            let updatedSummary = try #require(try context.repo.fetchSummary(forMeetingId: context.meeting.id))
+            )
 
-            #expect(try context.repo.fetchScreenshots(forMeetingId: context.meeting.id).isEmpty)
-            #expect(updatedDocument.sections[0].blocks == [.paragraph(caption)])
-            #expect(try context.repo.fetchSummary(forMeetingId: context.meeting.id)?.loadDocument() == updatedDocument)
-            #expect(updatedSummary.summary == """
-            ## Launch
-
-            Launch screen ([[\(context.meeting.id.uuidString)#00:00:42|00:00:42]])
-            """)
-            #expect(result.updatedSummaryMarkdown?.contains("![[") == false)
+            #expect(deletedScreenshots.map(\.id) == [unreferencedScreenshot.id])
+            #expect(try context.repo.fetchScreenshots(forMeetingId: context.meeting.id).map(\.id) == [referencedScreenshot.id])
+            #expect(try context.repo.fetchSummary(forMeetingId: context.meeting.id)?.loadDocument() == document)
         }
 
         @Test
@@ -276,13 +276,12 @@ import GRDB
                 )
             )
 
-            let result = try #require(try await context.repo.deleteScreenshots(
+            let deletedScreenshots = try await context.repo.deleteScreenshots(
                 ids: [screenshot.id],
                 meetingId: context.meeting.id
-            ))
+            )
 
-            #expect(result.updatedDocument == nil)
-            #expect(result.deletedScreenshots.map(\.id) == [screenshot.id])
+            #expect(deletedScreenshots.map(\.id) == [screenshot.id])
             #expect(try context.repo.fetchSummary(forMeetingId: context.meeting.id)?.document == nil)
         }
 

--- a/Tests/DahliaTests/SummaryDocumentCodableTests.swift
+++ b/Tests/DahliaTests/SummaryDocumentCodableTests.swift
@@ -105,6 +105,29 @@ import Foundation
         }
 
         @Test
+        func collectsReferencedScreenshotIds() {
+            let firstImageId = UUID.v7()
+            let secondImageId = UUID.v7()
+            let document = SummaryDocument(
+                title: "Summary",
+                sections: [
+                    SummarySection(
+                        id: .v7(),
+                        heading: "Design",
+                        blocks: [
+                            .image(screenshotId: firstImageId, caption: "First"),
+                            .paragraph("Notes"),
+                            .image(screenshotId: secondImageId, caption: "Second"),
+                            .image(screenshotId: firstImageId, caption: "Duplicate"),
+                        ]
+                    ),
+                ]
+            )
+
+            #expect(document.referencedScreenshotIds == [firstImageId, secondImageId])
+        }
+
+        @Test
         func removingScreenshotReferencesPreservesCaptionsAsParagraphs() {
             let removedImageId = UUID.v7()
             let retainedImageId = UUID.v7()

--- a/Tests/DahliaTests/VaultSummaryExportServiceTests.swift
+++ b/Tests/DahliaTests/VaultSummaryExportServiceTests.swift
@@ -147,17 +147,10 @@ import Foundation
         }
 
         @Test
-        func screenshotDeletionUpdatesStoredSummaryAndRemovesExportedImage() throws {
+        func screenshotDeletionRemovesExportedImage() throws {
             let vaultURL = FileManager.default.temporaryDirectory
                 .appending(path: UUID().uuidString, directoryHint: .isDirectory)
             defer { try? FileManager.default.removeItem(at: vaultURL) }
-
-            let summaryURL = vaultURL.appending(path: "Project/Summary.md")
-            try FileManager.default.createDirectory(
-                at: summaryURL.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-            try Data("Old summary".utf8).write(to: summaryURL)
 
             let screenshot = MeetingScreenshotRecord(
                 id: .v7(),
@@ -170,14 +163,11 @@ import Foundation
             let screenshotURL = ScreenshotExportService.screenshotsDirectoryURL(in: vaultURL)
                 .appending(path: ScreenshotExportService.filename(for: screenshot))
 
-            try VaultSummaryExportService.synchronizeScreenshotDeletion(
+            try ScreenshotExportService.deleteExportedScreenshots(
                 vaultURL: vaultURL,
-                storedSummaryRelativePath: "Project/Summary.md",
-                updatedSummaryMarkdown: "Updated summary",
-                deletedScreenshots: [screenshot]
+                screenshots: [screenshot]
             )
 
-            #expect(try String(contentsOf: summaryURL, encoding: .utf8) == "Updated summary")
             #expect(!FileManager.default.fileExists(atPath: screenshotURL.path))
         }
     }


### PR DESCRIPTION
## Summary

- protect screenshots referenced by a summary from deletion in the repository transaction
- mark referenced screenshots as locked in the UI and exclude them from individual and bulk deletion
- remove the obsolete flow that rewrote summaries after deleting referenced images
- update English and Japanese deletion guidance
- bump the app version to 0.5.4 and build number to 20
- add regression coverage for mixed referenced and unreferenced deletion requests

## Root cause

The screenshot deletion path deleted every requested screenshot from the database and Vault, then removed matching image blocks from the persisted summary. There was no guard for screenshots still referenced by the summary.

## Impact

Screenshots used in summaries remain available in the database, Vault export, and summary UI. Unreferenced screenshots can still be deleted normally. The repository enforces this independently of the UI.

## Validation

- `swift test --filter MeetingRepositorySummaryTests` — 7 tests passed
- `swift test --filter SummaryDocumentCodableTests` — 6 tests passed
- `swift test --filter VaultSummaryExportServiceTests` — 4 tests passed
- `swift build` — passed after the version bump
- `plutil -lint Resources/Info.plist` — passed
- SwiftFormat — passed for 337 files
- `git diff --check` — passed
- SwiftLint completed and reported pre-existing repository-wide violations outside this change