### PR TITLE
Remove legacy summary columns

### DIFF
--- a/Sources/Dahlia/Database/AppDatabaseManager.swift
+++ b/Sources/Dahlia/Database/AppDatabaseManager.swift
@@ -115,6 +115,10 @@ final class AppDatabaseManager: Sendable {
             try addMeetingDescriptionColumnIfNeeded(in: db)
         }
 
+        migrator.registerMigration("v21_removeLegacySummaryColumns") { db in
+            try LegacySummaryColumnsMigration.migrate(in: db)
+        }
+
         return migrator
     }()
 

--- a/Sources/Dahlia/Database/LegacySummaryColumnsMigration.swift
+++ b/Sources/Dahlia/Database/LegacySummaryColumnsMigration.swift
@@ -1,0 +1,96 @@
+import Foundation
+import GRDB
+
+enum LegacySummaryColumnsMigration {
+    static func migrate(in db: Database) throws {
+        guard try db.tableExists("summaries") else { return }
+        let columns = try db.columns(in: "summaries").map(\.name)
+        guard columns.contains("document") else { return }
+
+        try SummaryExportsMigration.migrate(in: db)
+        try createReplacementTables(in: db)
+        try copyValidSummaries(in: db)
+        try db.execute(
+            sql: """
+            INSERT INTO summary_exports_v21 (meetingId, type, url, createdAt, updatedAt)
+            SELECT exports.meetingId, exports.type, exports.url, exports.createdAt, exports.updatedAt
+            FROM summary_exports AS exports
+            JOIN summaries_v21 AS summaries ON summaries.meetingId = exports.meetingId
+            """
+        )
+
+        try db.drop(table: "summary_exports")
+        try db.drop(table: "summaries")
+        try db.rename(table: "summaries_v21", to: "summaries")
+        try createSummaryExportsTable(in: db)
+        try db.execute(
+            sql: """
+            INSERT INTO summary_exports (meetingId, type, url, createdAt, updatedAt)
+            SELECT meetingId, type, url, createdAt, updatedAt
+            FROM summary_exports_v21
+            """
+        )
+        try db.drop(table: "summary_exports_v21")
+        try db.create(
+            index: "summary_exports_on_type",
+            on: "summary_exports",
+            columns: ["type"],
+            ifNotExists: true
+        )
+    }
+
+    private static func createReplacementTables(in db: Database) throws {
+        let hasMeetingsTable = try db.tableExists("meetings")
+        try db.create(table: "summaries_v21") { table in
+            let meetingId = table.primaryKey("meetingId", .blob)
+            if hasMeetingsTable {
+                meetingId.references("meetings", onDelete: .cascade)
+            }
+            table.column("title", .text).notNull().defaults(to: "")
+            table.column("document", .text).notNull()
+            table.column("createdAt", .datetime).notNull()
+        }
+        try db.create(table: "summary_exports_v21") { table in
+            table.column("meetingId", .blob).notNull()
+            table.column("type", .text).notNull()
+            table.column("url", .text).notNull()
+            table.column("createdAt", .datetime).notNull()
+            table.column("updatedAt", .datetime).notNull()
+            table.primaryKey(["meetingId", "type"])
+        }
+    }
+
+    private static func createSummaryExportsTable(in db: Database) throws {
+        try db.create(table: "summary_exports") { table in
+            table.column("meetingId", .blob).notNull()
+                .references("summaries", column: "meetingId", onDelete: .cascade)
+            table.column("type", .text).notNull()
+            table.column("url", .text).notNull()
+            table.column("createdAt", .datetime).notNull()
+            table.column("updatedAt", .datetime).notNull()
+            table.primaryKey(["meetingId", "type"])
+        }
+    }
+
+    private static func copyValidSummaries(in db: Database) throws {
+        let rows = try Row.fetchAll(
+            db,
+            sql: "SELECT meetingId, title, document, createdAt FROM summaries"
+        )
+        for row in rows {
+            guard let document: String = row["document"],
+                  (try? JSONDecoder().decode(SummaryDocument.self, from: Data(document.utf8))) != nil
+            else { continue }
+            let meetingId: UUID = row["meetingId"]
+            let title: String = row["title"]
+            let createdAt: Date = row["createdAt"]
+            try db.execute(
+                sql: """
+                INSERT INTO summaries_v21 (meetingId, title, document, createdAt)
+                VALUES (?, ?, ?, ?)
+                """,
+                arguments: [meetingId, title, document, createdAt]
+            )
+        }
+    }
+}

--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -271,7 +271,6 @@ final class MeetingRepository {
     func applyGeneratedSummary(
         toMeetingId meetingId: UUID,
         document: SummaryDocument,
-        renderedBody: String,
         tags: [String]
     ) throws {
         try dbQueue.write { db in
@@ -291,10 +290,7 @@ final class MeetingRepository {
             let record = try SummaryRecord(
                 meetingId: meetingId,
                 title: normalizedTitle ?? existingSummary?.title ?? "",
-                summary: renderedBody,
                 document: document.databaseJSONString(),
-                vaultRelativePath: nil,
-                googleFileId: nil,
                 createdAt: existingSummary?.createdAt ?? Date()
             )
             try record.save(db)
@@ -501,10 +497,6 @@ final class MeetingRepository {
             let googleDocsURL = googleFileId?.nilIfBlank.flatMap { fileId in
                 SummaryExportRecord.googleDocsURL(fileId: fileId)
             }
-            try db.execute(
-                sql: "UPDATE summaries SET googleFileId = ? WHERE meetingId = ?",
-                arguments: [googleFileId?.nilIfBlank, meetingId]
-            )
             try SummaryExportRecord.setURL(
                 googleDocsURL,
                 meetingId: meetingId,
@@ -517,10 +509,6 @@ final class MeetingRepository {
     nonisolated func updateSummaryVaultRelativePath(forMeetingId meetingId: UUID, relativePath: String?) throws {
         try dbQueue.write { db in
             guard try SummaryRecord.fetchOne(db, key: meetingId) != nil else { return }
-            try db.execute(
-                sql: "UPDATE summaries SET vaultRelativePath = ? WHERE meetingId = ?",
-                arguments: [relativePath?.nilIfBlank, meetingId]
-            )
             try SummaryExportRecord.setURL(
                 relativePath?.nilIfBlank.flatMap(SummaryExportRecord.vaultURL(relativePath:)),
                 meetingId: meetingId,
@@ -533,7 +521,6 @@ final class MeetingRepository {
     func fetchSummaryVaultRelativePath(forMeetingId meetingId: UUID) throws -> String? {
         try dbQueue.read { db in
             try SummaryExportRecord.fetchOne(meetingId: meetingId, type: .vault, in: db)?.vaultRelativePath
-                ?? SummaryRecord.fetchOne(db, key: meetingId)?.vaultRelativePath
         }
     }
 
@@ -566,22 +553,7 @@ final class MeetingRepository {
     /// サマリーを保存する（insert or update）。
     nonisolated func upsertSummary(_ summary: SummaryRecord) throws {
         try dbQueue.write { db in
-            let googleDocsURL = summary.googleFileId?.nilIfBlank.flatMap { fileId in
-                SummaryExportRecord.googleDocsURL(fileId: fileId)
-            }
             try summary.save(db)
-            try SummaryExportRecord.setURL(
-                summary.vaultRelativePath?.nilIfBlank.flatMap(SummaryExportRecord.vaultURL(relativePath:)),
-                meetingId: summary.meetingId,
-                type: .vault,
-                in: db
-            )
-            try SummaryExportRecord.setURL(
-                googleDocsURL,
-                meetingId: summary.meetingId,
-                type: .googleDocs,
-                in: db
-            )
         }
     }
 
@@ -718,12 +690,6 @@ extension MeetingRepository {
     func renameProjectsByPrefix(oldPrefix: String, newPrefix: String, vaultId: UUID) throws {
         try dbQueue.write { db in
             try ProjectRecord.renameByPrefix(oldPrefix: oldPrefix, newPrefix: newPrefix, vaultId: vaultId, in: db)
-            try SummaryRecord.renameVaultRelativePathsByPrefix(
-                oldPrefix: oldPrefix,
-                newPrefix: newPrefix,
-                vaultId: vaultId,
-                in: db
-            )
             try SummaryExportRecord.renameVaultPathsByPrefix(
                 oldPrefix: oldPrefix,
                 newPrefix: newPrefix,
@@ -803,11 +769,6 @@ extension MeetingRepository {
                     _ = try MeetingRecord
                         .filter(meetingIds.contains(Column("id")))
                         .updateAll(db, Column("projectId").set(to: destinationId))
-                    try SummaryRecord.clearVaultRelativePaths(
-                        meetingIds: meetingIds,
-                        underProjectPrefix: name,
-                        in: db
-                    )
                     try SummaryExportRecord.clearVaultPaths(
                         meetingIds: meetingIds,
                         underProjectPrefix: name,

--- a/Sources/Dahlia/Database/SummaryRecord.swift
+++ b/Sources/Dahlia/Database/SummaryRecord.swift
@@ -7,96 +7,10 @@ struct SummaryRecord: Codable, FetchableRecord, PersistableRecord {
 
     var meetingId: UUID
     var title: String
-    var summary: String
-    var document: String? = nil
-    var vaultRelativePath: String?
-    var googleFileId: String?
+    var document: String
     var createdAt: Date
 
-    static func fetchAll(vaultId: UUID, in db: Database) throws -> [Self] {
-        try fetchAll(
-            db,
-            sql: """
-            SELECT summaries.*
-            FROM summaries
-            JOIN meetings ON meetings.id = summaries.meetingId
-            WHERE meetings.vaultId = ?
-            """,
-            arguments: [vaultId]
-        )
-    }
-
-    static func renameVaultRelativePathsByPrefix(
-        oldPrefix: String,
-        newPrefix: String,
-        vaultId: UUID,
-        in db: Database
-    ) throws {
-        let summaries = try fetchAll(vaultId: vaultId, in: db)
-
-        for var summary in summaries {
-            guard let relativePath = summary.vaultRelativePath,
-                  relativePath == oldPrefix || relativePath.hasPrefix(oldPrefix + "/")
-            else { continue }
-            summary.vaultRelativePath = newPrefix + relativePath.dropFirst(oldPrefix.count)
-            try summary.update(db)
-        }
-    }
-
-    static func renameVaultRelativePath(
-        from oldPath: String,
-        to newPath: String,
-        vaultId: UUID,
-        in db: Database
-    ) throws {
-        try db.execute(
-            sql: """
-            UPDATE summaries
-            SET vaultRelativePath = ?
-            WHERE vaultRelativePath = ?
-              AND meetingId IN (SELECT id FROM meetings WHERE vaultId = ?)
-            """,
-            arguments: [newPath, oldPath, vaultId]
-        )
-    }
-
-    static func clearVaultRelativePath(_ relativePath: String, vaultId: UUID, in db: Database) throws {
-        try db.execute(
-            sql: """
-            UPDATE summaries
-            SET vaultRelativePath = NULL
-            WHERE vaultRelativePath = ?
-              AND meetingId IN (SELECT id FROM meetings WHERE vaultId = ?)
-            """,
-            arguments: [relativePath, vaultId]
-        )
-    }
-
-    static func clearVaultRelativePaths(
-        meetingIds: Set<UUID>,
-        underProjectPrefix projectPrefix: String,
-        in db: Database
-    ) throws {
-        guard !meetingIds.isEmpty else { return }
-        let summaries = try SummaryRecord
-            .filter(meetingIds.contains(Column("meetingId")))
-            .fetchAll(db)
-        for var summary in summaries {
-            guard let path = summary.vaultRelativePath,
-                  ProjectRecord.belongsToHierarchy(path, prefix: projectPrefix)
-            else { continue }
-            summary.vaultRelativePath = nil
-            try summary.update(db)
-        }
-    }
-
-    func loadDocument() -> SummaryDocument {
-        if let document = document?.nilIfBlank,
-           let data = document.data(using: .utf8),
-           let decoded = try? JSONDecoder().decode(SummaryDocument.self, from: data) {
-            return decoded
-        }
-
-        return LegacyMarkdownSummaryParser.parse(markdown: summary, title: title)
+    func loadDocument() throws -> SummaryDocument {
+        try JSONDecoder().decode(SummaryDocument.self, from: Data(document.utf8))
     }
 }

--- a/Sources/Dahlia/Services/SummaryService.swift
+++ b/Sources/Dahlia/Services/SummaryService.swift
@@ -6,7 +6,6 @@ enum SummaryService {
         let document: SummaryDocument
         let fileName: String
         let markdown: String
-        let renderedBody: String
     }
 
     /// 要約を生成し、Markdown と関連メタデータを返す。
@@ -54,8 +53,7 @@ enum SummaryService {
         return GeneratedSummary(
             document: document,
             fileName: rendered.fileName,
-            markdown: rendered.markdown,
-            renderedBody: rendered.body
+            markdown: rendered.markdown
         )
     }
 

--- a/Sources/Dahlia/Services/VaultSummaryPathSynchronizer.swift
+++ b/Sources/Dahlia/Services/VaultSummaryPathSynchronizer.swift
@@ -7,12 +7,6 @@ struct VaultSummaryPathSynchronizer {
 
     func renamePath(from oldPath: String, to newPath: String) {
         try? dbQueue.write { db in
-            try SummaryRecord.renameVaultRelativePath(
-                from: oldPath,
-                to: newPath,
-                vaultId: vaultId,
-                in: db
-            )
             try SummaryExportRecord.renameVaultPath(
                 from: oldPath,
                 to: newPath,
@@ -23,12 +17,6 @@ struct VaultSummaryPathSynchronizer {
     }
 
     func renamePathsByPrefix(oldPrefix: String, newPrefix: String, in db: Database) throws {
-        try SummaryRecord.renameVaultRelativePathsByPrefix(
-            oldPrefix: oldPrefix,
-            newPrefix: newPrefix,
-            vaultId: vaultId,
-            in: db
-        )
         try SummaryExportRecord.renameVaultPathsByPrefix(
             oldPrefix: oldPrefix,
             newPrefix: newPrefix,
@@ -41,7 +29,6 @@ struct VaultSummaryPathSynchronizer {
         guard !relativePaths.isEmpty else { return }
         try? dbQueue.write { db in
             for relativePath in relativePaths {
-                try SummaryRecord.clearVaultRelativePath(relativePath, vaultId: vaultId, in: db)
                 try SummaryExportRecord.clearVaultPath(relativePath, vaultId: vaultId, in: db)
             }
         }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -764,23 +764,23 @@ final class CaptionViewModel: ObservableObject {
         let vaultExport = detail.summaryExports.first(where: { $0.type == .vault })
         let googleDocsExport = detail.summaryExports.first(where: { $0.type == .googleDocs })
 
-        let lastSummaryURL: URL? = if let summary = detail.summary {
+        let lastSummaryURL: URL? = if detail.summary != nil {
             SummaryService.findSummaryFile(
-                storedRelativePath: vaultExport?.vaultRelativePath ?? summary.vaultRelativePath,
+                storedRelativePath: vaultExport?.vaultRelativePath,
                 vaultURL: vaultURL
             )
         } else {
             nil
         }
 
-        return LoadedMeetingData(
+        return try LoadedMeetingData(
             createdAt: detail.meeting?.createdAt,
             recordingSessionRecords: detail.recordingSessions,
             recordingSessions: recordingSessions,
             segments: segments,
             screenshots: detail.screenshots,
             summaryDocument: detail.summary?.loadDocument(),
-            googleFileId: googleDocsExport?.googleDocumentID ?? detail.summary?.googleFileId,
+            googleFileId: googleDocsExport?.googleDocumentID,
             lastSummaryURL: lastSummaryURL,
             note: detail.note
         )
@@ -2068,7 +2068,6 @@ final class CaptionViewModel: ObservableObject {
                 try repo.applyGeneratedSummary(
                     toMeetingId: meetingId,
                     document: generatedSummary.document,
-                    renderedBody: generatedSummary.renderedBody,
                     tags: generatedSummary.document.tags
                 )
             }

--- a/Sources/DahliaMeetingAccess/DahliaMCPServer.swift
+++ b/Sources/DahliaMeetingAccess/DahliaMCPServer.swift
@@ -270,7 +270,7 @@ public final class DahliaMCPServer {
         [
             "name": "get_meeting",
             "title": "Get meeting",
-            "description": "Get meeting metadata and its stored Markdown summary from the configured vault. Returns null when no summary exists.",
+            "description": "Get meeting metadata and a Markdown summary generated from its stored document. Returns null when no summary exists.",
             "inputSchema": [
                 "type": "object",
                 "properties": ["meeting_id": ["type": "string", "format": "uuid"]],

--- a/Sources/DahliaMeetingAccess/MeetingAccessModels.swift
+++ b/Sources/DahliaMeetingAccess/MeetingAccessModels.swift
@@ -76,6 +76,7 @@ public enum MeetingAccessError: Error, LocalizedError, Equatable {
     case vaultNotFound
     case meetingNotFound
     case databaseUpgradeRequired
+    case invalidSummaryDocument
     case invalidCursor
     case invalidLimit(maximum: Int)
 
@@ -87,6 +88,8 @@ public enum MeetingAccessError: Error, LocalizedError, Equatable {
             "The meeting was not found in the configured vault."
         case .databaseUpgradeRequired:
             "The Dahlia database must be upgraded before meeting access can start. Open Dahlia once, then try again."
+        case .invalidSummaryDocument:
+            "The stored summary document is invalid. Open Dahlia and regenerate the summary."
         case .invalidCursor:
             "The cursor is invalid for the configured vault or meeting."
         case let .invalidLimit(maximum):

--- a/Sources/DahliaMeetingAccess/MeetingAccessStore.swift
+++ b/Sources/DahliaMeetingAccess/MeetingAccessStore.swift
@@ -112,7 +112,13 @@ public final class MeetingAccessStore: Sendable {
             guard let row = try meetingRow(id: id, in: db) else {
                 throw MeetingAccessError.meetingNotFound
             }
-            let summary: String? = row["summary"]
+            let document: String? = row["summaryDocument"]
+            let summary: String?
+            do {
+                summary = try document.map(StoredSummaryDocumentMarkdownRenderer.render(json:))
+            } catch {
+                throw MeetingAccessError.invalidSummaryDocument
+            }
             return MeetingDetail(vault: vault, meeting: Self.metadata(from: row), summary: summary)
         }
     }
@@ -218,7 +224,12 @@ public final class MeetingAccessStore: Sendable {
 
     private func fetchVault(in db: Database) throws -> ScopedVault {
         let meetingColumns = try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('meetings')")
-        guard meetingColumns.contains("description") else {
+        let summaryColumns = try Set(String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')"))
+        let legacySummaryColumns: Set = ["summary", "googleFileId", "vaultRelativePath"]
+        guard meetingColumns.contains("description"),
+              summaryColumns.contains("document"),
+              summaryColumns.isDisjoint(with: legacySummaryColumns)
+        else {
             throw MeetingAccessError.databaseUpgradeRequired
         }
         guard let row = try Row.fetchOne(
@@ -245,7 +256,7 @@ public final class MeetingAccessStore: Sendable {
                 meetings.duration,
                 meetings.createdAt,
                 summaries.meetingId IS NOT NULL AS hasSummary,
-                summaries.summary,
+                summaries.document AS summaryDocument,
                 (SELECT COUNT(*) FROM transcript_segments
                  WHERE transcript_segments.meetingId = meetings.id
                    AND transcript_segments.isConfirmed = 1) AS transcriptSegmentCount,

--- a/Sources/DahliaMeetingAccess/StoredSummaryDocumentMarkdownRenderer.swift
+++ b/Sources/DahliaMeetingAccess/StoredSummaryDocumentMarkdownRenderer.swift
@@ -1,0 +1,252 @@
+import Foundation
+
+enum StoredSummaryDocumentMarkdownRenderer {
+    static func render(json: String) throws -> String {
+        let document = try JSONDecoder().decode(StoredSummaryDocument.self, from: Data(json.utf8))
+        var chunks: [String] = []
+
+        if let title = normalized(document.title) {
+            chunks.append("# \(title)")
+        }
+        chunks.append(contentsOf: document.sections.compactMap(renderSection))
+        if let actionItems = renderActionItems(document.actionItems) {
+            chunks.append(actionItems)
+        }
+        return joined(chunks)
+    }
+
+    private static func renderSection(_ section: StoredSummarySection) -> String? {
+        var chunks: [String] = []
+        if let heading = normalized(section.heading) {
+            chunks.append("## \(heading)")
+        }
+        chunks.append(contentsOf: section.blocks.compactMap(renderBlock))
+        return joined(chunks).nonEmpty
+    }
+
+    private static func renderBlock(_ block: StoredSummaryBlock) -> String? {
+        switch block.content {
+        case let .paragraph(text):
+            normalized(text.text)
+        case let .bulletedList(items):
+            renderList(items.map(\.text), prefix: { _ in "-" })
+        case let .numberedList(items):
+            renderList(items.map(\.text), prefix: { "\($0 + 1)." })
+        case let .checklist(items):
+            items.compactMap { item in
+                normalized(item.text).map { "- [\(item.checked ? "x" : " ")] \($0)" }
+            }
+            .joined(separator: "\n")
+            .nonEmpty
+        case let .quote(text):
+            normalized(text.text)?
+                .components(separatedBy: .newlines)
+                .compactMap { normalized($0) }
+                .map { "> \($0)" }
+                .joined(separator: "\n")
+                .nonEmpty
+        case let .code(language, text):
+            text.text.nonEmpty.map { code in
+                let fence = codeFence(for: code)
+                let language = language.replacing(/[^A-Za-z0-9_+.-]/, with: "")
+                return "\(fence)\(language)\n\(code)\n\(fence)"
+            }
+        case let .image(caption):
+            normalized(caption.text)
+        case let .heading(level, text):
+            normalized(text.text).map {
+                "\(String(repeating: "#", count: min(max(level, 3), 6))) \($0)"
+            }
+        case let .table(headers, rows):
+            renderTable(headers: headers, rows: rows)
+        }
+    }
+
+    private static func renderList(_ items: [String], prefix: (Int) -> String) -> String? {
+        items.enumerated().compactMap { index, item in
+            normalized(item).map { "\(prefix(index)) \($0)" }
+        }
+        .joined(separator: "\n")
+        .nonEmpty
+    }
+
+    private static func renderTable(headers: [StoredSummaryText], rows: [[StoredSummaryText]]) -> String? {
+        guard !headers.isEmpty else { return nil }
+        let header = tableRow(headers)
+        let separator = "| " + headers.map { _ in "---" }.joined(separator: " | ") + " |"
+        return ([header, separator] + rows.map(tableRow)).joined(separator: "\n")
+    }
+
+    private static func tableRow(_ cells: [StoredSummaryText]) -> String {
+        let values = cells.map { text in
+            text.text
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .replacing("|", with: "\\|")
+                .replacing("\n", with: "<br>")
+        }
+        return "| " + values.joined(separator: " | ") + " |"
+    }
+
+    private static func renderActionItems(_ items: [StoredSummaryActionItem]) -> String? {
+        let lines = items.compactMap { item -> String? in
+            guard let title = normalized(item.title) else { return nil }
+            let assignee = normalized(item.assignee).map { " (\($0))" } ?? ""
+            return "- [ ] \(title)\(assignee)"
+        }
+        guard !lines.isEmpty else { return nil }
+        return (["## Action Items"] + lines).joined(separator: "\n")
+    }
+
+    private static func codeFence(for code: String) -> String {
+        var longestRun = 0
+        var currentRun = 0
+        for character in code {
+            if character == "`" {
+                currentRun += 1
+                longestRun = max(longestRun, currentRun)
+            } else {
+                currentRun = 0
+            }
+        }
+        return String(repeating: "`", count: max(3, longestRun + 1))
+    }
+
+    private static func normalized(_ text: String) -> String? {
+        text.trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacing(#/!\[([^\]]*)\]\([^)]+\)/#) { String($0.1) }
+            .nonEmpty
+    }
+
+    private static func joined(_ chunks: [String]) -> String {
+        chunks.joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+private struct StoredSummaryDocument: Decodable {
+    let title: String
+    let sections: [StoredSummarySection]
+    let actionItems: [StoredSummaryActionItem]
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case title
+        case sections
+        case actionItems
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        _ = try container.decode(Int.self, forKey: .schemaVersion)
+        title = try container.decode(String.self, forKey: .title)
+        sections = try container.decode([StoredSummarySection].self, forKey: .sections)
+        actionItems = try container.decodeIfPresent([StoredSummaryActionItem].self, forKey: .actionItems) ?? []
+    }
+}
+
+private struct StoredSummarySection: Decodable {
+    let heading: String
+    let blocks: [StoredSummaryBlock]
+}
+
+private struct StoredSummaryText: Decodable {
+    let text: String
+}
+
+private struct StoredSummaryActionItem: Decodable {
+    let title: String
+    let assignee: String
+}
+
+private struct StoredSummaryChecklistItem: Decodable {
+    let text: String
+    let checked: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case text
+        case checked
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        text = try container.decode(String.self, forKey: .text)
+        checked = (try? container.decode(Bool.self, forKey: .checked)) ?? false
+    }
+}
+
+private struct StoredSummaryBlock: Decodable {
+    enum Content {
+        case paragraph(StoredSummaryText)
+        case bulletedList([StoredSummaryText])
+        case numberedList([StoredSummaryText])
+        case checklist([StoredSummaryChecklistItem])
+        case quote(StoredSummaryText)
+        case code(language: String, text: StoredSummaryText)
+        case image(caption: StoredSummaryText)
+        case heading(level: Int, text: StoredSummaryText)
+        case table(headers: [StoredSummaryText], rows: [[StoredSummaryText]])
+    }
+
+    let content: Content
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case content
+        case items
+        case language
+        case level
+        case headers
+        case rows
+    }
+
+    private enum BlockType: String {
+        case paragraph
+        case bulletedList = "bulleted_list"
+        case numberedList = "numbered_list"
+        case checklist
+        case quote
+        case code
+        case image
+        case heading
+        case table
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decodeIfPresent(String.self, forKey: .type) ?? BlockType.paragraph.rawValue
+        let emptyText = StoredSummaryText(text: "")
+
+        switch BlockType(rawValue: type) {
+        case .paragraph, nil:
+            content = .paragraph((try? container.decode(StoredSummaryText.self, forKey: .content)) ?? emptyText)
+        case .bulletedList:
+            content = .bulletedList((try? container.decode([StoredSummaryText].self, forKey: .items)) ?? [])
+        case .numberedList:
+            content = .numberedList((try? container.decode([StoredSummaryText].self, forKey: .items)) ?? [])
+        case .checklist:
+            content = .checklist((try? container.decode([StoredSummaryChecklistItem].self, forKey: .items)) ?? [])
+        case .quote:
+            content = .quote((try? container.decode(StoredSummaryText.self, forKey: .content)) ?? emptyText)
+        case .code:
+            content = .code(
+                language: (try? container.decode(String.self, forKey: .language)) ?? "",
+                text: (try? container.decode(StoredSummaryText.self, forKey: .content)) ?? emptyText
+            )
+        case .image:
+            content = .image(caption: (try? container.decode(StoredSummaryText.self, forKey: .content)) ?? emptyText)
+        case .heading:
+            content = .heading(
+                level: (try? container.decode(Int.self, forKey: .level)) ?? 3,
+                text: (try? container.decode(StoredSummaryText.self, forKey: .content)) ?? emptyText
+            )
+        case .table:
+            content = .table(
+                headers: (try? container.decode([StoredSummaryText].self, forKey: .headers)) ?? [],
+                rows: (try? container.decode([[StoredSummaryText]].self, forKey: .rows)) ?? []
+            )
+        }
+    }
+}
+
+private extension String {
+    var nonEmpty: String? { isEmpty ? nil : self }
+}

--- a/Tests/DahliaTests/AppDatabaseManagerTests.swift
+++ b/Tests/DahliaTests/AppDatabaseManagerTests.swift
@@ -101,14 +101,14 @@ import GRDB
         }
 
         @Test
-        func initializesInMemoryDatabaseWithSummaryGoogleFileIdColumn() throws {
+        func initializesInMemoryDatabaseWithoutLegacySummaryColumns() throws {
             let database = try AppDatabaseManager(path: ":memory:")
 
             let columns = try database.dbQueue.read { db in
                 try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
             }
 
-            #expect(columns.contains("googleFileId"))
+            #expect(columns == ["meetingId", "title", "document", "createdAt"])
         }
 
         @Test
@@ -535,7 +535,7 @@ import GRDB
         }
 
         @Test
-        func existingV4DatabaseMigratesSummaryGoogleFileIdColumn() throws {
+        func existingV4DatabaseRemovesLegacySummaryColumns() throws {
             let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
                 .appendingPathComponent(UUID().uuidString)
                 .appendingPathExtension("sqlite")
@@ -564,7 +564,7 @@ import GRDB
                 try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
             }
 
-            #expect(columns.contains("googleFileId"))
+            #expect(columns == ["meetingId", "title", "document", "createdAt"])
         }
 
         @Test
@@ -623,7 +623,7 @@ import GRDB
         }
 
         @Test
-        func existingV8DatabaseAddsSummaryDocumentColumnWithoutBackfill() throws {
+        func existingV8DatabaseDropsSummaryWithoutDocument() throws {
             let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
                 .appendingPathComponent(UUID().uuidString)
                 .appendingPathExtension("sqlite")
@@ -694,15 +694,14 @@ import GRDB
             let result = try migrated.dbQueue.read { db in
                 try (
                     String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')"),
-                    Row.fetchOne(db, sql: "SELECT title, summary, document, googleFileId FROM summaries WHERE meetingId = ?", arguments: [meetingID])
+                    SummaryRecord.fetchOne(db, key: meetingID),
+                    SummaryExportRecord.fetchCount(db)
                 )
             }
 
-            #expect(result.0.contains("document"))
-            #expect(result.1?["title"] == "Legacy")
-            #expect(result.1?["summary"] == "## Summary\n\n![[\(screenshotID.uuidString).jpeg|Valid]]\n\n![[\(missingScreenshotID.uuidString).jpeg]]")
-            #expect(result.1?["document"] == nil as String?)
-            #expect(result.1?["googleFileId"] == "google-123")
+            #expect(result.0 == ["meetingId", "title", "document", "createdAt"])
+            #expect(result.1 == nil)
+            #expect(result.2 == 0)
         }
     }
 
@@ -721,14 +720,14 @@ import GRDB
             XCTAssertTrue(columns.contains("googleDriveFolderId"))
         }
 
-        func testInitializesInMemoryDatabaseWithSummaryGoogleFileIdColumn() throws {
+        func testInitializesInMemoryDatabaseWithoutLegacySummaryColumns() throws {
             let database = try AppDatabaseManager(path: ":memory:")
 
             let columns = try database.dbQueue.read { db in
                 try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
             }
 
-            XCTAssertTrue(columns.contains("googleFileId"))
+            XCTAssertEqual(columns, ["meetingId", "title", "document", "createdAt"])
         }
 
         func testInitializesInMemoryDatabaseWithTranscriptTranslatedTextColumn() throws {
@@ -870,7 +869,7 @@ import GRDB
             XCTAssertEqual(migratedVault?["name"], "Legacy Vault")
         }
 
-        func testExistingV4DatabaseMigratesSummaryGoogleFileIdColumn() throws {
+        func testExistingV4DatabaseRemovesLegacySummaryColumns() throws {
             let databaseURL = URL(fileURLWithPath: NSTemporaryDirectory())
                 .appendingPathComponent(UUID().uuidString)
                 .appendingPathExtension("sqlite")
@@ -899,7 +898,7 @@ import GRDB
                 try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
             }
 
-            XCTAssertTrue(columns.contains("googleFileId"))
+            XCTAssertEqual(columns, ["meetingId", "title", "document", "createdAt"])
         }
 
         func testExistingV5DatabaseMigratesTranscriptTranslatedTextColumnWithoutDataLoss() throws {

--- a/Tests/DahliaTests/MeetingAccessStoreTests.swift
+++ b/Tests/DahliaTests/MeetingAccessStoreTests.swift
@@ -1,4 +1,4 @@
-import DahliaMeetingAccess
+@testable import DahliaMeetingAccess
 import Foundation
 import GRDB
 @testable import Dahlia
@@ -50,8 +50,9 @@ import GRDB
             #expect(detail.meeting.name == "AI planning title")
             #expect(detail.meeting.description == "Product planning decisions")
             #expect(detail.meeting.calendarTitle == "Roadmap review")
-            #expect(detail.summary == "Markdown secret body")
+            #expect(detail.summary == "# AI planning title\n\n## Summary\n\nMarkdown secret body")
             #expect(detail.meeting.transcriptSegmentCount == 2)
+            #expect(try store.meeting(id: fixture.secondMeetingID).summary == nil)
             #expect(throws: MeetingAccessError.meetingNotFound) {
                 try store.meeting(id: fixture.otherVaultMeetingID)
             }
@@ -135,7 +136,7 @@ import GRDB
                 .uuidString)"}}}
             """#))
             #expect(((meetingCall["result"] as? [String: Any])?["structuredContent"] as? [String: Any])?["summary"] as? String ==
-                "Markdown secret body")
+                "# AI planning title\n\n## Summary\n\nMarkdown secret body")
 
             let transcriptCall = try Self.json(server.handleLine(#"""
             {"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"get_meeting_transcript","arguments":{"meeting_id":"\#(fixture
@@ -186,6 +187,120 @@ import GRDB
             #expect(throws: MeetingAccessError.databaseUpgradeRequired) {
                 try store.scopedVault()
             }
+        }
+
+        @Test
+        func v20SummaryColumnsRequireOpeningDahliaForMigration() throws {
+            let databaseURL = URL.temporaryDirectory
+                .appending(path: "dahlia-meeting-access-v20-\(UUID.v7().uuidString)")
+                .appendingPathExtension("sqlite")
+            defer { try? FileManager.default.removeItem(at: databaseURL) }
+            let vaultID = UUID.v7()
+            let queue = try DatabaseQueue(path: databaseURL.path)
+            try queue.write { db in
+                try db.execute(sql: "CREATE TABLE vaults (id BLOB PRIMARY KEY, name TEXT NOT NULL)")
+                try db.execute(sql: "CREATE TABLE meetings (id BLOB PRIMARY KEY, description TEXT NOT NULL)")
+                try db.execute(
+                    sql: """
+                    CREATE TABLE summaries (
+                        meetingId BLOB PRIMARY KEY,
+                        title TEXT NOT NULL,
+                        summary TEXT NOT NULL,
+                        document TEXT,
+                        googleFileId TEXT,
+                        vaultRelativePath TEXT,
+                        createdAt DATETIME NOT NULL
+                    )
+                    """
+                )
+                try db.execute(sql: "INSERT INTO vaults (id, name) VALUES (?, ?)", arguments: [vaultID, "Old"])
+            }
+            let store = try MeetingAccessStore(databaseURL: databaseURL, vaultID: vaultID)
+
+            #expect(throws: MeetingAccessError.databaseUpgradeRequired) {
+                try store.scopedVault()
+            }
+        }
+
+        @Test
+        func invalidSummaryDocumentReturnsDedicatedError() throws {
+            let fixture = try Fixture()
+            try fixture.manager.dbQueue.write { db in
+                try db.execute(
+                    sql: "UPDATE summaries SET document = 'not-json' WHERE meetingId = ?",
+                    arguments: [fixture.firstMeetingID]
+                )
+            }
+
+            #expect(throws: MeetingAccessError.invalidSummaryDocument) {
+                try fixture.store(vaultID: fixture.primaryVaultID).meeting(id: fixture.firstMeetingID)
+            }
+        }
+
+        @Test
+        func storedDocumentRendererGeneratesGenericMarkdownForAllBlocks() throws {
+            let document = SummaryDocument(
+                title: "Release plan",
+                sections: [
+                    SummarySection(
+                        id: .v7(),
+                        heading: "Decision",
+                        blocks: [
+                            .paragraph("Ship it", transcriptRef: TranscriptReference(time: "00:00:01")),
+                            .bulletedList(items: ["Alpha", "Beta"]),
+                            .numberedList(items: ["First", "Second"]),
+                            .checklist(items: [
+                                .init(text: "Done", checked: true),
+                                .init(text: "Pending", checked: false),
+                            ]),
+                            .quote("Quoted"),
+                            .code(language: "swift\n```evil", code: "let value = 1\n```breakout"),
+                            .image(screenshotId: .v7(), caption: "Screenshot"),
+                            .image(screenshotId: .v7(), caption: ""),
+                            .heading(level: 4, text: "Details"),
+                            .table(headers: ["Name", "State"], rows: [["A|B", "Ready\nNow"]]),
+                        ]
+                    ),
+                ],
+                actionItems: [SummaryActionItem(title: "Follow up", assignee: "Mina")]
+            )
+
+            let markdown = try StoredSummaryDocumentMarkdownRenderer.render(json: document.databaseJSONString())
+
+            #expect(markdown == """
+            # Release plan
+
+            ## Decision
+
+            Ship it
+
+            - Alpha
+            - Beta
+
+            1. First
+            2. Second
+
+            - [x] Done
+            - [ ] Pending
+
+            > Quoted
+
+            ````swiftevil
+            let value = 1
+            ```breakout
+            ````
+
+            Screenshot
+
+            #### Details
+
+            | Name | State |
+            | --- | --- |
+            | A\\|B | Ready<br>Now |
+
+            ## Action Items
+            - [ ] Follow up (Mina)
+            """)
         }
 
         private static func json(_ line: String?) throws -> [String: Any] {
@@ -305,7 +420,12 @@ import GRDB
             try SummaryRecord(
                 meetingId: firstMeetingID,
                 title: "AI planning title",
-                summary: "Markdown secret body",
+                document: SummaryDocument(
+                    title: "AI planning title",
+                    sections: [
+                        SummarySection(id: .v7(), heading: "Summary", blocks: [.paragraph("Markdown secret body")]),
+                    ]
+                ).databaseJSONString(),
                 createdAt: createdAt
             ).insert(db)
             try RecordingSessionRecord(

--- a/Tests/DahliaTests/MeetingRepositorySummaryTests.swift
+++ b/Tests/DahliaTests/MeetingRepositorySummaryTests.swift
@@ -34,7 +34,6 @@ import GRDB
             try context.repo.applyGeneratedSummary(
                 toMeetingId: context.meeting.id,
                 document: document,
-                renderedBody: "Summary body",
                 tags: ["team"]
             )
 
@@ -48,8 +47,7 @@ import GRDB
             let fetchedSummary = try context.repo.fetchSummary(forMeetingId: context.meeting.id)
             let summary = try #require(fetchedSummary)
 
-            #expect(summary.summary == "Summary body")
-            #expect(summary.loadDocument() == document)
+            #expect(try summary.loadDocument() == document)
             let meeting = try #require(try context.repo.fetchMeeting(id: context.meeting.id))
             #expect(meeting.name == "Weekly sync")
             #expect(meeting.description == "Planning and launch decisions")
@@ -60,26 +58,17 @@ import GRDB
         }
 
         @Test
-        func legacySummaryRecordLoadsDocumentFromMarkdownFallback() {
+        func invalidSummaryDocumentThrows() {
             let record = SummaryRecord(
                 meetingId: UUID.v7(),
-                title: "Legacy",
-                summary: "## Summary\n\n- Decide [[meeting#00:10:00|00:10:00]]",
-                document: nil,
-                vaultRelativePath: nil,
-                googleFileId: nil,
-                createdAt: Date()
+                title: "Invalid",
+                document: "not-json",
+                createdAt: .now
             )
 
-            let document = record.loadDocument()
-
-            #expect(document.title == "Legacy")
-            #expect(document.sections.first?.heading == "Summary")
-            #expect(document.sections.first?.blocks == [
-                .bulletedList(
-                    items: [SummaryText("Decide", transcriptRef: TranscriptReference(time: "00:10:00"))]
-                ),
-            ])
+            #expect(throws: DecodingError.self) {
+                try record.loadDocument()
+            }
         }
 
         @Test
@@ -89,11 +78,17 @@ import GRDB
                 SummaryRecord(
                     meetingId: context.meeting.id,
                     title: "Old",
-                    summary: "Old body",
-                    vaultRelativePath: "Acme/Existing.md",
-                    googleFileId: "old-google-file",
+                    document: try SummaryDocument(title: "Old", sections: []).databaseJSONString(),
                     createdAt: .now
                 )
+            )
+            try context.repo.updateSummaryVaultRelativePath(
+                forMeetingId: context.meeting.id,
+                relativePath: "Acme/Existing.md"
+            )
+            try context.repo.updateSummaryGoogleFileId(
+                forMeetingId: context.meeting.id,
+                googleFileId: "old-google-file"
             )
             let document = SummaryDocument(
                 title: "Updated",
@@ -104,14 +99,9 @@ import GRDB
             try context.repo.applyGeneratedSummary(
                 toMeetingId: context.meeting.id,
                 document: document,
-                renderedBody: "New body",
                 tags: []
             )
 
-            let fetchedSummary = try context.repo.fetchSummary(forMeetingId: context.meeting.id)
-            let summary = try #require(fetchedSummary)
-            #expect(summary.vaultRelativePath == nil)
-            #expect(summary.googleFileId == nil)
             #expect(try context.repo.fetchSummaryExport(
                 forMeetingId: context.meeting.id,
                 type: .vault
@@ -129,9 +119,7 @@ import GRDB
                 SummaryRecord(
                     meetingId: context.meeting.id,
                     title: "Summary",
-                    summary: "Body",
-                    vaultRelativePath: nil,
-                    googleFileId: nil,
+                    document: try SummaryDocument(title: "Summary", sections: []).databaseJSONString(),
                     createdAt: .now
                 )
             )
@@ -183,7 +171,6 @@ import GRDB
                     description: "First description",
                     sections: []
                 ),
-                renderedBody: "First",
                 tags: []
             )
             try context.repo.applyGeneratedSummary(
@@ -193,7 +180,6 @@ import GRDB
                     description: "  ",
                     sections: []
                 ),
-                renderedBody: "Second",
                 tags: []
             )
 
@@ -237,7 +223,6 @@ import GRDB
             try context.repo.applyGeneratedSummary(
                 toMeetingId: context.meeting.id,
                 document: document,
-                renderedBody: "Launch screen",
                 tags: []
             )
 
@@ -252,7 +237,7 @@ import GRDB
         }
 
         @Test
-        func deletingUnreferencedScreenshotDoesNotConvertLegacySummaryDocument() async throws {
+        func deletingUnreferencedScreenshotDoesNotChangeSummaryDocument() async throws {
             let context = try makeRepositoryContext()
             let screenshot = MeetingScreenshotRecord(
                 id: .v7(),
@@ -264,17 +249,16 @@ import GRDB
             try await context.manager.dbQueue.write { db in
                 try screenshot.insert(db)
             }
-            try context.repo.upsertSummary(
-                SummaryRecord(
-                    meetingId: context.meeting.id,
-                    title: "Legacy",
-                    summary: "## Notes\n\nNo screenshot reference",
-                    document: nil,
-                    vaultRelativePath: nil,
-                    googleFileId: nil,
-                    createdAt: .now
-                )
+            let document = SummaryDocument(
+                title: "Summary",
+                sections: [SummarySection(id: .v7(), heading: "Notes", blocks: [.paragraph("No screenshot reference")])]
             )
+            try context.repo.upsertSummary(SummaryRecord(
+                meetingId: context.meeting.id,
+                title: document.title,
+                document: try document.databaseJSONString(),
+                createdAt: .now
+            ))
 
             let deletedScreenshots = try await context.repo.deleteScreenshots(
                 ids: [screenshot.id],
@@ -282,7 +266,7 @@ import GRDB
             )
 
             #expect(deletedScreenshots.map(\.id) == [screenshot.id])
-            #expect(try context.repo.fetchSummary(forMeetingId: context.meeting.id)?.document == nil)
+            #expect(try context.repo.fetchSummary(forMeetingId: context.meeting.id)?.loadDocument() == document)
         }
 
         private func makeRepositoryContext() throws -> RepositoryContext {

--- a/Tests/DahliaTests/ProjectWorkspaceServiceTests.swift
+++ b/Tests/DahliaTests/ProjectWorkspaceServiceTests.swift
@@ -111,17 +111,14 @@ import GRDB
             let renamed = try context.service.renameProject(id: parent.id, newLeafName: "Renamed")
 
             let fetchedChildRecord = try context.repository.fetchProject(id: child.id)
-            let fetchedSummary = try context.repository.fetchSummary(forMeetingId: meeting.id)
             let vaultExport = try context.repository.fetchSummaryExport(
                 forMeetingId: meeting.id,
                 type: .vault
             )
             let fetchedChild = try #require(fetchedChildRecord)
-            let summary = try #require(fetchedSummary)
             #expect(renamed.name == "Renamed")
             #expect(fetchedChild.name == "Renamed/Child")
             #expect(fetchedChild.description == "Keep me")
-            #expect(summary.vaultRelativePath == "Renamed/Child/Summary.md")
             #expect(vaultExport?.url == "vault:///Renamed/Child/Summary.md")
             #expect(vaultExport?.vaultRelativePath == "Renamed/Child/Summary.md")
             #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Renamed/Child").path))
@@ -191,9 +188,8 @@ import GRDB
             )
             let summary = try #require(fetchedSummary)
             #expect(fetchedMeeting?.projectId == destination.id)
-            #expect(summary.vaultRelativePath == nil)
             #expect(vaultExport == nil)
-            #expect(summary.summary == "Body")
+            #expect(try summary.loadDocument().sections.first?.blocks == [.paragraph("Body")])
             #expect(try context.repository.fetchSegments(forMeetingId: meeting.id).count == 1)
             #expect(try context.repository.fetchTagsForMeeting(id: meeting.id).map(\.name) == ["important"])
             #expect(FileManager.default.fileExists(atPath: audioURL.path))
@@ -214,9 +210,11 @@ import GRDB
 
             try await context.service.deleteProjectHierarchy(id: source.id, meetingDisposition: .move(to: destination.id))
 
-            let fetchedSummary = try context.repository.fetchSummary(forMeetingId: meeting.id)
-            let summary = try #require(fetchedSummary)
-            #expect(summary.vaultRelativePath == "Archive/Summary.md")
+            let vaultExport = try context.repository.fetchSummaryExport(
+                forMeetingId: meeting.id,
+                type: .vault
+            )
+            #expect(vaultExport?.vaultRelativePath == "Archive/Summary.md")
         }
 
         @Test
@@ -336,10 +334,16 @@ import GRDB
                 SummaryRecord(
                     meetingId: meetingId,
                     title: "Summary",
-                    summary: "Body",
-                    vaultRelativePath: path,
+                    document: try SummaryDocument(
+                        title: "Summary",
+                        sections: [SummarySection(id: .v7(), heading: "Summary", blocks: [.paragraph("Body")])]
+                    ).databaseJSONString(),
                     createdAt: .now
                 )
+            )
+            try context.repository.updateSummaryVaultRelativePath(
+                forMeetingId: meetingId,
+                relativePath: path
             )
         }
 

--- a/Tests/DahliaTests/SummaryExportsMigrationTests.swift
+++ b/Tests/DahliaTests/SummaryExportsMigrationTests.swift
@@ -8,64 +8,98 @@ import GRDB
     @MainActor
     struct SummaryExportsMigrationTests {
         @Test
-        func initializesDatabaseWithSummaryExportsTable() throws {
+        func initializesDatabaseWithCanonicalSummarySchema() throws {
             let database = try AppDatabaseManager(path: ":memory:")
 
-            let columns = try database.dbQueue.read { db in
-                try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summary_exports')")
+            let result = try database.dbQueue.read { db in
+                try (
+                    db.columns(in: "summaries"),
+                    String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summary_exports')")
+                )
             }
 
-            #expect(columns == ["meetingId", "type", "url", "createdAt", "updatedAt"])
+            #expect(result.0.map(\.name) == ["meetingId", "title", "document", "createdAt"])
+            #expect(result.0.first(where: { $0.name == "document" })?.isNotNull == true)
+            #expect(result.1 == ["meetingId", "type", "url", "createdAt", "updatedAt"])
         }
 
         @Test
-        func migratesLegacyExportLocationsWithoutRemovingLegacyValues() throws {
+        func removesLegacyColumnsAndKeepsExportsForValidDocuments() throws {
             let databaseURL = URL.temporaryDirectory
                 .appending(path: UUID.v7().uuidString)
                 .appendingPathExtension("sqlite")
-            let meetingId = UUID.v7()
+            let validMeetingId = UUID.v7()
+            let legacyGoogleMeetingId = UUID.v7()
+            let nilDocumentMeetingId = UUID.v7()
+            let invalidDocumentMeetingId = UUID.v7()
             let createdAt = Date(timeIntervalSince1970: 1_700_000_000)
             defer { try? FileManager.default.removeItem(at: databaseURL) }
 
             let legacyQueue = try DatabaseQueue(path: databaseURL.path)
-            try createV18SummaryDatabase(
+            try createV20SummaryDatabase(
                 in: legacyQueue,
-                meetingId: meetingId,
+                validMeetingId: validMeetingId,
+                legacyGoogleMeetingId: legacyGoogleMeetingId,
+                nilDocumentMeetingId: nilDocumentMeetingId,
+                invalidDocumentMeetingId: invalidDocumentMeetingId,
                 createdAt: createdAt
             )
 
             let migrated = try AppDatabaseManager(path: databaseURL.path)
             let result = try migrated.dbQueue.read { db in
-                let exports = try SummaryExportRecord
-                    .filter(Column("meetingId") == meetingId)
-                    .order(Column("type"))
-                    .fetchAll(db)
-                let legacy = try Row.fetchOne(
-                    db,
-                    sql: "SELECT vaultRelativePath, googleFileId FROM summaries WHERE meetingId = ?",
-                    arguments: [meetingId]
+                try (
+                    db.columns(in: "summaries"),
+                    SummaryRecord.fetchOne(db, key: validMeetingId),
+                    SummaryRecord.fetchOne(db, key: legacyGoogleMeetingId),
+                    SummaryExportRecord
+                        .filter(Column("meetingId") == validMeetingId)
+                        .order(Column("type"))
+                        .fetchAll(db),
+                    SummaryExportRecord
+                        .filter(Column("meetingId") == legacyGoogleMeetingId)
+                        .fetchAll(db),
+                    SummaryRecord.fetchCount(db),
+                    SummaryExportRecord.fetchCount(db)
                 )
-                return try (exports, #require(legacy))
             }
 
-            #expect(result.0 == [
+            #expect(result.0.map(\.name) == ["meetingId", "title", "document", "createdAt"])
+            #expect(result.0.first(where: { $0.name == "document" })?.isNotNull == true)
+            #expect(result.1?.title == "Stored SQL title")
+            #expect(result.1?.createdAt == createdAt)
+            #expect(try result.1?.loadDocument().title == "Canonical")
+            #expect(result.2?.meetingId == legacyGoogleMeetingId)
+            #expect(result.3 == [
                 SummaryExportRecord(
-                    meetingId: meetingId,
+                    meetingId: validMeetingId,
                     type: .googleDocs,
-                    url: "https://docs.google.com/document/d/google-123/edit",
+                    url: "https://example.com/canonical-google-doc",
                     createdAt: createdAt,
                     updatedAt: createdAt
                 ),
                 SummaryExportRecord(
-                    meetingId: meetingId,
+                    meetingId: validMeetingId,
                     type: .vault,
                     url: "vault:///Project/Summary.md",
                     createdAt: createdAt,
                     updatedAt: createdAt
                 ),
             ])
-            #expect(result.1["vaultRelativePath"] == "Project/Summary.md" as String?)
-            #expect(result.1["googleFileId"] == "google-123" as String?)
+            #expect(result.4.map(\.url) == ["https://docs.google.com/document/d/legacy-google-only/edit"])
+            #expect(result.5 == 2)
+            #expect(result.6 == 3)
+
+            try migrated.dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM meetings WHERE id = ?", arguments: [validMeetingId])
+            }
+            let deletedCounts = try migrated.dbQueue.read { db in
+                try (
+                    SummaryRecord.filter(Column("meetingId") == validMeetingId).fetchCount(db),
+                    SummaryExportRecord.filter(Column("meetingId") == validMeetingId).fetchCount(db)
+                )
+            }
+            #expect(deletedCounts.0 == 0)
+            #expect(deletedCounts.1 == 0)
         }
 
         @Test
@@ -83,29 +117,49 @@ import GRDB
             #expect(record.vaultRelativePath == "Project/My Summary #1.md")
         }
 
-        private func createV18SummaryDatabase(
+        private func createV20SummaryDatabase(
             in dbQueue: DatabaseQueue,
-            meetingId: UUID,
+            validMeetingId: UUID,
+            legacyGoogleMeetingId: UUID,
+            nilDocumentMeetingId: UUID,
+            invalidDocumentMeetingId: UUID,
             createdAt: Date
         ) throws {
+            let validDocument = try SummaryDocument(
+                title: "Canonical",
+                sections: [SummarySection(id: .v7(), heading: "Summary", blocks: [.paragraph("Body")])]
+            ).databaseJSONString()
             try dbQueue.write { db in
+                try db.create(table: "meetings") { table in
+                    table.primaryKey("id", .blob)
+                }
                 try db.execute(
-                    sql: """
-                    CREATE TABLE summaries (
-                        meetingId BLOB PRIMARY KEY,
-                        title TEXT NOT NULL DEFAULT '',
-                        summary TEXT NOT NULL,
-                        document TEXT,
-                        vaultRelativePath TEXT,
-                        googleFileId TEXT,
-                        createdAt DATETIME NOT NULL
-                    )
-                    """
+                    sql: "INSERT INTO meetings (id) VALUES (?), (?), (?), (?)",
+                    arguments: [validMeetingId, legacyGoogleMeetingId, nilDocumentMeetingId, invalidDocumentMeetingId]
                 )
+                try db.create(table: "summaries") { table in
+                    table.primaryKey("meetingId", .blob)
+                        .references("meetings", onDelete: .cascade)
+                    table.column("title", .text).notNull().defaults(to: "")
+                    table.column("summary", .text).notNull()
+                    table.column("document", .text)
+                    table.column("vaultRelativePath", .text)
+                    table.column("googleFileId", .text)
+                    table.column("createdAt", .datetime).notNull()
+                }
+                try db.create(table: "summary_exports") { table in
+                    table.column("meetingId", .blob).notNull()
+                        .references("summaries", column: "meetingId", onDelete: .cascade)
+                    table.column("type", .text).notNull()
+                    table.column("url", .text).notNull()
+                    table.column("createdAt", .datetime).notNull()
+                    table.column("updatedAt", .datetime).notNull()
+                    table.primaryKey(["meetingId", "type"])
+                }
                 try db.create(table: "grdb_migrations") { table in
                     table.column("identifier", .text).primaryKey()
                 }
-                for migration in Self.v18MigrationIdentifiers {
+                for migration in Self.v20MigrationIdentifiers {
                     try db.execute(
                         sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)",
                         arguments: [migration]
@@ -115,22 +169,33 @@ import GRDB
                     sql: """
                     INSERT INTO summaries (
                         meetingId, title, summary, document, vaultRelativePath, googleFileId, createdAt
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES
+                        (?, 'Stored SQL title', 'Legacy body', ?, 'Project/Summary.md', 'legacy-google', ?),
+                        (?, 'Legacy Google', 'Legacy body', ?, NULL, 'legacy-google-only', ?),
+                        (?, 'No document', 'Ignored', NULL, 'Ignored/Nil.md', NULL, ?),
+                        (?, 'Invalid document', 'Ignored', 'not-json', 'Ignored/Invalid.md', NULL, ?)
                     """,
                     arguments: [
-                        meetingId,
-                        "Legacy",
-                        "Body",
-                        nil,
-                        "Project/Summary.md",
-                        "google-123",
-                        createdAt,
+                        validMeetingId, validDocument, createdAt,
+                        legacyGoogleMeetingId, validDocument, createdAt,
+                        nilDocumentMeetingId, createdAt,
+                        invalidDocumentMeetingId, createdAt,
+                    ]
+                )
+                try db.execute(
+                    sql: """
+                    INSERT INTO summary_exports (meetingId, type, url, createdAt, updatedAt)
+                    VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)
+                    """,
+                    arguments: [
+                        validMeetingId, SummaryExportType.googleDocs, "https://example.com/canonical-google-doc", createdAt, createdAt,
+                        invalidDocumentMeetingId, SummaryExportType.googleDocs, "https://example.com/ignored", createdAt, createdAt,
                     ]
                 )
             }
         }
 
-        private static let v18MigrationIdentifiers = [
+        private static let v20MigrationIdentifiers = [
             "v3_googleDriveFolderSchema",
             "v4_instructionsSchema",
             "v5_summaryGoogleFileId",
@@ -147,6 +212,8 @@ import GRDB
             "v16_calendarEventURL",
             "v17_calendarEventIntegrity",
             "v18_segmentedRecordingAudio",
+            "v19_summaryExports",
+            "v20_meetingDescription",
         ]
     }
 #endif

--- a/Tests/DahliaTests/SummaryVaultPathMigrationTests.swift
+++ b/Tests/DahliaTests/SummaryVaultPathMigrationTests.swift
@@ -8,18 +8,18 @@ import GRDB
     @MainActor
     struct SummaryVaultPathMigrationTests {
         @Test
-        func initializesDatabaseWithSummaryVaultRelativePathColumn() throws {
+        func initializesDatabaseWithoutSummaryVaultRelativePathColumn() throws {
             let database = try AppDatabaseManager(path: ":memory:")
 
             let columns = try database.dbQueue.read { db in
                 try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
             }
 
-            #expect(columns.contains("vaultRelativePath"))
+            #expect(columns == ["meetingId", "title", "document", "createdAt"])
         }
 
         @Test
-        func existingV12DatabaseAddsColumnWithoutDataLoss() throws {
+        func existingV12DatabaseDropsRowsWithoutValidDocuments() throws {
             let databaseURL = FileManager.default.temporaryDirectory
                 .appending(path: UUID().uuidString)
                 .appendingPathExtension("sqlite")
@@ -37,16 +37,12 @@ import GRDB
             let migrated = try AppDatabaseManager(path: databaseURL.path)
             let result = try migrated.dbQueue.read { db in
                 let columns = try String.fetchAll(db, sql: "SELECT name FROM pragma_table_info('summaries')")
-                let row = try Row.fetchOne(db, sql: "SELECT * FROM summaries WHERE meetingId = ?", arguments: [meetingId])
-                return try (columns, #require(row))
+                let row = try SummaryRecord.fetchOne(db, key: meetingId)
+                return (columns, row)
             }
-            let vaultRelativePath: String? = result.1["vaultRelativePath"]
 
-            #expect(result.0.contains("vaultRelativePath"))
-            #expect(result.1["title"] == "Legacy")
-            #expect(result.1["summary"] == "Body")
-            #expect(result.1["googleFileId"] == "drive-id")
-            #expect(vaultRelativePath == nil)
+            #expect(result.0 == ["meetingId", "title", "document", "createdAt"])
+            #expect(result.1 == nil)
         }
 
         private func createV12SummaryDatabase(

--- a/Tests/DahliaTests/VaultSyncSummaryPathTests.swift
+++ b/Tests/DahliaTests/VaultSyncSummaryPathTests.swift
@@ -25,13 +25,10 @@ import GRDB
                 flags: [renameFlag, renameFlag]
             )
 
-            let fetchedSummary = try context.repository.fetchSummary(forMeetingId: context.meeting.id)
             let vaultExport = try context.repository.fetchSummaryExport(
                 forMeetingId: context.meeting.id,
                 type: .vault
             )
-            let summary = try #require(fetchedSummary)
-            #expect(summary.vaultRelativePath == "Project/Renamed.md")
             #expect(vaultExport?.url == "vault:///Project/Renamed.md")
             #expect(vaultExport?.vaultRelativePath == "Project/Renamed.md")
         }
@@ -53,15 +50,12 @@ import GRDB
             )
 
             let fetchedProject = try context.repository.fetchProject(id: context.project.id)
-            let fetchedSummary = try context.repository.fetchSummary(forMeetingId: context.meeting.id)
             let vaultExport = try context.repository.fetchSummaryExport(
                 forMeetingId: context.meeting.id,
                 type: .vault
             )
             let project = try #require(fetchedProject)
-            let summary = try #require(fetchedSummary)
             #expect(project.name == "Renamed")
-            #expect(summary.vaultRelativePath == "Renamed/Summary.md")
             #expect(vaultExport?.url == "vault:///Renamed/Summary.md")
             #expect(vaultExport?.vaultRelativePath == "Renamed/Summary.md")
         }
@@ -79,9 +73,11 @@ import GRDB
 
             context.syncService.performInitialSync()
 
-            let fetchedSummary = try context.repository.fetchSummary(forMeetingId: context.meeting.id)
-            let summary = try #require(fetchedSummary)
-            #expect(summary.vaultRelativePath == "Project/Original.md")
+            let vaultExport = try context.repository.fetchSummaryExport(
+                forMeetingId: context.meeting.id,
+                type: .vault
+            )
+            #expect(vaultExport?.vaultRelativePath == "Project/Original.md")
         }
 
         private func makeContext(projectName: String, summaryRelativePath: String) throws -> TestContext {
@@ -118,11 +114,13 @@ import GRDB
                 SummaryRecord(
                     meetingId: meeting.id,
                     title: "Summary",
-                    summary: "Body",
-                    vaultRelativePath: summaryRelativePath,
-                    googleFileId: nil,
+                    document: try SummaryDocument(title: "Summary", sections: []).databaseJSONString(),
                     createdAt: .now
                 )
+            )
+            try repository.updateSummaryVaultRelativePath(
+                forMeetingId: meeting.id,
+                relativePath: summaryRelativePath
             )
 
             return TestContext(


### PR DESCRIPTION
## Summary
- add the v21 migration that removes legacy summary storage columns and preserves valid documents and exports
- make structured summary documents and summary_exports the canonical application storage
- render MCP summaries from stored documents as generic Markdown
- reject invalid summary documents and require Dahlia migration for legacy databases

## Validation
- targeted tests: 55 tests in 7 suites passed
- full test suite: 524 Swift Testing tests plus 3 XCTest tests passed
- swift build --target DahliaMCP passed with the real Sentry dependency
- CI=true ./scripts/lint.sh completed successfully
- deep-review findings addressed, including safe dynamic Markdown code fences