### PR TITLE
Preserve batch transcription after disk exhaustion

### DIFF
--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -189,7 +189,7 @@ actor BatchTranscriptionCoordinator {
         guard let recordingAudioStore else {
             throw RecordingAudioStoreError.storageUnavailable
         }
-        return try await recordingAudioStore.withVerifiedReadySegments(sessionId: job.session.id) { verified in
+        return try await recordingAudioStore.withVerifiedTranscribableSegments(sessionId: job.session.id) { verified in
             try await self.transcribe(
                 verifiedSegments: verified,
                 job: job,

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -155,9 +155,14 @@ actor BatchTranscriptionCoordinator {
         } catch {
             ErrorReportingService.capture(error, context: ["source": "batchTranscriptExport"])
         }
-        guard !job.session.retainAudioAfterBatch else { return }
+        guard !job.session.retainAudioAfterBatch,
+              let recordingAudioStore else { return }
         do {
-            try await recordingAudioStore?.requestPurge(sessionId: job.session.id)
+            // A failed tail is intentionally retained after partial recovery. Force-purging it
+            // cannot be resumed safely if deletion is interrupted before its intent is persisted.
+            let hasFailedSegments = try await recordingAudioStore.hasFailedSegments(sessionId: job.session.id)
+            guard !hasFailedSegments else { return }
+            try await recordingAudioStore.requestPurge(sessionId: job.session.id)
         } catch {
             ErrorReportingService.capture(error, context: ["source": "batchAudioPurge"])
         }

--- a/Sources/Dahlia/Services/RecordingAudioStore.swift
+++ b/Sources/Dahlia/Services/RecordingAudioStore.swift
@@ -69,6 +69,11 @@ actor RecordingAudioStore {
         let ranges: [RecordingAudioSegmentRangeRecord]
     }
 
+    private struct TranscriptionReadPlan {
+        let records: [RecordingAudioSegmentRecord]
+        let cutoff: TimeInterval?
+    }
+
     let configuration: Configuration
 
     private let dbQueue: DatabaseQueue
@@ -417,29 +422,21 @@ actor RecordingAudioStore {
         }
     }
 
-    func withVerifiedReadySegments<T: Sendable>(
+    func withVerifiedTranscribableSegments<T: Sendable>(
         sessionId: UUID,
         operation: @Sendable ([VerifiedSegment]) async throws -> T
     ) async throws -> T {
         let temporaryLease = try await acquireTemporarySessionLease(sessionId: sessionId)
         defer { withExtendedLifetime(temporaryLease) {} }
+        try await reconcilePendingSegmentsForReading(sessionId: sessionId)
         readLeaseCounts[sessionId, default: 0] += 1
         defer {
             let remaining = max(0, readLeaseCounts[sessionId, default: 1] - 1)
             readLeaseCounts[sessionId] = remaining == 0 ? nil : remaining
         }
-        let records = try await dbQueue.read { db in
-            try RecordingAudioSegmentRecord
-                .filter(Column("recordingSessionId") == sessionId)
-                .order(Column("source").asc, Column("segmentIndex").asc)
-                .fetchAll(db)
-        }
-        guard !records.isEmpty else { throw RecordingAudioStoreError.missingFile }
-        guard records.allSatisfy({ $0.state == .ready }), Self.hasContiguousSegmentIndices(records) else {
-            throw RecordingAudioStoreError.invalidState
-        }
+        let readPlan = try await transcriptionReadPlan(sessionId: sessionId)
         var verified: [VerifiedSegment] = []
-        for record in records {
+        for record in readPlan.records {
             guard let expectedFrames = record.sealedFrameCount,
                   let expectedBytes = record.byteCount,
                   let expectedDigest = record.sha256 else {
@@ -459,12 +456,24 @@ actor RecordingAudioStore {
                 guard metadata.byteCount == expectedBytes, metadata.sha256 == expectedDigest else {
                     throw RecordingAudioStoreError.integrityMismatch
                 }
-                let ranges = try await dbQueue.read { db in
+                var ranges = try await dbQueue.read { db in
                     try RecordingAudioSegmentRangeRecord
                         .filter(Column("audioSegmentId") == record.id)
                         .order(Column("startFrame").asc)
                         .fetchAll(db)
                 }
+                guard ranges.allSatisfy({ $0.frameCount != nil }) else {
+                    throw RecordingAudioStoreError.integrityMismatch
+                }
+                if let cutoff = readPlan.cutoff {
+                    ranges = Self.clippedRanges(
+                        ranges,
+                        toSessionOffset: cutoff,
+                        in: record,
+                        sealedFrameCount: expectedFrames
+                    )
+                }
+                guard !ranges.isEmpty else { continue }
                 verified.append(VerifiedSegment(segment: record, url: url, ranges: ranges))
             } catch RecordingAudioStoreError.integrityMismatch {
                 try await fail(segmentId: record.id, stage: "read", code: "integrityMismatch")
@@ -474,7 +483,79 @@ actor RecordingAudioStore {
                 throw RecordingAudioStoreError.missingFile
             }
         }
+        guard !verified.isEmpty else { throw RecordingAudioStoreError.invalidState }
         return try await operation(verified)
+    }
+
+    private func reconcilePendingSegmentsForReading(sessionId: UUID) async throws {
+        let segmentIds = try await dbQueue.read { db in
+            try UUID.fetchAll(
+                db,
+                sql: """
+                SELECT id FROM recording_audio_segments
+                WHERE recordingSessionId = ? AND state IN (?, ?)
+                ORDER BY source, segmentIndex
+                """,
+                arguments: [
+                    sessionId,
+                    RecordingAudioSegmentState.recording.rawValue,
+                    RecordingAudioSegmentState.finalizing.rawValue,
+                ]
+            )
+        }
+        for segmentId in segmentIds {
+            do {
+                _ = try await reconcile(segmentId: segmentId)
+            } catch RecordingAudioStoreError.integrityMismatch, RecordingAudioStoreError.missingFile {
+                // Reconciliation has already persisted a terminal failed state.
+                // The verified contiguous prefix can still be transcribed.
+            }
+        }
+    }
+
+    private func transcriptionReadPlan(sessionId: UUID) async throws -> TranscriptionReadPlan {
+        try await dbQueue.read { db in
+            let records = try RecordingAudioSegmentRecord
+                .filter(Column("recordingSessionId") == sessionId)
+                .order(Column("source").asc, Column("segmentIndex").asc)
+                .fetchAll(db)
+            guard !records.isEmpty else { throw RecordingAudioStoreError.missingFile }
+            guard records.allSatisfy({ [.ready, .failed].contains($0.state) }) else {
+                throw RecordingAudioStoreError.invalidState
+            }
+            guard records.contains(where: { $0.state == .failed }) else {
+                guard Self.hasContiguousSegmentIndices(records) else {
+                    throw RecordingAudioStoreError.invalidState
+                }
+                return TranscriptionReadPlan(records: records, cutoff: nil)
+            }
+
+            let progress = try RecordingAudioSourceProgressRecord
+                .filter(Column("recordingSessionId") == sessionId)
+                .fetchAll(db)
+            let requiredProgress = progress.filter(\.isRequired)
+            guard !requiredProgress.isEmpty,
+                  let durableCutoff = requiredProgress.map(\.durableThroughOffsetSeconds).min(),
+                  durableCutoff > 0 else {
+                throw RecordingAudioStoreError.invalidState
+            }
+            let readyPrefixBySource = Dictionary(
+                uniqueKeysWithValues: progress.compactMap { item in
+                    item.lastContiguousReadySegmentIndex.map { (item.source, $0) }
+                }
+            )
+            let transcribableRecords = records.filter { record in
+                guard record.state == .ready,
+                      let lastReadyIndex = readyPrefixBySource[record.source],
+                      record.segmentIndex <= lastReadyIndex else { return false }
+                return record.sessionStartOffsetSeconds < durableCutoff
+            }
+            guard !transcribableRecords.isEmpty,
+                  Self.hasContiguousSegmentIndices(transcribableRecords) else {
+                throw RecordingAudioStoreError.invalidState
+            }
+            return TranscriptionReadPlan(records: transcribableRecords, cutoff: durableCutoff)
+        }
     }
 
     func requestPurge(sessionId: UUID, includeFailed: Bool = false, at now: Date = .now) async throws {
@@ -1250,6 +1331,27 @@ actor RecordingAudioStore {
             sourceRecords.enumerated().allSatisfy { offset, record in
                 record.segmentIndex == offset
             }
+        }
+    }
+
+    private static func clippedRanges(
+        _ ranges: [RecordingAudioSegmentRangeRecord],
+        toSessionOffset cutoff: TimeInterval,
+        in segment: RecordingAudioSegmentRecord,
+        sealedFrameCount: Int64
+    ) -> [RecordingAudioSegmentRangeRecord] {
+        let duration = max(0, cutoff - segment.sessionStartOffsetSeconds)
+        let cutoffFrame = Int64((duration * segment.sampleRate).rounded(.down))
+        let availableFrameCount = min(sealedFrameCount, cutoffFrame)
+        guard availableFrameCount > 0 else { return [] }
+
+        return ranges.compactMap { range in
+            guard let frameCount = range.frameCount else { return nil }
+            let clippedFrameCount = min(range.startFrame + frameCount, availableFrameCount) - range.startFrame
+            guard clippedFrameCount > 0 else { return nil }
+            var clipped = range
+            clipped.frameCount = clippedFrameCount
+            return clipped
         }
     }
 

--- a/Sources/Dahlia/Services/RecordingAudioStore.swift
+++ b/Sources/Dahlia/Services/RecordingAudioStore.swift
@@ -422,6 +422,15 @@ actor RecordingAudioStore {
         }
     }
 
+    func hasFailedSegments(sessionId: UUID) async throws -> Bool {
+        try await dbQueue.read { db in
+            try RecordingAudioSegmentRecord
+                .filter(Column("recordingSessionId") == sessionId)
+                .filter(Column("state") == RecordingAudioSegmentState.failed.rawValue)
+                .fetchCount(db) > 0
+        }
+    }
+
     func withVerifiedTranscribableSegments<T: Sendable>(
         sessionId: UUID,
         operation: @Sendable ([VerifiedSegment]) async throws -> T

--- a/Tests/DahliaTests/RecordingAudioStoreTests.swift
+++ b/Tests/DahliaTests/RecordingAudioStoreTests.swift
@@ -149,7 +149,7 @@ import GRDB
 
             let store = try makeStore(fixture)
             await #expect(throws: (any Error).self) {
-                try await store.withVerifiedReadySegments(sessionId: fixture.session.id) { _ in true }
+                try await store.withVerifiedTranscribableSegments(sessionId: fixture.session.id) { _ in true }
             }
             let failed = try await fixture.database.dbQueue.read { db in
                 try (
@@ -162,6 +162,85 @@ import GRDB
             #expect(failed.1?.durableThroughOffsetSeconds == 0)
             #expect(failed.1?.lastContiguousReadySegmentIndex == nil)
             #expect(FileManager.default.fileExists(atPath: finalURL.path))
+        }
+
+        @Test
+        func unreadableFinalizingTailStillAllowsTranscribingCommonDurablePrefix() async throws {
+            let fixture = try BatchAudioTestFixture(name: "FailedTailDurablePrefix")
+            defer { fixture.removeFiles() }
+            let segmentedConfiguration = RecordingAudioStore.Configuration(
+                targetSegmentDuration: .milliseconds(5),
+                maximumFinalizingSegmentCountPerSource: 2,
+                maximumActiveSegmentDuration: .seconds(600),
+                maximumActiveSegmentByteCount: 64 * 1024 * 1024,
+                minimumAvailableCapacity: 0,
+                capacityCheckInterval: .seconds(5)
+            )
+            let recorder = try BatchAudioRecordingSession(
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL,
+                meetingId: fixture.meeting.id,
+                recordingSessionId: fixture.session.id,
+                recordingStartTime: fixture.now,
+                sampleRate: 16000,
+                configuration: segmentedConfiguration
+            )
+            let microphone = try await recorder.beginRange(
+                source: .microphone,
+                locale: Locale(identifier: "ja_JP"),
+                at: fixture.now
+            )
+            let system = try await recorder.beginRange(
+                source: .system,
+                locale: Locale(identifier: "ja_JP"),
+                at: fixture.now
+            )
+            try microphone.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 40))
+            _ = try await recorder.rotateRange(
+                source: .microphone,
+                locale: Locale(identifier: "en_US")
+            )
+            try microphone.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 120))
+            try system.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 80))
+            try system.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 80))
+            try await recorder.finish()
+
+            let segments = try await fixture.database.dbQueue.read { db in
+                try RecordingAudioSegmentRecord
+                    .order(Column("source").asc, Column("segmentIndex").asc)
+                    .fetchAll(db)
+            }
+            #expect(segments.count == 3)
+            let failedTail = try #require(segments.first { $0.source == .system && $0.segmentIndex == 1 })
+            let finalURL = fixture.managedRootURL.appending(path: failedTail.finalRelativePath)
+            let partialURL = fixture.managedRootURL.appending(path: failedTail.partialRelativePath)
+            try FileManager.default.moveItem(at: finalURL, to: partialURL)
+            try Data("not a caf".utf8).write(to: partialURL)
+            try await fixture.database.dbQueue.write { db in
+                guard var segment = try RecordingAudioSegmentRecord.fetchOne(db, key: failedTail.id) else { return }
+                segment.state = .finalizing
+                segment.finalizedAt = nil
+                try segment.update(db)
+            }
+
+            let store = try makeStore(fixture)
+            let transcribable = try await store.withVerifiedTranscribableSegments(
+                sessionId: fixture.session.id
+            ) { verified in
+                Dictionary(uniqueKeysWithValues: verified.map { segment in
+                    (segment.segment.source, segment.ranges.map { range in
+                        "\(range.localeIdentifier):\(range.frameCount ?? -1):\(range.sessionOffsetSeconds)"
+                    })
+                })
+            }
+
+            #expect(transcribable[.microphone] == ["ja_JP:40:0.0", "en_US:40:0.0025"])
+            #expect(transcribable[.system] == ["ja_JP:80:0.0"])
+            let recoveredTail = try await fixture.database.dbQueue.read { db in
+                try RecordingAudioSegmentRecord.fetchOne(db, key: failedTail.id)
+            }
+            #expect(recoveredTail?.state == .failed)
+            #expect(recoveredTail?.failureCode == "integrityMismatch")
         }
 
         @Test

--- a/Tests/DahliaTests/RecordingAudioStoreTests.swift
+++ b/Tests/DahliaTests/RecordingAudioStoreTests.swift
@@ -241,6 +241,7 @@ import GRDB
             }
             #expect(recoveredTail?.state == .failed)
             #expect(recoveredTail?.failureCode == "integrityMismatch")
+            #expect(try await store.hasFailedSegments(sessionId: fixture.session.id))
         }
 
         @Test


### PR DESCRIPTION
## Summary

- reconcile interrupted `recording` and `finalizing` audio segments before batch transcription reads them
- transcribe the verified contiguous prefix shared by all required audio sources when an unreadable tail remains
- clip locale ranges at the durable cutoff without including frames beyond it
- add regression coverage for an unreadable finalizing tail, multiple audio sources, and a locale boundary inside the retained prefix

## Root cause

When disk space ran low, the active CAF tail could remain `finalizing` or become `failed` while earlier immutable segments were still valid. Batch transcription required every segment to be `ready`, so retries returned `invalidState` and rejected the entire recording instead of using the already durable prefix.

## User impact

After this change, retrying batch transcription first reconciles unfinished tail state. If the tail is permanently unreadable, Dahlia preserves it but verifies and transcribes audio through the latest timestamp that is durable for every required source. Fully healthy recordings retain the existing full-recording behavior.

## Validation

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` — 522 Swift Testing tests in 94 suites and 3 XCTest tests passed
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter RecordingAudioStoreTests` — 20 tests passed after final review fixes
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build`
- SwiftFormat lint on all changed files
- `git diff --check`

## Related Sentry issues

- https://dahlia-app.sentry.io/issues/7614174996/
- https://dahlia-app.sentry.io/issues/7614177351/
- https://dahlia-app.sentry.io/issues/7614175623/
