### PR TITLE
Add meeting references to AI chat

### DIFF
--- a/Sources/Dahlia/DahliaApp.swift
+++ b/Sources/Dahlia/DahliaApp.swift
@@ -93,6 +93,7 @@ struct DahliaApp: App {
             if let sessionID {
                 CodexChatWindowView(
                     coordinator: chatCoordinator,
+                    sidebarViewModel: sidebarViewModel,
                     sessionID: sessionID
                 )
             } else {

--- a/Sources/Dahlia/Models/CodexChatMeetingPickerSelection.swift
+++ b/Sources/Dahlia/Models/CodexChatMeetingPickerSelection.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum CodexChatMeetingPickerSelection {
+    static func moving(
+        currentID: UUID?,
+        in references: [CodexChatMeetingReference],
+        by offset: Int
+    ) -> UUID? {
+        guard !references.isEmpty else { return nil }
+        guard let currentID,
+              let currentIndex = references.firstIndex(where: { $0.id == currentID })
+        else { return references[0].id }
+        let nextIndex = min(references.count - 1, max(0, currentIndex + offset))
+        return references[nextIndex].id
+    }
+}

--- a/Sources/Dahlia/Models/CodexChatMeetingReference.swift
+++ b/Sources/Dahlia/Models/CodexChatMeetingReference.swift
@@ -47,6 +47,44 @@ struct CodexChatMeetingReference: Identifiable, Equatable {
         tokens(in: text).compactMap(meetingID(from:))
     }
 
+    static func previewContent(in text: String) -> (referenceIDs: [UUID], instruction: String) {
+        var referenceIDs: [UUID] = []
+        var instruction = ""
+        var index = text.startIndex
+        var removedReference = false
+        var lastWordWasReference = false
+
+        while index < text.endIndex {
+            let separatorEnd = text[index...].firstIndex(where: { !$0.isWhitespace }) ?? text.endIndex
+            let separator = text[index ..< separatorEnd]
+            guard separatorEnd < text.endIndex else {
+                if !lastWordWasReference {
+                    instruction.append(contentsOf: separator)
+                }
+                break
+            }
+
+            let wordEnd = text[separatorEnd...].firstIndex(where: \Character.isWhitespace) ?? text.endIndex
+            let word = String(text[separatorEnd ..< wordEnd])
+            if let meetingID = meetingID(from: word) {
+                referenceIDs.append(meetingID)
+                removedReference = true
+                lastWordWasReference = true
+            } else {
+                if !instruction.isEmpty || !removedReference {
+                    instruction.append(contentsOf: separator)
+                } else if separator.count > 1 {
+                    instruction.append(contentsOf: separator.dropFirst())
+                }
+                instruction.append(word)
+                lastWordWasReference = false
+            }
+            index = wordEnd
+        }
+
+        return (referenceIDs, instruction)
+    }
+
     static func displayText(
         for text: String,
         namesByID: [UUID: String],
@@ -84,9 +122,12 @@ struct CodexChatMeetingReference: Identifiable, Equatable {
     }
 
     static func trailingMentionQuery(in text: String) -> String? {
-        guard text.last?.isWhitespace == false,
-              let lastWord = text.split(whereSeparator: \.isWhitespace).last,
-              lastWord.first == "@" else { return nil }
+        guard text.last?.isWhitespace == false else { return nil }
+        let wordStart = text.lastIndex(where: \.isWhitespace)
+            .map { text.index(after: $0) }
+            ?? text.startIndex
+        let lastWord = text[wordStart...]
+        guard lastWord.first == "@" else { return nil }
         return String(lastWord.dropFirst())
     }
 

--- a/Sources/Dahlia/Models/CodexChatMeetingReference.swift
+++ b/Sources/Dahlia/Models/CodexChatMeetingReference.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+struct CodexChatMeetingReference: Identifiable, Equatable {
+    let id: UUID
+    let name: String
+    let createdAt: Date
+
+    init(id: UUID, name: String, createdAt: Date) {
+        self.id = id
+        self.name = name
+        self.createdAt = createdAt
+    }
+
+    init(meeting: MeetingOverviewItem) {
+        id = meeting.meetingId
+        name = meeting.meetingName.nilIfBlank ?? L10n.newMeeting
+        createdAt = meeting.createdAt
+    }
+
+    static func suggestions(
+        from references: [Self],
+        excluding selectedIDs: [UUID],
+        query: String
+    ) -> [Self] {
+        let excluded = Set(selectedIDs)
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        return references
+            .filter { reference in
+                !excluded.contains(reference.id)
+                    && (trimmedQuery.isEmpty || reference.name.localizedStandardContains(trimmedQuery))
+            }
+            .sorted { lhs, rhs in
+                if lhs.createdAt == rhs.createdAt {
+                    return lhs.id.uuidString < rhs.id.uuidString
+                }
+                return lhs.createdAt > rhs.createdAt
+            }
+    }
+
+    static func serializedText(referenceIDs: [UUID], draft: String) -> String {
+        let references = referenceIDs.map { "meeting:\($0.uuidString.lowercased())" }
+        let components = references + [draft.nilIfBlank].compactMap(\.self)
+        return components.joined(separator: " ")
+    }
+
+    static func meetingIDs(in text: String) -> [UUID] {
+        tokens(in: text).compactMap(meetingID(from:))
+    }
+
+    static func displayText(
+        for text: String,
+        namesByID: [UUID: String],
+        unavailableName: String = L10n.meetingUnavailable
+    ) -> String {
+        guard text.range(of: meetingTokenPrefix, options: .caseInsensitive) != nil else { return text }
+        var result = ""
+        var searchStart = text.startIndex
+
+        while let prefixRange = text.range(
+            of: meetingTokenPrefix,
+            options: .caseInsensitive,
+            range: searchStart ..< text.endIndex
+        ) {
+            result.append(contentsOf: text[searchStart ..< prefixRange.lowerBound])
+            guard let uuidEnd = text.index(
+                prefixRange.upperBound,
+                offsetBy: uuidStringLength,
+                limitedBy: text.endIndex
+            ),
+                let meetingID = UUID(
+                    uuidString: String(text[prefixRange.upperBound ..< uuidEnd])
+                )
+            else {
+                result.append(contentsOf: text[prefixRange.lowerBound ..< prefixRange.upperBound])
+                searchStart = prefixRange.upperBound
+                continue
+            }
+
+            result.append(namesByID[meetingID] ?? unavailableName)
+            searchStart = uuidEnd
+        }
+        result.append(contentsOf: text[searchStart...])
+        return result
+    }
+
+    static func trailingMentionQuery(in text: String) -> String? {
+        guard text.last?.isWhitespace == false,
+              let lastWord = text.split(whereSeparator: \.isWhitespace).last,
+              lastWord.first == "@" else { return nil }
+        return String(lastWord.dropFirst())
+    }
+
+    static func removingTrailingMentionQuery(from text: String) -> String {
+        guard let query = trailingMentionQuery(in: text) else { return text }
+        let mentionLength = query.count + 1
+        return String(text.dropLast(mentionLength))
+    }
+
+    static func draftAfterSelectingReference(_ text: String, consumesTrailingMention: Bool) -> String {
+        consumesTrailingMention ? removingTrailingMentionQuery(from: text) : text
+    }
+
+    private static func tokens(in text: String) -> [String] {
+        text.split(whereSeparator: \.isWhitespace).map(String.init)
+    }
+
+    private static func meetingID(from token: String) -> UUID? {
+        guard token.hasPrefix(meetingTokenPrefix), token.count > meetingTokenPrefix.count else { return nil }
+        return UUID(uuidString: String(token.dropFirst(meetingTokenPrefix.count)))
+    }
+
+    private static let meetingTokenPrefix = "meeting:"
+    private static let uuidStringLength = 36
+}

--- a/Sources/Dahlia/Models/CodexChatStreamingUpdateLimiter.swift
+++ b/Sources/Dahlia/Models/CodexChatStreamingUpdateLimiter.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+@MainActor
+final class CodexChatStreamingUpdateLimiter {
+    private let minimumInterval: Duration
+    private let sleep: (Duration) async throws -> Void
+    private let publish: () -> Void
+    private var lastPublishedAt: ContinuousClock.Instant?
+    private var pendingTask: Task<Void, Never>?
+
+    init(
+        minimumInterval: Duration = .milliseconds(50),
+        sleep: @escaping (Duration) async throws -> Void = { try await Task.sleep(for: $0) },
+        publish: @escaping () -> Void
+    ) {
+        self.minimumInterval = minimumInterval
+        self.sleep = sleep
+        self.publish = publish
+    }
+
+    func submit(force: Bool = false) {
+        let now = ContinuousClock.now
+        guard !force, let lastPublishedAt else {
+            publishLatest(at: now)
+            return
+        }
+
+        let nextPublishAt = lastPublishedAt.advanced(by: minimumInterval)
+        guard now < nextPublishAt else {
+            publishLatest(at: now)
+            return
+        }
+        guard pendingTask == nil else { return }
+
+        let delay = now.duration(to: nextPublishAt)
+        let sleep = sleep
+        pendingTask = Task { [weak self] in
+            do {
+                try await sleep(delay)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            self?.publishLatest(at: .now)
+        }
+    }
+
+    private func publishLatest(at instant: ContinuousClock.Instant) {
+        pendingTask?.cancel()
+        pendingTask = nil
+        lastPublishedAt = instant
+        publish()
+    }
+}

--- a/Sources/Dahlia/Models/CodexChatTurnAccumulator.swift
+++ b/Sources/Dahlia/Models/CodexChatTurnAccumulator.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-struct CodexChatTurnAccumulator {
+@MainActor
+final class CodexChatTurnAccumulator {
     private var responseItemIDs: [String] = []
     private var responseTexts: [String: String] = [:]
     private var reasoningItemIDs: [String] = []
@@ -21,37 +22,37 @@ struct CodexChatTurnAccumulator {
         .joined(separator: "\n\n")
     }
 
-    mutating func appendResponseDelta(itemID: String, text: String) {
+    func appendResponseDelta(itemID: String, text: String) {
         registerResponseItem(itemID)
         responseTexts[itemID, default: ""] += text
     }
 
-    mutating func completeResponse(itemID: String, text: String?) {
+    func completeResponse(itemID: String, text: String?) {
         registerResponseItem(itemID)
         if let text {
             responseTexts[itemID] = text
         }
     }
 
-    mutating func appendReasoningDelta(itemID: String, summaryIndex: Int, text: String) {
+    func appendReasoningDelta(itemID: String, summaryIndex: Int, text: String) {
         registerReasoningItem(itemID)
         reasoningSections[itemID, default: [:]][summaryIndex, default: ""] += text
     }
 
-    mutating func completeReasoning(itemID: String, text: String) {
+    func completeReasoning(itemID: String, text: String) {
         registerReasoningItem(itemID)
         if let text = text.nilIfBlank {
             reasoningSections[itemID] = [0: text]
         }
     }
 
-    private mutating func registerResponseItem(_ itemID: String) {
+    private func registerResponseItem(_ itemID: String) {
         guard responseTexts[itemID] == nil else { return }
         responseItemIDs.append(itemID)
         responseTexts[itemID] = ""
     }
 
-    private mutating func registerReasoningItem(_ itemID: String) {
+    private func registerReasoningItem(_ itemID: String) {
         guard reasoningSections[itemID] == nil else { return }
         reasoningItemIDs.append(itemID)
         reasoningSections[itemID] = [:]

--- a/Sources/Dahlia/Models/CodexChatTurnEvent.swift
+++ b/Sources/Dahlia/Models/CodexChatTurnEvent.swift
@@ -8,4 +8,15 @@ enum CodexChatTurnEvent: Equatable {
     case reasoningCompleted(itemID: String, text: String)
     case interrupted
     case failed(message: String?)
+
+    var terminalCompletion: Bool? {
+        switch self {
+        case .completed(itemID: nil, text: _):
+            true
+        case .interrupted, .failed:
+            false
+        default:
+            nil
+        }
+    }
 }

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -687,6 +687,11 @@
 "Thought process" = "Thought process";
 "Selected" = "Selected";
 "Response performance" = "Response performance";
+"Meeting references" = "Meeting references";
+"Add meeting reference" = "Add meeting reference";
+"Remove meeting reference %@" = "Remove meeting reference %@";
+"No matching meetings" = "No matching meetings";
+"Meeting unavailable" = "Meeting unavailable";
 
 /* MCP */
 "MCP" = "MCP";

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -692,6 +692,7 @@
 "Remove meeting reference %@" = "Remove meeting reference %@";
 "No matching meetings" = "No matching meetings";
 "Meeting unavailable" = "Meeting unavailable";
+"Show meeting details" = "Show meeting details";
 
 /* MCP */
 "MCP" = "MCP";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -692,6 +692,7 @@
 "Remove meeting reference %@" = "%@ の参照を削除";
 "No matching meetings" = "一致するミーティングはありません";
 "Meeting unavailable" = "利用できないミーティング";
+"Show meeting details" = "ミーティングの詳細を表示";
 
 /* MCP */
 "MCP" = "MCP";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -687,6 +687,11 @@
 "Thought process" = "思考プロセス";
 "Selected" = "選択中";
 "Response performance" = "応答性能";
+"Meeting references" = "ミーティング参照";
+"Add meeting reference" = "ミーティングを参照";
+"Remove meeting reference %@" = "%@ の参照を削除";
+"No matching meetings" = "一致するミーティングはありません";
+"Meeting unavailable" = "利用できないミーティング";
 
 /* MCP */
 "MCP" = "MCP";

--- a/Sources/Dahlia/Services/CodexChatService.swift
+++ b/Sources/Dahlia/Services/CodexChatService.swift
@@ -12,7 +12,8 @@ actor CodexChatService: CodexChatServicing {
     When context has Type: MeetingDraft, do not call get_meeting for it because it has not been saved.
     A standalone meeting:<UUID> word directly identifies a meeting selected by the user.
     When one or more meeting:<UUID> words are present, call get_meeting with each UUID directly and do not call query_meetings first.
-    When neither a meeting:<UUID> word nor a Type: Meeting context is present, start with query_meetings, then use get_meeting for a selected meeting's summary.
+    When neither a meeting:<UUID> word nor a Type: Meeting context is present, start with query_meetings.
+    Then use get_meeting for a selected meeting's summary.
     Call get_meeting_transcript only when the original wording or detail is needed.
     Do not execute commands, access files, use external services, or request permissions.
     """

--- a/Sources/Dahlia/Services/CodexChatService.swift
+++ b/Sources/Dahlia/Services/CodexChatService.swift
@@ -9,8 +9,10 @@ actor CodexChatService: CodexChatServicing {
     The context applies only to the user message immediately following it. A message without context has no active meeting.
     Treat only the text after </context> as the user's request.
     You may use only the Dahlia meeting tools. When context has Type: Meeting, use its meeting_id directly with get_meeting.
-    Otherwise, start with query_meetings, then use get_meeting for a selected meeting's summary.
     When context has Type: MeetingDraft, do not call get_meeting for it because it has not been saved.
+    A standalone meeting:<UUID> word directly identifies a meeting selected by the user.
+    When one or more meeting:<UUID> words are present, call get_meeting with each UUID directly and do not call query_meetings first.
+    When neither a meeting:<UUID> word nor a Type: Meeting context is present, start with query_meetings, then use get_meeting for a selected meeting's summary.
     Call get_meeting_transcript only when the original wording or detail is needed.
     Do not execute commands, access files, use external services, or request permissions.
     """

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1329,4 +1329,5 @@ enum L10n {
         bundle: bundle
     ) }
     static var meetingUnavailable: String { String(localized: "Meeting unavailable", bundle: bundle) }
+    static var showMeetingReferenceDetails: String { String(localized: "Show meeting details", bundle: bundle) }
 }

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1318,4 +1318,15 @@ enum L10n {
     static var chatReasoning: String { String(localized: "Thought process", bundle: bundle) }
     static var selected: String { String(localized: "Selected", bundle: bundle) }
     static var responsePerformance: String { String(localized: "Response performance", bundle: bundle) }
+    static var meetingReferences: String { String(localized: "Meeting references", bundle: bundle) }
+    static var addMeetingReference: String { String(localized: "Add meeting reference", bundle: bundle) }
+    static func removeMeetingReference(_ name: String) -> String { String(
+        localized: "Remove meeting reference \(name)",
+        bundle: bundle
+    ) }
+    static var noMatchingMeetingReferences: String { String(
+        localized: "No matching meetings",
+        bundle: bundle
+    ) }
+    static var meetingUnavailable: String { String(localized: "Meeting unavailable", bundle: bundle) }
 }

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -21,6 +21,7 @@ final class CodexChatSessionModel: Identifiable {
     private(set) var availableMeetingReferences: [CodexChatMeetingReference] = []
     private(set) var selectedMeetingReferenceIDs: [UUID] = []
     private(set) var meetingNamesByID: [UUID: String] = [:]
+    private(set) var meetingReferencesByID: [UUID: CodexChatMeetingReference] = [:]
 
     @ObservationIgnored private let service: any CodexChatServicing
     @ObservationIgnored private let settings: AppSettings
@@ -412,13 +413,14 @@ extension CodexChatSessionModel {
 
 extension CodexChatSessionModel {
     func updateAvailableMeetings(_ meetings: [MeetingOverviewItem], catalogVaultID: UUID?) {
-        guard catalogVaultID == vaultID else { return }
+        guard let vaultID, catalogVaultID == vaultID else { return }
         let references = meetings
             .filter { $0.vaultId == vaultID }
             .map(CodexChatMeetingReference.init)
         availableMeetingReferences = references
         for reference in references {
             meetingNamesByID[reference.id] = reference.name
+            meetingReferencesByID[reference.id] = reference
         }
         let availableIDs = Set(references.map(\.id))
         selectedMeetingReferenceIDs.removeAll { !availableIDs.contains($0) }
@@ -428,6 +430,7 @@ extension CodexChatSessionModel {
         guard !selectedMeetingReferenceIDs.contains(reference.id) else { return }
         selectedMeetingReferenceIDs.append(reference.id)
         meetingNamesByID[reference.id] = reference.name
+        meetingReferencesByID[reference.id] = reference
     }
 
     func removeMeetingReference(id: UUID) {

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -26,6 +26,7 @@ final class CodexChatSessionModel: Identifiable {
     @ObservationIgnored private let service: any CodexChatServicing
     @ObservationIgnored private let settings: AppSettings
     @ObservationIgnored private let contextProvider: any CodexChatContextProviding
+    @ObservationIgnored private let streamingUpdateInterval: Duration
     @ObservationIgnored private var isStopRequested = false
     @ObservationIgnored private var isReleased = false
     @ObservationIgnored private var didUnsubscribe = false
@@ -40,7 +41,8 @@ final class CodexChatSessionModel: Identifiable {
         effort: String? = nil,
         service: any CodexChatServicing = CodexChatService.shared,
         settings: AppSettings = .shared,
-        contextProvider: any CodexChatContextProviding = CodexChatContextProvider()
+        contextProvider: any CodexChatContextProviding = CodexChatContextProvider(),
+        streamingUpdateInterval: Duration = .milliseconds(50)
     ) {
         self.id = id
         self.vaultID = vaultID ?? settings.currentVault?.id
@@ -52,6 +54,7 @@ final class CodexChatSessionModel: Identifiable {
         self.service = service
         self.settings = settings
         self.contextProvider = contextProvider
+        self.streamingUpdateInterval = streamingUpdateInterval
     }
 
     func prepare(forceRefresh: Bool = false) async {
@@ -152,9 +155,16 @@ final class CodexChatSessionModel: Identifiable {
         }
         unsubscribeIfPossible()
     }
+}
 
-    private func runTurn(text: String, context: CodexChatContext?, responseID: String) async {
-        var accumulator = CodexChatTurnAccumulator()
+private extension CodexChatSessionModel {
+    func runTurn(text: String, context: CodexChatContext?, responseID: String) async {
+        let accumulator = CodexChatTurnAccumulator()
+        let updateLimiter = CodexChatStreamingUpdateLimiter(
+            minimumInterval: streamingUpdateInterval
+        ) { [weak self, accumulator] in
+            self?.updateTurnResponse(id: responseID, from: accumulator)
+        }
         do {
             if models.isEmpty {
                 await prepare()
@@ -183,29 +193,51 @@ final class CodexChatSessionModel: Identifiable {
                 model: selectedModelID.nilIfBlank,
                 effort: selectedEffort
             )
-            var turnCompleted = false
-            for try await event in stream {
-                apply(event, responseID: responseID, accumulator: &accumulator)
-                if case .completed(itemID: nil, text: nil) = event {
-                    turnCompleted = true
-                }
-            }
+            let turnCompleted = try await consumeTurnEvents(
+                stream,
+                accumulator: accumulator,
+                updateLimiter: updateLimiter
+            )
+            updateLimiter.submit(force: true)
+            completeTurnResponse(responseID: responseID)
             if turnCompleted {
                 await reconcileFromRollout(preservingReasoningFrom: responseID)
             }
         } catch is CancellationError {
+            updateLimiter.submit(force: true)
             completeTurnResponse(responseID: responseID)
         } catch {
             errorMessage = error.localizedDescription
+            updateLimiter.submit(force: true)
             completeTurnResponse(responseID: responseID)
         }
         finishGeneration()
     }
 
+    func consumeTurnEvents(
+        _ stream: AsyncThrowingStream<CodexChatTurnEvent, any Error>,
+        accumulator: CodexChatTurnAccumulator,
+        updateLimiter: CodexChatStreamingUpdateLimiter
+    ) async throws -> Bool {
+        var eventsSinceYield = 0
+        for try await event in stream {
+            apply(event, accumulator: accumulator, updateLimiter: updateLimiter)
+            if let completedSuccessfully = event.terminalCompletion {
+                return completedSuccessfully
+            }
+            eventsSinceYield += 1
+            if eventsSinceYield == Self.maximumEventsBetweenYields {
+                eventsSinceYield = 0
+                await Task.yield()
+            }
+        }
+        return false
+    }
+
     private func apply(
         _ event: CodexChatTurnEvent,
-        responseID: String,
-        accumulator: inout CodexChatTurnAccumulator
+        accumulator: CodexChatTurnAccumulator,
+        updateLimiter: CodexChatStreamingUpdateLimiter
     ) {
         switch event {
         case let .started(turnID):
@@ -215,23 +247,23 @@ final class CodexChatSessionModel: Identifiable {
             }
         case let .delta(itemID, text):
             accumulator.appendResponseDelta(itemID: itemID, text: text)
-            updateTurnResponse(id: responseID, from: accumulator)
+            updateLimiter.submit()
         case let .completed(itemID?, text):
             accumulator.completeResponse(itemID: itemID, text: text)
-            updateTurnResponse(id: responseID, from: accumulator)
+            updateLimiter.submit(force: true)
         case .completed(itemID: nil, text: _):
-            completeTurnResponse(responseID: responseID)
+            updateLimiter.submit(force: true)
         case let .reasoningDelta(itemID, summaryIndex, text):
             accumulator.appendReasoningDelta(itemID: itemID, summaryIndex: summaryIndex, text: text)
-            updateTurnResponse(id: responseID, from: accumulator)
+            updateLimiter.submit()
         case let .reasoningCompleted(itemID, text):
             accumulator.completeReasoning(itemID: itemID, text: text)
-            updateTurnResponse(id: responseID, from: accumulator)
+            updateLimiter.submit(force: true)
         case .interrupted:
-            completeTurnResponse(responseID: responseID)
+            updateLimiter.submit(force: true)
         case let .failed(message):
             errorMessage = CodexAppServerError.turnFailed(message).localizedDescription
-            completeTurnResponse(responseID: responseID)
+            updateLimiter.submit(force: true)
         }
     }
 
@@ -259,8 +291,14 @@ final class CodexChatSessionModel: Identifiable {
 
     private func updateTurnResponse(id: String, from accumulator: CodexChatTurnAccumulator) {
         guard let index = messages.firstIndex(where: { $0.id == id }) else { return }
-        messages[index].text = accumulator.responseText
-        messages[index].reasoning = accumulator.reasoningText
+        let responseText = accumulator.responseText
+        let reasoningText = accumulator.reasoningText
+        if messages[index].text != responseText {
+            messages[index].text = responseText
+        }
+        if messages[index].reasoning != reasoningText {
+            messages[index].reasoning = reasoningText
+        }
     }
 
     private func reconcileFromRollout(preservingReasoningFrom responseID: String) async {
@@ -293,6 +331,8 @@ final class CodexChatSessionModel: Identifiable {
         isStopRequested = false
         unsubscribeIfPossible()
     }
+
+    private static let maximumEventsBetweenYields = 64
 
     private func unsubscribeIfPossible() {
         guard isReleased,

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -18,6 +18,9 @@ final class CodexChatSessionModel: Identifiable {
     private(set) var errorMessage: String?
     private(set) var activeTurnID: String?
     private(set) var lastSubmittedText: String?
+    private(set) var availableMeetingReferences: [CodexChatMeetingReference] = []
+    private(set) var selectedMeetingReferenceIDs: [UUID] = []
+    private(set) var meetingNamesByID: [UUID: String] = [:]
 
     @ObservationIgnored private let service: any CodexChatServicing
     @ObservationIgnored private let settings: AppSettings
@@ -104,13 +107,33 @@ final class CodexChatSessionModel: Identifiable {
     }
 
     func sendDraft() {
-        guard canSend, let text = draft.nilIfBlank else { return }
-        submit(text, clearsDraft: true)
+        guard canSend else { return }
+        let draftSnapshot = draft
+        let referenceIDsSnapshot = selectedMeetingReferenceIDs
+        let text = CodexChatMeetingReference.serializedText(
+            referenceIDs: referenceIDsSnapshot,
+            draft: draftSnapshot
+        )
+        submit(
+            text,
+            clearsDraft: true,
+            draftSnapshot: draftSnapshot,
+            referenceIDsSnapshot: referenceIDsSnapshot
+        )
     }
 
     func retry() {
         guard let lastSubmittedText else { return }
-        submit(lastSubmittedText, clearsDraft: draft == lastSubmittedText)
+        let currentText = CodexChatMeetingReference.serializedText(
+            referenceIDs: selectedMeetingReferenceIDs,
+            draft: draft
+        )
+        submit(
+            lastSubmittedText,
+            clearsDraft: currentText == lastSubmittedText,
+            draftSnapshot: draft,
+            referenceIDsSnapshot: selectedMeetingReferenceIDs
+        )
     }
 
     func stop() {
@@ -303,7 +326,12 @@ final class CodexChatSessionModel: Identifiable {
 }
 
 private extension CodexChatSessionModel {
-    func submit(_ text: String, clearsDraft: Bool) {
+    func submit(
+        _ text: String,
+        clearsDraft: Bool,
+        draftSnapshot: String? = nil,
+        referenceIDsSnapshot: [UUID] = []
+    ) {
         guard isBoundToCurrentVault,
               !isGenerating,
               text.nilIfBlank != nil else { return }
@@ -311,11 +339,21 @@ private extension CodexChatSessionModel {
         errorMessage = nil
 
         Task { [weak self] in
-            await self?.resolveContextAndRunTurn(text: text, clearsDraft: clearsDraft)
+            await self?.resolveContextAndRunTurn(
+                text: text,
+                clearsDraft: clearsDraft,
+                draftSnapshot: draftSnapshot ?? text,
+                referenceIDsSnapshot: referenceIDsSnapshot
+            )
         }
     }
 
-    func resolveContextAndRunTurn(text: String, clearsDraft: Bool) async {
+    func resolveContextAndRunTurn(
+        text: String,
+        clearsDraft: Bool,
+        draftSnapshot: String,
+        referenceIDsSnapshot: [UUID]
+    ) async {
         let context: CodexChatContext?
         do {
             guard let vaultID else { throw CodexAppServerError.invalidProtocolResponse }
@@ -332,8 +370,13 @@ private extension CodexChatSessionModel {
             finishGeneration()
             return
         }
-        if clearsDraft, draft == text {
-            draft = ""
+        if clearsDraft {
+            if draft == draftSnapshot {
+                draft = ""
+            }
+            if selectedMeetingReferenceIDs == referenceIDsSnapshot {
+                selectedMeetingReferenceIDs = []
+            }
         }
         lastSubmittedText = text
         messages.append(CodexChatMessage(role: .user, text: text, context: context))
@@ -346,13 +389,13 @@ private extension CodexChatSessionModel {
 
 extension CodexChatSessionModel {
     var displayTitle: String {
-        title.nilIfBlank ?? L10n.newChat
+        displayText(title.nilIfBlank ?? L10n.newChat)
     }
 
     var canSend: Bool {
         isBoundToCurrentVault
             && !isGenerating
-            && draft.nilIfBlank != nil
+            && (draft.nilIfBlank != nil || !selectedMeetingReferenceIDs.isEmpty)
     }
 
     var effortOptions: [CodexReasoningEffortOption] {
@@ -364,5 +407,38 @@ extension CodexChatSessionModel {
 
     var isBoundToCurrentVault: Bool {
         vaultID != nil && vaultID == settings.currentVault?.id
+    }
+}
+
+extension CodexChatSessionModel {
+    func updateAvailableMeetings(_ meetings: [MeetingOverviewItem], catalogVaultID: UUID?) {
+        guard catalogVaultID == vaultID else { return }
+        let references = meetings
+            .filter { $0.vaultId == vaultID }
+            .map(CodexChatMeetingReference.init)
+        availableMeetingReferences = references
+        for reference in references {
+            meetingNamesByID[reference.id] = reference.name
+        }
+        let availableIDs = Set(references.map(\.id))
+        selectedMeetingReferenceIDs.removeAll { !availableIDs.contains($0) }
+    }
+
+    func addMeetingReference(_ reference: CodexChatMeetingReference) {
+        guard !selectedMeetingReferenceIDs.contains(reference.id) else { return }
+        selectedMeetingReferenceIDs.append(reference.id)
+        meetingNamesByID[reference.id] = reference.name
+    }
+
+    func removeMeetingReference(id: UUID) {
+        selectedMeetingReferenceIDs.removeAll { $0 == id }
+    }
+
+    func meetingDisplayName(for id: UUID) -> String {
+        meetingNamesByID[id] ?? L10n.meetingUnavailable
+    }
+
+    func displayText(_ text: String) -> String {
+        CodexChatMeetingReference.displayText(for: text, namesByID: meetingNamesByID)
     }
 }

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -412,7 +412,11 @@ extension CodexChatSessionModel {
 }
 
 extension CodexChatSessionModel {
-    func updateAvailableMeetings(_ meetings: [MeetingOverviewItem], catalogVaultID: UUID?) {
+    func updateAvailableMeetings(
+        _ meetings: [MeetingOverviewItem],
+        catalogVaultID: UUID?,
+        isCatalogLoaded: Bool = true
+    ) {
         guard let vaultID, catalogVaultID == vaultID else { return }
         let references = meetings
             .filter { $0.vaultId == vaultID }
@@ -422,6 +426,7 @@ extension CodexChatSessionModel {
             meetingNamesByID[reference.id] = reference.name
             meetingReferencesByID[reference.id] = reference
         }
+        guard isCatalogLoaded else { return }
         let availableIDs = Set(references.map(\.id))
         selectedMeetingReferenceIDs.removeAll { !availableIDs.contains($0) }
     }

--- a/Sources/Dahlia/ViewModels/SidebarViewModel.swift
+++ b/Sources/Dahlia/ViewModels/SidebarViewModel.swift
@@ -15,6 +15,7 @@ final class SidebarViewModel {
     var selectedMeetingIds: Set<UUID> = []
     /// 現在の vault に属する全 meeting の一覧。
     var allMeetings: [MeetingOverviewItem] = []
+    private(set) var isMeetingCatalogLoaded = false
     /// 現在の vault に属する全 project の集約一覧。
     var allProjectItems: [ProjectOverviewItem] = []
     /// 現在の vault に属する全 instructions の一覧。
@@ -76,6 +77,7 @@ final class SidebarViewModel {
         fileWatcher = nil
         flatProjects.removeAll()
         allMeetings.removeAll()
+        isMeetingCatalogLoaded = false
         allProjectItems.removeAll()
         allInstructions.removeAll()
         allTags.removeAll()
@@ -208,12 +210,13 @@ final class SidebarViewModel {
             onError: { _ in },
             onChange: { [weak self] meetings in
                 Task { @MainActor in
-                    guard let self else { return }
+                    guard let self, self.currentVault?.id == vaultId else { return }
                     // 挿入前に計算された古いスナップショットが選択直後に届くことがあるため、
                     // 「スナップショットに無い ID」ではなく「前回から消えた ID」だけを選択から外す。
                     let removedIds = Set(self.allMeetings.map(\.meetingId))
                         .subtracting(meetings.map(\.meetingId))
                     self.allMeetings = meetings
+                    self.isMeetingCatalogLoaded = true
                     if !removedIds.isEmpty {
                         self.selectedMeetingIds.subtract(removedIds)
                     }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
@@ -3,43 +3,75 @@ import SwiftUI
 
 struct CodexChatComposer: View {
     @Bindable var session: CodexChatSessionModel
+    @State private var isMeetingPickerPresented = false
+    @State private var meetingQuery = ""
+    @State private var highlightedMeetingID: UUID?
+    @State private var suggestions: [CodexChatMeetingReference] = []
+    @State private var consumesTrailingMentionOnSelection = false
 
     var body: some View {
-        HStack(alignment: .bottom, spacing: 10) {
-            TextField(L10n.messageCodex, text: $session.draft, axis: .vertical)
-                .font(.body)
-                .textFieldStyle(.plain)
-                .lineLimit(1 ... 5)
-                .padding(.leading, 8)
-                .padding(.vertical, 6)
-                .contentShape(.rect)
-                .onContinuousHover(perform: updateTextInputCursor)
-                .accessibilityLabel(L10n.messageCodex)
-                .onSubmit(handleSubmit)
-
-            if session.isLoading, session.models.isEmpty {
-                ProgressView()
-                    .controlSize(.small)
-                    .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
-                    .accessibilityLabel(L10n.chatModelLoading)
-            } else if !session.models.isEmpty {
-                CodexChatConfigurationButton(session: session)
+        VStack(alignment: .leading, spacing: 2) {
+            if !session.selectedMeetingReferenceIDs.isEmpty {
+                CodexChatMeetingReferenceBar(
+                    referenceIDs: session.selectedMeetingReferenceIDs,
+                    name: session.meetingDisplayName,
+                    onRemove: session.removeMeetingReference
+                )
             }
 
-            if session.isGenerating {
-                CodexChatActionButton(
-                    label: L10n.stopGenerating,
-                    systemImage: "stop.fill",
-                    isEnabled: true,
-                    action: session.stop
-                )
-            } else {
-                CodexChatActionButton(
-                    label: L10n.sendMessage,
-                    systemImage: "arrow.up",
-                    isEnabled: session.canSend,
-                    action: session.sendDraft
-                )
+            HStack(alignment: .bottom, spacing: 10) {
+                TextField(L10n.messageCodex, text: $session.draft, axis: .vertical)
+                    .font(.body)
+                    .textFieldStyle(.plain)
+                    .lineLimit(1 ... 5)
+                    .padding(.leading, 8)
+                    .padding(.vertical, 6)
+                    .contentShape(.rect)
+                    .onContinuousHover(perform: updateTextInputCursor)
+                    .accessibilityLabel(L10n.messageCodex)
+                    .onSubmit(handleSubmit)
+                    .onMoveCommand(perform: handleMoveCommand)
+                    .onExitCommand(perform: closeMeetingPicker)
+
+                Button(L10n.addMeetingReference, systemImage: "at", action: showMeetingPicker)
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
+                    .contentShape(Rectangle())
+                    .help(L10n.addMeetingReference)
+                    .popover(isPresented: $isMeetingPickerPresented, arrowEdge: .bottom) {
+                        CodexChatMeetingPicker(
+                            references: suggestions,
+                            highlightedID: highlightedMeetingID,
+                            onSelect: selectMeeting
+                        )
+                    }
+
+                if session.isLoading, session.models.isEmpty {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
+                        .accessibilityLabel(L10n.chatModelLoading)
+                } else if !session.models.isEmpty {
+                    CodexChatConfigurationButton(session: session)
+                }
+
+                if session.isGenerating {
+                    CodexChatActionButton(
+                        label: L10n.stopGenerating,
+                        systemImage: "stop.fill",
+                        isEnabled: true,
+                        action: session.stop
+                    )
+                } else {
+                    CodexChatActionButton(
+                        label: L10n.sendMessage,
+                        systemImage: "arrow.up",
+                        isEnabled: session.canSend,
+                        action: session.sendDraft
+                    )
+                }
             }
         }
         .padding(6)
@@ -52,9 +84,22 @@ struct CodexChatComposer: View {
                 }
         }
         .shadow(color: .black.opacity(0.05), radius: 12, y: 3)
+        .onChange(of: session.draft, handleDraftChange)
+        .onChange(of: session.availableMeetingReferences) {
+            refreshSuggestionsIfPresented()
+        }
+        .onChange(of: session.selectedMeetingReferenceIDs) {
+            refreshSuggestionsIfPresented()
+        }
     }
 
     private func handleSubmit() {
+        if isMeetingPickerPresented,
+           let highlightedMeetingID,
+           let reference = suggestions.first(where: { $0.id == highlightedMeetingID }) {
+            selectMeeting(reference)
+            return
+        }
         guard NSApp.currentEvent?.modifierFlags.contains(.shift) == true else {
             session.sendDraft()
             return
@@ -66,6 +111,81 @@ struct CodexChatComposer: View {
         }
 
         textView.insertNewlineIgnoringFieldEditor(nil)
+    }
+
+    private func handleDraftChange(_: String, _ newValue: String) {
+        guard let query = CodexChatMeetingReference.trailingMentionQuery(in: newValue) else {
+            if isMeetingPickerPresented {
+                closeMeetingPicker()
+            }
+            return
+        }
+        meetingQuery = query
+        consumesTrailingMentionOnSelection = true
+        isMeetingPickerPresented = true
+        refreshSuggestions()
+    }
+
+    private func showMeetingPicker() {
+        meetingQuery = ""
+        consumesTrailingMentionOnSelection = false
+        isMeetingPickerPresented = true
+        refreshSuggestions()
+    }
+
+    private func closeMeetingPicker() {
+        isMeetingPickerPresented = false
+        meetingQuery = ""
+        highlightedMeetingID = nil
+        consumesTrailingMentionOnSelection = false
+    }
+
+    private func selectMeeting(_ reference: CodexChatMeetingReference) {
+        session.draft = CodexChatMeetingReference.draftAfterSelectingReference(
+            session.draft,
+            consumesTrailingMention: consumesTrailingMentionOnSelection
+        )
+        session.addMeetingReference(reference)
+        closeMeetingPicker()
+    }
+
+    private func refreshSuggestionsIfPresented() {
+        guard isMeetingPickerPresented else { return }
+        refreshSuggestions()
+    }
+
+    private func refreshSuggestions() {
+        suggestions = CodexChatMeetingReference.suggestions(
+            from: session.availableMeetingReferences,
+            excluding: session.selectedMeetingReferenceIDs,
+            query: meetingQuery
+        )
+        updateHighlightedMeeting()
+    }
+
+    private func updateHighlightedMeeting() {
+        guard !suggestions.contains(where: { $0.id == highlightedMeetingID }) else { return }
+        highlightedMeetingID = suggestions.first?.id
+    }
+
+    private func handleMoveCommand(_ direction: MoveCommandDirection) {
+        guard isMeetingPickerPresented, !suggestions.isEmpty else { return }
+        switch direction {
+        case .up:
+            highlightedMeetingID = CodexChatMeetingPickerSelection.moving(
+                currentID: highlightedMeetingID,
+                in: suggestions,
+                by: -1
+            )
+        case .down:
+            highlightedMeetingID = CodexChatMeetingPickerSelection.moving(
+                currentID: highlightedMeetingID,
+                in: suggestions,
+                by: 1
+            )
+        default:
+            return
+        }
     }
 
     private func updateTextInputCursor(_ phase: HoverPhase) {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
@@ -28,7 +28,7 @@ struct CodexChatComposer: View {
                     .background(.quaternary, in: Circle())
                     .contentShape(Circle())
                     .help(L10n.addMeetingReference)
-                    .popover(isPresented: $isMeetingPickerPresented, arrowEdge: .bottom) {
+                    .popover(isPresented: $isMeetingPickerPresented, arrowEdge: .top) {
                         CodexChatMeetingPicker(
                             references: suggestions,
                             highlightedID: highlightedMeetingID,

--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
@@ -14,12 +14,28 @@ struct CodexChatComposer: View {
             if !session.selectedMeetingReferenceIDs.isEmpty {
                 CodexChatMeetingReferenceBar(
                     referenceIDs: session.selectedMeetingReferenceIDs,
-                    name: session.meetingDisplayName,
+                    referencesByID: session.meetingReferencesByID,
                     onRemove: session.removeMeetingReference
                 )
             }
 
             HStack(alignment: .bottom, spacing: 10) {
+                Button(L10n.addMeetingReference, systemImage: "plus", action: showMeetingPicker)
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
+                    .background(.quaternary, in: Circle())
+                    .contentShape(Circle())
+                    .help(L10n.addMeetingReference)
+                    .popover(isPresented: $isMeetingPickerPresented, arrowEdge: .bottom) {
+                        CodexChatMeetingPicker(
+                            references: suggestions,
+                            highlightedID: highlightedMeetingID,
+                            onSelect: selectMeeting
+                        )
+                    }
+
                 TextField(L10n.messageCodex, text: $session.draft, axis: .vertical)
                     .font(.body)
                     .textFieldStyle(.plain)
@@ -32,21 +48,6 @@ struct CodexChatComposer: View {
                     .onSubmit(handleSubmit)
                     .onMoveCommand(perform: handleMoveCommand)
                     .onExitCommand(perform: closeMeetingPicker)
-
-                Button(L10n.addMeetingReference, systemImage: "at", action: showMeetingPicker)
-                    .labelStyle(.iconOnly)
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
-                    .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
-                    .contentShape(Rectangle())
-                    .help(L10n.addMeetingReference)
-                    .popover(isPresented: $isMeetingPickerPresented, arrowEdge: .bottom) {
-                        CodexChatMeetingPicker(
-                            references: suggestions,
-                            highlightedID: highlightedMeetingID,
-                            onSelect: selectMeeting
-                        )
-                    }
 
                 if session.isLoading, session.models.isEmpty {
                     ProgressView()

--- a/Sources/Dahlia/Views/CodexChat/CodexChatConversationView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatConversationView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CodexChatConversationView: View {
     let messages: [CodexChatMessage]
+    let meetingNamesByID: [UUID: String]
 
     var body: some View {
         let items = CodexChatConversationItem.build(from: messages)
@@ -13,7 +14,10 @@ struct CodexChatConversationView: View {
                         case let .contextDivider(_, context):
                             CodexChatContextDivider(context: context)
                         case let .message(message):
-                            CodexChatMessageRow(message: message)
+                            CodexChatMessageRow(
+                                message: message,
+                                meetingNamesByID: meetingNamesByID
+                            )
                         }
                     }
                     Color.clear

--- a/Sources/Dahlia/Views/CodexChat/CodexChatConversationView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatConversationView.swift
@@ -7,44 +7,26 @@ struct CodexChatConversationView: View {
 
     var body: some View {
         let items = CodexChatConversationItem.build(from: messages)
-        ScrollViewReader { proxy in
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 22) {
-                    ForEach(items) { item in
-                        switch item {
-                        case let .contextDivider(_, context):
-                            CodexChatContextDivider(context: context)
-                        case let .message(message):
-                            CodexChatMessageRow(
-                                message: message,
-                                meetingNamesByID: meetingNamesByID,
-                                meetingReferencesByID: meetingReferencesByID
-                            )
-                        }
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 22) {
+                ForEach(items) { item in
+                    switch item {
+                    case let .contextDivider(_, context):
+                        CodexChatContextDivider(context: context)
+                    case let .message(message):
+                        CodexChatMessageRow(
+                            message: message,
+                            meetingNamesByID: meetingNamesByID,
+                            meetingReferencesByID: meetingReferencesByID
+                        )
                     }
-                    Color.clear
-                        .frame(height: 1)
-                        .id(Self.bottomID)
-                        .accessibilityHidden(true)
                 }
-                .padding(.horizontal, CodexChatDesign.contentHorizontalPadding)
-                .padding(.vertical, 12)
             }
-            .onChange(of: messages.count) {
-                scrollToBottom(proxy)
-            }
-            .onChange(of: messages.last?.text) {
-                scrollToBottom(proxy)
-            }
+            .padding(.horizontal, CodexChatDesign.contentHorizontalPadding)
+            .padding(.vertical, 12)
         }
+        .defaultScrollAnchor(.bottom, for: .initialOffset)
+        .defaultScrollAnchor(.bottom, for: .sizeChanges)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    private static let bottomID = "codex-chat-bottom"
-
-    private func scrollToBottom(_ proxy: ScrollViewProxy) {
-        withAnimation(.easeOut(duration: 0.12)) {
-            proxy.scrollTo(Self.bottomID, anchor: .bottom)
-        }
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatConversationView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatConversationView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct CodexChatConversationView: View {
     let messages: [CodexChatMessage]
     let meetingNamesByID: [UUID: String]
+    let meetingReferencesByID: [UUID: CodexChatMeetingReference]
 
     var body: some View {
         let items = CodexChatConversationItem.build(from: messages)
@@ -16,7 +17,8 @@ struct CodexChatConversationView: View {
                         case let .message(message):
                             CodexChatMessageRow(
                                 message: message,
-                                meetingNamesByID: meetingNamesByID
+                                meetingNamesByID: meetingNamesByID,
+                                meetingReferencesByID: meetingReferencesByID
                             )
                         }
                     }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatEmptyStateView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatEmptyStateView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CodexChatEmptyStateView: View {
     let recentThreads: [CodexChatThreadSummary]
+    let meetingNamesByID: [UUID: String]
     let onOpenThread: (CodexChatThreadSummary) -> Void
     let onShowAll: () -> Void
 
@@ -18,7 +19,10 @@ struct CodexChatEmptyStateView: View {
                     Button {
                         onOpenThread(thread)
                     } label: {
-                        CodexChatThreadRow(thread: thread)
+                        CodexChatThreadRow(
+                            thread: thread,
+                            meetingNamesByID: meetingNamesByID
+                        )
                     }
                     .buttonStyle(.plain)
                     .foregroundStyle(.secondary)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatFloatingView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatFloatingView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CodexChatFloatingView: View {
     @Bindable var coordinator: CodexChatCoordinator
+    @Bindable var sidebarViewModel: SidebarViewModel
     let onPopOut: (CodexChatSessionID) -> Void
     let onOpenDetachedSession: (CodexChatSessionID) -> Void
 
@@ -11,10 +12,12 @@ struct CodexChatFloatingView: View {
 
     init(
         coordinator: CodexChatCoordinator,
+        sidebarViewModel: SidebarViewModel,
         onPopOut: @escaping (CodexChatSessionID) -> Void,
         onOpenDetachedSession: @escaping (CodexChatSessionID) -> Void
     ) {
         self.coordinator = coordinator
+        self.sidebarViewModel = sidebarViewModel
         self.onPopOut = onPopOut
         self.onOpenDetachedSession = onOpenDetachedSession
         _layout = State(initialValue: CodexChatFloatingLayout(dockSide: AppSettings.shared.codexChatDockSide))
@@ -27,6 +30,8 @@ struct CodexChatFloatingView: View {
                 CodexChatView(
                     session: coordinator.floatingSession,
                     coordinator: coordinator,
+                    meetings: sidebarViewModel.allMeetings,
+                    meetingCatalogVaultID: sidebarViewModel.currentVault?.id,
                     allowsPopOut: true,
                     onNewChat: coordinator.newFloatingChat,
                     onPopOut: popOut,

--- a/Sources/Dahlia/Views/CodexChat/CodexChatFloatingView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatFloatingView.swift
@@ -32,6 +32,7 @@ struct CodexChatFloatingView: View {
                     coordinator: coordinator,
                     meetings: sidebarViewModel.allMeetings,
                     meetingCatalogVaultID: sidebarViewModel.currentVault?.id,
+                    isMeetingCatalogLoaded: sidebarViewModel.isMeetingCatalogLoaded,
                     allowsPopOut: true,
                     onNewChat: coordinator.newFloatingChat,
                     onPopOut: popOut,

--- a/Sources/Dahlia/Views/CodexChat/CodexChatHistoryView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatHistoryView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CodexChatHistoryView: View {
     let threads: [CodexChatThreadSummary]
+    let meetingNamesByID: [UUID: String]
     let hasMore: Bool
     let isLoading: Bool
     let onNewChat: () -> Void
@@ -26,8 +27,11 @@ struct CodexChatHistoryView: View {
                     Button {
                         onOpenThread(thread)
                     } label: {
-                        CodexChatThreadRow(thread: thread)
-                            .padding(.vertical, 9)
+                        CodexChatThreadRow(
+                            thread: thread,
+                            meetingNamesByID: meetingNamesByID
+                        )
+                        .padding(.vertical, 9)
                     }
                     .buttonStyle(.plain)
                     .foregroundStyle(.secondary)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMeetingPicker.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMeetingPicker.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct CodexChatMeetingPicker: View {
+    let references: [CodexChatMeetingReference]
+    let highlightedID: UUID?
+    let onSelect: (CodexChatMeetingReference) -> Void
+    @AccessibilityFocusState private var accessibilityFocusedMeetingID: UUID?
+
+    var body: some View {
+        Group {
+            if references.isEmpty {
+                ContentUnavailableView(
+                    L10n.noMatchingMeetingReferences,
+                    systemImage: "calendar.badge.exclamationmark"
+                )
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 2) {
+                            ForEach(references) { reference in
+                                Button {
+                                    onSelect(reference)
+                                } label: {
+                                    CodexChatMeetingPickerRow(
+                                        reference: reference,
+                                        isHighlighted: reference.id == highlightedID
+                                    )
+                                }
+                                .buttonStyle(.plain)
+                                .id(reference.id)
+                                .accessibilityFocused(
+                                    $accessibilityFocusedMeetingID,
+                                    equals: reference.id
+                                )
+                            }
+                        }
+                        .padding(6)
+                    }
+                    .onChange(of: highlightedID) {
+                        guard let highlightedID else { return }
+                        proxy.scrollTo(highlightedID, anchor: .center)
+                        accessibilityFocusedMeetingID = highlightedID
+                    }
+                    .onAppear {
+                        accessibilityFocusedMeetingID = highlightedID
+                    }
+                }
+            }
+        }
+        .frame(minWidth: 280, idealWidth: 320, minHeight: 80, idealHeight: 260, maxHeight: 320)
+        .accessibilityLabel(L10n.meetingReferences)
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMeetingPickerRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMeetingPickerRow.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct CodexChatMeetingPickerRow: View {
+    let reference: CodexChatMeetingReference
+    let isHighlighted: Bool
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: isHighlighted ? "chevron.right" : "calendar")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(reference.name)
+                    .lineLimit(1)
+                Text(reference.createdAt, format: .dateTime.year().month(.abbreviated).day().hour().minute())
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 8)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(isHighlighted ? Color.accentColor.opacity(0.14) : .clear, in: RoundedRectangle(cornerRadius: 8))
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(isHighlighted ? .isSelected : [])
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMeetingReferenceBadge.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMeetingReferenceBadge.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct CodexChatMeetingReferenceBadge: View {
+    let name: String
+
+    var body: some View {
+        Label(name, systemImage: "calendar")
+            .lineLimit(1)
+            .frame(maxWidth: 240, alignment: .leading)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(.background.opacity(0.72), in: RoundedRectangle(cornerRadius: 6))
+            .overlay {
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(.separator, lineWidth: 1)
+            }
+            .contentShape(.rect)
+            .accessibilityElement(children: .combine)
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMeetingReferenceBar.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMeetingReferenceBar.swift
@@ -2,33 +2,35 @@ import SwiftUI
 
 struct CodexChatMeetingReferenceBar: View {
     let referenceIDs: [UUID]
-    let name: (UUID) -> String
+    let referencesByID: [UUID: CodexChatMeetingReference]
     let onRemove: (UUID) -> Void
 
     var body: some View {
         ScrollView(.horizontal) {
             HStack(spacing: 6) {
                 ForEach(referenceIDs, id: \.self) { id in
-                    let referenceName = name(id)
-                    Button {
-                        onRemove(id)
-                    } label: {
-                        Label(referenceName, systemImage: "calendar")
-                            .lineLimit(1)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .background(.quaternary, in: Capsule())
-                            .overlay(alignment: .trailing) {
-                                Image(systemName: "xmark.circle.fill")
-                                    .symbolRenderingMode(.hierarchical)
-                                    .foregroundStyle(.secondary)
-                                    .offset(x: 5, y: -8)
-                                    .accessibilityHidden(true)
-                            }
+                    let reference = referencesByID[id]
+                    let referenceName = reference?.name ?? L10n.meetingUnavailable
+                    ZStack(alignment: .topTrailing) {
+                        CodexChatMeetingReferencePreviewBadge(
+                            name: referenceName,
+                            reference: reference
+                        )
+                        Button(
+                            L10n.removeMeetingReference(referenceName),
+                            systemImage: "xmark.circle.fill"
+                        ) {
+                            onRemove(id)
+                        }
+                        .labelStyle(.iconOnly)
+                        .buttonStyle(.plain)
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 24, height: 24)
+                        .contentShape(Circle())
+                        .offset(x: 5, y: -5)
+                        .help(L10n.removeMeetingReference(referenceName))
                     }
-                    .buttonStyle(.plain)
-                    .help(L10n.removeMeetingReference(referenceName))
-                    .accessibilityLabel(L10n.removeMeetingReference(referenceName))
                 }
             }
             .padding(.top, 4)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMeetingReferenceBar.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMeetingReferenceBar.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct CodexChatMeetingReferenceBar: View {
+    let referenceIDs: [UUID]
+    let name: (UUID) -> String
+    let onRemove: (UUID) -> Void
+
+    var body: some View {
+        ScrollView(.horizontal) {
+            HStack(spacing: 6) {
+                ForEach(referenceIDs, id: \.self) { id in
+                    let referenceName = name(id)
+                    Button {
+                        onRemove(id)
+                    } label: {
+                        Label(referenceName, systemImage: "calendar")
+                            .lineLimit(1)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(.quaternary, in: Capsule())
+                            .overlay(alignment: .trailing) {
+                                Image(systemName: "xmark.circle.fill")
+                                    .symbolRenderingMode(.hierarchical)
+                                    .foregroundStyle(.secondary)
+                                    .offset(x: 5, y: -8)
+                                    .accessibilityHidden(true)
+                            }
+                    }
+                    .buttonStyle(.plain)
+                    .help(L10n.removeMeetingReference(referenceName))
+                    .accessibilityLabel(L10n.removeMeetingReference(referenceName))
+                }
+            }
+            .padding(.top, 4)
+            .padding(.horizontal, 8)
+        }
+        .scrollIndicators(.hidden)
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMeetingReferenceBar.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMeetingReferenceBar.swift
@@ -6,36 +6,33 @@ struct CodexChatMeetingReferenceBar: View {
     let onRemove: (UUID) -> Void
 
     var body: some View {
-        ScrollView(.horizontal) {
-            HStack(spacing: 6) {
-                ForEach(referenceIDs, id: \.self) { id in
-                    let reference = referencesByID[id]
-                    let referenceName = reference?.name ?? L10n.meetingUnavailable
-                    ZStack(alignment: .topTrailing) {
-                        CodexChatMeetingReferencePreviewBadge(
-                            name: referenceName,
-                            reference: reference
-                        )
-                        Button(
-                            L10n.removeMeetingReference(referenceName),
-                            systemImage: "xmark.circle.fill"
-                        ) {
-                            onRemove(id)
-                        }
-                        .labelStyle(.iconOnly)
-                        .buttonStyle(.plain)
-                        .symbolRenderingMode(.hierarchical)
-                        .foregroundStyle(.secondary)
-                        .frame(width: 24, height: 24)
-                        .contentShape(Circle())
-                        .offset(x: 5, y: -5)
-                        .help(L10n.removeMeetingReference(referenceName))
+        FlowLayout(spacing: 6, rowSpacing: 6) {
+            ForEach(referenceIDs, id: \.self) { id in
+                let reference = referencesByID[id]
+                let referenceName = reference?.name ?? L10n.meetingUnavailable
+                ZStack(alignment: .topTrailing) {
+                    CodexChatMeetingReferencePreviewBadge(
+                        name: referenceName,
+                        reference: reference
+                    )
+                    Button(
+                        L10n.removeMeetingReference(referenceName),
+                        systemImage: "xmark.circle.fill"
+                    ) {
+                        onRemove(id)
                     }
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.plain)
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 24, height: 24)
+                    .contentShape(Circle())
+                    .offset(x: 5, y: -5)
+                    .help(L10n.removeMeetingReference(referenceName))
                 }
             }
-            .padding(.top, 4)
-            .padding(.horizontal, 8)
         }
-        .scrollIndicators(.hidden)
+        .padding(.top, 4)
+        .padding(.horizontal, 8)
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMeetingReferenceDetailView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMeetingReferenceDetailView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct CodexChatMeetingReferenceDetailView: View {
+    let name: String
+    let reference: CodexChatMeetingReference?
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "calendar")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(name)
+                    .bold()
+                    .lineLimit(2)
+                if let reference {
+                    Text(reference.createdAt, format: .dateTime.year().month(.abbreviated).day().hour().minute())
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(12)
+        .frame(minWidth: 220, maxWidth: 320, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMeetingReferencePreviewBadge.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMeetingReferencePreviewBadge.swift
@@ -12,7 +12,7 @@ struct CodexChatMeetingReferencePreviewBadge: View {
         }
         .buttonStyle(.plain)
         .onHover(perform: showDetailsOnHover)
-        .popover(isPresented: $isDetailPresented, arrowEdge: .bottom) {
+        .popover(isPresented: $isDetailPresented, arrowEdge: .top) {
             CodexChatMeetingReferenceDetailView(name: name, reference: reference)
         }
         .accessibilityValue(accessibilityValue)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMeetingReferencePreviewBadge.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMeetingReferencePreviewBadge.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct CodexChatMeetingReferencePreviewBadge: View {
+    let name: String
+    let reference: CodexChatMeetingReference?
+    @State private var isDetailPresented = false
+    @State private var isHoverPresentation = false
+
+    var body: some View {
+        Button(action: showDetails) {
+            CodexChatMeetingReferenceBadge(name: name)
+        }
+        .buttonStyle(.plain)
+        .onHover(perform: showDetailsOnHover)
+        .popover(isPresented: $isDetailPresented, arrowEdge: .bottom) {
+            CodexChatMeetingReferenceDetailView(name: name, reference: reference)
+        }
+        .accessibilityValue(accessibilityValue)
+        .accessibilityHint(L10n.showMeetingReferenceDetails)
+    }
+
+    private var accessibilityValue: String {
+        reference?.createdAt.formatted(
+            .dateTime.year().month(.abbreviated).day().hour().minute()
+        ) ?? L10n.meetingUnavailable
+    }
+
+    private func showDetails() {
+        isHoverPresentation = false
+        isDetailPresented = true
+    }
+
+    private func showDetailsOnHover(_ isHovering: Bool) {
+        if isHovering {
+            isHoverPresentation = true
+            isDetailPresented = true
+        } else if isHoverPresentation {
+            isDetailPresented = false
+        }
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct CodexChatMessageRow: View {
     let message: CodexChatMessage
     let meetingNamesByID: [UUID: String]
+    let meetingReferencesByID: [UUID: CodexChatMeetingReference]
 
     var body: some View {
         let visibleText = message.role == .user ? userVisibleText : message.text
@@ -15,11 +16,14 @@ struct CodexChatMessageRow: View {
             if message.role == .user {
                 Spacer(minLength: 72)
                 VStack(alignment: .trailing, spacing: 4) {
-                    Text(displayText)
-                        .textSelection(.enabled)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 8)
-                        .background(.quaternary, in: RoundedRectangle(cornerRadius: 14))
+                    CodexChatUserMessageContent(
+                        rawText: visibleText,
+                        meetingNamesByID: meetingNamesByID,
+                        meetingReferencesByID: meetingReferencesByID
+                    )
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 14))
 
                     CodexChatCopyButton(text: displayText)
                 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
@@ -2,25 +2,32 @@ import SwiftUI
 
 struct CodexChatMessageRow: View {
     let message: CodexChatMessage
+    let meetingNamesByID: [UUID: String]
 
     var body: some View {
+        let visibleText = message.role == .user ? userVisibleText : message.text
+        let displayText = CodexChatMeetingReference.displayText(for: visibleText, namesByID: meetingNamesByID)
+        let displayReasoning = CodexChatMeetingReference.displayText(
+            for: message.reasoning,
+            namesByID: meetingNamesByID
+        )
         HStack(alignment: .top) {
             if message.role == .user {
                 Spacer(minLength: 72)
                 VStack(alignment: .trailing, spacing: 4) {
-                    Text(userVisibleText)
+                    Text(displayText)
                         .textSelection(.enabled)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 8)
                         .background(.quaternary, in: RoundedRectangle(cornerRadius: 14))
 
-                    CodexChatCopyButton(text: userVisibleText)
+                    CodexChatCopyButton(text: displayText)
                 }
             } else {
                 VStack(alignment: .leading, spacing: 10) {
-                    if !message.reasoning.isEmpty {
+                    if !displayReasoning.isEmpty {
                         CodexChatReasoningView(
-                            reasoning: message.reasoning,
+                            reasoning: displayReasoning,
                             isStreaming: message.isStreaming
                         )
                     }
@@ -28,17 +35,17 @@ struct CodexChatMessageRow: View {
                     if message.text.isEmpty, message.isStreaming {
                         ProgressView()
                             .controlSize(.small)
-                    } else if !message.text.isEmpty {
+                    } else if !displayText.isEmpty {
                         if message.isStreaming {
-                            Text(message.text)
+                            Text(displayText)
                                 .textSelection(.enabled)
                         } else {
-                            CodexChatMarkdownView(markdown: message.text)
+                            CodexChatMarkdownView(markdown: displayText)
                         }
                     }
 
-                    if !message.text.isEmpty, !message.isStreaming {
-                        CodexChatCopyButton(text: message.text)
+                    if !displayText.isEmpty, !message.isStreaming {
+                        CodexChatCopyButton(text: displayText)
                     }
                 }
                 Spacer(minLength: 40)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatThreadRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatThreadRow.swift
@@ -2,11 +2,15 @@ import SwiftUI
 
 struct CodexChatThreadRow: View {
     let thread: CodexChatThreadSummary
+    let meetingNamesByID: [UUID: String]
 
     var body: some View {
         HStack(spacing: 12) {
-            Text(thread.title.nilIfBlank ?? L10n.newChat)
-                .lineLimit(1)
+            Text(CodexChatMeetingReference.displayText(
+                for: thread.title.nilIfBlank ?? L10n.newChat,
+                namesByID: meetingNamesByID
+            ))
+            .lineLimit(1)
             Spacer(minLength: 12)
             Text(thread.updatedAt, format: .relative(presentation: .named))
                 .foregroundStyle(.tertiary)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatUserMessageContent.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatUserMessageContent.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct CodexChatUserMessageContent: View {
+    let rawText: String
+    let meetingNamesByID: [UUID: String]
+    let meetingReferencesByID: [UUID: CodexChatMeetingReference]
+
+    var body: some View {
+        let content = CodexChatMeetingReference.previewContent(in: rawText)
+        let displayInstruction = CodexChatMeetingReference.displayText(
+            for: content.instruction,
+            namesByID: meetingNamesByID
+        )
+
+        VStack(alignment: .leading, spacing: 6) {
+            if !content.referenceIDs.isEmpty {
+                FlowLayout(spacing: 6, rowSpacing: 6) {
+                    ForEach(content.referenceIDs.indices, id: \.self) { index in
+                        let id = content.referenceIDs[index]
+                        CodexChatMeetingReferencePreviewBadge(
+                            name: meetingNamesByID[id] ?? L10n.meetingUnavailable,
+                            reference: meetingReferencesByID[id]
+                        )
+                    }
+                }
+            }
+
+            if !displayInstruction.isEmpty {
+                Text(displayInstruction)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct CodexChatView: View {
     @Bindable var session: CodexChatSessionModel
     @Bindable var coordinator: CodexChatCoordinator
+    let meetings: [MeetingOverviewItem]
+    let meetingCatalogVaultID: UUID?
     let allowsPopOut: Bool
     let onNewChat: () -> Void
     let onPopOut: () -> Void
@@ -31,6 +33,7 @@ struct CodexChatView: View {
             if showsHistory {
                 CodexChatHistoryView(
                     threads: coordinator.history,
+                    meetingNamesByID: session.meetingNamesByID,
                     hasMore: coordinator.historyCursor != nil,
                     isLoading: coordinator.isLoadingHistory,
                     onNewChat: startNewChat,
@@ -40,11 +43,15 @@ struct CodexChatView: View {
             } else if session.messages.isEmpty {
                 CodexChatEmptyStateView(
                     recentThreads: Array(coordinator.history.prefix(3)),
+                    meetingNamesByID: session.meetingNamesByID,
                     onOpenThread: openHistoryThread,
                     onShowAll: showHistory
                 )
             } else {
-                CodexChatConversationView(messages: session.messages)
+                CodexChatConversationView(
+                    messages: session.messages,
+                    meetingNamesByID: session.meetingNamesByID
+                )
             }
 
             if let errorMessage = session.errorMessage {
@@ -65,13 +72,24 @@ struct CodexChatView: View {
         }
         .background(.background)
         .task { await prepare() }
+        .onChange(of: meetings) {
+            updateMeetingCatalog()
+        }
+        .onChange(of: meetingCatalogVaultID) {
+            updateMeetingCatalog()
+        }
     }
 
     private func prepare() async {
+        updateMeetingCatalog()
         await session.restore()
         if coordinator.history.isEmpty {
             await coordinator.refreshHistory()
         }
+    }
+
+    private func updateMeetingCatalog() {
+        session.updateAvailableMeetings(meetings, catalogVaultID: meetingCatalogVaultID)
     }
 
     private func showHistory() {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatView.swift
@@ -5,6 +5,7 @@ struct CodexChatView: View {
     @Bindable var coordinator: CodexChatCoordinator
     let meetings: [MeetingOverviewItem]
     let meetingCatalogVaultID: UUID?
+    let isMeetingCatalogLoaded: Bool
     let allowsPopOut: Bool
     let onNewChat: () -> Void
     let onPopOut: () -> Void
@@ -79,6 +80,9 @@ struct CodexChatView: View {
         .onChange(of: meetingCatalogVaultID) {
             updateMeetingCatalog()
         }
+        .onChange(of: isMeetingCatalogLoaded) {
+            updateMeetingCatalog()
+        }
     }
 
     private func prepare() async {
@@ -90,7 +94,11 @@ struct CodexChatView: View {
     }
 
     private func updateMeetingCatalog() {
-        session.updateAvailableMeetings(meetings, catalogVaultID: meetingCatalogVaultID)
+        session.updateAvailableMeetings(
+            meetings,
+            catalogVaultID: meetingCatalogVaultID,
+            isCatalogLoaded: isMeetingCatalogLoaded
+        )
     }
 
     private func showHistory() {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatView.swift
@@ -50,7 +50,8 @@ struct CodexChatView: View {
             } else {
                 CodexChatConversationView(
                     messages: session.messages,
-                    meetingNamesByID: session.meetingNamesByID
+                    meetingNamesByID: session.meetingNamesByID,
+                    meetingReferencesByID: session.meetingReferencesByID
                 )
             }
 

--- a/Sources/Dahlia/Views/CodexChat/CodexChatWindowView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatWindowView.swift
@@ -15,6 +15,7 @@ struct CodexChatWindowView: View {
                     coordinator: coordinator,
                     meetings: sidebarViewModel.allMeetings,
                     meetingCatalogVaultID: sidebarViewModel.currentVault?.id,
+                    isMeetingCatalogLoaded: sidebarViewModel.isMeetingCatalogLoaded,
                     allowsPopOut: false,
                     onNewChat: openNewWindow,
                     onPopOut: {},

--- a/Sources/Dahlia/Views/CodexChat/CodexChatWindowView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatWindowView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CodexChatWindowView: View {
     @Bindable var coordinator: CodexChatCoordinator
+    @Bindable var sidebarViewModel: SidebarViewModel
     let sessionID: CodexChatSessionID
 
     @Environment(\.openWindow) private var openWindow
@@ -12,6 +13,8 @@ struct CodexChatWindowView: View {
                 CodexChatView(
                     session: session,
                     coordinator: coordinator,
+                    meetings: sidebarViewModel.allMeetings,
+                    meetingCatalogVaultID: sidebarViewModel.currentVault?.id,
                     allowsPopOut: false,
                     onNewChat: openNewWindow,
                     onPopOut: {},

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -71,6 +71,7 @@ struct ContentView: View {
             if chatCoordinator.isFloatingVisible {
                 CodexChatFloatingView(
                     coordinator: chatCoordinator,
+                    sidebarViewModel: sidebarViewModel,
                     onPopOut: openDetachedChat,
                     onOpenDetachedSession: openDetachedChat
                 )

--- a/Tests/DahliaTests/CodexChatMeetingReferenceTests.swift
+++ b/Tests/DahliaTests/CodexChatMeetingReferenceTests.swift
@@ -32,6 +32,35 @@ import Foundation
         }
 
         @Test
+        func separatesStandaloneReferencesFromMessagePreview() throws {
+            let firstID = try #require(UUID(uuidString: "019b6f79-18c5-7000-8000-000000000001"))
+            let secondID = try #require(UUID(uuidString: "019b6f79-18c5-7000-8000-000000000002"))
+            let text = "meeting:\(firstID.uuidString) meeting:\(secondID.uuidString) Compare these\nmeetings"
+
+            let content = CodexChatMeetingReference.previewContent(in: text)
+
+            #expect(content.referenceIDs == [firstID, secondID])
+            #expect(content.instruction == "Compare these\nmeetings")
+            let embedded = CodexChatMeetingReference.previewContent(
+                in: "Compare meeting:\(firstID.uuidString)"
+            )
+            #expect(embedded.referenceIDs == [firstID])
+            #expect(embedded.instruction == "Compare")
+            let duplicate = CodexChatMeetingReference.previewContent(
+                in: "meeting:\(firstID.uuidString) Repeat meeting:\(firstID.uuidString)  "
+            )
+            #expect(duplicate.referenceIDs == [firstID, firstID])
+            #expect(duplicate.instruction == "Repeat")
+            let invalid = CodexChatMeetingReference.previewContent(in: "Keep meeting:not-a-uuid")
+            #expect(invalid.referenceIDs.isEmpty)
+            #expect(invalid.instruction == "Keep meeting:not-a-uuid")
+            let indented = CodexChatMeetingReference.previewContent(
+                in: "meeting:\(firstID.uuidString) \n  Keep indentation"
+            )
+            #expect(indented.instruction == "\n  Keep indentation")
+        }
+
+        @Test
         func resolvesDisplayNamesWithoutExposingUnknownIDs() throws {
             let knownID = try #require(UUID(uuidString: "019b6f79-18c5-7000-8000-000000000001"))
             let unknownID = try #require(UUID(uuidString: "019b6f79-18c5-7000-8000-000000000002"))
@@ -101,7 +130,7 @@ import Foundation
         }
 
         @Test
-        func pickerSelectionMovesAndClamps() throws {
+        func pickerSelectionMovesAndClamps() {
             let first = CodexChatMeetingReference(id: .v7(), name: "First", createdAt: .now)
             let second = CodexChatMeetingReference(id: .v7(), name: "Second", createdAt: .now)
             let references = [first, second]

--- a/Tests/DahliaTests/CodexChatMeetingReferenceTests.swift
+++ b/Tests/DahliaTests/CodexChatMeetingReferenceTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct CodexChatMeetingReferenceTests {
+        @Test
+        func serializesReferencesAndDraftAsSpaceSeparatedWords() throws {
+            let firstID = try #require(UUID(uuidString: "019b6f79-18c5-7000-8000-000000000001"))
+            let secondID = try #require(UUID(uuidString: "019b6f79-18c5-7000-8000-000000000002"))
+
+            let text = CodexChatMeetingReference.serializedText(
+                referenceIDs: [firstID, secondID],
+                draft: "Compare these meetings"
+            )
+
+            #expect(text == "meeting:019b6f79-18c5-7000-8000-000000000001 "
+                + "meeting:019b6f79-18c5-7000-8000-000000000002 Compare these meetings")
+            #expect(CodexChatMeetingReference.serializedText(referenceIDs: [firstID], draft: "  ")
+                == "meeting:019b6f79-18c5-7000-8000-000000000001")
+        }
+
+        @Test
+        func recognizesOnlyStandaloneValidMeetingTokens() throws {
+            let firstID = try #require(UUID(uuidString: "019b6f79-18c5-7000-8000-000000000001"))
+            let secondID = try #require(UUID(uuidString: "019b6f79-18c5-7000-8000-000000000002"))
+            let text = "meeting:\(firstID.uuidString) compare meeting:\(secondID.uuidString) "
+                + "suffixmeeting:\(firstID.uuidString) meeting:not-a-uuid meeting:\(firstID.uuidString)."
+
+            #expect(CodexChatMeetingReference.meetingIDs(in: text) == [firstID, secondID])
+        }
+
+        @Test
+        func resolvesDisplayNamesWithoutExposingUnknownIDs() throws {
+            let knownID = try #require(UUID(uuidString: "019b6f79-18c5-7000-8000-000000000001"))
+            let unknownID = try #require(UUID(uuidString: "019b6f79-18c5-7000-8000-000000000002"))
+            let text = "Review meeting:\(knownID.uuidString) and meeting:\(unknownID.uuidString)"
+
+            let display = CodexChatMeetingReference.displayText(
+                for: text,
+                namesByID: [knownID: "Weekly Sync"],
+                unavailableName: "Unavailable"
+            )
+
+            #expect(display == "Review Weekly Sync and Unavailable")
+            #expect(!display.contains(knownID.uuidString))
+            #expect(!display.contains(unknownID.uuidString))
+        }
+
+        @Test
+        func resolvesDisplayNamesInsidePunctuationAndMarkdown() throws {
+            let knownID = try #require(UUID(uuidString: "019b6f79-18c5-7000-8000-000000000001"))
+            let unknownID = try #require(UUID(uuidString: "019b6f79-18c5-7000-8000-000000000002"))
+            let text = "Review (Meeting:\(knownID.uuidString)), `MEETING:\(unknownID.uuidString)`."
+
+            let display = CodexChatMeetingReference.displayText(
+                for: text,
+                namesByID: [knownID: "Weekly Sync"],
+                unavailableName: "Unavailable"
+            )
+
+            #expect(display == "Review (Weekly Sync), `Unavailable`.")
+            #expect(!display.contains(knownID.uuidString))
+            #expect(!display.contains(unknownID.uuidString))
+            #expect(CodexChatMeetingReference.meetingIDs(in: text).isEmpty)
+        }
+
+        @Test
+        func suggestionsAreRecentFilteredAndExcludeSelectedMeetings() throws {
+            let selectedID = try #require(UUID(uuidString: "019b6f79-18c5-7000-8000-000000000001"))
+            let olderID = try #require(UUID(uuidString: "019b6f79-18c5-7000-8000-000000000002"))
+            let newerID = try #require(UUID(uuidString: "019b6f79-18c5-7000-8000-000000000003"))
+            let references = [
+                CodexChatMeetingReference(id: olderID, name: "Weekly Planning", createdAt: .now.addingTimeInterval(-60)),
+                CodexChatMeetingReference(id: selectedID, name: "Weekly Review", createdAt: .now),
+                CodexChatMeetingReference(id: newerID, name: "Weekly Planning", createdAt: .now.addingTimeInterval(-30)),
+            ]
+
+            let suggestions = CodexChatMeetingReference.suggestions(
+                from: references,
+                excluding: [selectedID],
+                query: "planning"
+            )
+
+            #expect(suggestions.map(\.id) == [newerID, olderID])
+        }
+
+        @Test
+        func extractsAndRemovesTrailingMentionQuery() {
+            #expect(CodexChatMeetingReference.trailingMentionQuery(in: "Review @week") == "week")
+            #expect(CodexChatMeetingReference.removingTrailingMentionQuery(from: "Review @week") == "Review ")
+            #expect(CodexChatMeetingReference.removingTrailingMentionQuery(from: "  @week") == "  ")
+            #expect(CodexChatMeetingReference.trailingMentionQuery(in: "mail@example.com") == nil)
+            #expect(CodexChatMeetingReference.trailingMentionQuery(in: "@")?.isEmpty == true)
+            #expect(CodexChatMeetingReference.trailingMentionQuery(in: "Review @week ") == nil)
+            #expect(CodexChatMeetingReference.draftAfterSelectingReference(
+                "Keep @word",
+                consumesTrailingMention: false
+            ) == "Keep @word")
+        }
+
+        @Test
+        func pickerSelectionMovesAndClamps() throws {
+            let first = CodexChatMeetingReference(id: .v7(), name: "First", createdAt: .now)
+            let second = CodexChatMeetingReference(id: .v7(), name: "Second", createdAt: .now)
+            let references = [first, second]
+
+            #expect(CodexChatMeetingPickerSelection.moving(currentID: nil, in: references, by: 1) == first.id)
+            #expect(CodexChatMeetingPickerSelection.moving(currentID: first.id, in: references, by: -1) == first.id)
+            #expect(CodexChatMeetingPickerSelection.moving(currentID: first.id, in: references, by: 1) == second.id)
+            #expect(CodexChatMeetingPickerSelection.moving(currentID: second.id, in: references, by: 1) == second.id)
+            #expect(CodexChatMeetingPickerSelection.moving(currentID: first.id, in: [], by: 1) == nil)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/CodexChatServiceTests.swift
+++ b/Tests/DahliaTests/CodexChatServiceTests.swift
@@ -53,6 +53,8 @@ import Foundation
             #expect(threadParams["developerInstructions"]?.stringValue?.contains("query_meetings") == true)
             #expect(threadParams["developerInstructions"]?.stringValue?.contains("meeting_id directly") == true)
             #expect(threadParams["developerInstructions"]?.stringValue?.contains("MeetingDraft") == true)
+            #expect(threadParams["developerInstructions"]?.stringValue?.contains("meeting:<UUID>") == true)
+            #expect(threadParams["developerInstructions"]?.stringValue?.contains("get_meeting with each UUID directly") == true)
 
             let turnParams = try #require(messages.first {
                 $0.objectValue?["method"]?.stringValue == "turn/start"

--- a/Tests/DahliaTests/CodexChatServiceTests.swift
+++ b/Tests/DahliaTests/CodexChatServiceTests.swift
@@ -50,11 +50,7 @@ import Foundation
             #expect(threadParams["cwd"] == .string(workspace.appending(path: vaultID.uuidString.lowercased()).path))
             let config = try #require(threadParams["config"]?.objectValue)
             expectChatConfiguration(config, vaultID: vaultID)
-            #expect(threadParams["developerInstructions"]?.stringValue?.contains("query_meetings") == true)
-            #expect(threadParams["developerInstructions"]?.stringValue?.contains("meeting_id directly") == true)
-            #expect(threadParams["developerInstructions"]?.stringValue?.contains("MeetingDraft") == true)
-            #expect(threadParams["developerInstructions"]?.stringValue?.contains("meeting:<UUID>") == true)
-            #expect(threadParams["developerInstructions"]?.stringValue?.contains("get_meeting with each UUID directly") == true)
+            expectDeveloperInstructions(threadParams["developerInstructions"]?.stringValue)
 
             let turnParams = try #require(messages.first {
                 $0.objectValue?["method"]?.stringValue == "turn/start"
@@ -222,6 +218,14 @@ import Foundation
                 ]),
                 "docs": .object(["enabled": .bool(false)]),
             ]))
+        }
+
+        private func expectDeveloperInstructions(_ instructions: String?) {
+            #expect(instructions?.contains("query_meetings") == true)
+            #expect(instructions?.contains("meeting_id directly") == true)
+            #expect(instructions?.contains("MeetingDraft") == true)
+            #expect(instructions?.contains("meeting:<UUID>") == true)
+            #expect(instructions?.contains("get_meeting with each UUID directly") == true)
         }
     }
 

--- a/Tests/DahliaTests/CodexChatSessionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatSessionModelTests.swift
@@ -38,6 +38,130 @@ import Foundation
         }
 
         @Test
+        func sendDraftSerializesMultipleMeetingReferencesBeforeInstruction() async {
+            let service = TestCodexChatService(mode: .complete)
+            let settings = AppSettings()
+            let vault = Self.testVault()
+            settings.currentVault = vault
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings
+            )
+            let first = Self.meetingReference(vaultID: vault.id, name: "First", offset: -60)
+            let second = Self.meetingReference(vaultID: vault.id, name: "Second", offset: 0)
+            session.updateAvailableMeetings([first, second], catalogVaultID: vault.id)
+            session.addMeetingReference(CodexChatMeetingReference(meeting: first))
+            session.addMeetingReference(CodexChatMeetingReference(meeting: second))
+            session.addMeetingReference(CodexChatMeetingReference(meeting: first))
+            session.draft = "Compare them"
+
+            session.sendDraft()
+            await waitUntil { !session.isGenerating }
+
+            let expected = "meeting:\(first.meetingId.uuidString.lowercased()) "
+                + "meeting:\(second.meetingId.uuidString.lowercased()) Compare them"
+            #expect(await service.sentTexts == [expected])
+            #expect(session.selectedMeetingReferenceIDs.isEmpty)
+            #expect(session.draft.isEmpty)
+            #expect(session.displayText(expected) == "First Second Compare them")
+
+            session.retry()
+            await waitUntil { !session.isGenerating }
+            #expect(await service.sentTexts == [expected, expected])
+        }
+
+        @Test
+        func meetingReferenceCanBeSentWithoutInstruction() async {
+            let service = TestCodexChatService(mode: .complete)
+            let settings = AppSettings()
+            let vault = Self.testVault()
+            settings.currentVault = vault
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings
+            )
+            let meeting = Self.meetingReference(vaultID: vault.id, name: "Reference Only", offset: 0)
+            session.updateAvailableMeetings([meeting], catalogVaultID: vault.id)
+            session.addMeetingReference(CodexChatMeetingReference(meeting: meeting))
+
+            #expect(session.canSend)
+            session.sendDraft()
+            await waitUntil { !session.isGenerating }
+
+            #expect(await service.sentTexts == ["meeting:\(meeting.meetingId.uuidString.lowercased())"])
+        }
+
+        @Test
+        func meetingCatalogUpdatesNamesAndPrunesDeletedDraftReferences() {
+            let settings = AppSettings()
+            let vault = Self.testVault()
+            settings.currentVault = vault
+            let session = CodexChatSessionModel(
+                service: TestCodexChatService(mode: .complete),
+                settings: settings
+            )
+            var meeting = Self.meetingReference(vaultID: vault.id, name: "Original", offset: 0)
+            session.updateAvailableMeetings([meeting], catalogVaultID: vault.id)
+            session.addMeetingReference(CodexChatMeetingReference(meeting: meeting))
+            meeting.meetingName = "Renamed"
+            session.updateAvailableMeetings([meeting], catalogVaultID: vault.id)
+
+            #expect(session.meetingDisplayName(for: meeting.meetingId) == "Renamed")
+            session.updateAvailableMeetings([], catalogVaultID: vault.id)
+            #expect(session.selectedMeetingReferenceIDs.isEmpty)
+            #expect(session.meetingDisplayName(for: meeting.meetingId) == "Renamed")
+        }
+
+        @Test
+        func anotherVaultCatalogDoesNotPruneDetachedSessionReferences() {
+            let settings = AppSettings()
+            let vault = Self.testVault()
+            settings.currentVault = vault
+            let session = CodexChatSessionModel(
+                vaultID: vault.id,
+                service: TestCodexChatService(mode: .complete),
+                settings: settings
+            )
+            let meeting = Self.meetingReference(vaultID: vault.id, name: "Original", offset: 0)
+            session.updateAvailableMeetings([meeting], catalogVaultID: vault.id)
+            session.addMeetingReference(CodexChatMeetingReference(meeting: meeting))
+
+            let otherVault = Self.testVault()
+            session.updateAvailableMeetings([], catalogVaultID: otherVault.id)
+
+            #expect(session.selectedMeetingReferenceIDs == [meeting.meetingId])
+            #expect(session.meetingDisplayName(for: meeting.meetingId) == "Original")
+
+            session.updateAvailableMeetings([], catalogVaultID: vault.id)
+            #expect(session.selectedMeetingReferenceIDs.isEmpty)
+        }
+
+        @Test
+        func restoredRawReferencesUseCachedNamesAcrossTitleAndMessages() {
+            let settings = AppSettings()
+            let vault = Self.testVault()
+            settings.currentVault = vault
+            let meeting = Self.meetingReference(vaultID: vault.id, name: "Weekly Sync", offset: 0)
+            let token = "meeting:\(meeting.meetingId.uuidString)"
+            let session = CodexChatSessionModel(
+                vaultID: vault.id,
+                title: "\(token) Review",
+                messages: [CodexChatMessage(role: .user, text: "Use (\(token)).")],
+                service: TestCodexChatService(mode: .complete),
+                settings: settings
+            )
+
+            session.updateAvailableMeetings([meeting], catalogVaultID: vault.id)
+
+            #expect(session.displayTitle == "Weekly Sync Review")
+            #expect(session.displayText(session.messages[0].text) == "Use (Weekly Sync).")
+        }
+
+        @Test
         func stopKeepsPartialResponse() async {
             let service = TestCodexChatService(mode: .block)
             let settings = AppSettings()
@@ -305,6 +429,23 @@ import Foundation
                 name: "Chat Test",
                 createdAt: .now,
                 lastOpenedAt: .now
+            )
+        }
+
+        private static func meetingReference(vaultID: UUID, name: String, offset: TimeInterval) -> MeetingOverviewItem {
+            MeetingOverviewItem(
+                meetingId: .v7(),
+                vaultId: vaultID,
+                projectId: nil,
+                projectName: nil,
+                meetingName: name,
+                status: .ready,
+                duration: nil,
+                createdAt: .now.addingTimeInterval(offset),
+                hasSummary: false,
+                segmentCount: 0,
+                latestSegmentText: nil,
+                tags: []
             )
         }
 

--- a/Tests/DahliaTests/CodexChatSessionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatSessionModelTests.swift
@@ -62,14 +62,14 @@ import Foundation
 
             let expected = "meeting:\(first.meetingId.uuidString.lowercased()) "
                 + "meeting:\(second.meetingId.uuidString.lowercased()) Compare them"
-            #expect(await service.sentTexts == [expected])
+            #expect(await service.sentTextBlocks == [[expected]])
             #expect(session.selectedMeetingReferenceIDs.isEmpty)
             #expect(session.draft.isEmpty)
             #expect(session.displayText(expected) == "First Second Compare them")
 
             session.retry()
             await waitUntil { !session.isGenerating }
-            #expect(await service.sentTexts == [expected, expected])
+            #expect(await service.sentTextBlocks == [[expected], [expected]])
         }
 
         @Test
@@ -92,7 +92,7 @@ import Foundation
             session.sendDraft()
             await waitUntil { !session.isGenerating }
 
-            #expect(await service.sentTexts == ["meeting:\(meeting.meetingId.uuidString.lowercased())"])
+            #expect(await service.sentTextBlocks == [["meeting:\(meeting.meetingId.uuidString.lowercased())"]])
         }
 
         @Test
@@ -138,6 +138,31 @@ import Foundation
 
             session.updateAvailableMeetings([], catalogVaultID: vault.id)
             #expect(session.selectedMeetingReferenceIDs.isEmpty)
+        }
+
+        @Test
+        func loadingSameVaultCatalogDoesNotPruneReferences() {
+            let settings = AppSettings()
+            let vault = Self.testVault()
+            settings.currentVault = vault
+            let session = CodexChatSessionModel(
+                vaultID: vault.id,
+                service: TestCodexChatService(mode: .complete),
+                settings: settings
+            )
+            let meeting = Self.meetingReference(vaultID: vault.id, name: "Original", offset: 0)
+            session.updateAvailableMeetings([meeting], catalogVaultID: vault.id)
+            session.addMeetingReference(CodexChatMeetingReference(meeting: meeting))
+
+            session.updateAvailableMeetings(
+                [],
+                catalogVaultID: vault.id,
+                isCatalogLoaded: false
+            )
+            #expect(session.selectedMeetingReferenceIDs == [meeting.meetingId])
+
+            session.updateAvailableMeetings([meeting], catalogVaultID: vault.id)
+            #expect(session.selectedMeetingReferenceIDs == [meeting.meetingId])
         }
 
         @Test

--- a/Tests/DahliaTests/CodexChatSessionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatSessionModelTests.swift
@@ -141,6 +141,22 @@ import Foundation
         }
 
         @Test
+        func missingVaultCatalogDoesNotPruneReferences() {
+            let settings = AppSettings()
+            settings.currentVault = nil
+            let session = CodexChatSessionModel(
+                service: TestCodexChatService(mode: .complete),
+                settings: settings
+            )
+            let reference = CodexChatMeetingReference(id: .v7(), name: "Cached", createdAt: .now)
+            session.addMeetingReference(reference)
+
+            session.updateAvailableMeetings([], catalogVaultID: nil)
+
+            #expect(session.selectedMeetingReferenceIDs == [reference.id])
+        }
+
+        @Test
         func restoredRawReferencesUseCachedNamesAcrossTitleAndMessages() {
             let settings = AppSettings()
             let vault = Self.testVault()

--- a/Tests/DahliaTests/CodexChatSessionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatSessionModelTests.swift
@@ -509,12 +509,17 @@ import Foundation
             }
             Issue.record("Timed out waiting for asynchronous chat state")
         }
+
     }
 
     actor TestCodexChatService: CodexChatServicing {
         enum Mode {
             case complete
             case block
+            case burstThenBlock
+            case bufferedBurstThenInterrupt
+            case finishesWithoutTerminal
+            case interruptedThenBlock
             case staleRollout
             case rolloutWithoutReasoning
             case multipleMessages
@@ -545,7 +550,8 @@ import Foundation
 
         func loadThread(id: String) async throws -> CodexChatThread {
             let assistantMessages: [CodexChatMessage] = switch mode {
-            case .complete, .block:
+            case .complete, .block, .burstThenBlock, .bufferedBurstThenInterrupt,
+                 .finishesWithoutTerminal, .interruptedThenBlock:
                 [CodexChatMessage(role: .assistant, text: "Final answer", reasoning: "Considered the question")]
             case .rolloutWithoutReasoning:
                 [CodexChatMessage(role: .assistant, text: "Final answer")]
@@ -610,6 +616,23 @@ import Foundation
                 continuation.finish()
             case .block:
                 continuation.yield(.delta(itemID: "item-1", text: "Partial"))
+                blockedContinuation = continuation
+            case .burstThenBlock:
+                continuation.yield(.delta(itemID: "item-1", text: "First"))
+                continuation.yield(.delta(itemID: "item-1", text: " second"))
+                blockedContinuation = continuation
+            case .bufferedBurstThenInterrupt:
+                for _ in 0 ..< 2048 {
+                    continuation.yield(.delta(itemID: "item-1", text: "x"))
+                }
+                continuation.yield(.interrupted)
+                continuation.finish()
+            case .finishesWithoutTerminal:
+                continuation.yield(.delta(itemID: "item-1", text: "Partial answer"))
+                continuation.finish()
+            case .interruptedThenBlock:
+                continuation.yield(.delta(itemID: "item-1", text: "Partial answer"))
+                continuation.yield(.interrupted)
                 blockedContinuation = continuation
             case .multipleMessages:
                 continuation.yield(.delta(itemID: "item-1", text: "First "))

--- a/Tests/DahliaTests/CodexChatStreamingSessionTests.swift
+++ b/Tests/DahliaTests/CodexChatStreamingSessionTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct CodexChatStreamingSessionTests {
+        @Test
+        func trailingUpdateAppearsWhileStreamIsStillWaiting() async {
+            let session = makeSession(mode: .burstThenBlock, updateInterval: .milliseconds(10))
+
+            session.draft = "Question"
+            session.sendDraft()
+            await waitUntil { session.messages.last?.text == "First" }
+            await waitUntilEventually { session.messages.last?.text == "First second" }
+
+            #expect(session.isGenerating)
+            #expect(session.messages.last?.text == "First second")
+            session.stop()
+            await waitUntil { !session.isGenerating }
+        }
+
+        @Test
+        func streamEndingWithoutTerminalEventFinalizesResponse() async {
+            let session = makeSession(mode: .finishesWithoutTerminal)
+
+            session.draft = "Question"
+            session.sendDraft()
+            await waitUntil { !session.isGenerating }
+
+            #expect(session.messages.last?.text == "Partial answer")
+            #expect(session.messages.last?.isStreaming == false)
+        }
+
+        @Test
+        func terminalEventFinalizesWithoutWaitingForStreamClose() async {
+            let session = makeSession(mode: .interruptedThenBlock)
+
+            session.draft = "Question"
+            session.sendDraft()
+            await waitUntil { !session.isGenerating }
+
+            #expect(session.messages.last?.text == "Partial answer")
+            #expect(session.messages.last?.isStreaming == false)
+        }
+
+        @Test
+        func bufferedBurstYieldsMainActorAndPreservesEveryDelta() async {
+            let session = makeSession(mode: .bufferedBurstThenInterrupt)
+
+            session.draft = "Question"
+            session.sendDraft()
+
+            await waitUntil { session.activeTurnID != nil }
+            #expect(session.isGenerating)
+            await waitUntilEventually { !session.isGenerating }
+            #expect(session.messages.last?.text == String(repeating: "x", count: 2048))
+        }
+
+        private func makeSession(
+            mode: TestCodexChatService.Mode,
+            updateInterval: Duration = .milliseconds(50)
+        ) -> CodexChatSessionModel {
+            let settings = AppSettings()
+            settings.currentVault = VaultRecord(
+                id: .v7(),
+                path: "/tmp/chat-streaming-test-vault",
+                name: "Chat Streaming Test",
+                createdAt: .now,
+                lastOpenedAt: .now
+            )
+            return CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: TestCodexChatService(mode: mode),
+                settings: settings,
+                streamingUpdateInterval: updateInterval
+            )
+        }
+
+        private func waitUntil(_ predicate: @MainActor () -> Bool) async {
+            for _ in 0 ..< 1000 {
+                if predicate() { return }
+                await Task.yield()
+            }
+            Issue.record("Timed out waiting for chat state")
+        }
+
+        private func waitUntilEventually(
+            timeout: Duration = .seconds(1),
+            _ predicate: @MainActor () -> Bool
+        ) async {
+            let deadline = ContinuousClock.now.advanced(by: timeout)
+            while ContinuousClock.now < deadline {
+                if predicate() { return }
+                try? await Task.sleep(for: .milliseconds(1))
+            }
+            Issue.record("Timed out waiting for chat state")
+        }
+    }
+#endif

--- a/Tests/DahliaTests/CodexChatStreamingUpdateLimiterTests.swift
+++ b/Tests/DahliaTests/CodexChatStreamingUpdateLimiterTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct CodexChatStreamingUpdateLimiterTests {
+        @Test
+        func publishesTheLatestSuppressedUpdateAtTheTrailingEdge() async {
+            var publishedTexts: [String] = []
+            let accumulator = CodexChatTurnAccumulator()
+            let sleeper = TestCodexChatStreamingSleeper()
+            let limiter = CodexChatStreamingUpdateLimiter(
+                minimumInterval: .milliseconds(10),
+                sleep: { _ in try await sleeper.sleep() },
+                publish: { publishedTexts.append(accumulator.responseText) }
+            )
+
+            accumulator.appendResponseDelta(itemID: "item", text: "First")
+            limiter.submit()
+            accumulator.appendResponseDelta(itemID: "item", text: " second")
+            limiter.submit()
+
+            #expect(publishedTexts == ["First"])
+            await waitUntil { sleeper.isWaiting }
+            sleeper.resume()
+            await waitUntil { publishedTexts.count == 2 }
+            #expect(publishedTexts == ["First", "First second"])
+        }
+
+        @Test
+        func forcedUpdateCancelsPendingTrailingPublish() async {
+            var publishedTexts: [String] = []
+            let accumulator = CodexChatTurnAccumulator()
+            let sleeper = TestCodexChatStreamingSleeper()
+            let limiter = CodexChatStreamingUpdateLimiter(
+                minimumInterval: .milliseconds(20),
+                sleep: { _ in try await sleeper.sleep() },
+                publish: { publishedTexts.append(accumulator.responseText) }
+            )
+
+            accumulator.appendResponseDelta(itemID: "item", text: "First")
+            limiter.submit()
+            accumulator.appendResponseDelta(itemID: "item", text: " second")
+            limiter.submit()
+            await waitUntil { sleeper.isWaiting }
+            limiter.submit(force: true)
+
+            sleeper.resume()
+            for _ in 0 ..< 10 {
+                await Task.yield()
+            }
+            #expect(publishedTexts == ["First", "First second"])
+        }
+
+        private func waitUntil(_ predicate: @MainActor () -> Bool) async {
+            for _ in 0 ..< 1000 {
+                if predicate() { return }
+                await Task.yield()
+            }
+            Issue.record("Timed out waiting for limiter state")
+        }
+    }
+
+    @MainActor
+    private final class TestCodexChatStreamingSleeper {
+        private var continuation: CheckedContinuation<Void, Never>?
+
+        var isWaiting: Bool {
+            continuation != nil
+        }
+
+        func sleep() async throws {
+            await withCheckedContinuation { continuation = $0 }
+        }
+
+        func resume() {
+            continuation?.resume()
+            continuation = nil
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary

- AI チャットの composer 左端に ChatGPT 風の `+` ボタンを追加し、`@` 入力補完とあわせて複数のミーティングを選択可能にしました
- UI では meeting name を表示し、Codex には `meeting:<UUID>` を通常の単語としてスペース区切りで送信します
- 選択済み・送信済みの参照をオブジェクト風のバッジで表示し、ホバー・クリック・キーボードで名前と日時を確認できます
- 送信済みメッセージ、履歴、タイトル、コピーでは UUID を名前または利用不可表示へ置換します
- vault 切り替え、改名、削除、履歴復元、再試行でも raw token と表示名を安全に扱います
- `origin/main` の表示中ミーティング context と統合し、カタログ再読込・vault 切り替え時の競合でも未送信参照を誤って削除しないようにしました
- Codex の developer instructions、英日ローカライズ、キーボード操作、VoiceOver 対応を追加しました
- AI 応答の token ごとに animated scroll と SwiftUI lazy layout を再計算していた処理を廃止し、native bottom anchor と 50ms の trailing throttle へ変更しました
- 大量にバッファされた delta は 64 event ごとに MainActor を yield し、terminal event 受信時は producer の close を待たず応答を確定します

## Why

個別のミーティングを明示して AI チャットへ指示できるようにしつつ、内部 ID を UI へ露出させず、検索を挟まず対象ミーティングを MCP で直接取得できるようにするためです。また、長い AI 応答で SwiftUI の layout transaction が過負荷になり、アプリがハングする問題を防ぎます。

## Validation

- `swift build`
- 対象チャットテスト: 37 tests / 5 suites passed
- `swift test`: Swift Testing 565 tests / 102 suites、XCTest 3 tests passed
- `CI=true ./scripts/lint.sh`: SwiftFormat clean、SwiftLint 完走（既存リポジトリ違反は non-blocking）
- 英日 `Localizable.strings`: `plutil -lint` passed
- deep-review 最終再レビュー: Critical / Major / Minor なし
