### PR TITLE
Minimize Google Calendar OAuth scopes

### DIFF
--- a/Sources/Dahlia/Services/GoogleSignInAdapter.swift
+++ b/Sources/Dahlia/Services/GoogleSignInAdapter.swift
@@ -20,7 +20,8 @@ enum GoogleOAuthScope {
         "profile",
     ]
     static let calendar: Set = [
-        "https://www.googleapis.com/auth/calendar.readonly",
+        "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+        "https://www.googleapis.com/auth/calendar.events.readonly",
     ]
     static let drive: Set = [
         "https://www.googleapis.com/auth/drive.file",

--- a/Tests/DahliaTests/GoogleCalendarConfigurationTests.swift
+++ b/Tests/DahliaTests/GoogleCalendarConfigurationTests.swift
@@ -7,6 +7,14 @@ import Testing
 @MainActor
 struct GoogleCalendarConfigurationTests {
     @Test
+    func calendarAuthorizationUsesCalendarListAndEventScopesOnly() {
+        #expect(GoogleOAuthScope.calendar == [
+            "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+            "https://www.googleapis.com/auth/calendar.events.readonly",
+        ])
+    }
+
+    @Test
     func clientIDIsReadFromEnvironment() {
         withTemporaryGoogleOAuthOverrides {
             withTemporaryEnvironmentValue("GOOGLE_CLIENT_ID", value: "client-id-from-env") {


### PR DESCRIPTION
## Summary

- replace the broad Google Calendar `calendar.readonly` scope
- request only `calendar.calendarlist.readonly` and `calendar.events.readonly`
- add a regression test that locks the minimized scope set

## Why

Dahlia only reads the user's calendar list and calendar events. Requesting the narrower API-specific read-only scopes reduces the OAuth permission surface while preserving the existing Calendar integration.

## Validation

- `swift test --filter GoogleCalendarConfigurationTests` (8 tests passed)
- `swift test --filter GoogleCalendarStoreTests` (12 tests passed)
- `swift build`
- `CI=true ./scripts/lint.sh` (SwiftFormat clean; SwiftLint reports pre-existing non-blocking violations)
