### PR TITLE
Fix lint toolchain warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -114,14 +114,16 @@ modifier_order:
   preferred_modifier_order:
     - acl
     - setterACL
+    - isolation
     - override
     - dynamic
-    - mutating
+    - mutators
     - lazy
     - final
     - required
     - convenience
     - typeMethods
+    - owned
 
 large_tuple:
   warning: 3

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -16,9 +16,9 @@ if ! command -v swiftformat &>/dev/null; then
 fi
 
 if [[ "$is_ci" == "true" ]]; then
-    swiftformat --lint Sources/
+    swiftformat --cache ignore --lint Sources/
 else
-    swiftformat Sources/
+    swiftformat --cache ignore Sources/
 fi
 echo "SwiftFormat: done"
 
@@ -33,11 +33,18 @@ if ! command -v swiftlint &>/dev/null; then
     exit 0
 fi
 
+swiftlint_command=(swiftlint)
+if [[ -z "${DEVELOPER_DIR:-}" ]] \
+    && [[ "$(xcode-select -p 2>/dev/null || true)" == "/Library/Developer/CommandLineTools" ]] \
+    && [[ -d "/Applications/Xcode.app/Contents/Developer" ]]; then
+    swiftlint_command=(env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swiftlint)
+fi
+
 if [[ "$is_ci" == "true" ]]; then
-    if ! swiftlint lint --quiet; then
+    if ! "${swiftlint_command[@]}" lint --quiet --no-cache; then
         echo "SwiftLint reported violations. Keeping non-blocking until existing violations are cleaned up."
     fi
 else
-    swiftlint lint --quiet || true
+    "${swiftlint_command[@]}" lint --quiet --no-cache || true
 fi
 echo "SwiftLint: done"


### PR DESCRIPTION
## Summary

- update the `modifier_order` configuration for the modifier groups supported by current SwiftLint
- disable SwiftFormat and SwiftLint caches to avoid cache write warnings during lint runs
- select the installed Xcode toolchain when `xcode-select` points at Command Line Tools, preventing SwiftLint from crashing while loading SourceKit

## Root cause

The lint configuration still used the old `mutating` modifier group and omitted newer groups. In environments where `xcode-select` resolves to Command Line Tools, SwiftLint also selected a SourceKit location that could not load `sourcekitdInProc.framework`.

## Impact

`./scripts/lint.sh` now reaches the end of both SwiftFormat and SwiftLint without the invalid-configuration, cache-write, or SourceKit crash warnings. Existing code-level SwiftLint violations remain intentionally non-blocking under the repository's current lint policy.

## Validation

- `bash -n scripts/lint.sh`
- `git diff --check`
- `CI=true ./scripts/lint.sh` (SwiftFormat and SwiftLint completed; existing violations remain non-blocking)