### PR TITLE
Include images in Google Docs clipboard copy

### DIFF
--- a/Sources/Dahlia/Services/SummaryRendering/GoogleDocsImageEncoder.swift
+++ b/Sources/Dahlia/Services/SummaryRendering/GoogleDocsImageEncoder.swift
@@ -1,0 +1,35 @@
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+enum GoogleDocsImageEncoder {
+    struct EncodedImage {
+        let data: Data
+        let pixelWidth: Int
+        let pixelHeight: Int
+    }
+
+    private static let maxLongEdge = 1600
+
+    static func encode(_ data: Data) -> EncodedImage? {
+        guard let image = CGImageDecoder.decode(data, maxPixelSize: maxLongEdge) else { return nil }
+
+        let encoded = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            encoded,
+            UTType.jpeg.identifier as CFString,
+            1,
+            nil
+        ) else { return nil }
+        CGImageDestinationAddImage(destination, image, [
+            kCGImageDestinationLossyCompressionQuality: 0.78,
+        ] as CFDictionary)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+
+        return EncodedImage(
+            data: encoded as Data,
+            pixelWidth: image.width,
+            pixelHeight: image.height
+        )
+    }
+}

--- a/Sources/Dahlia/Services/SummaryRendering/GoogleDocsSummaryRenderer.swift
+++ b/Sources/Dahlia/Services/SummaryRendering/GoogleDocsSummaryRenderer.swift
@@ -1,7 +1,4 @@
-import CoreGraphics
 import Foundation
-import ImageIO
-import UniformTypeIdentifiers
 
 enum GoogleDocsSummaryRenderer {
     struct RenderedDocument: Equatable {
@@ -9,14 +6,7 @@ enum GoogleDocsSummaryRenderer {
         let mimeType: String
     }
 
-    private struct PreparedImage {
-        let data: Data
-        let pixelWidth: Int
-        let pixelHeight: Int
-    }
-
     private static let documentWidthTwips = 9000
-    private static let imageMaxLongEdge = 1600
 
     static func render(
         document: SummaryDocument,
@@ -25,7 +15,7 @@ enum GoogleDocsSummaryRenderer {
         imageUnavailableText: String
     ) -> RenderedDocument {
         let screenshotsByID = Dictionary(uniqueKeysWithValues: context.screenshots.map { ($0.id, $0) })
-        var imageCache: [UUID: PreparedImage] = [:]
+        var imageCache: [UUID: GoogleDocsImageEncoder.EncodedImage] = [:]
         var body = ""
 
         if let title = normalizedText(document.title) {
@@ -70,7 +60,7 @@ enum GoogleDocsSummaryRenderer {
     private static func renderBlock(
         _ block: SummaryBlock,
         screenshotsByID: [UUID: MeetingScreenshotRecord],
-        imageCache: inout [UUID: PreparedImage],
+        imageCache: inout [UUID: GoogleDocsImageEncoder.EncodedImage],
         imageUnavailableText: String
     ) -> String {
         switch block.content {
@@ -160,15 +150,15 @@ enum GoogleDocsSummaryRenderer {
         screenshotID: UUID,
         caption: String,
         screenshotsByID: [UUID: MeetingScreenshotRecord],
-        imageCache: inout [UUID: PreparedImage],
+        imageCache: inout [UUID: GoogleDocsImageEncoder.EncodedImage],
         imageUnavailableText: String
     ) -> String {
-        let image: PreparedImage
+        let image: GoogleDocsImageEncoder.EncodedImage
         if let cached = imageCache[screenshotID] {
             image = cached
         } else {
             guard let screenshot = screenshotsByID[screenshotID],
-                  let prepared = prepareImage(screenshot.imageData) else {
+                  let prepared = GoogleDocsImageEncoder.encode(screenshot.imageData) else {
                 return unavailableImageBlock(caption: caption, message: imageUnavailableText)
             }
             imageCache[screenshotID] = prepared
@@ -285,28 +275,6 @@ enum GoogleDocsSummaryRenderer {
     private static func isSafeLink(_ link: URL) -> Bool {
         guard let scheme = link.scheme?.lowercased() else { return false }
         return ["http", "https", "mailto"].contains(scheme)
-    }
-
-    private static func prepareImage(_ data: Data) -> PreparedImage? {
-        guard let image = CGImageDecoder.decode(data, maxPixelSize: imageMaxLongEdge) else { return nil }
-
-        let encoded = NSMutableData()
-        guard let destination = CGImageDestinationCreateWithData(
-            encoded,
-            UTType.jpeg.identifier as CFString,
-            1,
-            nil
-        ) else { return nil }
-        CGImageDestinationAddImage(destination, image, [
-            kCGImageDestinationLossyCompressionQuality: 0.78,
-        ] as CFDictionary)
-        guard CGImageDestinationFinalize(destination) else { return nil }
-
-        return PreparedImage(
-            data: encoded as Data,
-            pixelWidth: image.width,
-            pixelHeight: image.height
-        )
     }
 
     private static func hexEncoded(_ data: Data) -> String {

--- a/Sources/Dahlia/Services/SummaryRendering/SummaryShareRenderer.swift
+++ b/Sources/Dahlia/Services/SummaryRendering/SummaryShareRenderer.swift
@@ -28,10 +28,17 @@ enum SummaryShareRenderer {
     static func render(
         document: SummaryDocument,
         actionItemsHeading: String,
-        for destination: Destination
+        for destination: Destination,
+        screenshots: [MeetingScreenshotRecord] = []
     ) -> SummaryShareContent {
-        SummaryShareContent(
-            html: renderHTML(document: document, actionItemsHeading: actionItemsHeading, destination: destination),
+        let screenshotsByID = Dictionary(uniqueKeysWithValues: screenshots.map { ($0.id, $0) })
+        return SummaryShareContent(
+            html: renderHTML(
+                document: document,
+                actionItemsHeading: actionItemsHeading,
+                destination: destination,
+                screenshotsByID: screenshotsByID
+            ),
             markdown: renderMarkdown(document: document, actionItemsHeading: actionItemsHeading)
         )
     }
@@ -142,7 +149,8 @@ enum SummaryShareRenderer {
     private static func renderHTML(
         document: SummaryDocument,
         actionItemsHeading: String,
-        destination: Destination
+        destination: Destination,
+        screenshotsByID: [UUID: MeetingScreenshotRecord]
     ) -> String {
         var chunks: [String] = []
 
@@ -151,7 +159,7 @@ enum SummaryShareRenderer {
         }
 
         chunks.append(contentsOf: document.sections.compactMap { section in
-            renderHTMLSection(section, destination: destination)
+            renderHTMLSection(section, destination: destination, screenshotsByID: screenshotsByID)
         })
 
         if let actionItems = renderHTMLActionItems(
@@ -174,7 +182,11 @@ enum SummaryShareRenderer {
         """
     }
 
-    private static func renderHTMLSection(_ section: SummarySection, destination: Destination) -> String? {
+    private static func renderHTMLSection(
+        _ section: SummarySection,
+        destination: Destination,
+        screenshotsByID: [UUID: MeetingScreenshotRecord]
+    ) -> String? {
         var chunks: [String] = []
 
         if let heading = normalizedInlineMarkdown(section.heading).nilIfBlank {
@@ -182,7 +194,7 @@ enum SummaryShareRenderer {
         }
 
         chunks.append(contentsOf: section.blocks.compactMap { block in
-            renderHTMLBlock(block, destination: destination)
+            renderHTMLBlock(block, destination: destination, screenshotsByID: screenshotsByID)
         })
         guard !chunks.isEmpty else { return nil }
 
@@ -195,7 +207,11 @@ enum SummaryShareRenderer {
         }
     }
 
-    private static func renderHTMLBlock(_ block: SummaryBlock, destination: Destination) -> String? {
+    private static func renderHTMLBlock(
+        _ block: SummaryBlock,
+        destination: Destination,
+        screenshotsByID: [UUID: MeetingScreenshotRecord]
+    ) -> String? {
         switch block.content {
         case let .paragraph(text):
             htmlParagraph(text.text, destination: destination)
@@ -209,16 +225,13 @@ enum SummaryShareRenderer {
             htmlParagraph(text.text, destination: destination).map { "<blockquote>\($0)</blockquote>" }
         case let .code(_, content):
             content.text.nilIfBlank.map { "<pre><code>\(escapeHTML($0))</code></pre>" }
-        case let .image(_, caption):
-            normalizedInlineMarkdown(caption.text).nilIfBlank.map {
-                let html = "<em>\(renderInlineHTML($0))</em>"
-                switch destination {
-                case .googleDocs:
-                    return "<p>\(html)</p>"
-                case .slack:
-                    return html
-                }
-            }
+        case let .image(screenshotID, caption):
+            renderHTMLImage(
+                screenshotID: screenshotID,
+                caption: caption.text,
+                destination: destination,
+                screenshotsByID: screenshotsByID
+            )
         case let .heading(level, content):
             normalizedInlineMarkdown(content.text).nilIfBlank.map {
                 let headingLevel = destination == .googleDocs ? clampedHeadingLevel(level) : level
@@ -227,6 +240,29 @@ enum SummaryShareRenderer {
         case let .table(headers, rows):
             renderHTMLTable(headers: headers, rows: rows, destination: destination)
         }
+    }
+
+    private static func renderHTMLImage(
+        screenshotID: UUID,
+        caption: String,
+        destination: Destination,
+        screenshotsByID: [UUID: MeetingScreenshotRecord]
+    ) -> String? {
+        let normalizedCaption = normalizedInlineMarkdown(caption).nilIfBlank
+        let captionHTML = normalizedCaption.map { "<em>\(renderInlineHTML($0))</em>" }
+
+        guard destination == .googleDocs else { return captionHTML }
+
+        guard let screenshot = screenshotsByID[screenshotID],
+              let mimeType = ImageEncoder.mimeType(for: screenshot.imageData) else {
+            return captionHTML.map { "<p>\($0)</p>" }
+        }
+
+        let source = "data:\(mimeType);base64,\(screenshot.imageData.base64EncodedString())"
+        let alt = normalizedCaption.map { " alt=\"\(escapeHTMLAttribute($0))\"" } ?? ""
+        let image = "<img src=\"\(source)\"\(alt)>"
+        guard let captionHTML else { return image }
+        return "<figure>\n\(image)\n<figcaption>\(captionHTML)</figcaption>\n</figure>"
     }
 
     private static func htmlParagraph(_ text: String, destination: Destination) -> String? {

--- a/Sources/Dahlia/Services/SummaryRendering/SummaryShareRenderer.swift
+++ b/Sources/Dahlia/Services/SummaryRendering/SummaryShareRenderer.swift
@@ -254,11 +254,11 @@ enum SummaryShareRenderer {
         guard destination == .googleDocs else { return captionHTML }
 
         guard let screenshot = screenshotsByID[screenshotID],
-              let mimeType = ImageEncoder.mimeType(for: screenshot.imageData) else {
+              let encodedImage = GoogleDocsImageEncoder.encode(screenshot.imageData) else {
             return captionHTML.map { "<p>\($0)</p>" }
         }
 
-        let source = "data:\(mimeType);base64,\(screenshot.imageData.base64EncodedString())"
+        let source = "data:image/jpeg;base64,\(encodedImage.data.base64EncodedString())"
         let alt = normalizedCaption.map { " alt=\"\(escapeHTMLAttribute($0))\"" } ?? ""
         let image = "<img src=\"\(source)\"\(alt)>"
         guard let captionHTML else { return image }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -209,7 +209,8 @@ final class CaptionViewModel: ObservableObject {
         let content = SummaryShareRenderer.render(
             document: currentSummaryDocument,
             actionItemsHeading: L10n.actionItems,
-            for: destination
+            for: destination,
+            screenshots: screenshots
         )
         guard content.markdown.nilIfBlank != nil else { return }
         SummaryPasteboardWriter.write(content)

--- a/Tests/DahliaTests/SummaryShareRendererTests.swift
+++ b/Tests/DahliaTests/SummaryShareRendererTests.swift
@@ -70,6 +70,48 @@ import Foundation
         }
 
         @Test
+        func embedsReferencedScreenshotOnlyInGoogleDocsHTML() throws {
+            let screenshotID = UUID.v7()
+            let screenshot = MeetingScreenshotRecord(
+                id: screenshotID,
+                meetingId: .v7(),
+                capturedAt: .now,
+                imageData: try makePNGData(),
+                mimeType: "image/png"
+            )
+            let document = SummaryDocument(
+                title: "Summary",
+                sections: [
+                    SummarySection(
+                        id: .v7(),
+                        heading: "",
+                        blocks: [.image(screenshotId: screenshotID, caption: "Launch <screen>")]
+                    ),
+                ]
+            )
+
+            let googleDocsContent = SummaryShareRenderer.render(
+                document: document,
+                actionItemsHeading: "Action Items",
+                for: .googleDocs,
+                screenshots: [screenshot]
+            )
+            let slackContent = SummaryShareRenderer.render(
+                document: document,
+                actionItemsHeading: "Action Items",
+                for: .slack,
+                screenshots: [screenshot]
+            )
+
+            #expect(googleDocsContent.html.contains("<img src=\"data:image/png;base64,"))
+            #expect(googleDocsContent.html.contains("alt=\"Launch &lt;screen&gt;\""))
+            #expect(googleDocsContent.html.contains("<figcaption><em>Launch &lt;screen&gt;</em></figcaption>"))
+            #expect(googleDocsContent.markdown.contains("Launch <screen>"))
+            #expect(!slackContent.html.contains("<img"))
+            #expect(slackContent.html.contains("<em>Launch &lt;screen&gt;</em>"))
+        }
+
+        @Test
         func rendersSlackHeadingsAndExplicitLineBreaks() {
             let document = SummaryDocument(
                 title: "Weekly Sync",
@@ -166,6 +208,27 @@ import Foundation
             #expect(items.count == 1)
             #expect(item.string(forType: .html) == content.html)
             #expect(item.string(forType: .string) == content.markdown)
+        }
+
+        private func makePNGData() throws -> Data {
+            let bitmap = try #require(NSBitmapImageRep(
+                bitmapDataPlanes: nil,
+                pixelsWide: 1,
+                pixelsHigh: 1,
+                bitsPerSample: 8,
+                samplesPerPixel: 4,
+                hasAlpha: true,
+                isPlanar: false,
+                colorSpaceName: .deviceRGB,
+                bytesPerRow: 0,
+                bitsPerPixel: 0
+            ))
+            let pixels = try #require(bitmap.bitmapData)
+            pixels[0] = 255
+            pixels[1] = 0
+            pixels[2] = 0
+            pixels[3] = 255
+            return try #require(bitmap.representation(using: .png, properties: [:]))
         }
     }
 #endif

--- a/Tests/DahliaTests/SummaryShareRendererTests.swift
+++ b/Tests/DahliaTests/SummaryShareRendererTests.swift
@@ -70,7 +70,7 @@ import Foundation
         }
 
         @Test
-        func embedsReferencedScreenshotOnlyInGoogleDocsHTML() throws {
+        func embedsReferencedScreenshotAsJPEGOnlyInGoogleDocsHTML() throws {
             let screenshotID = UUID.v7()
             let screenshot = MeetingScreenshotRecord(
                 id: screenshotID,
@@ -103,7 +103,7 @@ import Foundation
                 screenshots: [screenshot]
             )
 
-            #expect(googleDocsContent.html.contains("<img src=\"data:image/png;base64,"))
+            #expect(googleDocsContent.html.contains("<img src=\"data:image/jpeg;base64,"))
             #expect(googleDocsContent.html.contains("alt=\"Launch &lt;screen&gt;\""))
             #expect(googleDocsContent.html.contains("<figcaption><em>Launch &lt;screen&gt;</em></figcaption>"))
             #expect(googleDocsContent.markdown.contains("Launch <screen>"))


### PR DESCRIPTION
## Summary

- pass the current meeting screenshots into the summary share renderer
- embed referenced screenshots as validated image data URLs in Google Docs HTML
- preserve caption fallback behavior and keep Slack copying text-only
- cover both destinations with a focused renderer test

## Why

Google Docs clipboard copying previously rendered image blocks as captions only, even though the current meeting's screenshot data was already available in the view model.

## User impact

Pasting a summary copied with “Copy for Google Docs” now includes its referenced screenshots and captions.

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter SummaryShareRendererTests` — 5 tests passed
- Debug application target built successfully as part of the targeted test run
- `CI=true ./scripts/lint.sh` — SwiftFormat passed; SwiftLint reported pre-existing repository violations
