### PR TITLE
Improve settings usability and feedback

### DIFF
--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -103,6 +103,10 @@
 "Use Auto" = "Use Auto";
 "This instruction is currently used for summary generation." = "This instruction is currently used for summary generation.";
 "This instruction is not currently used for summary generation." = "This instruction is not currently used for summary generation.";
+"Changes save automatically." = "Changes save automatically.";
+"Enter a title to save this instruction." = "Enter a title to save this instruction.";
+"Delete instruction \"%@\"?" = "Delete instruction \"%@\"?";
+"This instruction will be permanently deleted. This cannot be undone." = "This instruction will be permanently deleted. This cannot be undone.";
 "No content yet" = "No content yet";
 "No results found" = "No results found";
 "No project" = "No project";
@@ -281,11 +285,11 @@
 "Target Language" = "Target Language";
 "Choose which language translated transcript lines should use." = "Choose which language translated transcript lines should use.";
 "Translation is automatically disabled when the target language matches the transcription language." = "Translation is automatically disabled when the target language matches the transcription language.";
-"Override developer-managed credentials used by external service integrations." = "Override developer-managed credentials used by external service integrations.";
+"Configure these only when your organization requires a company-managed Google OAuth client. Otherwise, leave them blank to use the app defaults." = "Configure these only when your organization requires a company-managed Google OAuth client. Otherwise, leave them blank to use the app defaults.";
 "Google OAuth Client ID" = "Google OAuth Client ID";
-"Leave blank to use the bundled or environment-provided GOOGLE_CLIENT_ID." = "Leave blank to use the bundled or environment-provided GOOGLE_CLIENT_ID.";
+"Leave blank to use the app's default client ID." = "Leave blank to use the app's default client ID.";
 "Google OAuth Client Secret" = "Google OAuth Client Secret";
-"Optional. Stored in Keychain and used before GOOGLE_CLIENT_SECRET when set." = "Optional. Stored in Keychain and used before GOOGLE_CLIENT_SECRET when set.";
+"Optional. Stored securely in Keychain. Leave blank to use the app's default client secret." = "Optional. Stored securely in Keychain. Leave blank to use the app's default client secret.";
 "Reconnect Google services after changing OAuth credentials." = "Reconnect Google services after changing OAuth credentials.";
 "Google Calendar" = "Google Calendar";
 "macOS Calendar" = "macOS Calendar";
@@ -331,7 +335,7 @@
 "Join" = "Join";
 "All day" = "All day";
 "Google Calendar is not configured" = "Google Calendar is not configured";
-"Set GOOGLE_CLIENT_ID before connecting Google Calendar." = "Set GOOGLE_CLIENT_ID in Developer Settings or the environment before connecting Google Calendar.";
+"Set a Google OAuth client ID in Developer Settings before connecting Google Calendar." = "Set a Google OAuth client ID in Developer Settings before connecting Google Calendar.";
 "Connect Google Calendar" = "Connect Google Calendar";
 "Connect Google Calendar from Settings to show your upcoming events on Home." = "Connect Google Calendar from Settings to show your upcoming events on Home.";
 "Connect Google Calendar from Settings to show your upcoming events here." = "Connect Google Calendar from Settings to show your upcoming events here.";
@@ -359,7 +363,7 @@
 "Untitled calendar" = "Untitled calendar";
 "No window is available to present Google sign-in." = "No window is available to present Google sign-in.";
 "No previous Google Calendar session was found." = "No previous Google Calendar session was found.";
-"This Google OAuth client requires a client secret. Set GOOGLE_CLIENT_SECRET to the value from Google Cloud Console and relaunch Dahlia." = "This Google OAuth client requires a client secret. Set the Google Cloud Console value in Developer Settings or GOOGLE_CLIENT_SECRET.";
+"This Google OAuth client requires a client secret. Enter the value from Google Cloud Console in Developer Settings and relaunch Dahlia." = "This Google OAuth client requires a client secret. Enter the value from Google Cloud Console in Developer Settings and relaunch Dahlia.";
 "Google sign-in could not access Keychain. Rebuild the app with ./scripts/run-dev.sh so it is code signed with the required Keychain entitlements." = "Google sign-in could not access Keychain. Rebuild the app with ./scripts/run-dev.sh so it is code signed with the required Keychain entitlements.";
 "Google Account" = "Google Account";
 "Untitled event" = "Untitled event";
@@ -416,6 +420,7 @@
 "Copy for Slack" = "Copy for Slack";
 "Summary Prompt" = "Summary Prompt";
 "Reset to Default" = "Reset to Default";
+"Restore App Defaults" = "Restore App Defaults";
 "Summary Template" = "Summary Template";
 "Open in Editor" = "Open in Editor";
 "Open Templates Folder" = "Open Templates Folder";
@@ -508,7 +513,7 @@
 "Could not configure the Google Drive export folder." = "Could not configure the Google Drive export folder.";
 "Open Cloud Storage Settings" = "Open Cloud Storage Settings";
 "No previous Google session was found." = "No previous Google session was found.";
-"Set GOOGLE_CLIENT_ID before connecting Google services." = "Set GOOGLE_CLIENT_ID in Developer Settings or the environment before connecting Google services.";
+"Set a Google OAuth client ID in Developer Settings before connecting Google services." = "Set a Google OAuth client ID in Developer Settings before connecting Google services.";
 "Unexpected response from Google" = "Unexpected response from Google";
 "Google HTTP %lld: %@" = "Google HTTP %lld: %@";
 "Google account connected, but Calendar access has not been granted yet." = "Google account connected, but Calendar access has not been granted yet.";
@@ -703,9 +708,14 @@
 "Vault Name" = "Vault Name";
 "Vault ID" = "Vault ID";
 "Copy Command" = "Copy Command";
+"Copied" = "Copied";
 "Codex CLI" = "Codex CLI";
 "Claude Code" = "Claude Code";
 "The MCP helper is not available in this app build." = "The MCP helper is not available in this app build.";
 "Select a vault before configuring MCP." = "Select a vault before configuring MCP.";
 "Each command registers read-only access to only the selected vault. Run it again after switching vaults." = "Each command registers read-only access to only the selected vault. Run it again after switching vaults.";
 "%@ registration command" = "%@ registration command";
+"Turn on meeting notifications to choose notification conditions." = "Turn on meeting notifications to choose notification conditions.";
+"Turn on transcript translation to choose a target language." = "Turn on transcript translation to choose a target language.";
+"Turn on live subtitles to choose their source and line count." = "Turn on live subtitles to choose their source and line count.";
+"Turn on automatic screenshots to choose the interval and change threshold." = "Turn on automatic screenshots to choose the interval and change threshold.";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -103,6 +103,10 @@
 "Use Auto" = "Auto を使用";
 "This instruction is currently used for summary generation." = "この instruction は現在の要約生成に使用されています。";
 "This instruction is not currently used for summary generation." = "この instruction は現在の要約生成には使用されていません。";
+"Changes save automatically." = "変更は自動的に保存されます。";
+"Enter a title to save this instruction." = "この instruction を保存するにはタイトルを入力してください。";
+"Delete instruction \"%@\"?" = "instruction「%@」を削除しますか？";
+"This instruction will be permanently deleted. This cannot be undone." = "この instruction は完全に削除されます。この操作は取り消せません。";
 "No content yet" = "まだ内容がありません";
 "No results found" = "結果が見つかりません";
 "No project" = "未設定";
@@ -281,11 +285,11 @@
 "Target Language" = "翻訳先の言語";
 "Choose which language translated transcript lines should use." = "翻訳済みの文字起こし行に使う言語を選びます。";
 "Translation is automatically disabled when the target language matches the transcription language." = "翻訳先の言語が文字起こし言語と同じ場合、翻訳は自動的に無効になります。";
-"Override developer-managed credentials used by external service integrations." = "外部サービス連携で使用する開発者管理の認証情報を上書きします。";
+"Configure these only when your organization requires a company-managed Google OAuth client. Otherwise, leave them blank to use the app defaults." = "会社のポリシーで自社管理の Google OAuth クライアントを使用する必要がある場合にのみ設定してください。通常は空欄のまま、アプリ規定の設定を使用できます。";
 "Google OAuth Client ID" = "Google OAuth クライアント ID";
-"Leave blank to use the bundled or environment-provided GOOGLE_CLIENT_ID." = "空欄の場合はバンドル済み、または環境変数の GOOGLE_CLIENT_ID を使用します。";
+"Leave blank to use the app's default client ID." = "空欄の場合は、アプリ規定のクライアント ID を使用します。";
 "Google OAuth Client Secret" = "Google OAuth クライアントシークレット";
-"Optional. Stored in Keychain and used before GOOGLE_CLIENT_SECRET when set." = "任意です。設定すると Keychain に保存され、GOOGLE_CLIENT_SECRET より優先して使用されます。";
+"Optional. Stored securely in Keychain. Leave blank to use the app's default client secret." = "任意です。Keychain に安全に保存されます。空欄の場合は、アプリ規定のクライアントシークレットを使用します。";
 "Reconnect Google services after changing OAuth credentials." = "OAuth 認証情報を変更した後は Google サービスを再接続してください。";
 "Google Calendar" = "Google カレンダー";
 "macOS Calendar" = "macOS カレンダー";
@@ -331,7 +335,7 @@
 "Join" = "参加";
 "All day" = "終日";
 "Google Calendar is not configured" = "Google カレンダーが未設定です";
-"Set GOOGLE_CLIENT_ID before connecting Google Calendar." = "Google カレンダーを接続する前に、開発者設定または環境変数で GOOGLE_CLIENT_ID を設定してください。";
+"Set a Google OAuth client ID in Developer Settings before connecting Google Calendar." = "Google カレンダーを接続する前に、開発者設定で Google OAuth クライアント ID を設定してください。";
 "Connect Google Calendar" = "Google カレンダーを接続";
 "Connect Google Calendar from Settings to show your upcoming events on Home." = "Home に予定を表示するには設定画面から Google カレンダーを接続してください。";
 "Connect Google Calendar from Settings to show your upcoming events here." = "ここに予定を表示するには設定画面から Google カレンダーを接続してください。";
@@ -359,7 +363,7 @@
 "Untitled calendar" = "タイトル未設定のカレンダー";
 "No window is available to present Google sign-in." = "Google サインインを表示できるウィンドウがありません。";
 "No previous Google Calendar session was found." = "以前の Google カレンダーセッションは見つかりませんでした。";
-"This Google OAuth client requires a client secret. Set GOOGLE_CLIENT_SECRET to the value from Google Cloud Console and relaunch Dahlia." = "この Google OAuth クライアントには client secret が必要です。Google Cloud Console の値を開発者設定または GOOGLE_CLIENT_SECRET に設定してください。";
+"This Google OAuth client requires a client secret. Enter the value from Google Cloud Console in Developer Settings and relaunch Dahlia." = "この Google OAuth クライアントにはクライアントシークレットが必要です。Google Cloud Console の値を開発者設定に入力し、Dahlia を再起動してください。";
 "Google sign-in could not access Keychain. Rebuild the app with ./scripts/run-dev.sh so it is code signed with the required Keychain entitlements." = "Google サインインが Keychain にアクセスできませんでした。必要な Keychain entitlement 付きでコード署名されるよう、./scripts/run-dev.sh でアプリを作り直してください。";
 "Google Account" = "Google アカウント";
 "Untitled event" = "タイトル未設定";
@@ -416,6 +420,7 @@
 "Copy for Slack" = "Slack 用にコピー";
 "Summary Prompt" = "要約プロンプト";
 "Reset to Default" = "デフォルトに戻す";
+"Restore App Defaults" = "アプリ規定に戻す";
 "Summary Template" = "要約テンプレート";
 "Open in Editor" = "エディタで開く";
 "Open Templates Folder" = "テンプレートフォルダを開く";
@@ -508,7 +513,7 @@
 "Could not configure the Google Drive export folder." = "Google Drive の書き出しフォルダを設定できませんでした。";
 "Open Cloud Storage Settings" = "Cloud Storage 設定を開く";
 "No previous Google session was found." = "以前の Google セッションは見つかりませんでした。";
-"Set GOOGLE_CLIENT_ID before connecting Google services." = "Google サービスを接続する前に、開発者設定または環境変数で GOOGLE_CLIENT_ID を設定してください。";
+"Set a Google OAuth client ID in Developer Settings before connecting Google services." = "Google サービスを接続する前に、開発者設定で Google OAuth クライアント ID を設定してください。";
 "Unexpected response from Google" = "Google から予期しないレスポンスが返されました";
 "Google HTTP %lld: %@" = "Google HTTP %lld: %@";
 "Google account connected, but Calendar access has not been granted yet." = "Google アカウントは接続済みですが、カレンダー権限はまだ付与されていません。";
@@ -703,9 +708,14 @@
 "Vault Name" = "保管庫名";
 "Vault ID" = "保管庫 ID";
 "Copy Command" = "コマンドをコピー";
+"Copied" = "コピーしました";
 "Codex CLI" = "Codex CLI";
 "Claude Code" = "Claude Code";
 "The MCP helper is not available in this app build." = "このアプリビルドではMCPヘルパーを利用できません。";
 "Select a vault before configuring MCP." = "MCPを設定する前に保管庫を選択してください。";
 "Each command registers read-only access to only the selected vault. Run it again after switching vaults." = "各コマンドは、選択中の保管庫だけへの読み取り専用アクセスを登録します。保管庫を切り替えた後は再実行してください。";
 "%@ registration command" = "%@ 登録コマンド";
+"Turn on meeting notifications to choose notification conditions." = "通知条件を選ぶには、ミーティング通知をオンにしてください。";
+"Turn on transcript translation to choose a target language." = "翻訳先の言語を選ぶには、文字起こし翻訳をオンにしてください。";
+"Turn on live subtitles to choose their source and line count." = "音声ソースと表示行数を選ぶには、ライブ字幕をオンにしてください。";
+"Turn on automatic screenshots to choose the interval and change threshold." = "取得間隔と変化量を選ぶには、自動スクリーンショットをオンにしてください。";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -15,7 +15,9 @@ enum L10n {
     /// UserDefaults から直接読み取ることで @MainActor 制約を回避する。
     private nonisolated static var bundle: Bundle {
         let rawValue = UserDefaults.standard.string(forKey: AppLanguage.userDefaultsKey) ?? AppLanguage.system.rawValue
-        if rawValue == cachedLanguageRaw { return cachedBundle }
+        if rawValue == cachedLanguageRaw {
+            return cachedBundle
+        }
         let resolved: Bundle = if let language = AppLanguage(rawValue: rawValue),
                                   let lprojName = language.lprojName,
                                   let path = Bundle.appModule.path(forResource: lprojName, ofType: "lproj"),
@@ -246,6 +248,17 @@ enum L10n {
         localized: "This instruction is not currently used for summary generation.",
         bundle: bundle
     ) }
+    static var changesSaveAutomatically: String { String(localized: "Changes save automatically.", bundle: bundle) }
+    static var instructionTitleRequired: String { String(localized: "Enter a title to save this instruction.", bundle: bundle) }
+    static var deleteInstructionWarning: String { String(
+        localized: "This instruction will be permanently deleted. This cannot be undone.",
+        bundle: bundle
+    ) }
+
+    static func deleteInstructionConfirmation(_ name: String) -> String {
+        String(format: String(localized: "Delete instruction \"%@\"?", bundle: bundle), name)
+    }
+
     static var instructionsEmptyContent: String { String(localized: "No content yet", bundle: bundle) }
     static var noResultsFound: String { String(localized: "No results found", bundle: bundle) }
     static var noProject: String { String(localized: "No project", bundle: bundle) }
@@ -379,6 +392,10 @@ enum L10n {
         localized: "Capture the screen during recording and save a new image when the display changes significantly.",
         bundle: bundle
     ) }
+    static var enableAutomaticScreenshotsToConfigure: String { String(
+        localized: "Turn on automatic screenshots to choose the interval and change threshold.",
+        bundle: bundle
+    ) }
     static var automaticScreenshotsToggleDescription: String { String(
         localized: "Automatically add screenshots while recording.",
         bundle: bundle
@@ -412,6 +429,11 @@ enum L10n {
             String(localized: "In batch mode, subtitles are temporary and the final transcript is created after recording stops.", bundle: bundle),
         ].joined(separator: " ")
     }
+
+    static var enableLiveSubtitlesToConfigure: String { String(
+        localized: "Turn on live subtitles to choose their source and line count.",
+        bundle: bundle
+    ) }
 
     static var systemAudioOnly: String { String(localized: "System Audio Only", bundle: bundle) }
     static var includeMicrophone: String { String(localized: "Include Microphone", bundle: bundle) }
@@ -565,6 +587,7 @@ enum L10n {
     static var mcp: String { String(localized: "MCP", bundle: bundle) }
     static var vaultID: String { String(localized: "Vault ID", bundle: bundle) }
     static var copyCommand: String { String(localized: "Copy Command", bundle: bundle) }
+    static var copied: String { String(localized: "Copied", bundle: bundle) }
     static var codexCLI: String { String(localized: "Codex CLI", bundle: bundle) }
     static var claudeCode: String { String(localized: "Claude Code", bundle: bundle) }
     static var mcpHelperUnavailable: String { String(
@@ -589,6 +612,10 @@ enum L10n {
     static var followSystem: String { String(localized: "Follow System", bundle: bundle) }
     static var notificationSettingsDescription: String { String(
         localized: "Choose one or both conditions. Calendar notifications use events from enabled calendar sources.",
+        bundle: bundle
+    ) }
+    static var enableMeetingNotificationsToChooseConditions: String { String(
+        localized: "Turn on meeting notifications to choose notification conditions.",
         bundle: bundle
     ) }
     static var transcriptionSettingsDescription: String { String(
@@ -624,18 +651,22 @@ enum L10n {
         localized: "Translation is automatically disabled when the target language matches the transcription language.",
         bundle: bundle
     ) }
+    static var enableTranscriptTranslationToChooseLanguage: String { String(
+        localized: "Turn on transcript translation to choose a target language.",
+        bundle: bundle
+    ) }
     static var developerSettingsDescription: String { String(
-        localized: "Override developer-managed credentials used by external service integrations.",
+        localized: "Configure these only when your organization requires a company-managed Google OAuth client. Otherwise, leave them blank to use the app defaults.",
         bundle: bundle
     ) }
     static var googleOAuthClientIDOverride: String { String(localized: "Google OAuth Client ID", bundle: bundle) }
     static var googleOAuthClientIDOverrideDescription: String { String(
-        localized: "Leave blank to use the bundled or environment-provided GOOGLE_CLIENT_ID.",
+        localized: "Leave blank to use the app's default client ID.",
         bundle: bundle
     ) }
     static var googleOAuthClientSecretOverride: String { String(localized: "Google OAuth Client Secret", bundle: bundle) }
     static var googleOAuthClientSecretOverrideDescription: String { String(
-        localized: "Optional. Stored in Keychain and used before GOOGLE_CLIENT_SECRET when set.",
+        localized: "Optional. Stored securely in Keychain. Leave blank to use the app's default client secret.",
         bundle: bundle
     ) }
     static var googleOAuthOverrideReconnectNotice: String { String(
@@ -779,7 +810,7 @@ enum L10n {
     static var calendarAllDay: String { googleCalendarAllDay }
     static var googleCalendarClientIDMissingTitle: String { String(localized: "Google Calendar is not configured", bundle: bundle) }
     static var googleCalendarClientIDMissingMessage: String { String(
-        localized: "Set GOOGLE_CLIENT_ID before connecting Google Calendar.",
+        localized: "Set a Google OAuth client ID in Developer Settings before connecting Google Calendar.",
         bundle: bundle
     ) }
     static var googleCalendarSignInRequiredTitle: String { String(localized: "Connect Google Calendar", bundle: bundle) }
@@ -844,11 +875,11 @@ enum L10n {
     static var googleCalendarNoPreviousSession: String { String(localized: "No previous Google Calendar session was found.", bundle: bundle) }
     static var googleAccountNoPreviousSession: String { String(localized: "No previous Google session was found.", bundle: bundle) }
     static var googleCalendarClientSecretMissingMessage: String { String(
-        localized: "This Google OAuth client requires a client secret. Set GOOGLE_CLIENT_SECRET to the value from Google Cloud Console and relaunch Dahlia.",
+        localized: "This Google OAuth client requires a client secret. Enter the value from Google Cloud Console in Developer Settings and relaunch Dahlia.",
         bundle: bundle
     ) }
     static var googleAccountClientIDMissingMessage: String { String(
-        localized: "Set GOOGLE_CLIENT_ID before connecting Google services.",
+        localized: "Set a Google OAuth client ID in Developer Settings before connecting Google services.",
         bundle: bundle
     ) }
     static var googleAccountClientSecretMissingMessage: String { googleCalendarClientSecretMissingMessage }
@@ -1104,6 +1135,7 @@ enum L10n {
     static var copySummaryForSlack: String { String(localized: "Copy for Slack", bundle: bundle) }
     static var summaryPrompt: String { String(localized: "Summary Prompt", bundle: bundle) }
     static var resetToDefault: String { String(localized: "Reset to Default", bundle: bundle) }
+    static var restoreAppDefaults: String { String(localized: "Restore App Defaults", bundle: bundle) }
     static var summaryTemplate: String { String(localized: "Summary Template", bundle: bundle) }
     static var openInEditor: String { String(localized: "Open in Editor", bundle: bundle) }
     static var openTemplatesFolder: String { String(localized: "Open Templates Folder", bundle: bundle) }

--- a/Sources/Dahlia/Views/Settings/DeveloperSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/DeveloperSettingsView.swift
@@ -8,7 +8,12 @@ struct DeveloperSettingsView: View {
     var body: some View {
         Form {
             Section {
-                LabeledContent {
+                VStack(alignment: .leading) {
+                    Text(L10n.googleOAuthClientIDOverride)
+                    Text(L10n.googleOAuthClientIDOverrideDescription)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+
                     TextField(
                         "",
                         text: $settings.googleOAuthClientIDOverride,
@@ -16,23 +21,24 @@ struct DeveloperSettingsView: View {
                     )
                     .font(.callout.monospaced())
                     .textFieldStyle(.roundedBorder)
+                    .accessibilityLabel(Text(L10n.googleOAuthClientIDOverride))
                     .onSubmit {
                         saveClientIDOverride()
                     }
-                } label: {
-                    Text(L10n.googleOAuthClientIDOverride)
-                    Text(L10n.googleOAuthClientIDOverrideDescription)
                 }
 
-                LabeledContent {
+                VStack(alignment: .leading) {
+                    Text(L10n.googleOAuthClientSecretOverride)
+                    Text(L10n.googleOAuthClientSecretOverrideDescription)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+
                     SecureField("", text: $clientSecretOverride)
                         .textFieldStyle(.roundedBorder)
+                        .accessibilityLabel(Text(L10n.googleOAuthClientSecretOverride))
                         .onSubmit {
                             saveClientSecretOverride()
                         }
-                } label: {
-                    Text(L10n.googleOAuthClientSecretOverride)
-                    Text(L10n.googleOAuthClientSecretOverrideDescription)
                 }
 
                 SettingsStatusMessage(
@@ -41,7 +47,7 @@ struct DeveloperSettingsView: View {
                     tint: .blue
                 )
 
-                Button(L10n.resetToDefault) {
+                Button(L10n.restoreAppDefaults) {
                     resetOverrides()
                 }
                 .disabled(!hasOverrides)

--- a/Sources/Dahlia/Views/Settings/GeneralSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/GeneralSettingsView.swift
@@ -73,7 +73,12 @@ struct GeneralSettingsView: View {
             } header: {
                 Text(L10n.notifications)
             } footer: {
-                Text(L10n.notificationSettingsDescription)
+                VStack(alignment: .leading) {
+                    Text(L10n.notificationSettingsDescription)
+                    if !settings.meetingDetectionEnabled {
+                        Text(L10n.enableMeetingNotificationsToChooseConditions)
+                    }
+                }
             }
         }
         .formStyle(.grouped)

--- a/Sources/Dahlia/Views/Settings/InstructionsSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/InstructionsSettingsView.swift
@@ -12,19 +12,28 @@ struct InstructionsSettingsView: View {
     @State private var draftName = ""
     @State private var draftContent = ""
     @State private var saveTask: Task<Void, Never>?
+    @State private var isSaving = false
+    @State private var instructionPendingDeletion: InstructionRecord?
+    @State private var isShowingDeleteConfirmation = false
     @FocusState private var isNameFieldFocused: Bool
 
     private let listWidth: CGFloat = 280
 
     var body: some View {
-        HStack(spacing: 0) {
-            instructionsList
-                .frame(minWidth: 220, idealWidth: listWidth, maxWidth: 320)
+        Group {
+            if sidebarViewModel.allInstructions.isEmpty {
+                emptyInstructionsView
+            } else {
+                HStack(spacing: 0) {
+                    instructionsList
+                        .frame(minWidth: 220, idealWidth: listWidth, maxWidth: 320)
 
-            Divider()
+                    Divider()
 
-            instructionEditor
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    instructionEditor
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .frame(minHeight: 440)
@@ -43,7 +52,19 @@ struct InstructionsSettingsView: View {
             saveTask?.cancel()
             persistDraftsIfNeeded()
         }
-        .onDeleteCommand(perform: deleteSelectedInstruction)
+        .onDeleteCommand(perform: requestSelectedInstructionDeletion)
+        .confirmationDialog(
+            deleteConfirmationTitle,
+            isPresented: $isShowingDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(L10n.delete, role: .destructive, action: confirmInstructionDeletion)
+            Button(L10n.cancel, role: .cancel) {
+                instructionPendingDeletion = nil
+            }
+        } message: {
+            Text(L10n.deleteInstructionWarning)
+        }
     }
 
     private var selectedInstruction: InstructionRecord? {
@@ -68,24 +89,20 @@ struct InstructionsSettingsView: View {
             .padding(.top, 16)
             .padding(.bottom, 12)
 
-            if sidebarViewModel.allInstructions.isEmpty {
-                emptyInstructionsView
-            } else {
-                List(selection: $selectedInstructionID) {
-                    ForEach(sidebarViewModel.allInstructions) { instruction in
-                        instructionRow(instruction)
-                            .tag(instruction.id)
-                            .contextMenu {
-                                Button(role: .destructive) {
-                                    sidebarViewModel.deleteInstruction(id: instruction.id)
-                                } label: {
-                                    Label(L10n.delete, systemImage: "trash")
-                                }
+            List(selection: $selectedInstructionID) {
+                ForEach(sidebarViewModel.allInstructions) { instruction in
+                    instructionRow(instruction)
+                        .tag(instruction.id)
+                        .contextMenu {
+                            Button(role: .destructive) {
+                                requestInstructionDeletion(instruction)
+                            } label: {
+                                Label(L10n.delete, systemImage: "trash")
                             }
-                    }
+                        }
                 }
-                .listStyle(.inset)
             }
+            .listStyle(.inset)
         }
     }
 
@@ -100,9 +117,9 @@ struct InstructionsSettingsView: View {
                             .font(.largeTitle.weight(.semibold))
                             .focused($isNameFieldFocused)
 
-                        Text(activeInstructionStatusText(for: selectedInstruction))
+                        Text(editorStatusText(for: selectedInstruction))
                             .font(.callout)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(isInstructionTitleValid ? Color.secondary : Color.red)
                     }
 
                     Spacer(minLength: 0)
@@ -120,7 +137,7 @@ struct InstructionsSettingsView: View {
                         }
 
                         Button(L10n.delete, role: .destructive) {
-                            deleteSelectedInstruction()
+                            requestSelectedInstructionDeletion()
                         }
                     }
                 }
@@ -137,8 +154,6 @@ struct InstructionsSettingsView: View {
                     .background(Color(nsColor: .textBackgroundColor))
                     .padding(12)
             }
-        } else if sidebarViewModel.allInstructions.isEmpty {
-            emptyInstructionsView
         } else {
             ContentUnavailableView {
                 Label(L10n.instructions, systemImage: "list.bullet.clipboard")
@@ -206,6 +221,18 @@ struct InstructionsSettingsView: View {
         return L10n.summaryInstructionNotSelected
     }
 
+    private var isInstructionTitleValid: Bool {
+        !draftName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func editorStatusText(for instruction: InstructionRecord) -> String {
+        guard isInstructionTitleValid else { return L10n.instructionTitleRequired }
+        if isSaving {
+            return L10n.saving
+        }
+        return "\(activeInstructionStatusText(for: instruction)) \(L10n.changesSaveAutomatically)"
+    }
+
     private func instruction(for id: UUID?) -> InstructionRecord? {
         guard let id else { return nil }
         return sidebarViewModel.allInstructions.first(where: { $0.id == id })
@@ -219,16 +246,32 @@ struct InstructionsSettingsView: View {
 
     private func syncDraftsFromSelection() {
         saveTask?.cancel()
+        isSaving = false
         draftName = selectedInstruction?.name ?? ""
         draftContent = selectedInstruction?.content ?? ""
     }
 
     private func scheduleSave() {
-        guard selectedInstruction != nil else { return }
+        guard let selectedInstruction else { return }
         saveTask?.cancel()
+        let trimmedName = draftName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            isSaving = false
+            return
+        }
+        guard trimmedName != selectedInstruction.name || draftContent != selectedInstruction.content else {
+            isSaving = false
+            return
+        }
+        isSaving = true
         saveTask = Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(350))
+            do {
+                try await Task.sleep(for: .milliseconds(350))
+            } catch {
+                return
+            }
             persistDraftsIfNeeded()
+            isSaving = false
         }
     }
 
@@ -240,10 +283,7 @@ struct InstructionsSettingsView: View {
         guard let selectedInstruction = instruction(for: instructionID) else { return }
 
         let trimmedName = draftName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedName.isEmpty else {
-            draftName = selectedInstruction.name
-            return
-        }
+        guard !trimmedName.isEmpty else { return }
 
         guard trimmedName != selectedInstruction.name || draftContent != selectedInstruction.content else { return }
         sidebarViewModel.updateInstruction(id: selectedInstruction.id, name: trimmedName, content: draftContent)
@@ -255,9 +295,27 @@ struct InstructionsSettingsView: View {
         isNameFieldFocused = true
     }
 
-    private func deleteSelectedInstruction() {
+    private var deleteConfirmationTitle: String {
+        guard let instructionPendingDeletion else { return L10n.delete }
+        return L10n.deleteInstructionConfirmation(instructionPendingDeletion.displayName)
+    }
+
+    private func requestSelectedInstructionDeletion() {
         guard let selectedInstruction else { return }
-        sidebarViewModel.deleteInstruction(id: selectedInstruction.id)
-        selectedInstructionID = sidebarViewModel.allInstructions.first(where: { $0.id != selectedInstruction.id })?.id
+        requestInstructionDeletion(selectedInstruction)
+    }
+
+    private func requestInstructionDeletion(_ instruction: InstructionRecord) {
+        instructionPendingDeletion = instruction
+        isShowingDeleteConfirmation = true
+    }
+
+    private func confirmInstructionDeletion() {
+        guard let instructionPendingDeletion else { return }
+        sidebarViewModel.deleteInstruction(id: instructionPendingDeletion.id)
+        if selectedInstructionID == instructionPendingDeletion.id {
+            selectedInstructionID = sidebarViewModel.allInstructions.first(where: { $0.id != instructionPendingDeletion.id })?.id
+        }
+        self.instructionPendingDeletion = nil
     }
 }

--- a/Sources/Dahlia/Views/Settings/MCPSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/MCPSettingsView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 struct MCPSettingsView: View {
     @ObservedObject private var settings = AppSettings.shared
+    @State private var copiedCommandTitle: String?
+    @State private var copyFeedbackTask: Task<Void, Never>?
 
     var body: some View {
         Form {
@@ -39,6 +41,9 @@ struct MCPSettingsView: View {
             }
         }
         .formStyle(.grouped)
+        .onDisappear {
+            copyFeedbackTask?.cancel()
+        }
     }
 
     private func commandContent(title: String, command: String) -> some View {
@@ -49,11 +54,11 @@ struct MCPSettingsView: View {
                     .textSelection(.enabled)
                     .multilineTextAlignment(.leading)
                     .accessibilityLabel(L10n.registrationCommand(title))
-                Button {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(command, forType: .string)
-                } label: {
-                    Label(L10n.copyCommand, systemImage: "doc.on.doc")
+                Button(
+                    copiedCommandTitle == title ? L10n.copied : L10n.copyCommand,
+                    systemImage: copiedCommandTitle == title ? "checkmark" : "doc.on.doc"
+                ) {
+                    copy(command, title: title)
                 }
             }
         } label: {
@@ -67,5 +72,21 @@ struct MCPSettingsView: View {
             helperURL: helperURL,
             vaultID: vault.id
         )
+    }
+
+    private func copy(_ command: String, title: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(command, forType: .string)
+        copiedCommandTitle = title
+
+        copyFeedbackTask?.cancel()
+        copyFeedbackTask = Task { @MainActor in
+            do {
+                try await Task.sleep(for: .seconds(2))
+            } catch {
+                return
+            }
+            copiedCommandTitle = nil
+        }
     }
 }

--- a/Sources/Dahlia/Views/Settings/ScreenshotSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/ScreenshotSettingsView.swift
@@ -37,7 +37,12 @@ struct ScreenshotSettingsView: View {
             } header: {
                 Text(L10n.automaticScreenshots)
             } footer: {
-                Text(L10n.automaticScreenshotsDescription)
+                VStack(alignment: .leading) {
+                    Text(L10n.automaticScreenshotsDescription)
+                    if !settings.automaticScreenshotEnabled {
+                        Text(L10n.enableAutomaticScreenshotsToConfigure)
+                    }
+                }
             }
         }
         .formStyle(.grouped)

--- a/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
@@ -74,10 +74,13 @@ struct TranscriptionSettingsView: View {
                     Text(L10n.translationTargetLanguageDescription)
                 }
                 .pickerStyle(.menu)
+                .disabled(!settings.transcriptTranslationEnabled)
             } header: {
                 Text(L10n.transcriptTranslation)
             } footer: {
-                if !settings.isTranscriptTranslationEffectivelyEnabled, settings.transcriptTranslationEnabled {
+                if !settings.transcriptTranslationEnabled {
+                    Text(L10n.enableTranscriptTranslationToChooseLanguage)
+                } else if !settings.isTranscriptTranslationEffectivelyEnabled {
                     Text(L10n.translationDisabledForMatchingLanguage)
                 }
             }
@@ -111,7 +114,12 @@ struct TranscriptionSettingsView: View {
             } header: {
                 Text(L10n.liveSubtitleOverlay)
             } footer: {
-                Text(L10n.liveSubtitleOverlayDescription)
+                VStack(alignment: .leading) {
+                    Text(L10n.liveSubtitleOverlayDescription)
+                    if !settings.liveSubtitleOverlayEnabled {
+                        Text(L10n.enableLiveSubtitlesToConfigure)
+                    }
+                }
             }
 
             Section {

--- a/Sources/Dahlia/Views/SettingsView.swift
+++ b/Sources/Dahlia/Views/SettingsView.swift
@@ -12,7 +12,7 @@ struct SettingsView: View {
         NavigationStack {
             HStack(spacing: 0) {
                 SettingsSidebarView(selection: $selection)
-                    .frame(width: 180)
+                    .frame(width: 200)
 
                 Divider()
 
@@ -25,6 +25,6 @@ struct SettingsView: View {
             }
             .navigationTitle(selection.label)
         }
-        .frame(minWidth: 860, minHeight: 560)
+        .frame(minWidth: 720, minHeight: 520)
     }
 }

--- a/Tests/DahliaTests/SettingsCategoryTests.swift
+++ b/Tests/DahliaTests/SettingsCategoryTests.swift
@@ -45,5 +45,24 @@
             #expect(SettingsGroup.allCases.last == .advanced)
             #expect(SettingsGroup.advanced.categories == [.developer, .audioDiagnostics])
         }
+
+        @Test
+        func settingsFeedbackCopyNamesTheActionAndAffectedInstruction() {
+            let instructionName = "Weekly review"
+
+            #expect(!L10n.copied.isEmpty)
+            #expect(!L10n.changesSaveAutomatically.isEmpty)
+            #expect(!L10n.instructionTitleRequired.isEmpty)
+            #expect(L10n.deleteInstructionConfirmation(instructionName).contains(instructionName))
+            #expect(!L10n.deleteInstructionWarning.isEmpty)
+        }
+
+        @Test
+        func developerSettingsCopyUsesUserFacingTerms() {
+            #expect(!L10n.googleOAuthClientIDOverrideDescription.contains("GOOGLE_CLIENT_ID"))
+            #expect(!L10n.googleOAuthClientSecretOverrideDescription.contains("GOOGLE_CLIENT_SECRET"))
+            #expect(!L10n.developerSettingsDescription.isEmpty)
+            #expect(!L10n.restoreAppDefaults.isEmpty)
+        }
     }
 #endif


### PR DESCRIPTION
## Summary

- keep the settings sidebar permanently visible and remove its collapse control
- clarify master-toggle dependencies, instruction autosave and deletion behavior, and MCP copy completion
- align Google OAuth credential fields and replace environment-variable terminology with user-facing app-default guidance
- update Japanese and English localization and add settings-focused regression coverage

## Why

The settings window mixed navigation behavior, grouping, and feedback patterns that made dependent controls and completed actions difficult to understand. Developer settings also exposed implementation details and rendered OAuth fields at inconsistent widths.

These changes keep the existing categories, raw values, saved selection, settings values, and integration behavior while making the UI more consistent with a quiet macOS settings experience.

## User impact

- settings navigation remains stable during window resizing
- disabled controls explain which master setting enables them
- instruction selection, autosave, empty titles, and deletion consequences are clearer
- copy actions provide immediate completion feedback
- OAuth overrides are presented as an exceptional organization-managed configuration, with matching field widths and VoiceOver labels

## Validation

- `swift build`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter SettingsCategoryTests` — 6 tests passed
- targeted SwiftFormat and SwiftLint — 0 violations
- English and Japanese `.strings` files validated with `plutil`
- manually verified the Japanese settings UI, resizing behavior, OAuth field alignment, and accessibility labels in the running app

`CI=true ./scripts/lint.sh` was also run. It remains blocked by pre-existing SwiftFormat violations in 15 unrelated files; the files changed by this PR pass targeted lint checks.
