### PR TITLE
Fix project description save follow-ups

### DIFF
--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -862,13 +862,15 @@ extension MeetingRepository {
         }
     }
 
-    func updateProjectDescription(id: UUID, description: String) throws {
+    @discardableResult
+    func updateProjectDescription(id: UUID, description: String) throws -> Bool {
         try dbQueue.write { db in
             guard var record = try ProjectRecord.fetchOne(db, key: id) else {
-                throw ProjectRecord.recordNotFound(db, key: id)
+                return false
             }
             record.description = description
             try record.update(db)
+            return true
         }
     }
 

--- a/Sources/Dahlia/Models/ProjectDescriptionChangeTracker.swift
+++ b/Sources/Dahlia/Models/ProjectDescriptionChangeTracker.swift
@@ -1,0 +1,13 @@
+struct ProjectDescriptionChangeTracker: Equatable {
+    private var programmaticValue: String?
+
+    mutating func prepareForProgrammaticChange(from currentValue: String, to newValue: String) {
+        programmaticValue = currentValue == newValue ? nil : newValue
+    }
+
+    mutating func shouldSaveChange(to newValue: String) -> Bool {
+        let shouldSave = programmaticValue != newValue
+        programmaticValue = nil
+        return shouldSave
+    }
+}

--- a/Sources/Dahlia/Models/ProjectDescriptionEditingState.swift
+++ b/Sources/Dahlia/Models/ProjectDescriptionEditingState.swift
@@ -1,0 +1,14 @@
+struct ProjectDescriptionEditingState: Equatable {
+    let text: String
+    let persistedText: String
+
+    var hasUnsavedChanges: Bool {
+        text != persistedText
+    }
+
+    init(persistedText: String?, draftText: String?) {
+        let persistedText = persistedText ?? ""
+        self.text = draftText ?? persistedText
+        self.persistedText = persistedText
+    }
+}

--- a/Sources/Dahlia/Models/ProjectDescriptionUpdateResult.swift
+++ b/Sources/Dahlia/Models/ProjectDescriptionUpdateResult.swift
@@ -1,0 +1,5 @@
+enum ProjectDescriptionUpdateResult: Equatable {
+    case saved
+    case projectNotFound
+    case failed
+}

--- a/Sources/Dahlia/ViewModels/SidebarViewModel.swift
+++ b/Sources/Dahlia/ViewModels/SidebarViewModel.swift
@@ -493,37 +493,6 @@ final class SidebarViewModel {
         }
     }
 
-    @discardableResult
-    func updateProjectDescription(id: UUID, description: String) -> Bool {
-        guard let meetingRepository else { return false }
-        do {
-            try meetingRepository.updateProjectDescription(id: id, description: description)
-            projectDescriptionDrafts[id] = nil
-            return true
-        } catch {
-            projectDescriptionDrafts[id] = description
-            lastError = error.localizedDescription
-            return false
-        }
-    }
-
-    func stageProjectDescriptionDraft(id: UUID, description: String) {
-        projectDescriptionDrafts[id] = description
-    }
-
-    func projectDescriptionDraft(id: UUID) -> String? {
-        projectDescriptionDrafts[id]
-    }
-
-    func projectDescription(id: UUID) -> String? {
-        do {
-            return try meetingRepository?.fetchProject(id: id)?.description
-        } catch {
-            lastError = error.localizedDescription
-            return nil
-        }
-    }
-
     // MARK: - Meeting Management
 
     func renameMeeting(id: UUID, newName: String) {
@@ -587,6 +556,41 @@ final class SidebarViewModel {
             try repository.moveMeetings(ids: ids, toProjectId: toProjectId)
         } catch {
             lastError = error.localizedDescription
+        }
+    }
+}
+
+extension SidebarViewModel {
+    func updateProjectDescription(id: UUID, description: String) -> ProjectDescriptionUpdateResult {
+        guard let meetingRepository else { return .failed }
+        do {
+            guard try meetingRepository.updateProjectDescription(id: id, description: description) else {
+                projectDescriptionDrafts[id] = nil
+                return .projectNotFound
+            }
+            projectDescriptionDrafts[id] = nil
+            return .saved
+        } catch {
+            projectDescriptionDrafts[id] = description
+            lastError = error.localizedDescription
+            return .failed
+        }
+    }
+
+    func stageProjectDescriptionDraft(id: UUID, description: String) {
+        projectDescriptionDrafts[id] = description
+    }
+
+    func projectDescriptionDraft(id: UUID) -> String? {
+        projectDescriptionDrafts[id]
+    }
+
+    func projectDescription(id: UUID) -> String? {
+        do {
+            return try meetingRepository?.fetchProject(id: id)?.description
+        } catch {
+            lastError = error.localizedDescription
+            return nil
         }
     }
 }

--- a/Sources/Dahlia/Views/ProjectManagementView.swift
+++ b/Sources/Dahlia/Views/ProjectManagementView.swift
@@ -433,13 +433,14 @@ private extension ProjectManagementView {
     }
 
     private func loadProjectDetails(for projectId: UUID?) {
-        let description = projectId.flatMap { id in
-            sidebarViewModel.projectDescriptionDraft(id: id)
-                ?? sidebarViewModel.projectDescription(id: id)
-        } ?? ""
-        projectDescription = description
-        lastSavedProjectDescription = description
-        descriptionStatusMessage = nil
+        let editingState = ProjectDescriptionEditingState(
+            persistedText: projectId.flatMap { sidebarViewModel.projectDescription(id: $0) },
+            draftText: projectId.flatMap { sidebarViewModel.projectDescriptionDraft(id: $0) }
+        )
+        projectDescription = editingState.text
+        lastSavedProjectDescription = editingState.persistedText
+        descriptionStatusMessage = editingState.hasUnsavedChanges ? L10n.projectDescriptionSaveFailed : nil
+        descriptionSaveFailed = editingState.hasUnsavedChanges
         projectName = projectId
             .flatMap { id in sidebarViewModel.allProjectItems.first(where: { $0.projectId == id }) }
             .map { leafName(for: $0.projectName) }
@@ -468,11 +469,15 @@ private extension ProjectManagementView {
         guard let projectId,
               projectDescription != lastSavedProjectDescription else { return true }
 
-        if sidebarViewModel.updateProjectDescription(id: projectId, description: projectDescription) {
+        switch sidebarViewModel.updateProjectDescription(id: projectId, description: projectDescription) {
+        case .saved:
             lastSavedProjectDescription = projectDescription
             descriptionStatusMessage = L10n.saved
             descriptionSaveFailed = false
-        } else {
+        case .projectNotFound:
+            descriptionStatusMessage = nil
+            descriptionSaveFailed = false
+        case .failed:
             descriptionStatusMessage = L10n.projectDescriptionSaveFailed
             descriptionSaveFailed = true
             return false

--- a/Sources/Dahlia/Views/ProjectManagementView.swift
+++ b/Sources/Dahlia/Views/ProjectManagementView.swift
@@ -22,6 +22,7 @@ struct ProjectManagementView: View {
     @State private var lastSavedProjectDescription = ""
     @State private var descriptionSaveTask: Task<Void, Never>?
     @State private var isRevertingSelectionAfterSaveFailure = false
+    @State private var projectDescriptionChangeTracker = ProjectDescriptionChangeTracker()
 
     private let sidebarWidth: CGFloat = 300
 
@@ -53,7 +54,8 @@ struct ProjectManagementView: View {
             }
             loadProjectDetails(for: newProjectId)
         }
-        .onChange(of: projectDescription) { _, _ in
+        .onChange(of: projectDescription) { _, newDescription in
+            guard projectDescriptionChangeTracker.shouldSaveChange(to: newDescription) else { return }
             scheduleProjectDescriptionSave()
         }
         .onDisappear {
@@ -436,6 +438,10 @@ private extension ProjectManagementView {
         let editingState = ProjectDescriptionEditingState(
             persistedText: projectId.flatMap { sidebarViewModel.projectDescription(id: $0) },
             draftText: projectId.flatMap { sidebarViewModel.projectDescriptionDraft(id: $0) }
+        )
+        projectDescriptionChangeTracker.prepareForProgrammaticChange(
+            from: projectDescription,
+            to: editingState.text
         )
         projectDescription = editingState.text
         lastSavedProjectDescription = editingState.persistedText

--- a/Tests/DahliaTests/ProjectDescriptionEditingStateTests.swift
+++ b/Tests/DahliaTests/ProjectDescriptionEditingStateTests.swift
@@ -19,6 +19,28 @@ struct ProjectDescriptionEditingStateTests {
     }
 
     @Test
+    func programmaticDraftRestorationDoesNotRequestSave() {
+        var tracker = ProjectDescriptionChangeTracker()
+
+        tracker.prepareForProgrammaticChange(from: "", to: "Unsaved description")
+        let shouldSaveRestoredDraft = tracker.shouldSaveChange(to: "Unsaved description")
+        let shouldSaveUserEdit = tracker.shouldSaveChange(to: "Edited description")
+
+        #expect(!shouldSaveRestoredDraft)
+        #expect(shouldSaveUserEdit)
+    }
+
+    @Test
+    func unchangedProgrammaticValueDoesNotSuppressLaterUserEdit() {
+        var tracker = ProjectDescriptionChangeTracker()
+
+        tracker.prepareForProgrammaticChange(from: "", to: "")
+        let shouldSaveUserEdit = tracker.shouldSaveChange(to: "User description")
+
+        #expect(shouldSaveUserEdit)
+    }
+
+    @Test
     func missingProjectDoesNotRemainAFailedDraft() throws {
         let database = try AppDatabaseManager(path: ":memory:")
         let viewModel = SidebarViewModel()

--- a/Tests/DahliaTests/ProjectDescriptionEditingStateTests.swift
+++ b/Tests/DahliaTests/ProjectDescriptionEditingStateTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+import Testing
+
+@MainActor
+struct ProjectDescriptionEditingStateTests {
+    @Test
+    func restoredDraftKeepsPersistedDescriptionAsSaveBaseline() {
+        let state = ProjectDescriptionEditingState(
+            persistedText: "Saved description",
+            draftText: "Unsaved description"
+        )
+
+        #expect(state.text == "Unsaved description")
+        #expect(state.persistedText == "Saved description")
+        #expect(state.hasUnsavedChanges)
+    }
+
+    @Test
+    func missingProjectDoesNotRemainAFailedDraft() throws {
+        let database = try AppDatabaseManager(path: ":memory:")
+        let viewModel = SidebarViewModel()
+        let deletedProjectId = UUID.v7()
+        viewModel.setAppDatabase(database)
+        viewModel.stageProjectDescriptionDraft(id: deletedProjectId, description: "Unsaved description")
+
+        let result = viewModel.updateProjectDescription(
+            id: deletedProjectId,
+            description: "Unsaved description"
+        )
+
+        #expect(result == .projectNotFound)
+        #expect(viewModel.projectDescriptionDraft(id: deletedProjectId) == nil)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- keep restored project-description drafts distinct from the persisted save baseline
- preserve unsaved/error state when reopening project management after a failed save
- distinguish a deleted project from a transient description-save failure so selection is not reverted to a deleted project
- add regression coverage for restored drafts and deleted-project saves

## Why

PR #120 was merged before two automated review findings arrived. A restored draft was being treated as already saved, and a debounced save racing with project deletion could reselect the deleted project.

## Impact

Unsaved project descriptions remain visibly retryable after reopening the window. Deleting a project while a description save is pending no longer leaves project management stuck on a deleted selection. There are no schema or dependency changes.

## Validation

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter ProjectDescriptionEditingStateTests` (2 tests)
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter AppDatabaseManagerTests` (18 tests)
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build`
- `CI=true ./scripts/lint.sh`
- `git diff --check`

Follow-up to #120.
