### PR TITLE
Prevent screenshot rendering hangs

### DIFF
--- a/Sources/Dahlia/Utilities/ScreenshotImageLoader.swift
+++ b/Sources/Dahlia/Utilities/ScreenshotImageLoader.swift
@@ -47,12 +47,6 @@ actor ScreenshotImageLoader {
         return image
     }
 
-    /// 拡大表示用。巨大な画像をキャッシュへ残さず、元のピクセル解像度でデコードする。
-    func originalImage(data: Data) -> CGImage? {
-        guard !Task.isCancelled else { return nil }
-        return CGImageDecoder.decode(data)
-    }
-
     func remove(screenshotID: UUID) {
         let keys = cache.keys.filter { $0.screenshotID == screenshotID }
         for key in keys {
@@ -82,26 +76,25 @@ final class ScreenshotImageLoadModel: ObservableObject {
         case failed
     }
 
-    enum TargetSize: Equatable {
-        case original
-        case maxPixelSize(Int)
+    @Published private(set) var state: State = .idle
+    private var loadGeneration: UInt64 = 0
+
+    func load(screenshotID: UUID, data: Data, maxPixelSize: Int) async {
+        loadGeneration &+= 1
+        let generation = loadGeneration
+        state = .loading
+        let image = await ScreenshotImageLoader.shared.image(
+            screenshotID: screenshotID,
+            data: data,
+            maxPixelSize: maxPixelSize
+        )
+        guard !Task.isCancelled, loadGeneration == generation else { return }
+        state = image.map(State.loaded) ?? .failed
     }
 
-    @Published private(set) var state: State = .idle
-
-    func load(screenshotID: UUID, data: Data, targetSize: TargetSize) async {
-        state = .loading
-        let image = switch targetSize {
-        case .original:
-            await ScreenshotImageLoader.shared.originalImage(data: data)
-        case let .maxPixelSize(size):
-            await ScreenshotImageLoader.shared.image(
-                screenshotID: screenshotID,
-                data: data,
-                maxPixelSize: size
-            )
-        }
-        guard !Task.isCancelled else { return }
-        state = image.map(State.loaded) ?? .failed
+    /// Lazy grid が保持している画面外 View からデコード済み画像を解放する。
+    func unload() {
+        loadGeneration &+= 1
+        state = .idle
     }
 }

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -140,8 +140,6 @@ private struct ScreenshotOverlayView: View {
 
 /// スクリーンショットのサムネイル表示。
 private struct ScreenshotThumbnailView: View {
-    private static let maximumPixelSize = 200
-
     let screenshot: MeetingScreenshotRecord
     let timestamp: String
     let viewModel: CaptionViewModel
@@ -224,7 +222,7 @@ private struct ScreenshotThumbnailView: View {
             await imageLoader.load(
                 screenshotID: screenshot.id,
                 data: screenshot.imageData,
-                maxPixelSize: Self.maximumPixelSize
+                maxPixelSize: ScreenshotGridSizing.maximumThumbnailPixelSize
             )
         }
         .onDisappear {

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -86,6 +86,10 @@ private struct DetailTabBar: View {
 
 /// スクリーンショット拡大表示オーバーレイ。
 private struct ScreenshotOverlayView: View {
+    /// Retina の全画面キャプチャを元解像度でレイヤー化すると、RenderBox の
+    /// surface allocation が枯渇し得る。画面表示には十分なサイズへ制限する。
+    private static let maximumDisplayPixelSize = 2400
+
     let screenshot: MeetingScreenshotRecord
     let onDismiss: () -> Void
     @StateObject private var imageLoader = ScreenshotImageLoadModel()
@@ -105,7 +109,6 @@ private struct ScreenshotOverlayView: View {
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .clipShape(RoundedRectangle(cornerRadius: 8))
-                    .shadow(radius: 20)
                     .padding(24)
             } else if case .failed = imageLoader.state {
                 Text(L10n.summaryImageUnavailable)
@@ -129,7 +132,7 @@ private struct ScreenshotOverlayView: View {
             await imageLoader.load(
                 screenshotID: screenshot.id,
                 data: screenshot.imageData,
-                targetSize: .original
+                maxPixelSize: Self.maximumDisplayPixelSize
             )
         }
     }
@@ -137,6 +140,8 @@ private struct ScreenshotOverlayView: View {
 
 /// スクリーンショットのサムネイル表示。
 private struct ScreenshotThumbnailView: View {
+    private static let maximumPixelSize = 200
+
     let screenshot: MeetingScreenshotRecord
     let timestamp: String
     let viewModel: CaptionViewModel
@@ -219,8 +224,11 @@ private struct ScreenshotThumbnailView: View {
             await imageLoader.load(
                 screenshotID: screenshot.id,
                 data: screenshot.imageData,
-                targetSize: .maxPixelSize(600)
+                maxPixelSize: Self.maximumPixelSize
             )
+        }
+        .onDisappear {
+            imageLoader.unload()
         }
     }
 

--- a/Sources/Dahlia/Views/ScreenshotGridSizing.swift
+++ b/Sources/Dahlia/Views/ScreenshotGridSizing.swift
@@ -2,4 +2,6 @@ enum ScreenshotGridSizing {
     static let minimumWidth = 110.0
     static let maximumWidth = 200.0
     static let defaultMinimumWidth = maximumWidth
+    /// 最大幅のタイルを標準的な 2x Retina で等倍表示できるデコード上限。
+    static let maximumThumbnailPixelSize = Int(maximumWidth * 2)
 }

--- a/Sources/Dahlia/Views/SummaryDocumentView.swift
+++ b/Sources/Dahlia/Views/SummaryDocumentView.swift
@@ -271,7 +271,7 @@ private struct SummaryScreenshotImageView: View {
             await imageLoader.load(
                 screenshotID: screenshotID,
                 data: data,
-                targetSize: .maxPixelSize(1200)
+                maxPixelSize: 1200
             )
         }
     }

--- a/Tests/DahliaTests/ScreenshotImageLoaderTests.swift
+++ b/Tests/DahliaTests/ScreenshotImageLoaderTests.swift
@@ -5,6 +5,7 @@ import Foundation
 #if canImport(Testing)
 import Testing
 
+@MainActor
 struct ScreenshotImageLoaderTests {
     @Test
     func downsampledImageRespectsPixelLimit() async throws {
@@ -43,16 +44,27 @@ struct ScreenshotImageLoaderTests {
     }
 
     @Test
-    func originalImageKeepsSourceResolution() async throws {
-        let image = try #require(makeImage(width: 320, height: 180))
+    func unloadingReleasesLoadedImageState() async throws {
+        let image = try #require(makeImage(width: 32, height: 32))
         let data = try #require(ImageEncoder.encode(image, quality: 0.8))
-        let loader = ScreenshotImageLoader(cacheCostLimit: 1_024 * 1_024)
+        let model = ScreenshotImageLoadModel()
 
-        let decoded = await loader.originalImage(data: data)
+        await model.load(
+            screenshotID: UUID.v7(),
+            data: data,
+            maxPixelSize: 32
+        )
+        guard case .loaded = model.state else {
+            Issue.record("Expected the image to finish loading")
+            return
+        }
 
-        let result = try #require(decoded)
-        #expect(result.width == 320)
-        #expect(result.height == 180)
+        model.unload()
+
+        guard case .idle = model.state else {
+            Issue.record("Expected unload to release the loaded image")
+            return
+        }
     }
 
     private func makeImage(width: Int, height: Int) -> CGImage? {


### PR DESCRIPTION
## Summary

- downsample expanded screenshots to a bounded 2400-pixel maximum
- downsample grid thumbnails to 200 pixels and release decoded images when cells leave the viewport
- guard asynchronous image loads against restoring stale images after unload
- remove the unbounded original-resolution UI loading path

## Why

Sentry issue [DAHLIA-APP-15](https://dahlia-app.sentry.io/issues/7607221669/) showed the main thread repeatedly blocked in RenderBox surface allocation while rendering screenshots. Full-resolution Retina captures and decoded thumbnails retained by lazy grid cells could exhaust rendering surfaces and hang the screenshot page.

The bounded decode sizes and off-screen release keep rendering memory proportional to the visible UI. Screenshot downloads continue using the original encoded data.

## Validation

- `swift test --filter ScreenshotImageLoaderTests` — 3 tests passed
- Debug build completed successfully as part of the test run
- `CI=true ./scripts/lint.sh` — SwiftFormat passed; SwiftLint reported existing non-blocking warnings
