### PR TITLE
Improve main window command layout and isolate development data

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,13 @@ let package = Package(
     ],
     targets: [
         .target(
+            name: "DahliaRuntimeSupport",
+            path: "Sources/DahliaRuntimeSupport"
+        ),
+        .target(
             name: "DahliaMeetingAccess",
             dependencies: [
+                "DahliaRuntimeSupport",
                 .product(name: "GRDB", package: "GRDB.swift"),
             ],
             path: "Sources/DahliaMeetingAccess"
@@ -31,6 +36,7 @@ let package = Package(
         .executableTarget(
             name: "Dahlia",
             dependencies: [
+                "DahliaRuntimeSupport",
                 .product(name: "GRDB", package: "GRDB.swift"),
                 .product(name: "Sentry", package: "sentry-cocoa"),
             ],
@@ -45,7 +51,7 @@ let package = Package(
         ),
         .testTarget(
             name: "DahliaTests",
-            dependencies: ["Dahlia", "DahliaMeetingAccess"],
+            dependencies: ["Dahlia", "DahliaMeetingAccess", "DahliaRuntimeSupport"],
             path: "Tests/DahliaTests",
             exclude: [
                 "AGENTS.md",

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ swift test
 ./scripts/lint.sh
 ```
 
-> **Note:** `swift run Dahlia` has no bundled Codex helper and cannot use Data Protection Keychain. Use `run-dev.sh` for full functionality. On their first run, the app-bundle scripts download the pinned official Codex 0.144.4 GitHub Release for `aarch64-apple-darwin`, verify its SHA-256, and cache it under `.build`.
+> **Note:** `swift run Dahlia` has no bundled Codex helper and cannot use Data Protection Keychain. Use `run-dev.sh` for full functionality. `run-dev.sh` uses the shared development profile at `~/Library/Application Support/Dahlia-Development`, keeping its database, recording recovery files, Codex state, and process lock separate from the release app. Development builds started by `run-dev.sh` share this profile with each other. On their first run, the app-bundle scripts download the pinned official Codex 0.144.4 GitHub Release for `aarch64-apple-darwin`, verify its SHA-256, and cache it under `.build`.
 
 The lint script and pre-commit hook use the exact SwiftFormat version managed by the independent `BuildTools` Swift package. SwiftPM resolves and caches the tool separately from the app's dependencies.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -51,7 +51,7 @@ swift test
 ./scripts/lint.sh
 ```
 
-> **注意:** `swift run Dahlia` には同梱 Codex ヘルパーがなく、Data Protection Keychain も使用できません。フル機能には `run-dev.sh` を使用してください。アプリバンドル用スクリプトの初回実行時は、固定した Codex 0.144.4 の公式 GitHub Release を `aarch64-apple-darwin` 向けに取得し、SHA-256 を検証して `.build` 配下へキャッシュします。
+> **注意:** `swift run Dahlia` には同梱 Codex ヘルパーがなく、Data Protection Keychain も使用できません。フル機能には `run-dev.sh` を使用してください。`run-dev.sh` は共有開発プロファイル `~/Library/Application Support/Dahlia-Development` を使用し、DB、録音復旧ファイル、Codex 状態、プロセスロックを正アプリから分離します。`run-dev.sh` で起動する開発版同士はこのプロファイルを共有します。アプリバンドル用スクリプトの初回実行時は、固定した Codex 0.144.4 の公式 GitHub Release を `aarch64-apple-darwin` 向けに取得し、SHA-256 を検証して `.build` 配下へキャッシュします。
 
 `build-app.sh` または `notarize.sh` の実行前に `SENTRY_DSN` を設定すると、生成される release アプリの `Info.plist` に DSN を埋め込み、Finder 起動でも Sentry を有効化できます。Debug 実行では送信しないため、`swift run Dahlia` と `run-dev.sh` は既定で Sentry イベントを送信しません。
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>21</string>
+    <string>22</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.5.5</string>
+    <string>0.5.6</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/Database/AppDatabaseManager.swift
+++ b/Sources/Dahlia/Database/AppDatabaseManager.swift
@@ -1,11 +1,12 @@
 // Migration order and helpers remain colocated so the complete schema history can be audited sequentially.
 // swiftlint:disable file_length
 
+import DahliaRuntimeSupport
 import Foundation
 import GRDB
 
 /// アプリ全体で単一の SQLite データベースを管理する。
-/// `~/Library/Application Support/Dahlia/dahlia.sqlite` に配置する。
+/// 正アプリは `Application Support/Dahlia`、`run-dev.sh` は分離した開発プロファイルに配置する。
 // swiftlint:disable:next type_body_length
 final class AppDatabaseManager: Sendable {
     let dbQueue: DatabaseQueue
@@ -35,10 +36,8 @@ final class AppDatabaseManager: Sendable {
 
     /// DB ファイルの URL。
     nonisolated static var databaseURL: URL {
-        FileManager.default
-            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("Dahlia")
-            .appendingPathComponent("dahlia.sqlite")
+        DahliaApplicationSupport.currentDirectoryURL
+            .appending(path: "dahlia.sqlite")
     }
 
     private static let migrator: DatabaseMigrator = {

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -162,6 +162,8 @@
 "Action items extracted from summaries will appear here." = "Action items extracted from summaries will appear here.";
 "We couldn't detect any conversation in this meeting." = "We couldn't detect any conversation in this meeting.";
 "Recording now" = "Recording now";
+"Recording Settings" = "Recording Settings";
+"Starts or stops recording for the selected meeting." = "Starts or stops recording for the selected meeting.";
 "Transcribing now" = "Live transcription";
 "Return to recording meeting" = "Return to recording meeting";
 "Return to transcribing meeting" = "Return to transcribing meeting";
@@ -228,6 +230,7 @@
 "Notes" = "Notes";
 "NotesPlaceholder" = "Add your private notes...";
 "Screenshots" = "Screenshots";
+"Meeting Content" = "Meeting Content";
 "Transcript" = "Transcript";
 "Assignee" = "Assignee";
 "Assign to me" = "Assign to me";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -63,7 +63,7 @@
 "Create a project at the top level of the vault." = "Vaultのトップ階層にプロジェクトを作成します。";
 "Could Not Create Project" = "プロジェクトを作成できませんでした";
 "The project folder could not be created." = "プロジェクトフォルダを作成できませんでした。";
-"New meeting" = "New meeting";
+"New meeting" = "新規ミーティング";
 "Meeting draft: %@" = "下書き: %@";
 "Context changed to %@" = "コンテキストが %@ に切り替わりました";
 "The selected meeting is no longer available." = "選択中のミーティングを読み込めませんでした。";
@@ -162,6 +162,8 @@
 "Action items extracted from summaries will appear here." = "要約から抽出された Action Items がここに表示されます。";
 "We couldn't detect any conversation in this meeting." = "この meeting では会話を検出できませんでした。";
 "Recording now" = "録音中";
+"Recording Settings" = "録音設定";
+"Starts or stops recording for the selected meeting." = "選択中のミーティングの録音を開始または停止します。";
 "Transcribing now" = "ライブ文字起こし中";
 "Return to recording meeting" = "録音中のミーティングに戻る";
 "Return to transcribing meeting" = "文字起こし中のミーティングに戻る";
@@ -228,6 +230,7 @@
 "Notes" = "ノート";
 "NotesPlaceholder" = "メモを入力...";
 "Screenshots" = "スクリーンショット";
+"Meeting Content" = "ミーティング内容";
 "Transcript" = "文字起こし";
 "Assignee" = "担当者";
 "Assign to me" = "自分に割り当てる";

--- a/Sources/Dahlia/Services/CodexChatWorkspace.swift
+++ b/Sources/Dahlia/Services/CodexChatWorkspace.swift
@@ -1,3 +1,4 @@
+import DahliaRuntimeSupport
 import Foundation
 
 protocol CodexChatWorkspaceLocating: Sendable {
@@ -12,9 +13,10 @@ struct ApplicationSupportCodexChatWorkspaceLocator: CodexChatWorkspaceLocating {
     }
 
     func workspaceURL(vaultID: UUID) throws -> URL {
-        let baseURL = applicationSupportURL ?? URL.applicationSupportDirectory
-        let workspaceURL = baseURL
-            .appending(path: "Dahlia", directoryHint: .isDirectory)
+        let dahliaApplicationSupportURL = applicationSupportURL.map {
+            $0.appending(path: "Dahlia", directoryHint: .isDirectory)
+        } ?? DahliaApplicationSupport.currentDirectoryURL
+        let workspaceURL = dahliaApplicationSupportURL
             .appending(path: "CodexChatWorkspace", directoryHint: .isDirectory)
             .appending(path: vaultID.uuidString.lowercased(), directoryHint: .isDirectory)
 

--- a/Sources/Dahlia/Services/CodexHome.swift
+++ b/Sources/Dahlia/Services/CodexHome.swift
@@ -1,3 +1,4 @@
+import DahliaRuntimeSupport
 import Foundation
 
 protocol CodexHomeLocating: Sendable {
@@ -12,9 +13,10 @@ struct ApplicationSupportCodexHomeLocator: CodexHomeLocating {
     }
 
     func homeURL() throws -> URL {
-        let baseURL = applicationSupportURL ?? URL.applicationSupportDirectory
-        let homeURL = baseURL
-            .appending(path: "Dahlia", directoryHint: .isDirectory)
+        let dahliaApplicationSupportURL = applicationSupportURL.map {
+            $0.appending(path: "Dahlia", directoryHint: .isDirectory)
+        } ?? DahliaApplicationSupport.currentDirectoryURL
+        let homeURL = dahliaApplicationSupportURL
             .appending(path: "Codex", directoryHint: .isDirectory)
 
         do {

--- a/Sources/Dahlia/Services/MCPRegistrationCommands.swift
+++ b/Sources/Dahlia/Services/MCPRegistrationCommands.swift
@@ -1,20 +1,34 @@
+import DahliaRuntimeSupport
 import Foundation
 
 struct MCPRegistrationCommands: Equatable {
     let codex: String
     let claude: String
 
-    init(helperURL: URL, vaultID: UUID) {
+    init(
+        helperURL: URL,
+        vaultID: UUID,
+        runtimeProfile: DahliaRuntimeProfile = DahliaApplicationSupport.profile()
+    ) {
         let helper = Self.shellQuote(helperURL.path)
         let vault = Self.shellQuote(vaultID.uuidString)
+        let invocation = Self.helperInvocation(helper: helper, runtimeProfile: runtimeProfile)
         codex = """
         codex mcp remove dahlia
-        codex mcp add dahlia -- \(helper) --vault-id \(vault)
+        codex mcp add dahlia -- \(invocation) --vault-id \(vault)
         """
         claude = """
         claude mcp remove --scope user dahlia
-        claude mcp add --scope user dahlia -- \(helper) --vault-id \(vault)
+        claude mcp add --scope user dahlia -- \(invocation) --vault-id \(vault)
         """
+    }
+
+    private static func helperInvocation(helper: String, runtimeProfile: DahliaRuntimeProfile) -> String {
+        guard runtimeProfile == .development else { return helper }
+        let assignment = shellQuote(
+            "\(DahliaApplicationSupport.profileEnvironmentKey)=\(DahliaRuntimeProfile.development.rawValue)"
+        )
+        return "/usr/bin/env \(assignment) \(helper)"
     }
 
     private static func shellQuote(_ value: String) -> String {

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1251,6 +1251,12 @@ enum L10n {
     static var systemAudioCaptureStopped: String { String(localized: "System audio capture stopped", bundle: bundle) }
     static var microphoneCaptureStopped: String { String(localized: "Microphone capture stopped", bundle: bundle) }
     static var recording: String { String(localized: "Recording", bundle: bundle) }
+    static var recordingSettings: String { String(localized: "Recording Settings", bundle: bundle) }
+    static var recordingCommandHint: String { String(
+        localized: "Starts or stops recording for the selected meeting.",
+        bundle: bundle
+    ) }
+    static var meetingContent: String { String(localized: "Meeting Content", bundle: bundle) }
 
     // MARK: - Sidebar Footer
 

--- a/Sources/Dahlia/Utilities/ObsidianLauncher.swift
+++ b/Sources/Dahlia/Utilities/ObsidianLauncher.swift
@@ -1,0 +1,19 @@
+import AppKit
+
+enum ObsidianLauncher {
+    private static let bundleIdentifier = "md.obsidian"
+
+    static var isInstalled: Bool {
+        NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) != nil
+    }
+
+    static func open(_ url: URL) {
+        var components = URLComponents()
+        components.scheme = "obsidian"
+        components.host = "open"
+        components.queryItems = [URLQueryItem(name: "path", value: url.path)]
+
+        guard let obsidianURL = components.url else { return }
+        NSWorkspace.shared.open(obsidianURL)
+    }
+}

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -25,19 +25,16 @@ struct ContentView: View {
         .toolbar(removing: .title)
         .toolbar {
             ToolbarItemGroup(placement: .navigation) {
-                Button {
+                Button(L10n.newMeeting, systemImage: "square.and.pencil") {
                     recordingCoordinator.createEmptyMeeting()
-                } label: {
-                    Label(L10n.newMeeting, systemImage: "square.and.pencil")
                 }
                 .labelStyle(.iconOnly)
+                .keyboardShortcut("n", modifiers: .command)
                 .help(L10n.newMeeting)
 
-                Button(action: returnToCalendarSchedule) {
-                    Label(L10n.showUpcomingSchedule, systemImage: "calendar")
-                }
-                .labelStyle(.iconOnly)
-                .help(L10n.showUpcomingSchedule)
+                Button(L10n.showUpcomingSchedule, systemImage: "calendar", action: returnToCalendarSchedule)
+                    .labelStyle(.iconOnly)
+                    .help(L10n.showUpcomingSchedule)
 
                 Button {
                     openWindow(id: WindowID.projectManager)
@@ -64,6 +61,7 @@ struct ContentView: View {
                 }
                 .labelStyle(.iconOnly)
                 .help(L10n.chat)
+                .accessibilityLabel(L10n.chat)
             }
         }
         .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -1,39 +1,10 @@
-import AppKit
 import SwiftUI
-
-private extension View {
-    @ViewBuilder
-    func actionCursor(isEnabled: Bool = true) -> some View {
-        if isEnabled {
-            self.pointerStyle(.link)
-        } else {
-            self
-        }
-    }
-}
 
 private enum NotesEditorLayout {
     static let editorPadding = EdgeInsets(top: 8, leading: 4, bottom: 8, trailing: 4)
     /// `TextEditor` keeps a small internal inset on macOS, so the placeholder needs
     /// a matching offset instead of using the same outer padding.
     static let placeholderPadding = EdgeInsets(top: 10, leading: 9, bottom: 0, trailing: 0)
-}
-
-private enum ObsidianLauncher {
-    private static let bundleIdentifier = "md.obsidian"
-
-    static let isInstalled: Bool =
-        NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) != nil
-
-    static func open(_ url: URL) {
-        var components = URLComponents()
-        components.scheme = "obsidian"
-        components.host = "open"
-        components.queryItems = [URLQueryItem(name: "path", value: url.path)]
-
-        guard let obsidianURL = components.url else { return }
-        NSWorkspace.shared.open(obsidianURL)
-    }
 }
 
 /// メイン領域のタブ種別。
@@ -52,35 +23,6 @@ enum DetailTab: String, CaseIterable, Identifiable {
         case .screenshots: L10n.screenshots
         case .transcript: L10n.transcript
         }
-    }
-}
-
-/// タイトルバー / ツールバーに表示する詳細タブ切り替え。
-private struct DetailTabBar: View {
-    @Binding var selection: DetailTab
-    @ObservedObject var viewModel: CaptionViewModel
-
-    /// フォルダ選択時（transcription 未選択）は全タブを無効化する。
-    /// 録音中は録音対象が存在するためタブを無効化しない。
-    private var isFolderOnly: Bool {
-        viewModel.currentMeetingId == nil && !viewModel.isListening && !viewModel.hasDraftMeeting
-    }
-
-    private var visibleTabs: [DetailTab] {
-        DetailTab.allCases
-    }
-
-    var body: some View {
-        Picker(L10n.transcript, selection: $selection) {
-            ForEach(visibleTabs) { tab in
-                Text(tab.label).tag(tab)
-            }
-        }
-        .pickerStyle(.segmented)
-        .labelsHidden()
-        .controlSize(.regular)
-        .disabled(isFolderOnly)
-        .frame(minWidth: 280)
     }
 }
 
@@ -338,24 +280,11 @@ private struct MeetingNameHeader: View {
 private struct MeetingActionsMenu: View {
     @ObservedObject var viewModel: CaptionViewModel
     var sidebarViewModel: SidebarViewModel
+    let onRename: () -> Void
 
     var body: some View {
         Menu {
-            Button {
-                guard let summaryURL = viewModel.lastSummaryURL else { return }
-                ObsidianLauncher.open(summaryURL)
-            } label: {
-                Label(L10n.openInObsidian, systemImage: "book.closed")
-            }
-            .disabled(viewModel.lastSummaryURL == nil || !ObsidianLauncher.isInstalled)
-
-            Button {
-                guard let browserURL = viewModel.currentSummaryGoogleFileURL else { return }
-                NSWorkspace.shared.open(browserURL)
-            } label: {
-                Label(L10n.openInBrowser, systemImage: "globe")
-            }
-            .disabled(viewModel.currentSummaryGoogleFileURL == nil)
+            Button(L10n.rename, systemImage: "pencil", action: onRename)
 
             Divider()
 
@@ -445,9 +374,13 @@ private struct MeetingDetailHeader: View {
     }
 
     private var controls: some View {
-        MeetingActionsMenu(viewModel: viewModel, sidebarViewModel: sidebarViewModel)
-            .controlSize(.regular)
-            .fixedSize(horizontal: true, vertical: false)
+        MeetingActionsMenu(
+            viewModel: viewModel,
+            sidebarViewModel: sidebarViewModel,
+            onRename: onBeginEditing
+        )
+        .controlSize(.regular)
+        .fixedSize(horizontal: true, vertical: false)
     }
 }
 
@@ -518,6 +451,11 @@ struct ControlPanelView: View {
                     onEditorTap: markMeetingNameEditorTap
                 )
             }
+
+            MeetingDetailNavigationBar(
+                selection: $selectedTab,
+                viewModel: viewModel
+            )
 
             // タブコンテンツ
             Group {
@@ -645,13 +583,13 @@ struct ControlPanelView: View {
 
     @ToolbarContentBuilder
     private var detailToolbar: some ToolbarContent {
-        ToolbarItem(placement: .principal) {
-            DetailTabBar(selection: $selectedTab, viewModel: viewModel)
-        }
+        ToolbarSpacer(.flexible, placement: .primaryAction)
 
-        ToolbarItem(placement: .primaryAction) {
+        ToolbarItemGroup(placement: .primaryAction) {
+            GenerateSummaryToolbarButton(viewModel: viewModel)
+
             if showsToolbarRecordButton {
-                SummaryToolbarControlGroup(
+                RecordToolbarButton(
                     viewModel: viewModel,
                     sidebarViewModel: sidebarViewModel,
                     recordingCoordinator: recordingCoordinator
@@ -668,29 +606,6 @@ struct ControlPanelView: View {
            viewModel.hasCurrentMeetingSummary {
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
-                    HStack(spacing: 12) {
-                        Button {
-                            guard let summaryURL = viewModel.lastSummaryURL else { return }
-                            ObsidianLauncher.open(summaryURL)
-                        } label: {
-                            Label(L10n.openInObsidian, systemImage: "book.closed")
-                        }
-                        .disabled(viewModel.lastSummaryURL == nil || !ObsidianLauncher.isInstalled)
-                        .actionCursor(isEnabled: viewModel.lastSummaryURL != nil && ObsidianLauncher.isInstalled)
-
-                        Button {
-                            guard let browserURL = viewModel.currentSummaryGoogleFileURL else { return }
-                            NSWorkspace.shared.open(browserURL)
-                        } label: {
-                            Label(L10n.openInBrowser, systemImage: "globe")
-                        }
-                        .disabled(viewModel.currentSummaryGoogleFileURL == nil)
-                        .actionCursor(isEnabled: viewModel.currentSummaryGoogleFileURL != nil)
-
-                        Spacer(minLength: 0)
-                    }
-                    .buttonStyle(.bordered)
-
                     SummaryDocumentView(
                         document: document,
                         imageDataProvider: { screenshotId in
@@ -905,7 +820,11 @@ struct ControlPanelView: View {
     }
 
     private var showsToolbarRecordButton: Bool {
-        !viewModel.isListening || viewModel.recordingMeetingId == viewModel.currentMeetingId
+        RecordingCommandState.showsDetailCommand(
+            isListening: viewModel.isListening,
+            recordingMeetingID: viewModel.recordingMeetingId,
+            currentMeetingID: viewModel.currentMeetingId
+        )
     }
 
     private var meetingMetadataText: String {

--- a/Sources/Dahlia/Views/DetailTabBar.swift
+++ b/Sources/Dahlia/Views/DetailTabBar.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+private extension DetailTab {
+    var keyboardShortcut: KeyEquivalent {
+        switch self {
+        case .notes: "1"
+        case .screenshots: "2"
+        case .transcript: "3"
+        case .summary: "4"
+        }
+    }
+}
+
+/// Navigation for the content that belongs to the selected meeting.
+struct DetailTabBar: View {
+    @Binding var selection: DetailTab
+    @ObservedObject var viewModel: CaptionViewModel
+
+    private var isFolderOnly: Bool {
+        viewModel.currentMeetingId == nil && !viewModel.isListening && !viewModel.hasDraftMeeting
+    }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(DetailTab.allCases) { tab in
+                Button(tab.label) { selection = tab }
+                    .buttonStyle(.plain)
+                    .font(.body)
+                    .bold(tab == selection)
+                    .foregroundStyle(tab == selection ? .primary : .secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .contentShape(.rect)
+                    .overlay(alignment: .bottom) {
+                        if tab == selection {
+                            Capsule()
+                                .fill(.primary)
+                                .frame(height: 2)
+                                .padding(.horizontal, 8)
+                        }
+                    }
+                    .keyboardShortcut(tab.keyboardShortcut, modifiers: .command)
+                    .help(tab.label)
+                    .accessibilityAddTraits(tab == selection ? .isSelected : [])
+            }
+        }
+        .disabled(isFolderOnly)
+        .fixedSize(horizontal: true, vertical: false)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(L10n.meetingContent)
+    }
+}

--- a/Sources/Dahlia/Views/MeetingDetailNavigationBar.swift
+++ b/Sources/Dahlia/Views/MeetingDetailNavigationBar.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// Keeps meeting tabs and tab-specific commands in the meeting detail region at every window width.
+struct MeetingDetailNavigationBar: View {
+    @Binding var selection: DetailTab
+    @ObservedObject var viewModel: CaptionViewModel
+
+    private var showsSummaryActions: Bool {
+        selection == .summary && (
+            viewModel.canShareCurrentSummary
+                || viewModel.lastSummaryURL != nil
+                || viewModel.currentSummaryGoogleFileURL != nil
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            DetailTabBar(selection: $selection, viewModel: viewModel)
+            if showsSummaryActions {
+                SummaryTabActions(viewModel: viewModel)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/Sources/Dahlia/Views/MeetingListSidebarView.swift
+++ b/Sources/Dahlia/Views/MeetingListSidebarView.swift
@@ -156,6 +156,7 @@ private struct RecordingStatusBar: View {
     let recordingCoordinator: RecordingCoordinator
 
     @AppStorage("liveSubtitleOverlayEnabled") private var liveSubtitleOverlayEnabled = false
+    @State private var isRecordingSettingsPresented = false
 
     private var recordingMeetingId: UUID? {
         viewModel.recordingMeetingId
@@ -197,45 +198,68 @@ private struct RecordingStatusBar: View {
         }
     }
 
-    var body: some View {
-        VStack(spacing: 10) {
-            HStack(spacing: 8) {
-                Button(action: returnToRecordingMeeting) {
-                    panelContent
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .disabled(recordingMeetingId == nil)
-                .help(recordingLabels.returnToMeeting)
-                .accessibilityLabel("\(recordingLabels.activity), \(recordingTitle)")
+    private var showsSidebarStop: Bool {
+        RecordingCommandState.showsSidebarStop(
+            recordingMeetingID: recordingMeetingId,
+            currentMeetingID: viewModel.currentMeetingId
+        )
+    }
 
-                Button {
+    var body: some View {
+        HStack(spacing: 8) {
+            Button(action: returnToRecordingMeeting) {
+                panelContent
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(recordingMeetingId == nil)
+            .help(recordingLabels.returnToMeeting)
+            .accessibilityLabel("\(recordingLabels.activity), \(recordingTitle)")
+
+            Button(L10n.recordingSettings, systemImage: "slider.horizontal.3") {
+                isRecordingSettingsPresented.toggle()
+            }
+            .labelStyle(.iconOnly)
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .help(L10n.recordingSettings)
+            .popover(isPresented: $isRecordingSettingsPresented, arrowEdge: .bottom) {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(L10n.recordingSettings)
+                        .font(.headline)
+                    Text(recordingLabels.activity)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Divider()
+                    VStack(spacing: 6) {
+                        microphoneMenu
+                        systemAudioMenu
+                        languageMenu
+                        RecordingLiveSubtitleToggle(isEnabled: $liveSubtitleOverlayEnabled)
+                        screenSourceMenu
+                    }
+                }
+                .padding(14)
+                .frame(width: 300)
+            }
+
+            if showsSidebarStop {
+                Button(recordingLabels.stop, systemImage: "stop.fill") {
                     recordingCoordinator.stopRecording()
-                } label: {
-                    Label(recordingLabels.stop, systemImage: "stop.fill")
                 }
                 .labelStyle(.iconOnly)
-                .buttonStyle(.bordered)
+                .buttonStyle(.borderedProminent)
+                .tint(.red)
                 .controlSize(.small)
                 .help(recordingLabels.stop)
             }
-
-            Divider()
-
-            VStack(spacing: 6) {
-                microphoneMenu
-                systemAudioMenu
-                languageMenu
-                RecordingLiveSubtitleToggle(isEnabled: $liveSubtitleOverlayEnabled)
-                screenSourceMenu
-            }
         }
         .padding(.horizontal, 10)
-        .padding(.vertical, 10)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .padding(.vertical, 8)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
         .overlay {
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .stroke(.quaternary, lineWidth: 1)
                 .allowsHitTesting(false)
         }
@@ -248,7 +272,7 @@ private struct RecordingStatusBar: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(recordingLabels.activity)
-                    .font(.caption2.weight(.semibold))
+                    .font(.caption.bold())
                     .foregroundStyle(.red)
 
                 Text(recordingTitle)

--- a/Sources/Dahlia/Views/SummaryTabActions.swift
+++ b/Sources/Dahlia/Views/SummaryTabActions.swift
@@ -1,0 +1,34 @@
+import AppKit
+import SwiftUI
+
+/// Commands that only apply to the selected meeting's generated summary.
+struct SummaryTabActions: View {
+    @ObservedObject var viewModel: CaptionViewModel
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ShareSummaryToolbarButton(viewModel: viewModel)
+
+            Menu(L10n.openSummary, systemImage: "arrow.up.forward.app") {
+                Button(L10n.openInObsidian, systemImage: "book.closed", action: openInObsidian)
+                    .disabled(viewModel.lastSummaryURL == nil || !ObsidianLauncher.isInstalled)
+
+                Button(L10n.openInBrowser, systemImage: "globe", action: openInBrowser)
+                    .disabled(viewModel.currentSummaryGoogleFileURL == nil)
+            }
+            .help(L10n.openSummary)
+        }
+        .buttonStyle(.bordered)
+        .fixedSize(horizontal: true, vertical: false)
+    }
+
+    private func openInObsidian() {
+        guard let summaryURL = viewModel.lastSummaryURL else { return }
+        ObsidianLauncher.open(summaryURL)
+    }
+
+    private func openInBrowser() {
+        guard let browserURL = viewModel.currentSummaryGoogleFileURL else { return }
+        NSWorkspace.shared.open(browserURL)
+    }
+}

--- a/Sources/Dahlia/Views/Toolbar/RecordingCommandState.swift
+++ b/Sources/Dahlia/Views/Toolbar/RecordingCommandState.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Centralizes recording command visibility so the same stop action is not duplicated across regions.
+struct RecordingCommandState: Equatable {
+    enum Action: Equatable {
+        case start
+        case stop
+    }
+
+    let action: Action
+    let isEnabled: Bool
+
+    init(isListening: Bool, canStartNewMeeting: Bool) {
+        action = isListening ? .stop : .start
+        isEnabled = isListening || canStartNewMeeting
+    }
+
+    static func showsDetailCommand(
+        isListening: Bool,
+        recordingMeetingID: UUID?,
+        currentMeetingID: UUID?
+    ) -> Bool {
+        !isListening || recordingMeetingID == currentMeetingID
+    }
+
+    static func showsSidebarStop(
+        recordingMeetingID: UUID?,
+        currentMeetingID: UUID?
+    ) -> Bool {
+        guard let recordingMeetingID else { return false }
+        return recordingMeetingID != currentMeetingID
+    }
+}

--- a/Sources/Dahlia/Views/Toolbar/SessionControls.swift
+++ b/Sources/Dahlia/Views/Toolbar/SessionControls.swift
@@ -5,22 +5,24 @@ struct RecordToolbarButton: View {
     var sidebarViewModel: SidebarViewModel
     let recordingCoordinator: RecordingCoordinator
 
-    private var isEnabled: Bool {
-        viewModel.isListening || recordingCoordinator.canStartNewMeeting
+    private var state: RecordingCommandState {
+        RecordingCommandState(
+            isListening: viewModel.isListening,
+            canStartNewMeeting: recordingCoordinator.canStartNewMeeting
+        )
     }
 
     var body: some View {
         Button(action: toggle) {
-            Label {
-                Text(label)
-            } icon: {
-                Image(systemName: iconName)
-                    .foregroundStyle(iconColor)
-            }
+            Label(label, systemImage: iconName)
         }
-        .disabled(!isEnabled)
-        .keyboardShortcut(.space, modifiers: [])
+        .labelStyle(.titleAndIcon)
+        .buttonStyle(.borderedProminent)
+        .tint(.red)
+        .disabled(!state.isEnabled)
+        .keyboardShortcut("r", modifiers: [.command, .shift])
         .help(label)
+        .accessibilityHint(L10n.recordingCommandHint)
     }
 
     private func toggle() {
@@ -37,18 +39,11 @@ struct RecordToolbarButton: View {
     }
 
     private var iconName: String {
-        viewModel.isListening ? "stop.fill" : "record.circle"
+        state.action == .stop ? "stop.fill" : "record.circle"
     }
 
     private var label: String {
-        viewModel.isListening ? L10n.stopRecording : L10n.startRecording
-    }
-
-    private var iconColor: Color {
-        if viewModel.isListening {
-            return .secondary
-        }
-        return isEnabled ? .red : .secondary
+        state.action == .stop ? L10n.stopRecording : L10n.startRecording
     }
 }
 
@@ -63,14 +58,20 @@ struct GenerateSummaryToolbarButton: View {
     var body: some View {
         Button(action: presentConfirmation) {
             Label {
-                Text(L10n.generateSummary)
+                Text(isGeneratingCurrentMeeting ? L10n.generatingSummary : L10n.generateSummary)
             } icon: {
-                Image(systemName: "sparkles")
-                    .foregroundStyle(summaryIconColor)
+                if isGeneratingCurrentMeeting {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Image(systemName: "sparkles")
+                }
             }
         }
+        .labelStyle(.titleAndIcon)
+        .buttonStyle(.bordered)
         .disabled(isGeneratingCurrentMeeting || !viewModel.canGenerateSummary)
-        .help(L10n.generateSummary)
+        .help(isGeneratingCurrentMeeting ? L10n.generatingSummary : L10n.generateSummary)
         .sheet(isPresented: $isConfirmationPresented) {
             SummaryGenerationConfirmationView(onGenerate: generateSummary)
         }
@@ -82,29 +83,6 @@ struct GenerateSummaryToolbarButton: View {
 
     private func generateSummary(options: SummaryGenerationOptions) {
         viewModel.triggerManualSummary(options: options)
-    }
-
-    private var summaryIconColor: Color {
-        isGeneratingCurrentMeeting || !viewModel.canGenerateSummary ? .secondary : Color.accentColor
-    }
-}
-
-struct SummaryToolbarControlGroup: View {
-    @ObservedObject var viewModel: CaptionViewModel
-    var sidebarViewModel: SidebarViewModel
-    let recordingCoordinator: RecordingCoordinator
-
-    var body: some View {
-        ControlGroup {
-            ShareSummaryToolbarButton(viewModel: viewModel)
-            GenerateSummaryToolbarButton(viewModel: viewModel)
-            RecordToolbarButton(
-                viewModel: viewModel,
-                sidebarViewModel: sidebarViewModel,
-                recordingCoordinator: recordingCoordinator
-            )
-        }
-        .labelStyle(.iconOnly)
     }
 }
 
@@ -123,6 +101,7 @@ struct ShareSummaryToolbarButton: View {
                     .foregroundStyle(viewModel.canShareCurrentSummary ? Color.accentColor : .secondary)
             }
         }
+        .labelStyle(.titleAndIcon)
         .disabled(!viewModel.canShareCurrentSummary)
         .help(L10n.shareSummary)
         .popover(isPresented: $isPopoverPresented, arrowEdge: .bottom) {

--- a/Sources/DahliaMeetingAccess/MeetingAccessStore.swift
+++ b/Sources/DahliaMeetingAccess/MeetingAccessStore.swift
@@ -1,12 +1,11 @@
+import DahliaRuntimeSupport
 import Foundation
 import GRDB
 
 public final class MeetingAccessStore: Sendable {
     public static var defaultDatabaseURL: URL {
-        FileManager.default
-            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("Dahlia")
-            .appendingPathComponent("dahlia.sqlite")
+        DahliaApplicationSupport.currentDirectoryURL
+            .appending(path: "dahlia.sqlite")
     }
 
     private let database: DatabaseQueue

--- a/Sources/DahliaRuntimeSupport/DahliaApplicationSupport.swift
+++ b/Sources/DahliaRuntimeSupport/DahliaApplicationSupport.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+public enum DahliaRuntimeProfile: String, Sendable {
+    case production
+    case development
+}
+
+public enum DahliaApplicationSupport {
+    public static let profileEnvironmentKey = "DAHLIA_RUNTIME_PROFILE"
+
+    public static func profile(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> DahliaRuntimeProfile {
+        #if DEBUG
+            guard environment[profileEnvironmentKey] == DahliaRuntimeProfile.development.rawValue else {
+                return .production
+            }
+            return .development
+        #else
+            return .production
+        #endif
+    }
+
+    public static func directoryURL(
+        applicationSupportDirectory: URL = .applicationSupportDirectory,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
+        applicationSupportDirectory.appending(
+            path: directoryName(for: profile(environment: environment)),
+            directoryHint: .isDirectory
+        )
+    }
+
+    public static var currentDirectoryURL: URL {
+        directoryURL()
+    }
+
+    private static func directoryName(for profile: DahliaRuntimeProfile) -> String {
+        switch profile {
+        case .production:
+            "Dahlia"
+        case .development:
+            "Dahlia-Development"
+        }
+    }
+}

--- a/Tests/DahliaTests/DahliaApplicationSupportTests.swift
+++ b/Tests/DahliaTests/DahliaApplicationSupportTests.swift
@@ -1,0 +1,58 @@
+import DahliaMeetingAccess
+import DahliaRuntimeSupport
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct DahliaApplicationSupportTests {
+        private let baseURL = URL(filePath: "/Users/test/Library/Application Support", directoryHint: .isDirectory)
+
+        @Test
+        func productionUsesTheExistingApplicationSupportDirectory() {
+            let directoryURL = DahliaApplicationSupport.directoryURL(
+                applicationSupportDirectory: baseURL,
+                environment: [:]
+            )
+
+            #expect(directoryURL == baseURL.appending(path: "Dahlia", directoryHint: .isDirectory))
+        }
+
+        @Test
+        func developmentUsesOneSharedSeparateApplicationSupportDirectory() {
+            let environment = [
+                DahliaApplicationSupport.profileEnvironmentKey: DahliaRuntimeProfile.development.rawValue,
+            ]
+            let firstURL = DahliaApplicationSupport.directoryURL(
+                applicationSupportDirectory: baseURL,
+                environment: environment
+            )
+            let secondURL = DahliaApplicationSupport.directoryURL(
+                applicationSupportDirectory: baseURL,
+                environment: environment
+            )
+
+            #expect(firstURL == baseURL.appending(path: "Dahlia-Development", directoryHint: .isDirectory))
+            #expect(secondURL == firstURL)
+        }
+
+        @Test
+        func unrecognizedProfileDoesNotRedirectTheProductionApp() {
+            let directoryURL = DahliaApplicationSupport.directoryURL(
+                applicationSupportDirectory: baseURL,
+                environment: [DahliaApplicationSupport.profileEnvironmentKey: "preview"]
+            )
+
+            #expect(directoryURL == baseURL.appending(path: "Dahlia", directoryHint: .isDirectory))
+        }
+
+        @Test
+        func appAndMeetingAccessHelperResolveTheSameDatabase() {
+            let expectedURL = DahliaApplicationSupport.currentDirectoryURL.appending(path: "dahlia.sqlite")
+
+            #expect(AppDatabaseManager.databaseURL == expectedURL)
+            #expect(MeetingAccessStore.defaultDatabaseURL == expectedURL)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/MCPRegistrationCommandsTests.swift
+++ b/Tests/DahliaTests/MCPRegistrationCommandsTests.swift
@@ -10,7 +10,8 @@ import Foundation
             let vaultID = try #require(UUID(uuidString: "019F6651-CCBE-7CF2-83B0-6EF955A9FD41"))
             let commands = MCPRegistrationCommands(
                 helperURL: URL(filePath: "/Applications/Dahlia's App.app/Contents/Helpers/dahlia-mcp"),
-                vaultID: vaultID
+                vaultID: vaultID,
+                runtimeProfile: .production
             )
 
             let quotedHelper = "'/Applications/Dahlia'\\''s App.app/Contents/Helpers/dahlia-mcp'"
@@ -18,6 +19,20 @@ import Foundation
             #expect(commands.codex == "codex mcp remove dahlia\ncodex mcp add dahlia -- \(quotedHelper) --vault-id \(quotedVault)")
             #expect(commands
                 .claude == "claude mcp remove --scope user dahlia\nclaude mcp add --scope user dahlia -- \(quotedHelper) --vault-id \(quotedVault)")
+        }
+
+        @Test
+        func developmentCommandsPreserveTheDevelopmentProfileForExternalHelpers() throws {
+            let vaultID = try #require(UUID(uuidString: "019F6651-CCBE-7CF2-83B0-6EF955A9FD41"))
+            let commands = MCPRegistrationCommands(
+                helperURL: URL(filePath: "/Applications/Dahlia Dev.app/Contents/Helpers/dahlia-mcp"),
+                vaultID: vaultID,
+                runtimeProfile: .development
+            )
+
+            let invocation = "/usr/bin/env 'DAHLIA_RUNTIME_PROFILE=development' '/Applications/Dahlia Dev.app/Contents/Helpers/dahlia-mcp'"
+            #expect(commands.codex.contains("-- \(invocation) --vault-id"))
+            #expect(commands.claude.contains("-- \(invocation) --vault-id"))
         }
     }
 #endif

--- a/Tests/DahliaTests/RecordingCommandStateTests.swift
+++ b/Tests/DahliaTests/RecordingCommandStateTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct RecordingCommandStateTests {
+        @Test
+        func startCommandReflectsCoordinatorAvailability() {
+            let disabled = RecordingCommandState(isListening: false, canStartNewMeeting: false)
+            let enabled = RecordingCommandState(isListening: false, canStartNewMeeting: true)
+
+            #expect(disabled.action == .start)
+            #expect(!disabled.isEnabled)
+            #expect(enabled.action == .start)
+            #expect(enabled.isEnabled)
+        }
+
+        @Test
+        func stopCommandRemainsEnabledDuringRecording() {
+            let state = RecordingCommandState(isListening: true, canStartNewMeeting: false)
+
+            #expect(state.action == .stop)
+            #expect(state.isEnabled)
+        }
+
+        @Test
+        func detailCommandOnlyControlsTheMeetingItRepresents() {
+            let recordingMeetingID = UUID()
+
+            #expect(RecordingCommandState.showsDetailCommand(
+                isListening: false,
+                recordingMeetingID: nil,
+                currentMeetingID: nil
+            ))
+            #expect(RecordingCommandState.showsDetailCommand(
+                isListening: true,
+                recordingMeetingID: recordingMeetingID,
+                currentMeetingID: recordingMeetingID
+            ))
+            #expect(!RecordingCommandState.showsDetailCommand(
+                isListening: true,
+                recordingMeetingID: recordingMeetingID,
+                currentMeetingID: UUID()
+            ))
+        }
+
+        @Test
+        func sidebarStopOnlyAppearsWhenDetailCannotStopTheRecording() {
+            let recordingMeetingID = UUID()
+
+            #expect(!RecordingCommandState.showsSidebarStop(
+                recordingMeetingID: nil,
+                currentMeetingID: UUID()
+            ))
+            #expect(!RecordingCommandState.showsSidebarStop(
+                recordingMeetingID: recordingMeetingID,
+                currentMeetingID: recordingMeetingID
+            ))
+            #expect(RecordingCommandState.showsSidebarStop(
+                recordingMeetingID: recordingMeetingID,
+                currentMeetingID: UUID()
+            ))
+            #expect(RecordingCommandState.showsSidebarStop(
+                recordingMeetingID: recordingMeetingID,
+                currentMeetingID: nil
+            ))
+        }
+
+        @Test
+        func recordingAlwaysHasExactlyOneMainWindowStopCommand() {
+            let recordingMeetingID = UUID()
+
+            for currentMeetingID in [recordingMeetingID, UUID(), nil] {
+                let showsDetail = RecordingCommandState.showsDetailCommand(
+                    isListening: true,
+                    recordingMeetingID: recordingMeetingID,
+                    currentMeetingID: currentMeetingID
+                )
+                let showsSidebar = RecordingCommandState.showsSidebarStop(
+                    recordingMeetingID: recordingMeetingID,
+                    currentMeetingID: currentMeetingID
+                )
+
+                #expect(showsDetail != showsSidebar)
+            }
+        }
+    }
+#endif

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -112,10 +112,10 @@ if [ "$(lipo -archs "${MACOS}/${APP_NAME}")" != "arm64" ]; then
 fi
 codesign --verify --deep --strict --verbose=2 "${APP_BUNDLE}"
 
-echo "=== Running ${APP_NAME} ==="
+echo "=== Running ${APP_NAME} (development profile) ==="
 LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
 if [ -x "$LSREGISTER" ]; then
     "$LSREGISTER" -f "${APP_BUNDLE}" >/dev/null 2>&1 || true
 fi
 
-exec "${MACOS}/${APP_NAME}"
+exec env DAHLIA_RUNTIME_PROFILE=development "${MACOS}/${APP_NAME}"


### PR DESCRIPTION
## Summary

- reorganize the main window around global commands, meeting-level commands, and tab-specific actions
- keep summary generation and recording at the trailing edge as the primary actions, with recording state and stop safety preserved
- replace the segmented detail picker with compact, accessible text tabs and consistent tab-local actions
- keep project management, settings, and chat discoverable in the global toolbar while moving low-frequency meeting actions into a menu
- isolate development database, recording recovery data, process lock, Codex state, and MCP helper access under `Dahlia-Development`
- bump the app version to 0.5.6 (22) and update Japanese and English localization

## Design rationale

The layout now separates app-wide navigation and settings from operations affecting the selected meeting. Persistent primary actions stay visible at the trailing edge, while contextual and lower-frequency commands live near the content they affect. The flatter tab treatment avoids competing with the primary action hierarchy and remains usable at narrower window widths.

## Validation

- `swift build`
- `swift test` — 611 Swift Testing tests in 109 suites and 3 XCTest tests passed
- targeted application-support, MCP-registration, recording-command, summary-generation, and database tests
- `CI=true ./scripts/lint.sh` — passed (existing non-blocking SwiftLint warnings remain)
- `plutil -lint` for Info.plist and Japanese/English localization
- live inspection at normal and narrow widths, including stopped and recording states

Claude review was intentionally skipped for this iteration.
