### PR TITLE
Restore recording settings panel

### DIFF
--- a/Sources/Recavia/Views/MeetingListSidebarView.swift
+++ b/Sources/Recavia/Views/MeetingListSidebarView.swift
@@ -156,7 +156,6 @@ private struct RecordingStatusBar: View {
     let recordingCoordinator: RecordingCoordinator
 
     @AppStorage("liveSubtitleOverlayEnabled") private var liveSubtitleOverlayEnabled = false
-    @State private var isRecordingSettingsPresented = false
 
     private var recordingMeetingId: UUID? {
         viewModel.recordingMeetingId
@@ -206,53 +205,38 @@ private struct RecordingStatusBar: View {
     }
 
     var body: some View {
-        HStack(spacing: 8) {
-            Button(action: returnToRecordingMeeting) {
-                panelContent
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .disabled(recordingMeetingId == nil)
-            .help(recordingLabels.returnToMeeting)
-            .accessibilityLabel("\(recordingLabels.activity), \(recordingTitle)")
+        VStack(spacing: 10) {
+            HStack(spacing: 8) {
+                Button(action: returnToRecordingMeeting) {
+                    panelContent
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(recordingMeetingId == nil)
+                .help(recordingLabels.returnToMeeting)
+                .accessibilityLabel("\(recordingLabels.activity), \(recordingTitle)")
 
-            Button(L10n.recordingSettings, systemImage: "slider.horizontal.3") {
-                isRecordingSettingsPresented.toggle()
-            }
-            .labelStyle(.iconOnly)
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-            .help(L10n.recordingSettings)
-            .popover(isPresented: $isRecordingSettingsPresented, arrowEdge: .bottom) {
-                VStack(alignment: .leading, spacing: 10) {
-                    Text(L10n.recordingSettings)
-                        .font(.headline)
-                    Text(recordingLabels.activity)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                    Divider()
-                    VStack(spacing: 6) {
-                        microphoneMenu
-                        systemAudioMenu
-                        languageMenu
-                        RecordingLiveSubtitleToggle(isEnabled: $liveSubtitleOverlayEnabled)
-                        screenSourceMenu
+                if showsSidebarStop {
+                    Button(recordingLabels.stop, systemImage: "stop.fill") {
+                        recordingCoordinator.stopRecording()
                     }
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.borderedProminent)
+                    .tint(.red)
+                    .controlSize(.small)
+                    .help(recordingLabels.stop)
                 }
-                .padding(14)
-                .frame(width: 300)
             }
 
-            if showsSidebarStop {
-                Button(recordingLabels.stop, systemImage: "stop.fill") {
-                    recordingCoordinator.stopRecording()
-                }
-                .labelStyle(.iconOnly)
-                .buttonStyle(.borderedProminent)
-                .tint(.red)
-                .controlSize(.small)
-                .help(recordingLabels.stop)
+            Divider()
+
+            VStack(spacing: 6) {
+                microphoneMenu
+                systemAudioMenu
+                languageMenu
+                RecordingLiveSubtitleToggle(isEnabled: $liveSubtitleOverlayEnabled)
+                screenSourceMenu
             }
         }
         .padding(.horizontal, 10)


### PR DESCRIPTION
## 概要

- 録音中パネル内にマイク、システム音声、言語、字幕、画面の設定を常時表示します
- 設定ボタンと、クリック後に表示されていたポップオーバーを削除します
- 録音停止ボタンの既存の表示条件は維持します

## 背景

メインウィンドウ改善時のレイアウト変更により、以前は録音中パネル内に表示されていた録音設定がポップオーバーへ移動し、確認・変更に追加のクリックが必要になっていました。従来の直接操作できるレイアウトへ戻します。

## ユーザーへの影響

録音中に各音声ソースや字幕、画面設定の現在値をすぐ確認でき、その場で変更できます。録音処理や停止操作の挙動は変わりません。

## 検証

- `swift build`
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter RecordingCommandStateTests`（5 tests passed）
- `CI=true ./scripts/lint.sh`（SwiftFormat: 0 files require formatting。SwiftLint は既存警告のみ）
