### PR TITLE
Prevent chat hover events from reaching summaries

### DIFF
--- a/Sources/Recavia/Views/CodexChat/CodexChatFloatingView.swift
+++ b/Sources/Recavia/Views/CodexChat/CodexChatFloatingView.swift
@@ -43,6 +43,7 @@ struct CodexChatFloatingView: View {
                 )
                 .frame(width: layout.size.width, height: layout.size.height)
                 .clipShape(RoundedRectangle(cornerRadius: 24))
+                .contentShape(.interaction, RoundedRectangle(cornerRadius: 24))
                 .overlay {
                     RoundedRectangle(cornerRadius: 24)
                         .stroke(.separator.opacity(0.6), lineWidth: 1)


### PR DESCRIPTION
## Summary

- define the floating chat's rounded rectangle as its explicit interaction region
- prevent hover events over the chat surface from reaching transcript timestamp badges behind it
- preserve interactions with summary content outside the floating chat

## Root cause

The floating chat was visually clipped to a rounded rectangle, but that same shape was not explicitly registered for interaction hit testing. Hover tracking could therefore reach summary timestamp badges underneath visually occupied chat areas and open transcript popovers above the chat.

## User impact

Transcript source popovers no longer appear while the pointer is over the floating AI chat window.

## Validation

- `swift build`
- `CI=true ./scripts/lint.sh` (passes; existing repository warnings remain)
- `git diff --check`