### PR TITLE
Move summary actions to toolbar and actions menu

### DIFF
--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -434,6 +434,7 @@
 "Summary generated" = "Summary generated";
 "Open Summary" = "Open Summary";
 "Generate Summary" = "Generate Summary";
+"Share" = "Share";
 "Share Summary" = "Share Summary";
 "Export to Google Docs" = "Export to Google Docs";
 "Could not export the summary to Google Docs." = "Could not export the summary to Google Docs.";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -434,6 +434,7 @@
 "Summary generated" = "要約が生成されました";
 "Open Summary" = "要約を開く";
 "Generate Summary" = "要約を生成";
+"Share" = "共有";
 "Share Summary" = "要約を共有";
 "Export to Google Docs" = "Google Docs に書き出す";
 "Could not export the summary to Google Docs." = "要約を Google Docs に書き出せませんでした。";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1176,6 +1176,7 @@ enum L10n {
     static var summaryGenerated: String { String(localized: "Summary generated", bundle: bundle) }
     static var openSummary: String { String(localized: "Open Summary", bundle: bundle) }
     static var generateSummary: String { String(localized: "Generate Summary", bundle: bundle) }
+    static var share: String { String(localized: "Share", bundle: bundle) }
     static var shareSummary: String { String(localized: "Share Summary", bundle: bundle) }
     static var exportToGoogleDocs: String { String(localized: "Export to Google Docs", bundle: bundle) }
     static var googleDocsExportFailed: String { String(localized: "Could not export the summary to Google Docs.", bundle: bundle) }

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -288,9 +288,17 @@ private struct MeetingActionsMenu: View {
     var sidebarViewModel: SidebarViewModel
     let onRename: () -> Void
 
+    private var canOpenSummary: Bool {
+        viewModel.lastSummaryURL != nil || viewModel.currentSummaryGoogleFileURL != nil
+    }
+
     var body: some View {
         Menu {
             Button(L10n.rename, systemImage: "pencil", action: onRename)
+
+            if canOpenSummary {
+                SummaryOpenMenu(viewModel: viewModel)
+            }
 
             Divider()
 
@@ -592,6 +600,7 @@ struct ControlPanelView: View {
         ToolbarSpacer(.flexible, placement: .primaryAction)
 
         ToolbarItemGroup(placement: .primaryAction) {
+            ShareSummaryToolbarButton(viewModel: viewModel)
             GenerateSummaryToolbarButton(viewModel: viewModel)
 
             if showsToolbarRecordButton {

--- a/Sources/Dahlia/Views/MeetingDetailNavigationBar.swift
+++ b/Sources/Dahlia/Views/MeetingDetailNavigationBar.swift
@@ -5,21 +5,7 @@ struct MeetingDetailNavigationBar: View {
     @Binding var selection: DetailTab
     @ObservedObject var viewModel: CaptionViewModel
 
-    private var showsSummaryActions: Bool {
-        selection == .summary && (
-            viewModel.canShareCurrentSummary
-                || viewModel.lastSummaryURL != nil
-                || viewModel.currentSummaryGoogleFileURL != nil
-        )
-    }
-
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            DetailTabBar(selection: $selection, viewModel: viewModel)
-            if showsSummaryActions {
-                SummaryTabActions(viewModel: viewModel)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        DetailTabBar(selection: $selection, viewModel: viewModel)
     }
 }

--- a/Sources/Dahlia/Views/SummaryTabActions.swift
+++ b/Sources/Dahlia/Views/SummaryTabActions.swift
@@ -1,25 +1,18 @@
 import AppKit
 import SwiftUI
 
-/// Commands that only apply to the selected meeting's generated summary.
-struct SummaryTabActions: View {
+/// External destinations for the selected meeting's generated summary.
+struct SummaryOpenMenu: View {
     @ObservedObject var viewModel: CaptionViewModel
 
     var body: some View {
-        HStack(spacing: 8) {
-            ShareSummaryToolbarButton(viewModel: viewModel)
+        Menu(L10n.openSummary, systemImage: "arrow.up.forward.app") {
+            Button(L10n.openInObsidian, systemImage: "book.closed", action: openInObsidian)
+                .disabled(viewModel.lastSummaryURL == nil || !ObsidianLauncher.isInstalled)
 
-            Menu(L10n.openSummary, systemImage: "arrow.up.forward.app") {
-                Button(L10n.openInObsidian, systemImage: "book.closed", action: openInObsidian)
-                    .disabled(viewModel.lastSummaryURL == nil || !ObsidianLauncher.isInstalled)
-
-                Button(L10n.openInBrowser, systemImage: "globe", action: openInBrowser)
-                    .disabled(viewModel.currentSummaryGoogleFileURL == nil)
-            }
-            .help(L10n.openSummary)
+            Button(L10n.openInBrowser, systemImage: "globe", action: openInBrowser)
+                .disabled(viewModel.currentSummaryGoogleFileURL == nil)
         }
-        .buttonStyle(.bordered)
-        .fixedSize(horizontal: true, vertical: false)
     }
 
     private func openInObsidian() {

--- a/Sources/Dahlia/Views/Toolbar/SessionControls.swift
+++ b/Sources/Dahlia/Views/Toolbar/SessionControls.swift
@@ -95,13 +95,14 @@ struct ShareSummaryToolbarButton: View {
             isPopoverPresented = true
         } label: {
             Label {
-                Text(L10n.shareSummary)
+                Text(L10n.share)
             } icon: {
                 Image(systemName: "square.and.arrow.up")
                     .foregroundStyle(viewModel.canShareCurrentSummary ? Color.accentColor : .secondary)
             }
         }
         .labelStyle(.titleAndIcon)
+        .buttonStyle(.bordered)
         .disabled(!viewModel.canShareCurrentSummary)
         .help(L10n.shareSummary)
         .popover(isPresented: $isPopoverPresented, arrowEdge: .bottom) {


### PR DESCRIPTION
## Summary

- move the summary share button into the top-right toolbar, immediately before Generate Summary
- shorten the visible share label to "Share" / "共有" while retaining the detailed help text
- move Open Summary into the meeting Actions menu and remove the summary-tab action row

## Why

Sharing and generating summaries are closely related actions, so placing them together improves discoverability and visual grouping. Less frequently used external-open destinations now live in the existing Actions menu.

## User impact

The summary tab has more room for content, while summary sharing remains available from the toolbar. Existing Obsidian and browser open behavior is unchanged.

## Validation

- `swift build`
- `CI=true ./scripts/lint.sh` (SwiftFormat passed; SwiftLint continues to report the pre-existing function-length violation in `CaptionViewModel.swift`)
- `git diff --check`
