### PR TITLE
Add chat thinking indicator

### DIFF
--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -709,6 +709,7 @@
 "Hide chat" = "Hide chat";
 "Send message" = "Send message";
 "Stop generating" = "Stop generating";
+"Thinking" = "Thinking";
 "Message Codex" = "Message Codex";
 "Open AI Connection Settings" = "Open AI Connection Settings";
 "Loading models…" = "Loading models…";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -709,6 +709,7 @@
 "Hide chat" = "チャットを隠す";
 "Send message" = "メッセージを送信";
 "Stop generating" = "生成を停止";
+"Thinking" = "考えています";
 "Message Codex" = "Codex にメッセージ";
 "Open AI Connection Settings" = "AI 接続設定を開く";
 "Loading models…" = "モデルを読み込み中…";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1411,6 +1411,7 @@ enum L10n {
     static var hideChat: String { String(localized: "Hide chat", bundle: bundle) }
     static var sendMessage: String { String(localized: "Send message", bundle: bundle) }
     static var stopGenerating: String { String(localized: "Stop generating", bundle: bundle) }
+    static var chatThinking: String { String(localized: "Thinking", bundle: bundle) }
     static var messageCodex: String { String(localized: "Message Codex", bundle: bundle) }
     static var openAISettings: String { String(localized: "Open AI Connection Settings", bundle: bundle) }
     static var chatModelLoading: String { String(localized: "Loading models…", bundle: bundle) }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
@@ -37,8 +37,7 @@ struct CodexChatMessageRow: View {
                     }
 
                     if message.text.isEmpty, message.isStreaming {
-                        ProgressView()
-                            .controlSize(.small)
+                        CodexChatThinkingIndicator()
                     } else if !displayText.isEmpty {
                         if message.isStreaming {
                             Text(displayText)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatThinkingIndicator.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatThinkingIndicator.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct CodexChatThinkingIndicator: View {
+    @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(L10n.chatThinking)
+
+            if accessibilityReduceMotion {
+                dots(activeIndex: nil)
+            } else {
+                TimelineView(.periodic(from: .now, by: 0.28)) { context in
+                    dots(activeIndex: activeIndex(at: context.date))
+                }
+            }
+        }
+        .font(.callout)
+        .foregroundStyle(.secondary)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(L10n.chatThinking)
+    }
+
+    private func dots(activeIndex: Int?) -> some View {
+        HStack(spacing: 3) {
+            ForEach(0 ..< 3, id: \.self) { index in
+                let isActive = activeIndex == index
+                Circle()
+                    .frame(width: 4, height: 4)
+                    .scaleEffect(isActive ? 1 : 0.75)
+                    .opacity(activeIndex == nil || isActive ? 1 : 0.3)
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: activeIndex)
+        .accessibilityHidden(true)
+    }
+
+    private func activeIndex(at date: Date) -> Int {
+        Int(date.timeIntervalSinceReferenceDate / 0.28) % 3
+    }
+}


### PR DESCRIPTION
## Summary

- replace the empty streaming spinner with a localized thinking indicator
- animate three dots from left to right while waiting for the AI response
- respect Reduce Motion and provide an accessible label

## Why

The previous spinner did not clearly communicate that the AI was actively preparing a response. The new indicator gives users explicit feedback in Japanese and English while preserving the existing streaming flow.

## Validation

- `swift build`
- `swift test --filter CodexChatSessionModelTests` (18 tests passed)
- `CI=true ./scripts/lint.sh` (SwiftFormat clean; existing SwiftLint warnings only)
