### PR TITLE
Add live transcription mode to AI chat

### DIFF
--- a/Sources/Dahlia/DahliaApp.swift
+++ b/Sources/Dahlia/DahliaApp.swift
@@ -44,6 +44,15 @@ struct DahliaApp: App {
             liveSubtitleOverlayService: liveSubtitleOverlayService
         )
         let chatCoordinator = CodexChatCoordinator()
+        chatCoordinator.liveModeStatusDidChange = { [weak viewModel] isEnabled in
+            viewModel?.setChatLiveModeEnabled(isEnabled)
+        }
+        viewModel.finalizedLiveTranscriptHandler = { [weak chatCoordinator] text in
+            chatCoordinator?.receiveFinalizedLiveTranscript(text)
+        }
+        viewModel.chatLiveModeFailureHandler = { [weak chatCoordinator] in
+            chatCoordinator?.disableLiveMode()
+        }
 
         _viewModel = StateObject(wrappedValue: viewModel)
         _sidebarViewModel = State(initialValue: sidebarViewModel)

--- a/Sources/Dahlia/DahliaApp.swift
+++ b/Sources/Dahlia/DahliaApp.swift
@@ -47,8 +47,8 @@ struct DahliaApp: App {
         chatCoordinator.liveModeStatusDidChange = { [weak viewModel] isEnabled in
             viewModel?.setChatLiveModeEnabled(isEnabled)
         }
-        viewModel.finalizedLiveTranscriptHandler = { [weak chatCoordinator] text in
-            chatCoordinator?.receiveFinalizedLiveTranscript(text)
+        viewModel.finalizedLiveTranscriptHandler = { [weak chatCoordinator] text, wasTruncated in
+            chatCoordinator?.receiveFinalizedLiveTranscript(text, wasTruncated: wasTruncated)
         }
         viewModel.chatLiveModeFailureHandler = { [weak chatCoordinator] in
             chatCoordinator?.disableLiveMode()

--- a/Sources/Dahlia/Models/TranscriptionSessionPlan.swift
+++ b/Sources/Dahlia/Models/TranscriptionSessionPlan.swift
@@ -3,11 +3,12 @@
 struct TranscriptionSessionPlan: Equatable {
     let finalMode: TranscriptionMode
     var liveSubtitlesEnabled: Bool
+    var liveChatEnabled = false
     let retainBatchAudio: Bool
 
-    /// 正本文字起こし、またはライブ字幕のために逐次認識が必要か。
+    /// 正本文字起こし、ライブ字幕、またはライブチャットのために逐次認識が必要か。
     var requiresLiveRecognition: Bool {
-        finalMode == .realtime || liveSubtitlesEnabled
+        finalMode == .realtime || liveSubtitlesEnabled || liveChatEnabled
     }
 
     /// バッチ文字起こし用の音声を録音するか。

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -712,6 +712,12 @@
 "Stop generating" = "Stop generating";
 "Thinking" = "Thinking";
 "Message Codex" = "Message Codex";
+"Live mode" = "Live mode";
+"Turn on live mode" = "Turn on live mode";
+"Turn off live mode" = "Turn off live mode";
+"Live mode on" = "Live mode on";
+"Live mode off" = "Live mode off";
+"Some older live transcript was skipped because the chat backlog was too large." = "Some older live transcript was skipped because the chat backlog was too large.";
 "Open AI Connection Settings" = "Open AI Connection Settings";
 "Loading models…" = "Loading models…";
 "This chat is no longer available." = "This chat is no longer available.";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -712,6 +712,12 @@
 "Stop generating" = "生成を停止";
 "Thinking" = "考えています";
 "Message Codex" = "Codex にメッセージ";
+"Live mode" = "ライブモード";
+"Turn on live mode" = "ライブモードをオンにする";
+"Turn off live mode" = "ライブモードをオフにする";
+"Live mode on" = "ライブモード：オン";
+"Live mode off" = "ライブモード：オフ";
+"Some older live transcript was skipped because the chat backlog was too large." = "チャットの待機量が上限を超えたため、古いライブ文字起こしの一部をスキップしました。";
 "Open AI Connection Settings" = "AI 接続設定を開く";
 "Loading models…" = "モデルを読み込み中…";
 "This chat is no longer available." = "このチャットは利用できなくなりました。";

--- a/Sources/Dahlia/Services/CodexChatPromptCodec.swift
+++ b/Sources/Dahlia/Services/CodexChatPromptCodec.swift
@@ -27,15 +27,16 @@ enum CodexChatPromptCodec {
         isLiveMode: Bool,
         liveTranscript: String? = nil
     ) -> [String] {
+        let liveTranscript = liveTranscript?.nilIfBlank
         var blocks: [String] = []
         if context != nil || isLiveMode {
             blocks.append(encodeContext(
                 context,
                 isLiveMode: isLiveMode,
-                containsLiveTranscript: liveTranscript?.nilIfBlank != nil
+                containsLiveTranscript: liveTranscript != nil
             ))
         }
-        if let liveTranscript = liveTranscript?.nilIfBlank {
+        if let liveTranscript {
             blocks.append(liveTranscriptBlock(liveTranscript))
         }
         if let text = text?.nilIfBlank {

--- a/Sources/Dahlia/Services/CodexChatPromptCodec.swift
+++ b/Sources/Dahlia/Services/CodexChatPromptCodec.swift
@@ -6,6 +6,10 @@ enum CodexChatPromptCodec {
     private static let contextClosingTag = "</context>"
     private static let meetingDescription = "  You are viewing a meeting in the Dahlia App.\n"
     private static let meetingDraftDescription = "  You are viewing an unsaved meeting draft in the Dahlia App.\n"
+    private static let liveModeDescription = "  Live mode is enabled. You are receiving finalized live transcription from Dahlia."
+    private static let hiddenLiveTranscriptDescription = "  This turn contains one hidden live transcript block."
+    private static let liveTranscriptStart = "<live_transcript>"
+    private static let liveTranscriptEnd = "</live_transcript>"
 
     static func encode(text: String, context: CodexChatContext?) -> String {
         guard let context else { return text }
@@ -17,8 +21,45 @@ enum CodexChatPromptCodec {
         return [encodeContext(context), text]
     }
 
+    static func encodeTextBlocks(
+        text: String?,
+        context: CodexChatContext?,
+        isLiveMode: Bool,
+        liveTranscript: String? = nil
+    ) -> [String] {
+        var blocks: [String] = []
+        if context != nil || isLiveMode {
+            blocks.append(encodeContext(
+                context,
+                isLiveMode: isLiveMode,
+                containsLiveTranscript: liveTranscript?.nilIfBlank != nil
+            ))
+        }
+        if let liveTranscript = liveTranscript?.nilIfBlank {
+            blocks.append(liveTranscriptBlock(liveTranscript))
+        }
+        if let text = text?.nilIfBlank {
+            blocks.append(text)
+        }
+        return blocks
+    }
+
     private static func encodeContext(_ context: CodexChatContext) -> String {
+        encodeContext(context, isLiveMode: false)
+    }
+
+    private static func encodeContext(
+        _ context: CodexChatContext?,
+        isLiveMode: Bool,
+        containsLiveTranscript: Bool = false
+    ) -> String {
         var lines = ["<context>"]
+        if isLiveMode {
+            lines.append(liveModeDescription)
+        }
+        if containsLiveTranscript {
+            lines.append(hiddenLiveTranscriptDescription)
+        }
         switch context {
         case let .meeting(id, name, calendarEvent):
             lines.append("  You are viewing a meeting in the Dahlia App.")
@@ -31,6 +72,8 @@ enum CodexChatPromptCodec {
             lines.append("  Type: MeetingDraft")
             lines.append(element(name: "meeting_name", value: name, indentation: 2))
             append(calendarEvent, to: &lines)
+        case nil:
+            break
         }
         lines.append("</context>")
         return lines.joined(separator: "\n")
@@ -54,6 +97,9 @@ enum CodexChatPromptCodec {
 
     static func decodeTextBlocks(_ textBlocks: [String]) -> (text: String, context: CodexChatContext?) {
         guard let firstText = textBlocks.first else { return ("", nil) }
+        if let decoded = decodeLiveModeTextBlocks(textBlocks) {
+            return decoded
+        }
         if textBlocks.count == 2,
            let context = canonicalContext(from: firstText) {
             return (textBlocks[1], context)
@@ -63,6 +109,40 @@ enum CodexChatPromptCodec {
 
     static func visibleUserText(from text: String) -> String {
         decodeUserText(text).text
+    }
+
+    private static func decodeLiveModeTextBlocks(
+        _ textBlocks: [String]
+    ) -> (text: String, context: CodexChatContext?)? {
+        guard let first = textBlocks.first,
+              first.hasPrefix("<context>\n" + liveModeDescription + "\n"),
+              first.hasSuffix("\n</context>") else { return nil }
+
+        let containsLiveTranscript = first.contains("\n" + hiddenLiveTranscriptDescription + "\n")
+        var contextBlock = first.replacing(liveModeDescription + "\n", with: "")
+        contextBlock = contextBlock.replacing(hiddenLiveTranscriptDescription + "\n", with: "")
+        let context = contextBlock == "<context>\n</context>" ? nil : canonicalContext(from: contextBlock)
+        guard context != nil || contextBlock == "<context>\n</context>" else { return nil }
+
+        var visibleBlocks = Array(textBlocks.dropFirst())
+        if containsLiveTranscript,
+           let firstVisible = visibleBlocks.first,
+           isCanonicalLiveTranscriptBlock(firstVisible) {
+            visibleBlocks.removeFirst()
+        }
+        return (visibleBlocks.joined(separator: "\n"), context)
+    }
+
+    private static func liveTranscriptBlock(_ text: String) -> String {
+        liveTranscriptStart + escape(text) + liveTranscriptEnd
+    }
+
+    private static func isCanonicalLiveTranscriptBlock(_ block: String) -> Bool {
+        guard block.hasPrefix(liveTranscriptStart), block.hasSuffix(liveTranscriptEnd) else { return false }
+        let valueStart = block.index(block.startIndex, offsetBy: liveTranscriptStart.count)
+        let valueEnd = block.index(block.endIndex, offsetBy: -liveTranscriptEnd.count)
+        let encoded = String(block[valueStart ..< valueEnd])
+        return unescape(encoded).map(liveTranscriptBlock) == block
     }
 
     private static func decodeUserText(_ text: String) -> (text: String, context: CodexChatContext?) {

--- a/Sources/Dahlia/Services/FinalizedLiveTranscriptRelay.swift
+++ b/Sources/Dahlia/Services/FinalizedLiveTranscriptRelay.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+actor FinalizedLiveTranscriptRelay {
+    struct Delivery: Equatable, Sendable {
+        let sessionID: UUID
+        let text: String
+        let wasTruncated: Bool
+    }
+
+    typealias Sink = @MainActor @Sendable (Delivery) async -> Void
+
+    static let maximumPendingCharacters = 100_000
+
+    private let sink: Sink
+    private var pendingDelivery: Delivery?
+    private var worker: Task<Void, Never>?
+
+    init(sink: @escaping Sink) {
+        self.sink = sink
+    }
+
+    func enqueue(sessionID: UUID, text: String) {
+        guard let text = text.nilIfBlank else { return }
+        let combined = pendingDelivery.map { $0.text + "\n" + text } ?? text
+        let wasTruncated = pendingDelivery?.wasTruncated == true
+            || combined.count > Self.maximumPendingCharacters
+        pendingDelivery = Delivery(
+            sessionID: sessionID,
+            text: String(combined.suffix(Self.maximumPendingCharacters)),
+            wasTruncated: wasTruncated
+        )
+        startWorkerIfNeeded()
+    }
+
+    func finish() async {
+        await worker?.value
+    }
+
+    func cancel() {
+        pendingDelivery = nil
+        worker?.cancel()
+        worker = nil
+    }
+
+    private func startWorkerIfNeeded() {
+        guard worker == nil else { return }
+        worker = Task { [weak self] in
+            await self?.drain()
+        }
+    }
+
+    private func drain() async {
+        while !Task.isCancelled, let delivery = takePendingDelivery() {
+            await sink(delivery)
+        }
+        worker = nil
+    }
+
+    private func takePendingDelivery() -> Delivery? {
+        defer { pendingDelivery = nil }
+        return pendingDelivery
+    }
+}

--- a/Sources/Dahlia/Services/RecordingSessionController+Reconfiguration.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController+Reconfiguration.swift
@@ -23,17 +23,50 @@ extension RecordingSessionController {
             throw RecordingSessionControllerError.sessionNotActive
         }
         guard snapshot.plan.liveSubtitlesEnabled != isEnabled else { return snapshot }
+        var updatedPlan = snapshot.plan
+        updatedPlan.liveSubtitlesEnabled = isEnabled
+        return try await applyLiveRecognitionPlan(
+            updatedPlan,
+            replacing: snapshot,
+            translateSegment: translateSegment
+        )
+    }
 
-        if snapshot.plan.finalMode == .batch, isEnabled {
+    func setLiveChatEnabled(
+        _ isEnabled: Bool,
+        translateSegment: ProgressiveSegmentTranslationHandler?
+    ) async throws -> Snapshot {
+        guard case let .capturing(snapshot) = state else {
+            throw RecordingSessionControllerError.sessionNotActive
+        }
+        guard snapshot.plan.liveChatEnabled != isEnabled else { return snapshot }
+        var updatedPlan = snapshot.plan
+        updatedPlan.liveChatEnabled = isEnabled
+        return try await applyLiveRecognitionPlan(
+            updatedPlan,
+            replacing: snapshot,
+            translateSegment: translateSegment
+        )
+    }
+
+    private func applyLiveRecognitionPlan(
+        _ updatedPlan: TranscriptionSessionPlan,
+        replacing snapshot: Snapshot,
+        translateSegment: ProgressiveSegmentTranslationHandler?
+    ) async throws -> Snapshot {
+        if snapshot.plan.finalMode == .batch,
+           !snapshot.plan.requiresLiveRecognition,
+           updatedPlan.requiresLiveRecognition {
             try await enableBatchLiveRecognition(
                 snapshot: snapshot,
                 translateSegment: translateSegment
             )
-        } else if snapshot.plan.finalMode == .batch {
+        } else if snapshot.plan.finalMode == .batch,
+                  snapshot.plan.requiresLiveRecognition,
+                  !updatedPlan.requiresLiveRecognition {
             await disableBatchLiveRecognition()
         }
-
-        return try commitLiveSubtitleState(isEnabled, sessionId: snapshot.sessionId)
+        return try commitLiveRecognitionPlan(updatedPlan, sessionId: snapshot.sessionId)
     }
 
     private func enableBatchLiveRecognition(
@@ -161,12 +194,15 @@ extension RecordingSessionController {
         }
     }
 
-    private func commitLiveSubtitleState(_ isEnabled: Bool, sessionId: UUID) throws -> Snapshot {
+    private func commitLiveRecognitionPlan(
+        _ plan: TranscriptionSessionPlan,
+        sessionId: UUID
+    ) throws -> Snapshot {
         guard case var .capturing(snapshot) = state,
               snapshot.sessionId == sessionId else {
             throw RecordingSessionControllerError.sessionNotActive
         }
-        snapshot.plan.liveSubtitlesEnabled = isEnabled
+        snapshot.plan = plan
         transition(to: .capturing(snapshot))
         return snapshot
     }

--- a/Sources/Dahlia/Services/TranscriptionEventPipeline.swift
+++ b/Sources/Dahlia/Services/TranscriptionEventPipeline.swift
@@ -7,6 +7,7 @@ import Foundation
 /// preview は音源ごとに最新値だけを保持する。UI backlog は上限超過時に DB 再読込へ集約する。
 actor TranscriptionEventPipeline { // swiftlint:disable:this type_body_length
     typealias UISink = @MainActor @Sendable ([TranscriptionEvent]) async -> Void
+    typealias EventObserver = @Sendable (TranscriptionEvent) -> Void
     typealias UIReloadSink = @MainActor @Sendable () async -> Void
     typealias PersistenceSink = @Sendable ([TranscriptionEvent]) async throws -> Void
     typealias PersistenceFlushSink = @Sendable () async throws -> Void
@@ -49,6 +50,7 @@ actor TranscriptionEventPipeline { // swiftlint:disable:this type_body_length
     }
 
     private let uiSink: UISink
+    private let eventObserver: EventObserver?
     private let uiReloadSink: UIReloadSink
     private let persistenceSink: PersistenceSink
     private let persistenceFlushSink: PersistenceFlushSink
@@ -86,6 +88,7 @@ actor TranscriptionEventPipeline { // swiftlint:disable:this type_body_length
 
     init(
         uiSink: @escaping UISink,
+        eventObserver: EventObserver? = nil,
         uiReloadSink: @escaping UIReloadSink = {},
         persistenceSink: @escaping PersistenceSink,
         persistenceFlushSink: @escaping PersistenceFlushSink = {},
@@ -100,6 +103,7 @@ actor TranscriptionEventPipeline { // swiftlint:disable:this type_body_length
             bufferingPolicy: .unbounded
         )
         self.uiSink = uiSink
+        self.eventObserver = eventObserver
         self.uiReloadSink = uiReloadSink
         self.persistenceSink = persistenceSink
         self.persistenceFlushSink = persistenceFlushSink
@@ -138,6 +142,9 @@ actor TranscriptionEventPipeline { // swiftlint:disable:this type_body_length
     func enqueue(_ event: TranscriptionEvent) {
         guard isAcceptingEvents else { return }
 
+        // Observers that require every event must run before the bounded UI projection
+        // compacts finalized events into a reload marker.
+        eventObserver?(event)
         enqueueUIEvent(event)
         uiSignalContinuation.yield()
 

--- a/Sources/Dahlia/Services/TranscriptionEventPipeline.swift
+++ b/Sources/Dahlia/Services/TranscriptionEventPipeline.swift
@@ -7,7 +7,7 @@ import Foundation
 /// preview は音源ごとに最新値だけを保持する。UI backlog は上限超過時に DB 再読込へ集約する。
 actor TranscriptionEventPipeline { // swiftlint:disable:this type_body_length
     typealias UISink = @MainActor @Sendable ([TranscriptionEvent]) async -> Void
-    typealias EventObserver = @Sendable (TranscriptionEvent) -> Void
+    typealias EventObserver = @Sendable (TranscriptionEvent) async -> Void
     typealias UIReloadSink = @MainActor @Sendable () async -> Void
     typealias PersistenceSink = @Sendable ([TranscriptionEvent]) async throws -> Void
     typealias PersistenceFlushSink = @Sendable () async throws -> Void
@@ -139,12 +139,12 @@ actor TranscriptionEventPipeline { // swiftlint:disable:this type_body_length
         }
     }
 
-    func enqueue(_ event: TranscriptionEvent) {
+    func enqueue(_ event: TranscriptionEvent) async {
         guard isAcceptingEvents else { return }
 
         // Observers that require every event must run before the bounded UI projection
         // compacts finalized events into a reload marker.
-        eventObserver?(event)
+        await eventObserver?(event)
         enqueueUIEvent(event)
         uiSignalContinuation.yield()
 

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1414,6 +1414,15 @@ enum L10n {
     static var stopGenerating: String { String(localized: "Stop generating", bundle: bundle) }
     static var chatThinking: String { String(localized: "Thinking", bundle: bundle) }
     static var messageCodex: String { String(localized: "Message Codex", bundle: bundle) }
+    static var chatLiveMode: String { String(localized: "Live mode", bundle: bundle) }
+    static var enableChatLiveMode: String { String(localized: "Turn on live mode", bundle: bundle) }
+    static var disableChatLiveMode: String { String(localized: "Turn off live mode", bundle: bundle) }
+    static var chatLiveModeOn: String { String(localized: "Live mode on", bundle: bundle) }
+    static var chatLiveModeOff: String { String(localized: "Live mode off", bundle: bundle) }
+    static var chatLiveTranscriptBacklogTruncated: String {
+        String(localized: "Some older live transcript was skipped because the chat backlog was too large.", bundle: bundle)
+    }
+
     static var openAISettings: String { String(localized: "Open AI Connection Settings", bundle: bundle) }
     static var chatModelLoading: String { String(localized: "Loading models…", bundle: bundle) }
     static var chatWindowUnavailable: String { String(localized: "This chat is no longer available.", bundle: bundle) }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -326,9 +326,6 @@ final class CaptionViewModel: ObservableObject {
             } catch {
                 guard self.activeTranscriptionPlan?.liveChatEnabled == isEnabled else { return }
                 self.errorMessage = error.localizedDescription
-                // A failed enable and a failed disable both converge on the privacy-safe
-                // state shared with chat sessions. The next recording must not restart
-                // recognition while every chat has live mode switched off.
                 self.isChatLiveModeEnabled = false
                 self.activeTranscriptionPlan?.liveChatEnabled = false
                 self.chatLiveModeFailureHandler?()

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -103,6 +103,8 @@ final class CaptionViewModel: ObservableObject {
     }
 
     let liveCaptionStore = LiveCaptionStore()
+    var finalizedLiveTranscriptHandler: (@MainActor (String) -> Void)?
+    var chatLiveModeFailureHandler: (@MainActor () -> Void)?
 
     @Published var isListening = false
     @Published var isFinalizingRecording = false
@@ -300,6 +302,40 @@ final class CaptionViewModel: ObservableObject {
         isListening && activeTranscriptionMode == .batch
     }
 
+    func setChatLiveModeEnabled(_ isEnabled: Bool) {
+        guard isChatLiveModeEnabled != isEnabled else { return }
+        isChatLiveModeEnabled = isEnabled
+
+        guard var plan = activeTranscriptionPlan,
+              let recordingSessionId = activeRecordingSessionId else { return }
+        plan.liveChatEnabled = isEnabled
+        activeTranscriptionPlan = plan
+
+        guard case let .recording(activeSessionID) = recordingLifecycle,
+              activeSessionID == recordingSessionId else { return }
+        enqueueRecordingConfiguration { [weak self] _ in
+            guard let self,
+                  self.activeTranscriptionPlan?.liveChatEnabled == isEnabled else { return }
+            do {
+                let locale = self.resolvedSelectedLocale()
+                let snapshot = try await self.recordingSessionController.setLiveChatEnabled(
+                    isEnabled,
+                    translateSegment: self.translationHandler(for: locale)
+                )
+                self.activeControllerSources = snapshot.enabledSources
+            } catch {
+                guard self.activeTranscriptionPlan?.liveChatEnabled == isEnabled else { return }
+                self.errorMessage = error.localizedDescription
+                // A failed enable and a failed disable both converge on the privacy-safe
+                // state shared with chat sessions. The next recording must not restart
+                // recognition while every chat has live mode switched off.
+                self.isChatLiveModeEnabled = false
+                self.activeTranscriptionPlan?.liveChatEnabled = false
+                self.chatLiveModeFailureHandler?()
+            }
+        }
+    }
+
     /// 少なくとも 1 つの音声ソースが有効か。
     var hasEnabledAudioSource: Bool { isMicEnabled || isSystemAudioEnabled }
 
@@ -357,6 +393,7 @@ final class CaptionViewModel: ObservableObject {
     private var failedPersistenceService: MeetingPersistenceService?
     private var failedTranscriptionEventPipeline: TranscriptionEventPipeline?
     private var transcriptionEventPipeline: TranscriptionEventPipeline?
+    private var isChatLiveModeEnabled = false
     private var batchTranscriptionCoordinator: BatchTranscriptionCoordinator?
     private let recordingSessionController = RecordingSessionController()
     private var activeTranscriptionPlan: TranscriptionSessionPlan?
@@ -1593,6 +1630,13 @@ final class CaptionViewModel: ObservableObject {
                     self?.handleTranscriptionEvent(event)
                 }
             },
+            eventObserver: { [weak self] event in
+                guard case let .finalized(segment) = event,
+                      segment.isConfirmed else { return }
+                Task { @MainActor [weak self] in
+                    self?.forwardFinalizedLiveTranscript(segment)
+                }
+            },
             uiReloadSink: { [weak recordingTranscriptStore] in
                 guard let recordingTranscriptStore else { return }
                 _ = await recordingTranscriptStore.reloadLatestAfterUICompaction()
@@ -1734,6 +1778,7 @@ final class CaptionViewModel: ObservableObject {
         var transcriptionPlan = TranscriptionSessionPlan(
             finalMode: transcriptionMode,
             liveSubtitlesEnabled: AppSettings.shared.liveSubtitleOverlayEnabled,
+            liveChatEnabled: isChatLiveModeEnabled,
             retainBatchAudio: retainAudioAfterBatch
         )
         let primaryLocale = resolvedSelectedLocale()
@@ -2858,6 +2903,13 @@ final class CaptionViewModel: ObservableObject {
         }
     }
 
+    private func forwardFinalizedLiveTranscript(_ segment: TranscriptSegment) {
+        guard let plan = activeTranscriptionPlan,
+              plan.liveChatEnabled,
+              segment.sessionId == activeRecordingSessionId else { return }
+        finalizedLiveTranscriptHandler?(segment.text)
+    }
+
     private func controllerSourceConfiguration(
         for source: RecordingAudioSource,
         plan: TranscriptionSessionPlan? = nil
@@ -2985,14 +3037,18 @@ final class CaptionViewModel: ObservableObject {
     ) async throws -> TranscriptionSessionPlan {
         var plan = initialPlan
         while recordingLifecycle == .starting(recordingSessionId) {
-            let desiredValue = activeTranscriptionPlan?.liveSubtitlesEnabled
+            let desiredSubtitles = activeTranscriptionPlan?.liveSubtitlesEnabled
                 ?? AppSettings.shared.liveSubtitleOverlayEnabled
-            guard plan.liveSubtitlesEnabled != desiredValue else { return plan }
+            let desiredLiveChat = activeTranscriptionPlan?.liveChatEnabled ?? isChatLiveModeEnabled
+            guard plan.liveSubtitlesEnabled != desiredSubtitles ||
+                plan.liveChatEnabled != desiredLiveChat else { return plan }
 
             try ensureSessionIsActive(recordingSessionId)
-            guard activeTranscriptionPlan?.liveSubtitlesEnabled == desiredValue else { continue }
+            guard activeTranscriptionPlan?.liveSubtitlesEnabled == desiredSubtitles,
+                  activeTranscriptionPlan?.liveChatEnabled == desiredLiveChat else { continue }
 
-            plan.liveSubtitlesEnabled = desiredValue
+            plan.liveSubtitlesEnabled = desiredSubtitles
+            plan.liveChatEnabled = desiredLiveChat
             return plan
         }
         throw CancellationError()
@@ -3012,9 +3068,19 @@ final class CaptionViewModel: ObservableObject {
                     translateSegment: translationHandler(for: locale)
                 )
                 activeControllerSources = snapshot.enabledSources
-                appliedPlan = latestPlan
+                appliedPlan = snapshot.plan
             }
-            guard activeTranscriptionPlan?.liveSubtitlesEnabled == latestPlan.liveSubtitlesEnabled else {
+            if appliedPlan.liveChatEnabled != latestPlan.liveChatEnabled {
+                let locale = resolvedSelectedLocale()
+                let snapshot = try await recordingSessionController.setLiveChatEnabled(
+                    latestPlan.liveChatEnabled,
+                    translateSegment: translationHandler(for: locale)
+                )
+                activeControllerSources = snapshot.enabledSources
+                appliedPlan = snapshot.plan
+            }
+            guard activeTranscriptionPlan?.liveSubtitlesEnabled == latestPlan.liveSubtitlesEnabled,
+                  activeTranscriptionPlan?.liveChatEnabled == latestPlan.liveChatEnabled else {
                 continue
             }
             return latestPlan

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -103,7 +103,7 @@ final class CaptionViewModel: ObservableObject {
     }
 
     let liveCaptionStore = LiveCaptionStore()
-    var finalizedLiveTranscriptHandler: (@MainActor (String) -> Void)?
+    var finalizedLiveTranscriptHandler: (@MainActor (String, Bool) -> Void)?
     var chatLiveModeFailureHandler: (@MainActor () -> Void)?
 
     @Published var isListening = false
@@ -390,6 +390,7 @@ final class CaptionViewModel: ObservableObject {
     private var failedPersistenceService: MeetingPersistenceService?
     private var failedTranscriptionEventPipeline: TranscriptionEventPipeline?
     private var transcriptionEventPipeline: TranscriptionEventPipeline?
+    private var liveTranscriptRelay: FinalizedLiveTranscriptRelay?
     private var isChatLiveModeEnabled = false
     private var batchTranscriptionCoordinator: BatchTranscriptionCoordinator?
     private let recordingSessionController = RecordingSessionController()
@@ -1471,6 +1472,7 @@ final class CaptionViewModel: ObservableObject {
     ) -> MeetingRepository.AppendRecordingContext? {
         persistenceService = nil
         transcriptionEventPipeline = nil
+        liveTranscriptRelay = nil
         stopAutomaticScreenshotCapture()
 
         guard let existingMeetingId else {
@@ -1621,18 +1623,21 @@ final class CaptionViewModel: ObservableObject {
 
     private func installTranscriptionEventPipeline(persistenceService: MeetingPersistenceService) {
         let recordingTranscriptStore = store
+        let liveTranscriptRelay = FinalizedLiveTranscriptRelay { [weak self] delivery in
+            self?.forwardFinalizedLiveTranscript(delivery)
+        }
+        self.liveTranscriptRelay = liveTranscriptRelay
         transcriptionEventPipeline = TranscriptionEventPipeline(
             uiSink: { [weak self] events in
                 for event in events {
                     self?.handleTranscriptionEvent(event)
                 }
             },
-            eventObserver: { [weak self] event in
+            eventObserver: { event in
                 guard case let .finalized(segment) = event,
-                      segment.isConfirmed else { return }
-                Task { @MainActor [weak self] in
-                    self?.forwardFinalizedLiveTranscript(segment)
-                }
+                      segment.isConfirmed,
+                      let sessionID = segment.sessionId else { return }
+                await liveTranscriptRelay.enqueue(sessionID: sessionID, text: segment.text)
             },
             uiReloadSink: { [weak recordingTranscriptStore] in
                 guard let recordingTranscriptStore else { return }
@@ -1675,7 +1680,9 @@ final class CaptionViewModel: ObservableObject {
                 ErrorReportingService.capture(error, context: ["source": "startTranscriptionPersistence"])
             }
         }
+        await liveTranscriptRelay?.finish()
         transcriptionEventPipeline = nil
+        liveTranscriptRelay = nil
         stopAutomaticScreenshotCapture()
         await persistenceService?.cancel()
         persistenceService = nil
@@ -1889,6 +1896,7 @@ final class CaptionViewModel: ObservableObject {
                 await task.value
             }
             let stoppingTranscriptionEventPipeline = transcriptionEventPipeline
+            let stoppingLiveTranscriptRelay = liveTranscriptRelay
             if let stoppingTranscriptionEventPipeline {
                 do {
                     try await stoppingTranscriptionEventPipeline.finish()
@@ -1896,7 +1904,9 @@ final class CaptionViewModel: ObservableObject {
                     ErrorReportingService.capture(error, context: ["source": "stopTranscriptionPersistence"])
                 }
             }
+            await stoppingLiveTranscriptRelay?.finish()
             transcriptionEventPipeline = nil
+            liveTranscriptRelay = nil
             let stoppingPersistenceService = persistenceService
             let persistenceResult = await stoppingPersistenceService?.stop()
                 ?? .failure(message: L10n.recordingSessionNotActive)
@@ -2900,11 +2910,11 @@ final class CaptionViewModel: ObservableObject {
         }
     }
 
-    private func forwardFinalizedLiveTranscript(_ segment: TranscriptSegment) {
+    private func forwardFinalizedLiveTranscript(_ delivery: FinalizedLiveTranscriptRelay.Delivery) {
         guard let plan = activeTranscriptionPlan,
               plan.liveChatEnabled,
-              segment.sessionId == activeRecordingSessionId else { return }
-        finalizedLiveTranscriptHandler?(segment.text)
+              delivery.sessionID == activeRecordingSessionId else { return }
+        finalizedLiveTranscriptHandler?(delivery.text, delivery.wasTruncated)
     }
 
     private func controllerSourceConfiguration(

--- a/Sources/Dahlia/ViewModels/CodexChatCoordinator.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatCoordinator.swift
@@ -18,6 +18,7 @@ final class CodexChatCoordinator {
     @ObservationIgnored private let settings: AppSettings
     @ObservationIgnored private let contextProvider: CodexChatContextProvider
     @ObservationIgnored private var historyGeneration = 0
+    @ObservationIgnored var liveModeStatusDidChange: (@MainActor (Bool) -> Void)?
 
     init(
         service: any CodexChatServicing = CodexChatService.shared,
@@ -34,6 +35,7 @@ final class CodexChatCoordinator {
         )
         floatingSessionID = session.id
         sessions[session.id] = session
+        configureLiveModeHandler(for: session)
     }
 
     var floatingSession: CodexChatSessionModel {
@@ -175,6 +177,18 @@ final class CodexChatCoordinator {
         )
     }
 
+    func receiveFinalizedLiveTranscript(_ text: String) {
+        for session in sessions.values where session.isLiveModeEnabled {
+            session.receiveFinalizedLiveTranscript(text)
+        }
+    }
+
+    func disableLiveMode() {
+        for session in sessions.values where session.isLiveModeEnabled {
+            session.disableLiveMode()
+        }
+    }
+
     func refreshHistory() async {
         historyGeneration += 1
         let generation = historyGeneration
@@ -219,7 +233,11 @@ final class CodexChatCoordinator {
               !detachedSessionIDs.contains(id),
               let session = sessions.removeValue(forKey: id)
         else { return }
+        let wasLive = session.isLiveModeEnabled
         session.release()
+        if wasLive {
+            notifyLiveModeStatusChanged()
+        }
     }
 
     private func replaceFloatingSession(
@@ -239,7 +257,7 @@ final class CodexChatCoordinator {
         backendThreadID: String? = nil,
         title: String = ""
     ) -> CodexChatSessionModel {
-        CodexChatSessionModel(
+        let session = CodexChatSessionModel(
             id: id,
             vaultID: vaultID,
             backendThreadID: backendThreadID,
@@ -248,5 +266,17 @@ final class CodexChatCoordinator {
             settings: settings,
             contextProvider: contextProvider
         )
+        configureLiveModeHandler(for: session)
+        return session
+    }
+
+    private func configureLiveModeHandler(for session: CodexChatSessionModel) {
+        session.setLiveModeChangeHandler { [weak self] _ in
+            self?.notifyLiveModeStatusChanged()
+        }
+    }
+
+    private func notifyLiveModeStatusChanged() {
+        liveModeStatusDidChange?(sessions.values.contains(where: \.isLiveModeEnabled))
     }
 }

--- a/Sources/Dahlia/ViewModels/CodexChatCoordinator.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatCoordinator.swift
@@ -177,9 +177,9 @@ final class CodexChatCoordinator {
         )
     }
 
-    func receiveFinalizedLiveTranscript(_ text: String) {
+    func receiveFinalizedLiveTranscript(_ text: String, wasTruncated: Bool = false) {
         for session in sessions.values where session.isLiveModeEnabled {
-            session.receiveFinalizedLiveTranscript(text)
+            session.receiveFinalizedLiveTranscript(text, wasTruncated: wasTruncated)
         }
     }
 

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -209,24 +209,10 @@ private extension CodexChatSessionModel {
             }
             try Task.checkCancellation()
             try ensureLiveTurnCanContinue(liveTranscript)
-            if backendThreadID == nil {
-                guard isBoundToCurrentVault, let vaultID else {
-                    throw CodexAppServerError.invalidProtocolResponse
-                }
-                let thread = try await service.startThread(
-                    model: selectedModelID.nilIfBlank,
-                    effort: selectedEffort,
-                    vaultID: vaultID
-                )
-                apply(thread, preservingPendingMessages: true)
-                let threadTitle = liveTranscript == nil ? text ?? L10n.newChat : L10n.chatLiveMode
-                title = threadTitle
-                await service.setThreadName(threadID: thread.id, name: threadTitle)
-                try ensureLiveTurnCanContinue(liveTranscript)
-            }
-            guard let backendThreadID else {
-                throw CodexAppServerError.invalidProtocolResponse
-            }
+            let backendThreadID = try await ensureBackendThread(
+                text: text,
+                liveTranscript: liveTranscript
+            )
             try ensureLiveTurnCanContinue(liveTranscript)
 
             let stream = try await service.send(
@@ -391,6 +377,26 @@ private extension CodexChatSessionModel {
 
     private static let maximumEventsBetweenYields = 64
 
+    func ensureBackendThread(text: String?, liveTranscript: String?) async throws -> String {
+        if let backendThreadID {
+            return backendThreadID
+        }
+        guard isBoundToCurrentVault, let vaultID else {
+            throw CodexAppServerError.invalidProtocolResponse
+        }
+        let thread = try await service.startThread(
+            model: selectedModelID.nilIfBlank,
+            effort: selectedEffort,
+            vaultID: vaultID
+        )
+        apply(thread, preservingPendingMessages: true)
+        let threadTitle = liveTranscript == nil ? text ?? L10n.newChat : L10n.chatLiveMode
+        title = threadTitle
+        await service.setThreadName(threadID: thread.id, name: threadTitle)
+        try ensureLiveTurnCanContinue(liveTranscript)
+        return thread.id
+    }
+
     func ensureLiveTurnCanContinue(_ liveTranscript: String?) throws {
         guard liveTranscript != nil else { return }
         guard isLiveModeEnabled, !isStopRequested else { throw CancellationError() }
@@ -545,9 +551,7 @@ private extension CodexChatSessionModel {
     }
 
     func appendPendingLiveTranscript(_ text: String) {
-        let combined = [pendingLiveTranscript, text]
-            .compactMap { $0?.nilIfBlank }
-            .joined(separator: "\n")
+        let combined = pendingLiveTranscript.map { $0 + "\n" + text } ?? text
         guard combined.count > Self.maximumPendingLiveTranscriptCharacters else {
             pendingLiveTranscript = combined
             return

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -18,10 +18,12 @@ final class CodexChatSessionModel: Identifiable {
     private(set) var errorMessage: String?
     private(set) var activeTurnID: String?
     private(set) var lastSubmittedText: String?
+    private(set) var failedLiveTranscript: String?
     private(set) var availableMeetingReferences: [CodexChatMeetingReference] = []
     private(set) var selectedMeetingReferenceIDs: [UUID] = []
     private(set) var meetingNamesByID: [UUID: String] = [:]
     private(set) var meetingReferencesByID: [UUID: CodexChatMeetingReference] = [:]
+    private(set) var isLiveModeEnabled = false
 
     @ObservationIgnored private let service: any CodexChatServicing
     @ObservationIgnored private let settings: AppSettings
@@ -30,6 +32,10 @@ final class CodexChatSessionModel: Identifiable {
     @ObservationIgnored private var isStopRequested = false
     @ObservationIgnored private var isReleased = false
     @ObservationIgnored private var didUnsubscribe = false
+    @ObservationIgnored private var pendingLiveTranscript: String?
+    @ObservationIgnored private var didTruncatePendingLiveTranscript = false
+    @ObservationIgnored private var isActiveTurnLiveTranscript = false
+    @ObservationIgnored private var liveModeChangeHandler: (@MainActor (Bool) -> Void)?
 
     init(
         id: CodexChatSessionID = CodexChatSessionID(),
@@ -127,6 +133,11 @@ final class CodexChatSessionModel: Identifiable {
     }
 
     func retry() {
+        if let failedLiveTranscript {
+            self.failedLiveTranscript = nil
+            submit("", clearsDraft: false, liveTranscript: failedLiveTranscript)
+            return
+        }
         guard let lastSubmittedText else { return }
         let currentText = CodexChatMeetingReference.serializedText(
             referenceIDs: selectedMeetingReferenceIDs,
@@ -147,6 +158,26 @@ final class CodexChatSessionModel: Identifiable {
         Task { await service.interrupt(threadID: backendThreadID, turnID: activeTurnID) }
     }
 
+    func toggleLiveMode() {
+        setLiveModeEnabled(!isLiveModeEnabled)
+    }
+
+    func disableLiveMode() {
+        setLiveModeEnabled(false)
+    }
+
+    func receiveFinalizedLiveTranscript(_ text: String) {
+        guard isLiveModeEnabled,
+              isBoundToCurrentVault,
+              let text = text.nilIfBlank else { return }
+        appendPendingLiveTranscript(text)
+        sendNextLiveTranscriptIfPossible()
+    }
+
+    func setLiveModeChangeHandler(_ handler: @escaping @MainActor (Bool) -> Void) {
+        liveModeChangeHandler = handler
+    }
+
     func release() {
         guard !isReleased else { return }
         isReleased = true
@@ -158,18 +189,26 @@ final class CodexChatSessionModel: Identifiable {
 }
 
 private extension CodexChatSessionModel {
-    func runTurn(text: String, context: CodexChatContext?, responseID: String) async {
+    func runTurn(
+        text: String?,
+        liveTranscript: String?,
+        context: CodexChatContext?,
+        responseID: String,
+        isLiveModeSnapshot: Bool
+    ) async {
         let accumulator = CodexChatTurnAccumulator()
         let updateLimiter = CodexChatStreamingUpdateLimiter(
             minimumInterval: streamingUpdateInterval
         ) { [weak self, accumulator] in
             self?.updateTurnResponse(id: responseID, from: accumulator)
         }
+        var shouldContinueLiveQueue = false
         do {
             if models.isEmpty {
                 await prepare()
             }
             try Task.checkCancellation()
+            try ensureLiveTurnCanContinue(liveTranscript)
             if backendThreadID == nil {
                 guard isBoundToCurrentVault, let vaultID else {
                     throw CodexAppServerError.invalidProtocolResponse
@@ -180,16 +219,24 @@ private extension CodexChatSessionModel {
                     vaultID: vaultID
                 )
                 apply(thread, preservingPendingMessages: true)
-                title = text
-                await service.setThreadName(threadID: thread.id, name: text)
+                let threadTitle = liveTranscript == nil ? text ?? L10n.newChat : L10n.chatLiveMode
+                title = threadTitle
+                await service.setThreadName(threadID: thread.id, name: threadTitle)
+                try ensureLiveTurnCanContinue(liveTranscript)
             }
             guard let backendThreadID else {
                 throw CodexAppServerError.invalidProtocolResponse
             }
+            try ensureLiveTurnCanContinue(liveTranscript)
 
             let stream = try await service.send(
                 threadID: backendThreadID,
-                textBlocks: CodexChatPromptCodec.encodeTextBlocks(text: text, context: context),
+                textBlocks: CodexChatPromptCodec.encodeTextBlocks(
+                    text: text,
+                    context: context,
+                    isLiveMode: isLiveModeSnapshot,
+                    liveTranscript: liveTranscript
+                ),
                 model: selectedModelID.nilIfBlank,
                 effort: selectedEffort
             )
@@ -202,16 +249,22 @@ private extension CodexChatSessionModel {
             completeTurnResponse(responseID: responseID)
             if turnCompleted {
                 await reconcileFromRollout(preservingReasoningFrom: responseID)
+                shouldContinueLiveQueue = true
+            } else if let liveTranscript, isLiveModeEnabled, !isStopRequested {
+                failedLiveTranscript = liveTranscript
             }
         } catch is CancellationError {
             updateLimiter.submit(force: true)
             completeTurnResponse(responseID: responseID)
         } catch {
             errorMessage = error.localizedDescription
+            if let liveTranscript, isLiveModeEnabled {
+                failedLiveTranscript = liveTranscript
+            }
             updateLimiter.submit(force: true)
             completeTurnResponse(responseID: responseID)
         }
-        finishGeneration()
+        finishGeneration(continueLiveQueue: shouldContinueLiveQueue)
     }
 
     func consumeTurnEvents(
@@ -325,14 +378,23 @@ private extension CodexChatSessionModel {
         apply(reconciledThread, preservingPendingMessages: thread.messages.count < messages.count)
     }
 
-    private func finishGeneration() {
+    private func finishGeneration(continueLiveQueue: Bool = false) {
         isGenerating = false
         activeTurnID = nil
         isStopRequested = false
+        isActiveTurnLiveTranscript = false
         unsubscribeIfPossible()
+        if continueLiveQueue {
+            sendNextLiveTranscriptIfPossible()
+        }
     }
 
     private static let maximumEventsBetweenYields = 64
+
+    func ensureLiveTurnCanContinue(_ liveTranscript: String?) throws {
+        guard liveTranscript != nil else { return }
+        guard isLiveModeEnabled, !isStopRequested else { throw CancellationError() }
+    }
 
     private func unsubscribeIfPossible() {
         guard isReleased,
@@ -371,20 +433,25 @@ private extension CodexChatSessionModel {
         _ text: String,
         clearsDraft: Bool,
         draftSnapshot: String? = nil,
-        referenceIDsSnapshot: [UUID] = []
+        referenceIDsSnapshot: [UUID] = [],
+        liveTranscript: String? = nil
     ) {
         guard isBoundToCurrentVault,
               !isGenerating,
-              text.nilIfBlank != nil else { return }
+              text.nilIfBlank != nil || liveTranscript?.nilIfBlank != nil else { return }
         isGenerating = true
         errorMessage = nil
+        isActiveTurnLiveTranscript = liveTranscript != nil
+        let isLiveModeSnapshot = liveTranscript != nil || isLiveModeEnabled
 
         Task { [weak self] in
             await self?.resolveContextAndRunTurn(
                 text: text,
                 clearsDraft: clearsDraft,
                 draftSnapshot: draftSnapshot ?? text,
-                referenceIDsSnapshot: referenceIDsSnapshot
+                referenceIDsSnapshot: referenceIDsSnapshot,
+                liveTranscript: liveTranscript,
+                isLiveModeSnapshot: isLiveModeSnapshot
             )
         }
     }
@@ -393,20 +460,27 @@ private extension CodexChatSessionModel {
         text: String,
         clearsDraft: Bool,
         draftSnapshot: String,
-        referenceIDsSnapshot: [UUID]
+        referenceIDsSnapshot: [UUID],
+        liveTranscript: String?,
+        isLiveModeSnapshot: Bool
     ) async {
         let context: CodexChatContext?
         do {
             guard let vaultID else { throw CodexAppServerError.invalidProtocolResponse }
             context = try await contextProvider.currentContext(vaultID: vaultID)
         } catch {
-            lastSubmittedText = text
+            if liveTranscript == nil {
+                lastSubmittedText = text
+            } else if isLiveModeEnabled {
+                failedLiveTranscript = liveTranscript
+            }
             errorMessage = error.localizedDescription
             finishGeneration()
             return
         }
         guard !isReleased,
               !isStopRequested,
+              liveTranscript == nil || isLiveModeEnabled,
               isBoundToCurrentVault else {
             finishGeneration()
             return
@@ -419,13 +493,70 @@ private extension CodexChatSessionModel {
                 selectedMeetingReferenceIDs = []
             }
         }
-        lastSubmittedText = text
-        messages.append(CodexChatMessage(role: .user, text: text, context: context))
+        if liveTranscript == nil {
+            lastSubmittedText = text
+            messages.append(CodexChatMessage(role: .user, text: text, context: context))
+        }
         let responseID = "pending-\(UUID.v7().uuidString)"
         messages.append(CodexChatMessage(id: responseID, role: .assistant, text: "", isStreaming: true))
 
-        await runTurn(text: text, context: context, responseID: responseID)
+        await runTurn(
+            text: liveTranscript == nil ? text : nil,
+            liveTranscript: liveTranscript,
+            context: context,
+            responseID: responseID,
+            isLiveModeSnapshot: isLiveModeSnapshot
+        )
     }
+
+    func setLiveModeEnabled(_ isEnabled: Bool) {
+        guard isLiveModeEnabled != isEnabled else { return }
+        isLiveModeEnabled = isEnabled
+        if !isEnabled {
+            pendingLiveTranscript = nil
+            failedLiveTranscript = nil
+            didTruncatePendingLiveTranscript = false
+            if isGenerating, isActiveTurnLiveTranscript {
+                stop()
+            }
+        }
+        liveModeChangeHandler?(isEnabled)
+    }
+
+    func sendNextLiveTranscriptIfPossible() {
+        guard isLiveModeEnabled,
+              !isReleased,
+              !isGenerating,
+              failedLiveTranscript == nil,
+              draft.nilIfBlank == nil,
+              selectedMeetingReferenceIDs.isEmpty,
+              let transcript = pendingLiveTranscript else { return }
+        pendingLiveTranscript = nil
+        let wasTruncated = didTruncatePendingLiveTranscript
+        didTruncatePendingLiveTranscript = false
+        submit(
+            "",
+            clearsDraft: false,
+            liveTranscript: transcript
+        )
+        if wasTruncated {
+            errorMessage = L10n.chatLiveTranscriptBacklogTruncated
+        }
+    }
+
+    func appendPendingLiveTranscript(_ text: String) {
+        let combined = [pendingLiveTranscript, text]
+            .compactMap { $0?.nilIfBlank }
+            .joined(separator: "\n")
+        guard combined.count > Self.maximumPendingLiveTranscriptCharacters else {
+            pendingLiveTranscript = combined
+            return
+        }
+        pendingLiveTranscript = String(combined.suffix(Self.maximumPendingLiveTranscriptCharacters))
+        didTruncatePendingLiveTranscript = true
+    }
+
+    static let maximumPendingLiveTranscriptCharacters = 100_000
 }
 
 extension CodexChatSessionModel {
@@ -437,6 +568,10 @@ extension CodexChatSessionModel {
         isBoundToCurrentVault
             && !isGenerating
             && (draft.nilIfBlank != nil || !selectedMeetingReferenceIDs.isEmpty)
+    }
+
+    var hasRetryableSubmission: Bool {
+        failedLiveTranscript != nil || lastSubmittedText != nil
     }
 
     var effortOptions: [CodexReasoningEffortOption] {

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -1,6 +1,11 @@
 import Foundation
 import Observation
 
+private enum CodexChatFailedSubmission {
+    case manual(String)
+    case liveTranscript(String)
+}
+
 @MainActor
 @Observable
 final class CodexChatSessionModel: Identifiable {
@@ -9,13 +14,21 @@ final class CodexChatSessionModel: Identifiable {
     private(set) var backendThreadID: String?
     private(set) var title: String
     private(set) var messages: [CodexChatMessage]
-    var draft = ""
+    var draft = "" {
+        didSet {
+            if draft.nilIfBlank == nil {
+                sendNextLiveTranscriptIfPossible()
+            }
+        }
+    }
+
     var selectedModelID: String
     var selectedEffort: String
     private(set) var models: [CodexModel] = []
     private(set) var isLoading = false
     private(set) var isGenerating = false
     private(set) var errorMessage: String?
+    private(set) var noticeMessage: String?
     private(set) var activeTurnID: String?
     private(set) var lastSubmittedText: String?
     private(set) var failedLiveTranscript: String?
@@ -35,6 +48,11 @@ final class CodexChatSessionModel: Identifiable {
     @ObservationIgnored private var pendingLiveTranscript: String?
     @ObservationIgnored private var didTruncatePendingLiveTranscript = false
     @ObservationIgnored private var isActiveTurnLiveTranscript = false
+    @ObservationIgnored private var activeSubmissionID: UUID?
+    @ObservationIgnored private var activeResponseID: String?
+    @ObservationIgnored private var turnTask: Task<Void, Never>?
+    @ObservationIgnored private var failedSubmission: CodexChatFailedSubmission?
+    @ObservationIgnored private var usesLiveModePlaceholderTitle = false
     @ObservationIgnored private var liveModeChangeHandler: (@MainActor (Bool) -> Void)?
 
     init(
@@ -133,29 +151,29 @@ final class CodexChatSessionModel: Identifiable {
     }
 
     func retry() {
-        if let failedLiveTranscript {
+        switch failedSubmission {
+        case let .liveTranscript(failedLiveTranscript):
             self.failedLiveTranscript = nil
+            failedSubmission = nil
             submit("", clearsDraft: false, liveTranscript: failedLiveTranscript)
-            return
+        case let .manual(text):
+            failedSubmission = nil
+            retryManualSubmission(text)
+        case nil:
+            guard let lastSubmittedText else { return }
+            retryManualSubmission(lastSubmittedText)
         }
-        guard let lastSubmittedText else { return }
-        let currentText = CodexChatMeetingReference.serializedText(
-            referenceIDs: selectedMeetingReferenceIDs,
-            draft: draft
-        )
-        submit(
-            lastSubmittedText,
-            clearsDraft: currentText == lastSubmittedText,
-            draftSnapshot: draft,
-            referenceIDsSnapshot: selectedMeetingReferenceIDs
-        )
     }
 
     func stop() {
         guard isGenerating, !isStopRequested else { return }
         isStopRequested = true
-        guard let backendThreadID, let activeTurnID else { return }
-        Task { await service.interrupt(threadID: backendThreadID, turnID: activeTurnID) }
+        turnTask?.cancel()
+        if let backendThreadID, let activeTurnID {
+            Task { await service.interrupt(threadID: backendThreadID, turnID: activeTurnID) }
+        }
+        finalizeActiveResponseForCancellation()
+        finishGeneration(submissionID: activeSubmissionID)
     }
 
     func toggleLiveMode() {
@@ -166,10 +184,13 @@ final class CodexChatSessionModel: Identifiable {
         setLiveModeEnabled(false)
     }
 
-    func receiveFinalizedLiveTranscript(_ text: String) {
+    func receiveFinalizedLiveTranscript(_ text: String, wasTruncated: Bool = false) {
         guard isLiveModeEnabled,
               isBoundToCurrentVault,
               let text = text.nilIfBlank else { return }
+        if wasTruncated {
+            noticeMessage = L10n.chatLiveTranscriptBacklogTruncated
+        }
         appendPendingLiveTranscript(text)
         sendNextLiveTranscriptIfPossible()
     }
@@ -194,26 +215,26 @@ private extension CodexChatSessionModel {
         liveTranscript: String?,
         context: CodexChatContext?,
         responseID: String,
-        isLiveModeSnapshot: Bool
-    ) async {
+        isLiveModeSnapshot: Bool,
+        submissionID: UUID
+    ) async -> Bool {
         let accumulator = CodexChatTurnAccumulator()
         let updateLimiter = CodexChatStreamingUpdateLimiter(
             minimumInterval: streamingUpdateInterval
         ) { [weak self, accumulator] in
             self?.updateTurnResponse(id: responseID, from: accumulator)
         }
-        var shouldContinueLiveQueue = false
         do {
             if models.isEmpty {
                 await prepare()
             }
-            try Task.checkCancellation()
-            try ensureLiveTurnCanContinue(liveTranscript)
+            try ensureSubmissionCanContinue(submissionID, liveTranscript: liveTranscript)
             let backendThreadID = try await ensureBackendThread(
                 text: text,
-                liveTranscript: liveTranscript
+                liveTranscript: liveTranscript,
+                submissionID: submissionID
             )
-            try ensureLiveTurnCanContinue(liveTranscript)
+            try ensureSubmissionCanContinue(submissionID, liveTranscript: liveTranscript)
 
             let stream = try await service.send(
                 threadID: backendThreadID,
@@ -226,40 +247,50 @@ private extension CodexChatSessionModel {
                 model: selectedModelID.nilIfBlank,
                 effort: selectedEffort
             )
+            try ensureSubmissionCanContinue(submissionID, liveTranscript: liveTranscript)
             let turnCompleted = try await consumeTurnEvents(
                 stream,
                 accumulator: accumulator,
-                updateLimiter: updateLimiter
+                updateLimiter: updateLimiter,
+                submissionID: submissionID,
+                liveTranscript: liveTranscript
             )
             updateLimiter.submit(force: true)
             completeTurnResponse(responseID: responseID)
             if turnCompleted {
-                await reconcileFromRollout(preservingReasoningFrom: responseID)
-                shouldContinueLiveQueue = true
-            } else if let liveTranscript, isLiveModeEnabled, !isStopRequested {
-                failedLiveTranscript = liveTranscript
+                await reconcileFromRollout(
+                    preservingReasoningFrom: responseID,
+                    submissionID: submissionID
+                )
+            } else if !isStopRequested,
+                      errorMessage != nil || liveTranscript != nil {
+                recordFailedSubmission(text: text, liveTranscript: liveTranscript)
             }
+            return turnCompleted
         } catch is CancellationError {
             updateLimiter.submit(force: true)
             completeTurnResponse(responseID: responseID)
+            return false
         } catch {
+            guard activeSubmissionID == submissionID else { return false }
             errorMessage = error.localizedDescription
-            if let liveTranscript, isLiveModeEnabled {
-                failedLiveTranscript = liveTranscript
-            }
+            recordFailedSubmission(text: text, liveTranscript: liveTranscript)
             updateLimiter.submit(force: true)
             completeTurnResponse(responseID: responseID)
+            return false
         }
-        finishGeneration(continueLiveQueue: shouldContinueLiveQueue)
     }
 
     func consumeTurnEvents(
         _ stream: AsyncThrowingStream<CodexChatTurnEvent, any Error>,
         accumulator: CodexChatTurnAccumulator,
-        updateLimiter: CodexChatStreamingUpdateLimiter
+        updateLimiter: CodexChatStreamingUpdateLimiter,
+        submissionID: UUID,
+        liveTranscript: String?
     ) async throws -> Bool {
         var eventsSinceYield = 0
         for try await event in stream {
+            try ensureSubmissionCanContinue(submissionID, liveTranscript: liveTranscript)
             apply(event, accumulator: accumulator, updateLimiter: updateLimiter)
             if let completedSuccessfully = event.terminalCompletion {
                 return completedSuccessfully
@@ -328,6 +359,17 @@ private extension CodexChatSessionModel {
         }
     }
 
+    private func finalizeActiveResponseForCancellation() {
+        guard let activeResponseID,
+              let index = messages.firstIndex(where: { $0.id == activeResponseID }) else { return }
+        messages[index].isStreaming = false
+        if activeTurnID == nil,
+           messages[index].text.isEmpty,
+           messages[index].reasoning.isEmpty {
+            messages.remove(at: index)
+        }
+    }
+
     private func updateTurnResponse(id: String, from accumulator: CodexChatTurnAccumulator) {
         guard let index = messages.firstIndex(where: { $0.id == id }) else { return }
         let responseText = accumulator.responseText
@@ -340,10 +382,14 @@ private extension CodexChatSessionModel {
         }
     }
 
-    private func reconcileFromRollout(preservingReasoningFrom responseID: String) async {
+    private func reconcileFromRollout(
+        preservingReasoningFrom responseID: String,
+        submissionID: UUID
+    ) async {
         guard let backendThreadID,
               let thread = try? await service.loadThread(id: backendThreadID)
         else { return }
+        guard activeSubmissionID == submissionID, !Task.isCancelled else { return }
         let streamedReasoning = messages
             .first(where: { $0.id == responseID })?
             .reasoning
@@ -364,11 +410,18 @@ private extension CodexChatSessionModel {
         apply(reconciledThread, preservingPendingMessages: thread.messages.count < messages.count)
     }
 
-    private func finishGeneration(continueLiveQueue: Bool = false) {
+    private func finishGeneration(
+        submissionID: UUID?,
+        continueLiveQueue: Bool = false
+    ) {
+        guard activeSubmissionID == submissionID else { return }
         isGenerating = false
         activeTurnID = nil
         isStopRequested = false
         isActiveTurnLiveTranscript = false
+        activeSubmissionID = nil
+        activeResponseID = nil
+        turnTask = nil
         unsubscribeIfPossible()
         if continueLiveQueue {
             sendNextLiveTranscriptIfPossible()
@@ -377,7 +430,11 @@ private extension CodexChatSessionModel {
 
     private static let maximumEventsBetweenYields = 64
 
-    func ensureBackendThread(text: String?, liveTranscript: String?) async throws -> String {
+    func ensureBackendThread(
+        text: String?,
+        liveTranscript: String?,
+        submissionID: UUID
+    ) async throws -> String {
         if let backendThreadID {
             return backendThreadID
         }
@@ -389,17 +446,67 @@ private extension CodexChatSessionModel {
             effort: selectedEffort,
             vaultID: vaultID
         )
+        try ensureSubmissionCanContinue(submissionID, liveTranscript: liveTranscript)
         apply(thread, preservingPendingMessages: true)
         let threadTitle = liveTranscript == nil ? text ?? L10n.newChat : L10n.chatLiveMode
         title = threadTitle
         await service.setThreadName(threadID: thread.id, name: threadTitle)
-        try ensureLiveTurnCanContinue(liveTranscript)
+        usesLiveModePlaceholderTitle = liveTranscript != nil
+        try ensureSubmissionCanContinue(submissionID, liveTranscript: liveTranscript)
         return thread.id
     }
 
-    func ensureLiveTurnCanContinue(_ liveTranscript: String?) throws {
-        guard liveTranscript != nil else { return }
-        guard isLiveModeEnabled, !isStopRequested else { throw CancellationError() }
+    func ensureSubmissionCanContinue(_ submissionID: UUID, liveTranscript: String?) throws {
+        guard activeSubmissionID == submissionID, !Task.isCancelled else {
+            throw CancellationError()
+        }
+        guard liveTranscript == nil || isLiveModeEnabled, !isStopRequested else {
+            throw CancellationError()
+        }
+    }
+
+    func retryManualSubmission(_ text: String) {
+        let currentText = CodexChatMeetingReference.serializedText(
+            referenceIDs: selectedMeetingReferenceIDs,
+            draft: draft
+        )
+        submit(
+            text,
+            clearsDraft: currentText == text,
+            draftSnapshot: draft,
+            referenceIDsSnapshot: selectedMeetingReferenceIDs
+        )
+    }
+
+    func prepareFailureStateForSubmission(liveTranscript: String?) {
+        if liveTranscript == nil, let failedLiveTranscript {
+            appendPendingLiveTranscript(failedLiveTranscript)
+            self.failedLiveTranscript = nil
+        }
+        failedSubmission = nil
+    }
+
+    func recordFailedSubmission(text: String?, liveTranscript: String?) {
+        if let liveTranscript, isLiveModeEnabled {
+            recordFailedLiveTranscript(liveTranscript)
+        } else if let text = text?.nilIfBlank {
+            lastSubmittedText = text
+            failedSubmission = .manual(text)
+        }
+    }
+
+    func recordFailedLiveTranscript(_ text: String) {
+        failedLiveTranscript = text
+        failedSubmission = .liveTranscript(text)
+    }
+
+    func replaceLiveModePlaceholderTitleIfNeeded(with text: String) async -> Bool {
+        guard usesLiveModePlaceholderTitle,
+              let backendThreadID else { return false }
+        usesLiveModePlaceholderTitle = false
+        title = text
+        await service.setThreadName(threadID: backendThreadID, name: text)
+        return true
     }
 
     private func unsubscribeIfPossible() {
@@ -445,19 +552,23 @@ private extension CodexChatSessionModel {
         guard isBoundToCurrentVault,
               !isGenerating,
               text.nilIfBlank != nil || liveTranscript?.nilIfBlank != nil else { return }
+        prepareFailureStateForSubmission(liveTranscript: liveTranscript)
         isGenerating = true
         errorMessage = nil
         isActiveTurnLiveTranscript = liveTranscript != nil
         let isLiveModeSnapshot = liveTranscript != nil || isLiveModeEnabled
+        let submissionID = UUID.v7()
+        activeSubmissionID = submissionID
 
-        Task { [weak self] in
+        turnTask = Task { [weak self] in
             await self?.resolveContextAndRunTurn(
                 text: text,
                 clearsDraft: clearsDraft,
                 draftSnapshot: draftSnapshot ?? text,
                 referenceIDsSnapshot: referenceIDsSnapshot,
                 liveTranscript: liveTranscript,
-                isLiveModeSnapshot: isLiveModeSnapshot
+                isLiveModeSnapshot: isLiveModeSnapshot,
+                submissionID: submissionID
             )
         }
     }
@@ -468,29 +579,30 @@ private extension CodexChatSessionModel {
         draftSnapshot: String,
         referenceIDsSnapshot: [UUID],
         liveTranscript: String?,
-        isLiveModeSnapshot: Bool
+        isLiveModeSnapshot: Bool,
+        submissionID: UUID
     ) async {
+        var shouldContinueLiveQueue = false
+        defer {
+            finishGeneration(
+                submissionID: submissionID,
+                continueLiveQueue: shouldContinueLiveQueue
+            )
+        }
         let context: CodexChatContext?
         do {
             guard let vaultID else { throw CodexAppServerError.invalidProtocolResponse }
             context = try await contextProvider.currentContext(vaultID: vaultID)
+            try ensureSubmissionCanContinue(submissionID, liveTranscript: liveTranscript)
+        } catch is CancellationError {
+            return
         } catch {
-            if liveTranscript == nil {
-                lastSubmittedText = text
-            } else if isLiveModeEnabled {
-                failedLiveTranscript = liveTranscript
-            }
+            guard activeSubmissionID == submissionID else { return }
+            recordFailedSubmission(text: text, liveTranscript: liveTranscript)
             errorMessage = error.localizedDescription
-            finishGeneration()
             return
         }
-        guard !isReleased,
-              !isStopRequested,
-              liveTranscript == nil || isLiveModeEnabled,
-              isBoundToCurrentVault else {
-            finishGeneration()
-            return
-        }
+        guard !isReleased, isBoundToCurrentVault else { return }
         if clearsDraft {
             if draft == draftSnapshot {
                 draft = ""
@@ -499,20 +611,28 @@ private extension CodexChatSessionModel {
                 selectedMeetingReferenceIDs = []
             }
         }
+        var replacedLiveModePlaceholderTitle = false
         if liveTranscript == nil {
             lastSubmittedText = text
             messages.append(CodexChatMessage(role: .user, text: text, context: context))
+            replacedLiveModePlaceholderTitle = await replaceLiveModePlaceholderTitleIfNeeded(with: text)
+            guard activeSubmissionID == submissionID, !Task.isCancelled else { return }
         }
         let responseID = "pending-\(UUID.v7().uuidString)"
         messages.append(CodexChatMessage(id: responseID, role: .assistant, text: "", isStreaming: true))
+        activeResponseID = responseID
 
-        await runTurn(
+        shouldContinueLiveQueue = await runTurn(
             text: liveTranscript == nil ? text : nil,
             liveTranscript: liveTranscript,
             context: context,
             responseID: responseID,
-            isLiveModeSnapshot: isLiveModeSnapshot
+            isLiveModeSnapshot: isLiveModeSnapshot,
+            submissionID: submissionID
         )
+        if replacedLiveModePlaceholderTitle {
+            title = text
+        }
     }
 
     func setLiveModeEnabled(_ isEnabled: Bool) {
@@ -521,7 +641,9 @@ private extension CodexChatSessionModel {
         if !isEnabled {
             pendingLiveTranscript = nil
             failedLiveTranscript = nil
+            failedSubmission = nil
             didTruncatePendingLiveTranscript = false
+            noticeMessage = nil
             if isGenerating, isActiveTurnLiveTranscript {
                 stop()
             }
@@ -533,6 +655,7 @@ private extension CodexChatSessionModel {
         guard isLiveModeEnabled,
               !isReleased,
               !isGenerating,
+              errorMessage == nil,
               failedLiveTranscript == nil,
               draft.nilIfBlank == nil,
               selectedMeetingReferenceIDs.isEmpty,
@@ -546,7 +669,7 @@ private extension CodexChatSessionModel {
             liveTranscript: transcript
         )
         if wasTruncated {
-            errorMessage = L10n.chatLiveTranscriptBacklogTruncated
+            noticeMessage = L10n.chatLiveTranscriptBacklogTruncated
         }
     }
 
@@ -608,6 +731,7 @@ extension CodexChatSessionModel {
         guard isCatalogLoaded else { return }
         let availableIDs = Set(references.map(\.id))
         selectedMeetingReferenceIDs.removeAll { !availableIDs.contains($0) }
+        sendNextLiveTranscriptIfPossible()
     }
 
     func addMeetingReference(_ reference: CodexChatMeetingReference) {
@@ -619,6 +743,7 @@ extension CodexChatSessionModel {
 
     func removeMeetingReference(id: UUID) {
         selectedMeetingReferenceIDs.removeAll { $0 == id }
+        sendNextLiveTranscriptIfPossible()
     }
 
     func meetingDisplayName(for id: UUID) -> String {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
@@ -36,6 +36,20 @@ struct CodexChatComposer: View {
                         )
                     }
 
+                Button(L10n.chatLiveMode, systemImage: "waveform", action: session.toggleLiveMode)
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(session.isLiveModeEnabled ? Color.accentColor : .secondary)
+                    .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
+                    .background(
+                        session.isLiveModeEnabled ? Color.accentColor.opacity(0.16) : Color.secondary.opacity(0.08),
+                        in: Circle()
+                    )
+                    .contentShape(Circle())
+                    .disabled(!session.isBoundToCurrentVault)
+                    .help(session.isLiveModeEnabled ? L10n.disableChatLiveMode : L10n.enableChatLiveMode)
+                    .accessibilityValue(session.isLiveModeEnabled ? L10n.chatLiveModeOn : L10n.chatLiveModeOff)
+
                 TextField(L10n.messageCodex, text: $session.draft, axis: .vertical)
                     .font(.body)
                     .textFieldStyle(.plain)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatView.swift
@@ -59,7 +59,7 @@ struct CodexChatView: View {
             if let errorMessage = session.errorMessage {
                 CodexChatErrorView(
                     message: errorMessage,
-                    onRetry: session.lastSubmittedText == nil ? retryConnection : session.retry
+                    onRetry: session.hasRetryableSubmission ? session.retry : retryConnection
                 )
             } else if let historyError = coordinator.historyError {
                 CodexChatErrorView(

--- a/Sources/Dahlia/Views/CodexChat/CodexChatView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatView.swift
@@ -68,6 +68,15 @@ struct CodexChatView: View {
                 )
             }
 
+            if let noticeMessage = session.noticeMessage {
+                Label(noticeMessage, systemImage: "info.circle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, CodexChatDesign.contentHorizontalPadding)
+                    .padding(.vertical, 6)
+            }
+
             CodexChatComposer(session: session)
                 .padding(.horizontal, CodexChatDesign.composerHorizontalPadding)
                 .padding(.bottom, CodexChatDesign.composerBottomPadding)

--- a/Tests/DahliaTests/CodexChatCoordinatorTests.swift
+++ b/Tests/DahliaTests/CodexChatCoordinatorTests.swift
@@ -164,6 +164,27 @@ import Foundation
             #expect(contexts.map { $0?.meetingName } == ["First draft", "Second draft", "History draft"])
         }
 
+        @Test
+        func liveModeStatusRemainsEnabledUntilTheLastSessionTurnsItOff() throws {
+            let settings = AppSettings()
+            settings.currentVault = Self.vault(name: "Live")
+            let coordinator = CodexChatCoordinator(
+                service: CoordinatorTestCodexChatService(),
+                settings: settings
+            )
+            let detachedID = coordinator.newDetachedChat()
+            let detachedSession = try #require(coordinator.session(for: detachedID))
+            var statuses: [Bool] = []
+            coordinator.liveModeStatusDidChange = { statuses.append($0) }
+
+            coordinator.floatingSession.toggleLiveMode()
+            detachedSession.toggleLiveMode()
+            coordinator.floatingSession.toggleLiveMode()
+            detachedSession.toggleLiveMode()
+
+            #expect(statuses == [true, true, true, false])
+        }
+
         private static func threadSummary(id: String) -> CodexChatThreadSummary {
             CodexChatThreadSummary(id: id, title: "History", updatedAt: .now)
         }

--- a/Tests/DahliaTests/CodexChatPromptCodecTests.swift
+++ b/Tests/DahliaTests/CodexChatPromptCodecTests.swift
@@ -6,6 +6,57 @@ import Foundation
 
     struct CodexChatPromptCodecTests {
         @Test
+        func liveModeWrapsTranscriptAndKeepsItOutOfVisibleUserText() {
+            let blocks = CodexChatPromptCodec.encodeTextBlocks(
+                text: nil,
+                context: nil,
+                isLiveMode: true,
+                liveTranscript: "Speaker & <guest>\nNext line"
+            )
+
+            #expect(blocks == [
+                """
+                <context>
+                  Live mode is enabled. You are receiving finalized live transcription from Dahlia.
+                  This turn contains one hidden live transcript block.
+                </context>
+                """,
+                "<live_transcript>Speaker &amp; &lt;guest&gt;&#10;Next line</live_transcript>",
+            ])
+            let decoded = CodexChatPromptCodec.decodeTextBlocks(blocks)
+            #expect(decoded.text.isEmpty)
+            #expect(decoded.context == nil)
+        }
+
+        @Test
+        func manualCanonicalLiveTranscriptTagRemainsVisible() {
+            let manualText = "<live_transcript>keep this visible</live_transcript>"
+            let blocks = CodexChatPromptCodec.encodeTextBlocks(
+                text: manualText,
+                context: nil,
+                isLiveMode: true
+            )
+
+            let decoded = CodexChatPromptCodec.decodeTextBlocks(blocks)
+
+            #expect(decoded.text == manualText)
+            #expect(decoded.context == nil)
+        }
+
+        @Test
+        func manualMessageRemainsVisibleWhileLiveModeIsEnabled() {
+            let blocks = CodexChatPromptCodec.encodeTextBlocks(
+                text: "Please summarize that",
+                context: nil,
+                isLiveMode: true
+            )
+
+            let decoded = CodexChatPromptCodec.decodeTextBlocks(blocks)
+            #expect(decoded.text == "Please summarize that")
+            #expect(decoded.context == nil)
+        }
+
+        @Test
         func meetingContextRoundTripsWithEscapedCalendarMetadata() throws {
             let meetingID = try #require(UUID(uuidString: "01234567-89AB-CDEF-0123-456789ABCDEF"))
             let start = Date(timeIntervalSince1970: 1_704_067_200.125)

--- a/Tests/DahliaTests/CodexChatSessionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatSessionModelTests.swift
@@ -7,6 +7,51 @@ import Foundation
     @MainActor
     struct CodexChatSessionModelTests {
         @Test
+        func liveTranscriptIsSentWithoutAddingAUserMessageAndManualChatStaysVisible() async {
+            let service = TestCodexChatService(mode: .staleRollout)
+            let settings = AppSettings()
+            settings.currentVault = Self.testVault()
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings
+            )
+
+            session.toggleLiveMode()
+            session.receiveFinalizedLiveTranscript("Finalized speech")
+            await waitUntil { !session.isGenerating }
+
+            #expect(session.messages.allSatisfy { $0.role == .assistant })
+            #expect(await service.sentTextBlocks == [
+                [
+                    """
+                    <context>
+                      Live mode is enabled. You are receiving finalized live transcription from Dahlia.
+                      This turn contains one hidden live transcript block.
+                    </context>
+                    """,
+                    "<live_transcript>Finalized speech</live_transcript>",
+                ],
+            ])
+            #expect(await service.threadNames == [L10n.chatLiveMode])
+
+            session.draft = "A visible question"
+            session.sendDraft()
+            await waitUntil { !session.isGenerating }
+
+            #expect(session.messages.filter { $0.role == .user }.map(\.text) == ["A visible question"])
+            #expect(await service.sentTextBlocks.last == [
+                """
+                <context>
+                  Live mode is enabled. You are receiving finalized live transcription from Dahlia.
+                </context>
+                """,
+                "A visible question",
+            ])
+        }
+
+        @Test
         func firstSendCreatesThreadAndStreamsThenReconcilesRollout() async {
             let service = TestCodexChatService(mode: .complete)
             let settings = AppSettings()
@@ -512,6 +557,89 @@ import Foundation
 
     }
 
+    extension CodexChatSessionModelTests {
+        @Test
+        func failedLiveTranscriptCanBeRetriedWithoutBecomingVisible() async {
+            let service = TestCodexChatService(mode: .failThenComplete)
+            let settings = AppSettings()
+            settings.currentVault = Self.testVault()
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings
+            )
+
+            session.toggleLiveMode()
+            session.receiveFinalizedLiveTranscript("Retry this speech")
+            await waitUntil { !session.isGenerating }
+
+            #expect(session.failedLiveTranscript == "Retry this speech")
+            #expect(session.hasRetryableSubmission)
+            #expect(session.messages.allSatisfy { $0.role != .user })
+
+            session.retry()
+            await waitUntil { !session.isGenerating }
+
+            #expect(session.failedLiveTranscript == nil)
+            let sentTextBlocks = await service.sentTextBlocks
+            #expect(sentTextBlocks.count == 2)
+            #expect(sentTextBlocks[0] == sentTextBlocks[1])
+            #expect(session.messages.allSatisfy { $0.role != .user })
+        }
+
+        @Test
+        func liveTranscriptsQueuedDuringGenerationAreCoalesced() async {
+            let service = TestCodexChatService(mode: .block)
+            let settings = AppSettings()
+            settings.currentVault = Self.testVault()
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings
+            )
+
+            session.toggleLiveMode()
+            session.receiveFinalizedLiveTranscript("first")
+            await waitUntilAsync { await service.sentTextBlocks.count == 1 }
+            session.receiveFinalizedLiveTranscript("second")
+            session.receiveFinalizedLiveTranscript("third")
+
+            await service.completeBlockedTurn()
+            await waitUntilAsync { await service.sentTextBlocks.count == 2 }
+
+            #expect(await service.sentTextBlocks[1].last == "<live_transcript>second&#10;third</live_transcript>")
+            session.disableLiveMode()
+            await waitUntil { !session.isGenerating }
+        }
+
+        @Test
+        func disablingLiveModeCancelsTranscriptBeforeContextResolutionCompletes() async {
+            let service = TestCodexChatService(mode: .complete)
+            let settings = AppSettings()
+            settings.currentVault = Self.testVault()
+            let contextProvider = TestCodexChatContextProvider(shouldBlock: true)
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings,
+                contextProvider: contextProvider
+            )
+
+            session.toggleLiveMode()
+            session.receiveFinalizedLiveTranscript("Do not send this")
+            await waitUntil { contextProvider.requestCount == 1 }
+            session.disableLiveMode()
+            contextProvider.resume()
+            await waitUntil { !session.isGenerating }
+
+            #expect(await service.sentTextBlocks.isEmpty)
+            #expect(session.failedLiveTranscript == nil)
+        }
+    }
+
     actor TestCodexChatService: CodexChatServicing {
         enum Mode {
             case complete
@@ -520,6 +648,7 @@ import Foundation
             case bufferedBurstThenInterrupt
             case finishesWithoutTerminal
             case interruptedThenBlock
+            case failThenComplete
             case staleRollout
             case rolloutWithoutReasoning
             case multipleMessages
@@ -551,25 +680,26 @@ import Foundation
         func loadThread(id: String) async throws -> CodexChatThread {
             let assistantMessages: [CodexChatMessage] = switch mode {
             case .complete, .block, .burstThenBlock, .bufferedBurstThenInterrupt,
-                 .finishesWithoutTerminal, .interruptedThenBlock:
+                 .finishesWithoutTerminal, .interruptedThenBlock, .failThenComplete:
                 [CodexChatMessage(role: .assistant, text: "Final answer", reasoning: "Considered the question")]
             case .rolloutWithoutReasoning:
                 [CodexChatMessage(role: .assistant, text: "Final answer")]
             case .staleRollout, .multipleMessages:
                 []
             }
-            let flattenedText = sentTextBlocks.last?.joined() ?? "Question"
-            let decoded = CodexChatPromptCodec.decodeTextBlocks([flattenedText])
+            let decoded = CodexChatPromptCodec.decodeTextBlocks(sentTextBlocks.last ?? ["Question"])
+            let userMessages: [CodexChatMessage] = decoded.text.nilIfBlank.map { text in
+                let message = CodexChatMessage(
+                    role: .user,
+                    text: text,
+                    context: decoded.context
+                )
+                return [message]
+            } ?? []
             return CodexChatThread(
                 id: id,
                 title: "Question",
-                messages: [
-                    CodexChatMessage(
-                        role: .user,
-                        text: decoded.text,
-                        context: decoded.context
-                    ),
-                ] + assistantMessages,
+                messages: userMessages + assistantMessages,
                 model: nil,
                 reasoningEffort: nil
             )
@@ -600,10 +730,13 @@ import Foundation
             effort _: String
         ) async throws -> AsyncThrowingStream<CodexChatTurnEvent, any Error> {
             sentTextBlocks.append(textBlocks)
+            if mode == .failThenComplete, sentTextBlocks.count == 1 {
+                throw CodexAppServerError.invalidProtocolResponse
+            }
             let (stream, continuation) = AsyncThrowingStream<CodexChatTurnEvent, any Error>.makeStream()
             continuation.yield(.started(turnID: "turn-1"))
             switch mode {
-            case .complete, .staleRollout, .rolloutWithoutReasoning:
+            case .complete, .staleRollout, .rolloutWithoutReasoning, .failThenComplete:
                 continuation.yield(.reasoningDelta(
                     itemID: "reasoning-1",
                     summaryIndex: 0,
@@ -652,6 +785,12 @@ import Foundation
             blockedContinuation = nil
         }
 
+        func completeBlockedTurn() {
+            blockedContinuation?.yield(.completed(itemID: nil, text: nil))
+            blockedContinuation?.finish()
+            blockedContinuation = nil
+        }
+
         func unsubscribe(threadID: String) async {
             unsubscribedThreadIDs.append(threadID)
         }
@@ -675,20 +814,37 @@ import Foundation
     private final class TestCodexChatContextProvider: CodexChatContextProviding {
         var context: CodexChatContext?
         var error: CodexAppServerError?
+        var requestCount = 0
+        private var shouldBlock: Bool
+        private var continuation: CheckedContinuation<Void, Never>?
 
         init(
             context: CodexChatContext? = nil,
-            error: CodexAppServerError? = nil
+            error: CodexAppServerError? = nil,
+            shouldBlock: Bool = false
         ) {
             self.context = context
             self.error = error
+            self.shouldBlock = shouldBlock
         }
 
         func currentContext(vaultID _: UUID) async throws -> CodexChatContext? {
+            requestCount += 1
+            if shouldBlock {
+                await withCheckedContinuation { continuation in
+                    self.continuation = continuation
+                }
+            }
             if let error {
                 throw error
             }
             return context
+        }
+
+        func resume() {
+            shouldBlock = false
+            continuation?.resume()
+            continuation = nil
         }
     }
 

--- a/Tests/DahliaTests/CodexChatSessionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatSessionModelTests.swift
@@ -49,6 +49,8 @@ import Foundation
                 """,
                 "A visible question",
             ])
+            #expect(session.title == "A visible question")
+            #expect(await service.threadNames == [L10n.chatLiveMode, "A visible question"])
         }
 
         @Test
@@ -260,10 +262,11 @@ import Foundation
             )
             session.draft = "Question"
             session.sendDraft()
-            await waitUntil { session.activeTurnID != nil }
+            await waitUntil { session.messages.last?.text == "Partial" }
 
             session.stop()
             await waitUntil { !session.isGenerating }
+            await waitUntilAsync { await service.interruptCount == 1 }
 
             #expect(session.messages.last?.text == "Partial")
             #expect(session.messages.last?.isStreaming == false)
@@ -632,11 +635,126 @@ import Foundation
             session.receiveFinalizedLiveTranscript("Do not send this")
             await waitUntil { contextProvider.requestCount == 1 }
             session.disableLiveMode()
-            contextProvider.resume()
             await waitUntil { !session.isGenerating }
 
             #expect(await service.sentTextBlocks.isEmpty)
             #expect(session.failedLiveTranscript == nil)
+            contextProvider.resume()
+        }
+
+        @Test
+        func manualSendAfterLiveFailureRequeuesTheFailedTranscript() async {
+            let service = TestCodexChatService(mode: .failThenComplete)
+            let settings = AppSettings()
+            settings.currentVault = Self.testVault()
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings
+            )
+
+            session.toggleLiveMode()
+            session.receiveFinalizedLiveTranscript("Failed live speech")
+            await waitUntil { !session.isGenerating }
+            #expect(session.failedLiveTranscript == "Failed live speech")
+
+            session.draft = "Manual recovery"
+            session.sendDraft()
+            await waitUntilAsync { await service.sentTextBlocks.count == 3 }
+            await waitUntil { !session.isGenerating }
+
+            let sentTextBlocks = await service.sentTextBlocks
+            #expect(sentTextBlocks[1].last == "Manual recovery")
+            #expect(sentTextBlocks[2].last == "<live_transcript>Failed live speech</live_transcript>")
+            #expect(session.failedLiveTranscript == nil)
+        }
+
+        @Test
+        func pendingLiveTranscriptResumesWhenDraftAndReferencesAreCleared() async {
+            let service = TestCodexChatService(mode: .complete)
+            let settings = AppSettings()
+            let vault = Self.testVault()
+            settings.currentVault = vault
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings
+            )
+
+            session.toggleLiveMode()
+            session.draft = "Still editing"
+            session.receiveFinalizedLiveTranscript("queued for draft")
+            #expect(await service.sentTextBlocks.isEmpty)
+
+            session.draft = ""
+            await waitUntilAsync { await service.sentTextBlocks.count == 1 }
+            await waitUntil { !session.isGenerating }
+
+            let meeting = Self.meetingReference(vaultID: vault.id, name: "Blocking reference", offset: 0)
+            session.updateAvailableMeetings([meeting], catalogVaultID: vault.id)
+            session.addMeetingReference(CodexChatMeetingReference(meeting: meeting))
+            session.receiveFinalizedLiveTranscript("queued for reference")
+            #expect(await service.sentTextBlocks.count == 1)
+
+            session.removeMeetingReference(id: meeting.meetingId)
+            await waitUntilAsync { await service.sentTextBlocks.count == 2 }
+            await waitUntil { !session.isGenerating }
+
+            #expect(await service.sentTextBlocks[1].last == "<live_transcript>queued for reference</live_transcript>")
+        }
+
+        @Test
+        func retryUsesTheMostRecentlyFailedManualSubmission() async {
+            let service = TestCodexChatService(mode: .alwaysFail)
+            let settings = AppSettings()
+            settings.currentVault = Self.testVault()
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings
+            )
+
+            session.toggleLiveMode()
+            session.receiveFinalizedLiveTranscript("Earlier live failure")
+            await waitUntil { !session.isGenerating }
+
+            session.draft = "Latest manual failure"
+            session.sendDraft()
+            await waitUntil { !session.isGenerating }
+            session.retry()
+            await waitUntilAsync { await service.sentTextBlocks.count == 3 }
+            await waitUntil { !session.isGenerating }
+
+            let sentTextBlocks = await service.sentTextBlocks
+            #expect(sentTextBlocks[1].last == "Latest manual failure")
+            #expect(sentTextBlocks[2].last == "Latest manual failure")
+        }
+
+        @Test
+        func truncatedLiveTranscriptUsesNoticeWithoutRetryError() async {
+            let service = TestCodexChatService(mode: .block)
+            let settings = AppSettings()
+            settings.currentVault = Self.testVault()
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings
+            )
+
+            session.toggleLiveMode()
+            session.receiveFinalizedLiveTranscript("Truncated speech", wasTruncated: true)
+            await waitUntilAsync { await service.sentTextBlocks.count == 1 }
+
+            #expect(session.isGenerating)
+            #expect(session.noticeMessage == L10n.chatLiveTranscriptBacklogTruncated)
+            #expect(session.errorMessage == nil)
+
+            session.disableLiveMode()
+            await waitUntil { !session.isGenerating }
         }
     }
 
@@ -649,6 +767,7 @@ import Foundation
             case finishesWithoutTerminal
             case interruptedThenBlock
             case failThenComplete
+            case alwaysFail
             case staleRollout
             case rolloutWithoutReasoning
             case multipleMessages
@@ -680,7 +799,7 @@ import Foundation
         func loadThread(id: String) async throws -> CodexChatThread {
             let assistantMessages: [CodexChatMessage] = switch mode {
             case .complete, .block, .burstThenBlock, .bufferedBurstThenInterrupt,
-                 .finishesWithoutTerminal, .interruptedThenBlock, .failThenComplete:
+                 .finishesWithoutTerminal, .interruptedThenBlock, .failThenComplete, .alwaysFail:
                 [CodexChatMessage(role: .assistant, text: "Final answer", reasoning: "Considered the question")]
             case .rolloutWithoutReasoning:
                 [CodexChatMessage(role: .assistant, text: "Final answer")]
@@ -733,10 +852,13 @@ import Foundation
             if mode == .failThenComplete, sentTextBlocks.count == 1 {
                 throw CodexAppServerError.invalidProtocolResponse
             }
+            if mode == .alwaysFail {
+                throw CodexAppServerError.invalidProtocolResponse
+            }
             let (stream, continuation) = AsyncThrowingStream<CodexChatTurnEvent, any Error>.makeStream()
             continuation.yield(.started(turnID: "turn-1"))
             switch mode {
-            case .complete, .staleRollout, .rolloutWithoutReasoning, .failThenComplete:
+            case .complete, .staleRollout, .rolloutWithoutReasoning, .failThenComplete, .alwaysFail:
                 continuation.yield(.reasoningDelta(
                     itemID: "reasoning-1",
                     summaryIndex: 0,

--- a/Tests/DahliaTests/FinalizedLiveTranscriptRelayTests.swift
+++ b/Tests/DahliaTests/FinalizedLiveTranscriptRelayTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct FinalizedLiveTranscriptRelayTests {
+        @Test
+        func relayPreservesOrderWhileCoalescingABlockedBacklog() async {
+            let recorder = LiveTranscriptDeliveryRecorder(blocksFirstDelivery: true)
+            let relay = FinalizedLiveTranscriptRelay { delivery in
+                await recorder.append(delivery)
+            }
+            let sessionID = UUID.v7()
+            let expectedTexts = (0 ..< 1_000).map { "final-\($0)" }
+
+            await relay.enqueue(sessionID: sessionID, text: expectedTexts[0])
+            await recorder.waitForCount(1)
+            for text in expectedTexts.dropFirst() {
+                await relay.enqueue(sessionID: sessionID, text: text)
+            }
+
+            await recorder.open()
+            await relay.finish()
+
+            let deliveries = await recorder.snapshot()
+            #expect(deliveries.map(\.sessionID).allSatisfy { $0 == sessionID })
+            #expect(deliveries.map(\.text).joined(separator: "\n") == expectedTexts.joined(separator: "\n"))
+            #expect(deliveries.allSatisfy { !$0.wasTruncated })
+        }
+
+        @Test
+        func relayBoundsBacklogAndReportsTruncation() async {
+            let recorder = LiveTranscriptDeliveryRecorder(blocksFirstDelivery: true)
+            let relay = FinalizedLiveTranscriptRelay { delivery in
+                await recorder.append(delivery)
+            }
+            let sessionID = UUID.v7()
+
+            await relay.enqueue(sessionID: sessionID, text: "initial")
+            await recorder.waitForCount(1)
+            await relay.enqueue(
+                sessionID: sessionID,
+                text: String(repeating: "x", count: FinalizedLiveTranscriptRelay.maximumPendingCharacters + 10)
+            )
+
+            await recorder.open()
+            await relay.finish()
+
+            let deliveries = await recorder.snapshot()
+            #expect(deliveries.count == 2)
+            #expect(deliveries[1].text.count == FinalizedLiveTranscriptRelay.maximumPendingCharacters)
+            #expect(deliveries[1].wasTruncated)
+        }
+    }
+
+    private actor LiveTranscriptDeliveryRecorder {
+        private var deliveries: [FinalizedLiveTranscriptRelay.Delivery] = []
+        private var blocksFirstDelivery: Bool
+        private var continuation: CheckedContinuation<Void, Never>?
+
+        init(blocksFirstDelivery: Bool) {
+            self.blocksFirstDelivery = blocksFirstDelivery
+        }
+
+        func append(_ delivery: FinalizedLiveTranscriptRelay.Delivery) async {
+            deliveries.append(delivery)
+            if deliveries.count == 1, blocksFirstDelivery {
+                await withCheckedContinuation { continuation in
+                    self.continuation = continuation
+                }
+            }
+        }
+
+        func open() {
+            blocksFirstDelivery = false
+            continuation?.resume()
+            continuation = nil
+        }
+
+        func snapshot() -> [FinalizedLiveTranscriptRelay.Delivery] {
+            deliveries
+        }
+
+        func waitForCount(_ count: Int) async {
+            for _ in 0 ..< 1_000 {
+                if deliveries.count >= count { return }
+                await Task.yield()
+            }
+            Issue.record("Timed out waiting for live transcript delivery")
+        }
+    }
+#endif

--- a/Tests/DahliaTests/RecordingSessionControllerTests.swift
+++ b/Tests/DahliaTests/RecordingSessionControllerTests.swift
@@ -115,6 +115,28 @@
         }
 
         @Test
+        func liveChatKeepsBatchRecognizerWhenSubtitlesAreDisabled() async throws {
+            let runtime = try await makeRuntime(mode: .batch, liveSubtitlesEnabled: false)
+
+            var snapshot = try await runtime.controller.setLiveChatEnabled(true, translateSegment: nil)
+            #expect(snapshot.plan.liveChatEnabled)
+            #expect(await runtime.controller.resourceCounts().recognizers == 2)
+
+            snapshot = try await runtime.controller.setLiveSubtitlesEnabled(true, translateSegment: nil)
+            snapshot = try await runtime.controller.setLiveSubtitlesEnabled(false, translateSegment: nil)
+            #expect(snapshot.plan.liveChatEnabled)
+            #expect(!snapshot.plan.liveSubtitlesEnabled)
+            #expect(await runtime.controller.resourceCounts().recognizers == 2)
+
+            snapshot = try await runtime.controller.setLiveChatEnabled(false, translateSegment: nil)
+            #expect(!snapshot.plan.requiresLiveRecognition)
+            #expect(await runtime.controller.resourceCounts().recognizers == 0)
+
+            _ = try await runtime.controller.stop()
+            await runtime.controller.completeStop()
+        }
+
+        @Test
         func failedBatchLiveToggleDoesNotCommitEnabledPlan() async throws {
             let runtime = try await makeRuntime(
                 mode: .batch,

--- a/Tests/DahliaTests/TranscriptionEventPipelineTests.swift
+++ b/Tests/DahliaTests/TranscriptionEventPipelineTests.swift
@@ -1,11 +1,50 @@
 #if canImport(Testing)
     // swiftlint:disable file_length
     import Foundation
+    import os
     import Testing
     @testable import Dahlia
 
     // swiftlint:disable:next type_body_length
     struct TranscriptionEventPipelineTests {
+        @Test
+        func eventObserverReceivesEveryFinalizedEventWhenUILaneCompacts() async throws {
+            let uiGate = AsyncTestGate()
+            let uiEvents = TranscriptionEventProbe()
+            let observedFinalizedCount = OSAllocatedUnfairLock(initialState: 0)
+            let pipeline = TranscriptionEventPipeline(
+                uiSink: { events in
+                    await uiEvents.append(contentsOf: events)
+                    await uiGate.wait()
+                },
+                eventObserver: { event in
+                    guard case let .finalized(segment) = event, segment.isConfirmed else { return }
+                    observedFinalizedCount.withLock { $0 += 1 }
+                },
+                persistenceSink: { _ in }
+            )
+
+            await pipeline.start()
+            await pipeline.enqueue(.failure(
+                sessionId: .v7(),
+                pipelineID: .v7(),
+                sourceLabel: "mic",
+                message: "block UI"
+            ))
+            await uiEvents.waitForCount(1)
+            for index in 0 ..< 1000 {
+                await pipeline.enqueue(.finalized(TranscriptSegment(
+                    startTime: Date(timeIntervalSince1970: Double(index)),
+                    text: "final-\(index)",
+                    isConfirmed: true
+                )))
+            }
+
+            #expect(observedFinalizedCount.withLock { $0 } == 1000)
+            await uiGate.open()
+            try await pipeline.finish()
+        }
+
         @Test
         func persistenceContinuesWhileUISinkIsSuspended() async throws {
             let uiGate = AsyncTestGate()
@@ -137,7 +176,7 @@
             await pipeline.start()
             await pipeline.enqueue(blockingEvent)
             await uiEvents.waitForCount(1)
-            for index in 0 ..< 1_000 {
+            for index in 0 ..< 1000 {
                 await pipeline.enqueue(.previewTranslation(
                     sessionId: sessionID,
                     segmentID: segmentID,
@@ -279,7 +318,7 @@
             await pipeline.start()
             await pipeline.enqueue(blockingEvent)
             await uiEvents.waitForCount(1)
-            for index in 0 ..< 1_000 {
+            for index in 0 ..< 1000 {
                 if index == 100 {
                     await pipeline.enqueue(retainedFailure)
                 }
@@ -302,7 +341,7 @@
             #expect(await reloads.value() > 0)
             #expect(await uiEvents.snapshot().contains(retainedFailure))
             #expect(await uiEvents.snapshot().count <= TranscriptionEventPipeline.maximumPendingUIEventCount + 2)
-            #expect(await persistedEvents.snapshot().count == 1_000)
+            #expect(await persistedEvents.snapshot().count == 1000)
             let operationValues = await operations.snapshot()
             let persistedIndex = try #require(operationValues.firstIndex(of: "persisted"))
             let reloadIndex = try #require(operationValues.firstIndex(of: "reload"))
@@ -337,7 +376,7 @@
                 message: "block UI"
             ))
             await uiEvents.waitForCount(1)
-            for index in 0 ..< 1_000 {
+            for index in 0 ..< 1000 {
                 await pipeline.enqueue(.finalized(TranscriptSegment(
                     startTime: Date(timeIntervalSince1970: Double(index)),
                     text: "final-\(index)",

--- a/Tests/DahliaTests/TranscriptionSessionPlanTests.swift
+++ b/Tests/DahliaTests/TranscriptionSessionPlanTests.swift
@@ -71,5 +71,20 @@
             #expect(plan.recordsBatchAudio)
             #expect(plan.retainBatchAudio)
         }
+
+        @Test
+        func liveChatRequiresRecognitionWithoutPersistingRealtimeTranscript() {
+            let plan = TranscriptionSessionPlan(
+                finalMode: .batch,
+                liveSubtitlesEnabled: false,
+                liveChatEnabled: true,
+                retainBatchAudio: true
+            )
+
+            #expect(plan.requiresLiveRecognition)
+            #expect(plan.liveRecognizerCountPerSource == 1)
+            #expect(plan.recordsBatchAudio)
+            #expect(!plan.persistsRealtimeTranscript)
+        }
     }
 #endif


### PR DESCRIPTION
## Summary

- add an AI chat live mode that forwards finalized live transcription, including during batch recording
- mark live requests in `<context>` and wrap hidden input in `<live_transcript>` while keeping manually typed chat visible
- coordinate live recognition across chat sessions and recording reconfiguration
- make delivery lossless across UI event compaction, bound and coalesce the pending backlog, support retry, and cancel hidden sends when live mode is disabled

## Why

Users need finalized speech to flow directly into AI chat without duplicating transcript text in the visible conversation. The event pipeline previously had no lossless consumer for this use case, and hidden input needed explicit provenance and lifecycle handling.

## Impact

Users can toggle live mode from the chat composer. Finalized transcript input is sent to the model but omitted from chat history, while normal typed messages remain visible. Batch recording keeps the live recognizer only while subtitles or live chat require it.

## Validation

- `swift build`
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` — 634 tests in 112 suites passed
- targeted live-mode, prompt codec, event pipeline, and coordinator tests
- `CI=true ./scripts/lint.sh`
- `git diff --check`