### PR TITLE
Allow chat steering during active responses

### DIFF
--- a/Sources/Dahlia/Models/CodexChatPendingInput.swift
+++ b/Sources/Dahlia/Models/CodexChatPendingInput.swift
@@ -1,0 +1,4 @@
+enum CodexChatPendingInput {
+    case manual(String)
+    case liveTranscript(String, wasTruncated: Bool)
+}

--- a/Sources/Dahlia/Services/CodexChatService.swift
+++ b/Sources/Dahlia/Services/CodexChatService.swift
@@ -205,6 +205,22 @@ actor CodexChatService: CodexChatServicing {
         )
     }
 
+    func steer(threadID: String, turnID: String, textBlocks: [String]) async throws {
+        _ = try await appServer.request(
+            method: "turn/steer",
+            params: .object([
+                "expectedTurnId": .string(turnID),
+                "input": .array(textBlocks.map { text in
+                    .object([
+                        "type": .string("text"),
+                        "text": .string(text),
+                    ])
+                }),
+                "threadId": .string(threadID),
+            ])
+        )
+    }
+
     func interrupt(threadID: String, turnID: String) async {
         _ = try? await appServer.request(
             method: "turn/interrupt",

--- a/Sources/Dahlia/Services/CodexChatServicing.swift
+++ b/Sources/Dahlia/Services/CodexChatServicing.swift
@@ -13,6 +13,7 @@ protocol CodexChatServicing: Sendable {
         model: String?,
         effort: String
     ) async throws -> AsyncThrowingStream<CodexChatTurnEvent, any Error>
+    func steer(threadID: String, turnID: String, textBlocks: [String]) async throws
     func interrupt(threadID: String, turnID: String) async
     func unsubscribe(threadID: String) async
 }

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -47,10 +47,12 @@ final class CodexChatSessionModel: Identifiable {
     @ObservationIgnored private var didUnsubscribe = false
     @ObservationIgnored private var pendingLiveTranscript: String?
     @ObservationIgnored private var didTruncatePendingLiveTranscript = false
+    @ObservationIgnored private var pendingManualInputs: [String] = []
     @ObservationIgnored private var isActiveTurnLiveTranscript = false
     @ObservationIgnored private var activeSubmissionID: UUID?
     @ObservationIgnored private var activeResponseID: String?
     @ObservationIgnored private var turnTask: Task<Void, Never>?
+    @ObservationIgnored private var steerTask: Task<Void, Never>?
     @ObservationIgnored private var failedSubmission: CodexChatFailedSubmission?
     @ObservationIgnored private var usesLiveModePlaceholderTitle = false
     @ObservationIgnored private var liveModeChangeHandler: (@MainActor (Bool) -> Void)?
@@ -142,6 +144,14 @@ final class CodexChatSessionModel: Identifiable {
             referenceIDs: referenceIDsSnapshot,
             draft: draftSnapshot
         )
+        if isGenerating {
+            enqueueManualInput(
+                text,
+                draftSnapshot: draftSnapshot,
+                referenceIDsSnapshot: referenceIDsSnapshot
+            )
+            return
+        }
         submit(
             text,
             clearsDraft: true,
@@ -202,6 +212,10 @@ final class CodexChatSessionModel: Identifiable {
     func release() {
         guard !isReleased else { return }
         isReleased = true
+        steerTask?.cancel()
+        steerTask = nil
+        pendingManualInputs.removeAll()
+        pendingLiveTranscript = nil
         if isGenerating {
             stop()
         }
@@ -315,6 +329,7 @@ private extension CodexChatSessionModel {
             if isStopRequested, let backendThreadID {
                 Task { await service.interrupt(threadID: backendThreadID, turnID: turnID) }
             }
+            processPendingInputIfPossible()
         case let .delta(itemID, text):
             accumulator.appendResponseDelta(itemID: itemID, text: text)
             updateLimiter.submit()
@@ -411,8 +426,7 @@ private extension CodexChatSessionModel {
     }
 
     private func finishGeneration(
-        submissionID: UUID?,
-        continueLiveQueue: Bool = false
+        submissionID: UUID?
     ) {
         guard activeSubmissionID == submissionID else { return }
         isGenerating = false
@@ -423,9 +437,7 @@ private extension CodexChatSessionModel {
         activeResponseID = nil
         turnTask = nil
         unsubscribeIfPossible()
-        if continueLiveQueue {
-            sendNextLiveTranscriptIfPossible()
-        }
+        processPendingInputIfPossible()
     }
 
     private static let maximumEventsBetweenYields = 64
@@ -582,12 +594,8 @@ private extension CodexChatSessionModel {
         isLiveModeSnapshot: Bool,
         submissionID: UUID
     ) async {
-        var shouldContinueLiveQueue = false
         defer {
-            finishGeneration(
-                submissionID: submissionID,
-                continueLiveQueue: shouldContinueLiveQueue
-            )
+            finishGeneration(submissionID: submissionID)
         }
         let context: CodexChatContext?
         do {
@@ -604,12 +612,10 @@ private extension CodexChatSessionModel {
         }
         guard !isReleased, isBoundToCurrentVault else { return }
         if clearsDraft {
-            if draft == draftSnapshot {
-                draft = ""
-            }
-            if selectedMeetingReferenceIDs == referenceIDsSnapshot {
-                selectedMeetingReferenceIDs = []
-            }
+            clearComposer(
+                draftSnapshot: draftSnapshot,
+                referenceIDsSnapshot: referenceIDsSnapshot
+            )
         }
         var replacedLiveModePlaceholderTitle = false
         if liveTranscript == nil {
@@ -622,7 +628,7 @@ private extension CodexChatSessionModel {
         messages.append(CodexChatMessage(id: responseID, role: .assistant, text: "", isStreaming: true))
         activeResponseID = responseID
 
-        shouldContinueLiveQueue = await runTurn(
+        _ = await runTurn(
             text: liveTranscript == nil ? text : nil,
             liveTranscript: liveTranscript,
             context: context,
@@ -651,15 +657,164 @@ private extension CodexChatSessionModel {
         liveModeChangeHandler?(isEnabled)
     }
 
+    func enqueueManualInput(
+        _ text: String,
+        draftSnapshot: String,
+        referenceIDsSnapshot: [UUID]
+    ) {
+        lastSubmittedText = text
+        pendingManualInputs.append(text)
+        clearComposer(
+            draftSnapshot: draftSnapshot,
+            referenceIDsSnapshot: referenceIDsSnapshot
+        )
+        processPendingInputIfPossible()
+    }
+
+    func clearComposer(
+        draftSnapshot: String,
+        referenceIDsSnapshot: [UUID]
+    ) {
+        if draft == draftSnapshot {
+            draft = ""
+        }
+        if selectedMeetingReferenceIDs == referenceIDsSnapshot {
+            selectedMeetingReferenceIDs = []
+        }
+    }
+
+    func processPendingInputIfPossible() {
+        guard !isReleased,
+              isBoundToCurrentVault,
+              steerTask == nil,
+              errorMessage == nil else { return }
+        if isGenerating {
+            startSteeringPendingInputIfPossible()
+        } else if !pendingManualInputs.isEmpty {
+            let text = pendingManualInputs.removeFirst()
+            submit(text, clearsDraft: false)
+        } else {
+            sendNextLiveTranscriptIfPossible()
+        }
+    }
+
+    func startSteeringPendingInputIfPossible() {
+        guard let backendThreadID,
+              let activeTurnID,
+              let input = dequeuePendingSteerInput() else { return }
+        steerTask = Task { [weak self] in
+            await self?.steer(input, threadID: backendThreadID, turnID: activeTurnID)
+        }
+    }
+
+    func dequeuePendingSteerInput() -> CodexChatPendingInput? {
+        if !pendingManualInputs.isEmpty {
+            return .manual(pendingManualInputs.removeFirst())
+        }
+        guard isLiveModeEnabled,
+              failedLiveTranscript == nil,
+              let transcript = pendingLiveTranscript else { return nil }
+        pendingLiveTranscript = nil
+        let wasTruncated = didTruncatePendingLiveTranscript
+        didTruncatePendingLiveTranscript = false
+        return .liveTranscript(transcript, wasTruncated: wasTruncated)
+    }
+
+    func steer(_ input: CodexChatPendingInput, threadID: String, turnID: String) async {
+        defer {
+            steerTask = nil
+            processPendingInputIfPossible()
+        }
+        do {
+            guard let vaultID else { throw CodexAppServerError.invalidProtocolResponse }
+            let context = try await contextProvider.currentContext(vaultID: vaultID)
+            guard !Task.isCancelled,
+                  isGenerating,
+                  activeTurnID == turnID,
+                  backendThreadID == threadID else {
+                requeue(input)
+                return
+            }
+
+            let text: String?
+            let liveTranscript: String?
+            switch input {
+            case let .manual(manualText):
+                text = manualText
+                liveTranscript = nil
+            case let .liveTranscript(transcript, _):
+                guard isLiveModeEnabled else { return }
+                text = nil
+                liveTranscript = transcript
+            }
+            try await service.steer(
+                threadID: threadID,
+                turnID: turnID,
+                textBlocks: CodexChatPromptCodec.encodeTextBlocks(
+                    text: text,
+                    context: context,
+                    isLiveMode: isLiveModeEnabled,
+                    liveTranscript: liveTranscript
+                )
+            )
+            await applySuccessfulSteer(input, context: context)
+        } catch is CancellationError {
+            requeue(input)
+        } catch {
+            if !isGenerating || activeTurnID != turnID {
+                requeue(input)
+            } else {
+                errorMessage = error.localizedDescription
+                recordSteerFailure(input)
+            }
+        }
+    }
+
+    func applySuccessfulSteer(_ input: CodexChatPendingInput, context: CodexChatContext?) async {
+        switch input {
+        case let .manual(text):
+            messages.append(CodexChatMessage(role: .user, text: text, context: context))
+            _ = await replaceLiveModePlaceholderTitleIfNeeded(with: text)
+        case let .liveTranscript(_, wasTruncated):
+            if wasTruncated {
+                noticeMessage = L10n.chatLiveTranscriptBacklogTruncated
+            }
+        }
+    }
+
+    func recordSteerFailure(_ input: CodexChatPendingInput) {
+        switch input {
+        case let .manual(text):
+            recordFailedSubmission(text: text, liveTranscript: nil)
+        case let .liveTranscript(text, _):
+            recordFailedSubmission(text: nil, liveTranscript: text)
+        }
+    }
+
+    func requeue(_ input: CodexChatPendingInput) {
+        guard !isReleased else { return }
+        switch input {
+        case let .manual(text):
+            pendingManualInputs.insert(text, at: 0)
+        case let .liveTranscript(text, wasTruncated):
+            let combined = pendingLiveTranscript.map { text + "\n" + $0 } ?? text
+            pendingLiveTranscript = String(combined.suffix(Self.maximumPendingLiveTranscriptCharacters))
+            didTruncatePendingLiveTranscript = wasTruncated
+                || combined.count > Self.maximumPendingLiveTranscriptCharacters
+                || didTruncatePendingLiveTranscript
+        }
+    }
+
     func sendNextLiveTranscriptIfPossible() {
         guard isLiveModeEnabled,
               !isReleased,
-              !isGenerating,
               errorMessage == nil,
               failedLiveTranscript == nil,
-              draft.nilIfBlank == nil,
-              selectedMeetingReferenceIDs.isEmpty,
               let transcript = pendingLiveTranscript else { return }
+        if isGenerating {
+            startSteeringPendingInputIfPossible()
+            return
+        }
         pendingLiveTranscript = nil
         let wasTruncated = didTruncatePendingLiveTranscript
         didTruncatePendingLiveTranscript = false
@@ -693,7 +848,6 @@ extension CodexChatSessionModel {
 
     var canSend: Bool {
         isBoundToCurrentVault
-            && !isGenerating
             && (draft.nilIfBlank != nil || !selectedMeetingReferenceIDs.isEmpty)
     }
 

--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
@@ -72,7 +72,7 @@ struct CodexChatComposer: View {
                     CodexChatConfigurationButton(session: session)
                 }
 
-                if session.isGenerating {
+                if session.isGenerating, !session.canSend {
                     CodexChatActionButton(
                         label: L10n.stopGenerating,
                         systemImage: "stop.fill",

--- a/Tests/DahliaTests/CodexChatCoordinatorTests.swift
+++ b/Tests/DahliaTests/CodexChatCoordinatorTests.swift
@@ -250,6 +250,7 @@ import Foundation
             AsyncThrowingStream { $0.finish() }
         }
 
+        func steer(threadID _: String, turnID _: String, textBlocks _: [String]) async throws {}
         func interrupt(threadID _: String, turnID _: String) async {}
         func unsubscribe(threadID _: String) async {}
 
@@ -316,6 +317,7 @@ import Foundation
             return AsyncThrowingStream<CodexChatTurnEvent, any Error> { $0.finish() }
         }
 
+        func steer(threadID _: String, turnID _: String, textBlocks _: [String]) async throws {}
         func interrupt(threadID _: String, turnID _: String) async {}
 
         func unsubscribe(threadID: String) async {

--- a/Tests/DahliaTests/CodexChatServiceTests.swift
+++ b/Tests/DahliaTests/CodexChatServiceTests.swift
@@ -91,6 +91,39 @@ import Foundation
         }
 
         @Test
+        func steeringAddsTextBlocksToTheExpectedActiveTurn() async throws {
+            let transport = TestCodexChatAppServerTransport()
+            let appServer = CodexAppServerService(transportFactory: { transport })
+            let service = CodexChatService(
+                appServer: appServer,
+                workspaceLocator: TestCodexChatWorkspaceLocator(url: URL(filePath: "/tmp/dahlia-chat-tests"))
+            )
+
+            try await service.steer(
+                threadID: "thread-1",
+                turnID: "turn-1",
+                textBlocks: ["Live context", "New instruction"]
+            )
+
+            let params = try #require(await transport.messages().first {
+                $0.objectValue?["method"]?.stringValue == "turn/steer"
+            }?.objectValue?["params"]?.objectValue)
+            #expect(params["threadId"] == .string("thread-1"))
+            #expect(params["expectedTurnId"] == .string("turn-1"))
+            #expect(params["input"] == .array([
+                .object([
+                    "type": .string("text"),
+                    "text": .string("Live context"),
+                ]),
+                .object([
+                    "type": .string("text"),
+                    "text": .string("New instruction"),
+                ]),
+            ]))
+            await appServer.shutdown()
+        }
+
+        @Test
         func turnInterruptionAndFailureAreTypedEvents() async throws {
             let interrupted = try await events(for: .interrupted)
             let failed = try await events(for: .failed)

--- a/Tests/DahliaTests/CodexChatSessionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatSessionModelTests.swift
@@ -592,32 +592,6 @@ import Foundation
         }
 
         @Test
-        func liveTranscriptsQueuedDuringGenerationAreCoalesced() async {
-            let service = TestCodexChatService(mode: .block)
-            let settings = AppSettings()
-            settings.currentVault = Self.testVault()
-            let session = CodexChatSessionModel(
-                modelID: "default-model",
-                effort: "medium",
-                service: service,
-                settings: settings
-            )
-
-            session.toggleLiveMode()
-            session.receiveFinalizedLiveTranscript("first")
-            await waitUntilAsync { await service.sentTextBlocks.count == 1 }
-            session.receiveFinalizedLiveTranscript("second")
-            session.receiveFinalizedLiveTranscript("third")
-
-            await service.completeBlockedTurn()
-            await waitUntilAsync { await service.sentTextBlocks.count == 2 }
-
-            #expect(await service.sentTextBlocks[1].last == "<live_transcript>second&#10;third</live_transcript>")
-            session.disableLiveMode()
-            await waitUntil { !session.isGenerating }
-        }
-
-        @Test
         func disablingLiveModeCancelsTranscriptBeforeContextResolutionCompletes() async {
             let service = TestCodexChatService(mode: .complete)
             let settings = AppSettings()
@@ -643,7 +617,7 @@ import Foundation
         }
 
         @Test
-        func manualSendAfterLiveFailureRequeuesTheFailedTranscript() async {
+        func manualSendAfterLiveFailureSteersTheRecoveredTranscript() async {
             let service = TestCodexChatService(mode: .failThenComplete)
             let settings = AppSettings()
             settings.currentVault = Self.testVault()
@@ -661,48 +635,13 @@ import Foundation
 
             session.draft = "Manual recovery"
             session.sendDraft()
-            await waitUntilAsync { await service.sentTextBlocks.count == 3 }
+            await waitUntilAsync { await service.steeredTextBlocks.count == 1 }
             await waitUntil { !session.isGenerating }
 
             let sentTextBlocks = await service.sentTextBlocks
             #expect(sentTextBlocks[1].last == "Manual recovery")
-            #expect(sentTextBlocks[2].last == "<live_transcript>Failed live speech</live_transcript>")
+            #expect(await service.steeredTextBlocks[0].last == "<live_transcript>Failed live speech</live_transcript>")
             #expect(session.failedLiveTranscript == nil)
-        }
-
-        @Test
-        func pendingLiveTranscriptResumesWhenDraftAndReferencesAreCleared() async {
-            let service = TestCodexChatService(mode: .complete)
-            let settings = AppSettings()
-            let vault = Self.testVault()
-            settings.currentVault = vault
-            let session = CodexChatSessionModel(
-                modelID: "default-model",
-                effort: "medium",
-                service: service,
-                settings: settings
-            )
-
-            session.toggleLiveMode()
-            session.draft = "Still editing"
-            session.receiveFinalizedLiveTranscript("queued for draft")
-            #expect(await service.sentTextBlocks.isEmpty)
-
-            session.draft = ""
-            await waitUntilAsync { await service.sentTextBlocks.count == 1 }
-            await waitUntil { !session.isGenerating }
-
-            let meeting = Self.meetingReference(vaultID: vault.id, name: "Blocking reference", offset: 0)
-            session.updateAvailableMeetings([meeting], catalogVaultID: vault.id)
-            session.addMeetingReference(CodexChatMeetingReference(meeting: meeting))
-            session.receiveFinalizedLiveTranscript("queued for reference")
-            #expect(await service.sentTextBlocks.count == 1)
-
-            session.removeMeetingReference(id: meeting.meetingId)
-            await waitUntilAsync { await service.sentTextBlocks.count == 2 }
-            await waitUntil { !session.isGenerating }
-
-            #expect(await service.sentTextBlocks[1].last == "<live_transcript>queued for reference</live_transcript>")
         }
 
         @Test
@@ -775,6 +714,7 @@ import Foundation
 
         let mode: Mode
         private(set) var sentTextBlocks: [[String]] = []
+        private(set) var steeredTextBlocks: [[String]] = []
         private(set) var threadNames: [String] = []
         private(set) var interruptCount = 0
         private(set) var unsubscribedThreadIDs: [String] = []
@@ -905,6 +845,10 @@ import Foundation
             blockedContinuation?.yield(.interrupted)
             blockedContinuation?.finish()
             blockedContinuation = nil
+        }
+
+        func steer(threadID _: String, turnID _: String, textBlocks: [String]) async throws {
+            steeredTextBlocks.append(textBlocks)
         }
 
         func completeBlockedTurn() {

--- a/Tests/DahliaTests/CodexChatSteeringTests.swift
+++ b/Tests/DahliaTests/CodexChatSteeringTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct CodexChatSteeringTests {
+        @Test
+        func liveTranscriptsSteerTheActiveTurnAsTheyArrive() async {
+            let service = TestCodexChatService(mode: .block)
+            let session = makeSession(service: service)
+
+            session.toggleLiveMode()
+            session.receiveFinalizedLiveTranscript("first")
+            await waitUntil { session.activeTurnID != nil }
+            session.receiveFinalizedLiveTranscript("second")
+            session.receiveFinalizedLiveTranscript("third")
+
+            await waitUntilAsync { await service.steeredTextBlocks.count == 2 }
+
+            #expect(await service.steeredTextBlocks.map(\.last) == [
+                "<live_transcript>second</live_transcript>",
+                "<live_transcript>third</live_transcript>",
+            ])
+            session.disableLiveMode()
+            await waitUntil { !session.isGenerating }
+        }
+
+        @Test
+        func manualInputSteersTheActiveTurnWithoutStoppingItsResponse() async {
+            let service = TestCodexChatService(mode: .block)
+            let session = makeSession(service: service)
+
+            session.draft = "First question"
+            session.sendDraft()
+            await waitUntil { session.activeTurnID != nil }
+
+            session.draft = "Follow-up while responding"
+            #expect(session.canSend)
+            session.sendDraft()
+            await waitUntilAsync { await service.steeredTextBlocks.count == 1 }
+
+            #expect(session.isGenerating)
+            #expect(session.draft.isEmpty)
+            #expect(session.messages.filter { $0.role == .user }.map(\.text) == [
+                "First question",
+                "Follow-up while responding",
+            ])
+            #expect(await service.steeredTextBlocks == [["Follow-up while responding"]])
+            session.stop()
+            await waitUntil { !session.isGenerating }
+        }
+
+        @Test
+        func liveTranscriptDoesNotWaitForManualDraftDuringGeneration() async {
+            let service = TestCodexChatService(mode: .block)
+            let session = makeSession(service: service)
+
+            session.toggleLiveMode()
+            session.draft = "Initial request"
+            session.sendDraft()
+            await waitUntil { session.activeTurnID != nil }
+
+            session.draft = "Still editing"
+            session.receiveFinalizedLiveTranscript("send immediately")
+            await waitUntilAsync { await service.steeredTextBlocks.count == 1 }
+
+            #expect(session.draft == "Still editing")
+            #expect(await service.steeredTextBlocks[0].last == "<live_transcript>send immediately</live_transcript>")
+            session.stop()
+            await waitUntil { !session.isGenerating }
+        }
+
+        private func makeSession(service: TestCodexChatService) -> CodexChatSessionModel {
+            let settings = AppSettings()
+            settings.currentVault = VaultRecord(
+                id: .v7(),
+                path: "/tmp/chat-steering-test-vault",
+                name: "Chat Steering Test",
+                createdAt: .now,
+                lastOpenedAt: .now
+            )
+            return CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings
+            )
+        }
+
+        private func waitUntil(_ predicate: @MainActor () -> Bool) async {
+            for _ in 0 ..< 1000 {
+                if predicate() { return }
+                await Task.yield()
+            }
+            Issue.record("Timed out waiting for chat state")
+        }
+
+        private func waitUntilAsync(
+            _ predicate: @escaping @Sendable () async -> Bool
+        ) async {
+            for _ in 0 ..< 1000 {
+                if await predicate() { return }
+                await Task.yield()
+            }
+            Issue.record("Timed out waiting for asynchronous chat state")
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary

- add Codex `turn/steer` support for active chat turns
- queue and inject manual messages while the assistant is responding
- send finalized live transcripts incrementally without waiting for the active response
- show Stop only when responding with no sendable draft; otherwise show Send

## Why

Chat input was serialized behind the active assistant response, so manual follow-ups and live transcription could not be delivered until generation finished. This change routes pending input into the active turn while preserving retry, cancellation, and transcript backlog behavior.

## User impact

Users can send typed follow-ups and live transcription while an AI response is still streaming. The composer remains actionable: Stop appears for an empty draft during generation, and Send appears when content is ready.

## Validation

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter CodexChat` — 81 tests passed across 14 suites
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build`
- `CI=true ./scripts/lint.sh` — SwiftFormat clean; existing non-blocking SwiftLint warnings remain
- `git diff --check`
