### PR TITLE
Render chat markdown while streaming

### DIFF
--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownBlockView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownBlockView.swift
@@ -1,26 +1,26 @@
 import SwiftUI
 
 struct CodexChatMarkdownBlockView: View {
-    let block: CodexChatMarkdownBlock
+    let block: CodexChatMarkdownRenderedBlock
 
     var body: some View {
         switch block {
         case let .paragraph(text):
-            markdownText(text)
+            renderedText(text)
         case let .heading(level, text):
-            markdownText(text)
+            renderedText(text)
                 .font(headingFont(for: level))
                 .fontWeight(.semibold)
         case let .unorderedList(items):
             VStack(alignment: .leading, spacing: 10) {
-                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
-                    CodexChatMarkdownListRow(marker: "•", text: item)
+                ForEach(items.indices, id: \.self) { index in
+                    CodexChatMarkdownListRow(marker: "•", text: items[index])
                 }
             }
         case let .orderedList(items):
             VStack(alignment: .leading, spacing: 10) {
-                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
-                    CodexChatMarkdownListRow(marker: item.marker, text: item.text)
+                ForEach(items.indices, id: \.self) { index in
+                    CodexChatMarkdownListRow(marker: items[index].marker, text: items[index].text)
                 }
             }
         case let .blockquote(text):
@@ -28,7 +28,7 @@ struct CodexChatMarkdownBlockView: View {
                 RoundedRectangle(cornerRadius: 1)
                     .fill(.tertiary)
                     .frame(width: 3)
-                markdownText(text)
+                renderedText(text)
                     .foregroundStyle(.secondary)
             }
         case let .code(language, text):
@@ -51,16 +51,9 @@ struct CodexChatMarkdownBlockView: View {
         }
     }
 
-    private func markdownText(_ value: String) -> some View {
-        Text(attributedMarkdown(value))
+    private func renderedText(_ value: AttributedString) -> some View {
+        Text(value)
             .textSelection(.enabled)
-    }
-
-    private func attributedMarkdown(_ value: String) -> AttributedString {
-        (try? AttributedString(
-            markdown: value,
-            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        )) ?? AttributedString(value)
     }
 
     private func headingFont(for level: Int) -> Font {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownCache.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownCache.swift
@@ -1,21 +1,55 @@
-@MainActor
-enum CodexChatMarkdownCache {
-    private static let capacity = 32
-    private static var blocksByMarkdown: [String: [CodexChatMarkdownBlock]] = [:]
-    private static var insertionOrder: [String] = []
+actor CodexChatMarkdownCache {
+    static let shared = CodexChatMarkdownCache()
 
-    static func blocks(for markdown: String) -> [CodexChatMarkdownBlock] {
-        if let blocks = blocksByMarkdown[markdown] {
-            return blocks
-        }
+    private let capacity: Int
+    private let maximumCost: Int
+    private var blocksByMarkdown: [String: [CodexChatMarkdownRenderedBlock]] = [:]
+    private var costsByMarkdown: [String: Int] = [:]
+    private var insertionOrder: [String] = []
+    private var totalCost = 0
 
-        let blocks = CodexChatMarkdownParser.parse(markdown)
-        if insertionOrder.count == capacity, let oldest = insertionOrder.first {
+    init(
+        capacity: Int = 32,
+        maximumCost: Int = 512 * 1024
+    ) {
+        self.capacity = capacity
+        self.maximumCost = maximumCost
+    }
+
+    func blocks(for markdown: String) -> [CodexChatMarkdownRenderedBlock]? {
+        blocksByMarkdown[markdown]
+    }
+
+    func insert(
+        _ blocks: [CodexChatMarkdownRenderedBlock],
+        for markdown: String
+    ) {
+        guard blocksByMarkdown[markdown] == nil,
+              capacity > 0,
+              maximumCost > 0
+        else { return }
+
+        let cost = markdown.utf8.count
+        guard cost <= maximumCost else { return }
+
+        while insertionOrder.count >= capacity || totalCost + cost > maximumCost {
+            guard let oldest = insertionOrder.first else { break }
             blocksByMarkdown.removeValue(forKey: oldest)
+            totalCost -= costsByMarkdown.removeValue(forKey: oldest) ?? 0
             insertionOrder.removeFirst()
         }
+
         blocksByMarkdown[markdown] = blocks
+        costsByMarkdown[markdown] = cost
         insertionOrder.append(markdown)
-        return blocks
+        totalCost += cost
+    }
+
+    func cachedEntryCount() -> Int {
+        blocksByMarkdown.count
+    }
+
+    func cachedCost() -> Int {
+        totalCost
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownInput.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownInput.swift
@@ -1,0 +1,4 @@
+struct CodexChatMarkdownInput: Equatable, Sendable {
+    let markdown: String
+    let isStreaming: Bool
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownListRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownListRow.swift
@@ -2,22 +2,15 @@ import SwiftUI
 
 struct CodexChatMarkdownListRow: View {
     let marker: String
-    let text: String
+    let text: AttributedString
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
             Text(marker)
                 .frame(minWidth: 14, alignment: .trailing)
-            Text(attributedMarkdown)
+            Text(text)
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
-    }
-
-    private var attributedMarkdown: AttributedString {
-        (try? AttributedString(
-            markdown: text,
-            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        )) ?? AttributedString(text)
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownParser.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownParser.swift
@@ -1,21 +1,25 @@
 import Foundation
 
 enum CodexChatMarkdownParser {
-    static func parse(_ markdown: String) -> [CodexChatMarkdownBlock] {
-        let normalized = markdown
-            .replacingOccurrences(of: "\r\n", with: "\n")
-            .replacingOccurrences(of: "\r", with: "\n")
+    static func parse(_ markdown: String) throws -> [CodexChatMarkdownBlock] {
+        try Task.checkCancellation()
+        let normalizedLineEndings = markdown.replacingOccurrences(of: "\r\n", with: "\n")
+        try Task.checkCancellation()
+        let normalized = normalizedLineEndings.replacingOccurrences(of: "\r", with: "\n")
+        try Task.checkCancellation()
         let lines = normalized.components(separatedBy: "\n")
+        try Task.checkCancellation()
         var blocks: [CodexChatMarkdownBlock] = []
         var index = 0
 
         while index < lines.count {
+            try Task.checkCancellation()
             if lines[index].trimmingCharacters(in: .whitespaces).isEmpty {
                 index += 1
                 continue
             }
 
-            if let block = parseFence(lines, index: &index) {
+            if let block = try parseFence(lines, index: &index) {
                 blocks.append(block)
             } else if let block = parseHeading(lines[index]) {
                 blocks.append(block)
@@ -24,11 +28,11 @@ enum CodexChatMarkdownParser {
                 blocks.append(.divider)
                 index += 1
             } else if isBlockquote(lines[index]) {
-                blocks.append(parseBlockquote(lines, index: &index))
+                try blocks.append(parseBlockquote(lines, index: &index))
             } else if let marker = listMarker(in: lines[index]) {
-                blocks.append(parseList(lines, index: &index, kind: marker.kind))
+                try blocks.append(parseList(lines, index: &index, kind: marker.kind))
             } else {
-                blocks.append(parseParagraph(lines, index: &index))
+                try blocks.append(parseParagraph(lines, index: &index))
             }
         }
 
@@ -49,7 +53,7 @@ enum CodexChatMarkdownParser {
     private static func parseFence(
         _ lines: [String],
         index: inout Int
-    ) -> CodexChatMarkdownBlock? {
+    ) throws -> CodexChatMarkdownBlock? {
         let opening = lines[index].trimmingCharacters(in: .whitespaces)
         guard opening.hasPrefix("```") else { return nil }
 
@@ -58,6 +62,7 @@ enum CodexChatMarkdownParser {
         var codeLines: [String] = []
         while index < lines.count,
               !lines[index].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
+            try Task.checkCancellation()
             codeLines.append(lines[index])
             index += 1
         }
@@ -87,9 +92,10 @@ enum CodexChatMarkdownParser {
     private static func parseBlockquote(
         _ lines: [String],
         index: inout Int
-    ) -> CodexChatMarkdownBlock {
+    ) throws -> CodexChatMarkdownBlock {
         var quoteLines: [String] = []
         while index < lines.count, isBlockquote(lines[index]) {
+            try Task.checkCancellation()
             let trimmed = removingLeadingWhitespace(from: lines[index])
             quoteLines.append(removingLeadingWhitespace(from: String(trimmed.dropFirst())))
             index += 1
@@ -101,16 +107,18 @@ enum CodexChatMarkdownParser {
         _ lines: [String],
         index: inout Int,
         kind: ListKind
-    ) -> CodexChatMarkdownBlock {
+    ) throws -> CodexChatMarkdownBlock {
         var items: [String] = []
         var orderedItems: [CodexChatMarkdownOrderedItem] = []
 
         while index < lines.count {
+            try Task.checkCancellation()
             guard let marker = listMarker(in: lines[index]), marker.kind == kind else { break }
             var itemLines = [marker.content]
             index += 1
 
             while index < lines.count {
+                try Task.checkCancellation()
                 if lines[index].trimmingCharacters(in: .whitespaces).isEmpty {
                     let next = nextNonemptyLine(in: lines, after: index)
                     if let next,
@@ -146,10 +154,11 @@ enum CodexChatMarkdownParser {
     private static func parseParagraph(
         _ lines: [String],
         index: inout Int
-    ) -> CodexChatMarkdownBlock {
+    ) throws -> CodexChatMarkdownBlock {
         var paragraphLines: [String] = []
         while index < lines.count,
               !lines[index].trimmingCharacters(in: .whitespaces).isEmpty {
+            try Task.checkCancellation()
             if !paragraphLines.isEmpty, isBlockStart(lines[index]) {
                 break
             }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownProjection.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownProjection.swift
@@ -1,0 +1,4 @@
+struct CodexChatMarkdownProjection: Sendable {
+    let markdown: String
+    let blocks: [CodexChatMarkdownRenderedBlock]
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownProjectionModel.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownProjectionModel.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class CodexChatMarkdownProjectionModel {
+    private(set) var projection: CodexChatMarkdownProjection?
+    private(set) var pendingSuffix: String?
+    private(set) var canDisplayProjection = false
+
+    @ObservationIgnored private let renderer: any CodexChatMarkdownRendering
+    @ObservationIgnored private var currentInput: CodexChatMarkdownInput?
+    @ObservationIgnored private var pendingInput: CodexChatMarkdownInput?
+    @ObservationIgnored private var renderTask: Task<Void, Never>?
+
+    init(renderer: any CodexChatMarkdownRendering = CodexChatMarkdownRenderer()) {
+        self.renderer = renderer
+    }
+
+    func submit(_ input: CodexChatMarkdownInput) {
+        currentInput = input
+        updateDisplay(for: input)
+
+        if !input.isStreaming,
+           let projection,
+           projection.markdown == input.markdown {
+            pendingInput = nil
+            let renderer = renderer
+            Task {
+                await renderer.cache(projection.blocks, for: input.markdown)
+            }
+            return
+        }
+
+        pendingInput = input
+        startNextRenderIfNeeded()
+    }
+
+    func cancel() {
+        currentInput = nil
+        pendingInput = nil
+        renderTask?.cancel()
+    }
+
+    private func startNextRenderIfNeeded() {
+        guard renderTask == nil, let input = pendingInput else { return }
+        pendingInput = nil
+        let renderer = renderer
+
+        renderTask = Task { [weak self] in
+            let blocks = try? await renderer.blocks(
+                for: input.markdown,
+                cacheResult: !input.isStreaming
+            )
+            self?.finishRender(
+                blocks: blocks,
+                input: input
+            )
+        }
+    }
+
+    private func finishRender(
+        blocks: [CodexChatMarkdownRenderedBlock]?,
+        input: CodexChatMarkdownInput
+    ) {
+        renderTask = nil
+        if let blocks,
+           let currentInput,
+           currentInput.markdown == input.markdown {
+            projection = CodexChatMarkdownProjection(markdown: input.markdown, blocks: blocks)
+            updateDisplay(for: currentInput)
+            if !currentInput.isStreaming {
+                let renderer = renderer
+                Task {
+                    await renderer.cache(blocks, for: input.markdown)
+                }
+            }
+            if pendingInput?.markdown == input.markdown {
+                pendingInput = nil
+            }
+        }
+        startNextRenderIfNeeded()
+    }
+
+    private func updateDisplay(for input: CodexChatMarkdownInput) {
+        guard let projection,
+              input.markdown.hasPrefix(projection.markdown)
+        else {
+            canDisplayProjection = false
+            pendingSuffix = nil
+            return
+        }
+
+        canDisplayProjection = true
+        let suffix = String(input.markdown.dropFirst(projection.markdown.count))
+        pendingSuffix = suffix.nilIfBlank == nil ? nil : suffix
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownProjectionModel.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownProjectionModel.swift
@@ -8,6 +8,14 @@ final class CodexChatMarkdownProjectionModel {
     private(set) var pendingSuffix: String?
     private(set) var canDisplayProjection = false
 
+    var canDisplayPendingSuffix: Bool {
+        guard let pendingSuffix else { return true }
+        guard projection?.markdown.last?.isNewline != true,
+              !pendingSuffix.contains(where: \.isNewline)
+        else { return false }
+        return projection?.blocks.last?.acceptsPendingSuffix == true
+    }
+
     @ObservationIgnored private let renderer: any CodexChatMarkdownRendering
     @ObservationIgnored private var currentInput: CodexChatMarkdownInput?
     @ObservationIgnored private var pendingInput: CodexChatMarkdownInput?
@@ -66,10 +74,11 @@ final class CodexChatMarkdownProjectionModel {
         renderTask = nil
         if let blocks,
            let currentInput,
-           currentInput.markdown == input.markdown {
+           currentInput.markdown.hasPrefix(input.markdown) {
             projection = CodexChatMarkdownProjection(markdown: input.markdown, blocks: blocks)
             updateDisplay(for: currentInput)
-            if !currentInput.isStreaming {
+            if !currentInput.isStreaming,
+               currentInput.markdown == input.markdown {
                 let renderer = renderer
                 Task {
                     await renderer.cache(blocks, for: input.markdown)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownProjectionView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownProjectionView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct CodexChatMarkdownProjectionView: View {
+    let blocks: [CodexChatMarkdownRenderedBlock]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(blocks.indices, id: \.self) { index in
+                CodexChatMarkdownBlockView(block: blocks[index])
+            }
+        }
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownProjectionView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownProjectionView.swift
@@ -2,12 +2,29 @@ import SwiftUI
 
 struct CodexChatMarkdownProjectionView: View {
     let blocks: [CodexChatMarkdownRenderedBlock]
+    let pendingSuffix: String?
+
+    init(
+        blocks: [CodexChatMarkdownRenderedBlock],
+        pendingSuffix: String? = nil
+    ) {
+        self.blocks = blocks
+        self.pendingSuffix = pendingSuffix
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             ForEach(blocks.indices, id: \.self) { index in
-                CodexChatMarkdownBlockView(block: blocks[index])
+                CodexChatMarkdownBlockView(block: block(at: index))
             }
         }
+    }
+
+    private func block(at index: Int) -> CodexChatMarkdownRenderedBlock {
+        guard index == blocks.indices.last,
+              let pendingSuffix
+        else { return blocks[index] }
+
+        return blocks[index].appendingPendingSuffix(pendingSuffix) ?? blocks[index]
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRenderedBlock.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRenderedBlock.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum CodexChatMarkdownRenderedBlock: Sendable {
+    case paragraph(AttributedString)
+    case heading(level: Int, text: AttributedString)
+    case unorderedList([AttributedString])
+    case orderedList([CodexChatMarkdownRenderedOrderedItem])
+    case blockquote(AttributedString)
+    case code(language: String?, text: String)
+    case divider
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRenderedBlock.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRenderedBlock.swift
@@ -8,4 +8,48 @@ enum CodexChatMarkdownRenderedBlock: Sendable {
     case blockquote(AttributedString)
     case code(language: String?, text: String)
     case divider
+
+    var acceptsPendingSuffix: Bool {
+        switch self {
+        case let .unorderedList(items):
+            !items.isEmpty
+        case let .orderedList(items):
+            !items.isEmpty
+        case .divider:
+            false
+        default:
+            true
+        }
+    }
+
+    func appendingPendingSuffix(_ suffix: String) -> Self? {
+        let attributedSuffix = AttributedString(suffix)
+        switch self {
+        case var .paragraph(text):
+            text.append(attributedSuffix)
+            return .paragraph(text)
+        case let .heading(level, originalText):
+            var text = originalText
+            text.append(attributedSuffix)
+            return .heading(level: level, text: text)
+        case var .unorderedList(items):
+            guard let lastIndex = items.indices.last else { return nil }
+            items[lastIndex].append(attributedSuffix)
+            return .unorderedList(items)
+        case var .orderedList(items):
+            guard let lastIndex = items.indices.last else { return nil }
+            let item = items[lastIndex]
+            var text = item.text
+            text.append(attributedSuffix)
+            items[lastIndex] = CodexChatMarkdownRenderedOrderedItem(marker: item.marker, text: text)
+            return .orderedList(items)
+        case var .blockquote(text):
+            text.append(attributedSuffix)
+            return .blockquote(text)
+        case let .code(language, text):
+            return .code(language: language, text: text + suffix)
+        case .divider:
+            return nil
+        }
+    }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRenderedOrderedItem.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRenderedOrderedItem.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct CodexChatMarkdownRenderedOrderedItem: Sendable {
+    let marker: String
+    let text: AttributedString
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRenderer.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRenderer.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+actor CodexChatMarkdownRenderer: CodexChatMarkdownRendering {
+    private let cache: CodexChatMarkdownCache
+    private var previousParsedBlocks: [CodexChatMarkdownBlock] = []
+    private var previousRenderedBlocks: [CodexChatMarkdownRenderedBlock] = []
+
+    init(cache: CodexChatMarkdownCache = .shared) {
+        self.cache = cache
+    }
+
+    func blocks(
+        for markdown: String,
+        cacheResult: Bool
+    ) async throws -> [CodexChatMarkdownRenderedBlock] {
+        try Task.checkCancellation()
+        if cacheResult, let blocks = await cache.blocks(for: markdown) {
+            return blocks
+        }
+
+        let parsedBlocks = try CodexChatMarkdownParser.parse(markdown)
+        let blocks = try renderReusingStablePrefix(parsedBlocks)
+        if cacheResult {
+            await cache.insert(blocks, for: markdown)
+        }
+        return blocks
+    }
+
+    func cache(
+        _ blocks: [CodexChatMarkdownRenderedBlock],
+        for markdown: String
+    ) async {
+        await cache.insert(blocks, for: markdown)
+    }
+
+    private func renderReusingStablePrefix(
+        _ parsedBlocks: [CodexChatMarkdownBlock]
+    ) throws -> [CodexChatMarkdownRenderedBlock] {
+        let reusableCount = zip(previousParsedBlocks, parsedBlocks)
+            .prefix(while: { $0.0 == $0.1 })
+            .count
+        var renderedBlocks = Array(previousRenderedBlocks.prefix(reusableCount))
+        renderedBlocks.reserveCapacity(parsedBlocks.count)
+        for block in parsedBlocks.dropFirst(reusableCount) {
+            try Task.checkCancellation()
+            try renderedBlocks.append(render(block))
+        }
+        previousParsedBlocks = parsedBlocks
+        previousRenderedBlocks = renderedBlocks
+        return renderedBlocks
+    }
+
+    private func render(_ block: CodexChatMarkdownBlock) throws -> CodexChatMarkdownRenderedBlock {
+        try Task.checkCancellation()
+        return switch block {
+        case let .paragraph(text):
+            .paragraph(attributedMarkdown(text))
+        case let .heading(level, text):
+            .heading(level: level, text: attributedMarkdown(text))
+        case let .unorderedList(items):
+            try .unorderedList(items.map { item in
+                try Task.checkCancellation()
+                return attributedMarkdown(item)
+            })
+        case let .orderedList(items):
+            try .orderedList(items.map { item in
+                try Task.checkCancellation()
+                return CodexChatMarkdownRenderedOrderedItem(
+                    marker: item.marker,
+                    text: attributedMarkdown(item.text)
+                )
+            })
+        case let .blockquote(text):
+            .blockquote(attributedMarkdown(text))
+        case let .code(language, text):
+            .code(language: language, text: text)
+        case .divider:
+            .divider
+        }
+    }
+
+    private func attributedMarkdown(_ value: String) -> AttributedString {
+        (try? AttributedString(
+            markdown: value,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )) ?? AttributedString(value)
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRendering.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRendering.swift
@@ -1,0 +1,11 @@
+protocol CodexChatMarkdownRendering: Sendable {
+    func blocks(
+        for markdown: String,
+        cacheResult: Bool
+    ) async throws -> [CodexChatMarkdownRenderedBlock]
+
+    func cache(
+        _ blocks: [CodexChatMarkdownRenderedBlock],
+        for markdown: String
+    ) async
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownView.swift
@@ -2,16 +2,38 @@ import SwiftUI
 
 struct CodexChatMarkdownView: View {
     let markdown: String
+    let isStreaming: Bool
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
-                CodexChatMarkdownBlockView(block: block)
-            }
-        }
+    @State private var projectionModel: CodexChatMarkdownProjectionModel
+
+    init(markdown: String, isStreaming: Bool = false) {
+        self.markdown = markdown
+        self.isStreaming = isStreaming
+        _projectionModel = State(initialValue: CodexChatMarkdownProjectionModel())
     }
 
-    private var blocks: [CodexChatMarkdownBlock] {
-        CodexChatMarkdownCache.blocks(for: markdown)
+    var body: some View {
+        Group {
+            if let projection = projectionModel.projection,
+               projectionModel.canDisplayProjection {
+                VStack(alignment: .leading, spacing: 0) {
+                    CodexChatMarkdownProjectionView(blocks: projection.blocks)
+                    if let pendingSuffix = projectionModel.pendingSuffix {
+                        Text(pendingSuffix)
+                            .textSelection(.enabled)
+                    }
+                }
+            } else {
+                Text(markdown)
+                    .textSelection(.enabled)
+            }
+        }
+        .onChange(
+            of: CodexChatMarkdownInput(markdown: markdown, isStreaming: isStreaming),
+            initial: true
+        ) { _, input in
+            projectionModel.submit(input)
+        }
+        .onDisappear(perform: projectionModel.cancel)
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownView.swift
@@ -15,14 +15,12 @@ struct CodexChatMarkdownView: View {
     var body: some View {
         Group {
             if let projection = projectionModel.projection,
-               projectionModel.canDisplayProjection {
-                VStack(alignment: .leading, spacing: 0) {
-                    CodexChatMarkdownProjectionView(blocks: projection.blocks)
-                    if let pendingSuffix = projectionModel.pendingSuffix {
-                        Text(pendingSuffix)
-                            .textSelection(.enabled)
-                    }
-                }
+               projectionModel.canDisplayProjection,
+               projectionModel.canDisplayPendingSuffix {
+                CodexChatMarkdownProjectionView(
+                    blocks: projection.blocks,
+                    pendingSuffix: projectionModel.pendingSuffix
+                )
             } else {
                 Text(markdown)
                     .textSelection(.enabled)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
@@ -39,12 +39,10 @@ struct CodexChatMessageRow: View {
                     if message.text.isEmpty, message.isStreaming {
                         CodexChatThinkingIndicator()
                     } else if !displayText.isEmpty {
-                        if message.isStreaming {
-                            Text(displayText)
-                                .textSelection(.enabled)
-                        } else {
-                            CodexChatMarkdownView(markdown: displayText)
-                        }
+                        CodexChatMarkdownView(
+                            markdown: displayText,
+                            isStreaming: message.isStreaming
+                        )
                     }
 
                     if !displayText.isEmpty, !message.isStreaming {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatReasoningView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatReasoningView.swift
@@ -8,13 +8,10 @@ struct CodexChatReasoningView: View {
 
     var body: some View {
         DisclosureGroup(isExpanded: $isExpanded) {
-            Group {
-                if isStreaming {
-                    Text(reasoning)
-                } else {
-                    CodexChatMarkdownView(markdown: reasoning)
-                }
-            }
+            CodexChatMarkdownView(
+                markdown: reasoning,
+                isStreaming: isStreaming
+            )
             .padding(.top, 8)
         } label: {
             Text(L10n.chatReasoning)

--- a/Tests/DahliaTests/CodexChatMarkdownCacheTests.swift
+++ b/Tests/DahliaTests/CodexChatMarkdownCacheTests.swift
@@ -1,0 +1,40 @@
+#if canImport(Testing)
+    import Foundation
+    import Testing
+    @testable import Dahlia
+
+    struct CodexChatMarkdownCacheTests {
+        @Test func doesNotCacheStreamingProjections() async throws {
+            let cache = CodexChatMarkdownCache(capacity: 2)
+            let renderer = CodexChatMarkdownRenderer(cache: cache)
+
+            _ = try await renderer.blocks(for: "**partial", cacheResult: false)
+
+            #expect(await cache.cachedEntryCount() == 0)
+        }
+
+        @Test func keepsCompletedProjectionCacheCountBounded() async throws {
+            let cache = CodexChatMarkdownCache(capacity: 2)
+            let renderer = CodexChatMarkdownRenderer(cache: cache)
+
+            _ = try await renderer.blocks(for: "first", cacheResult: true)
+            _ = try await renderer.blocks(for: "second", cacheResult: true)
+            _ = try await renderer.blocks(for: "third", cacheResult: true)
+
+            #expect(await cache.cachedEntryCount() == 2)
+        }
+
+        @Test func keepsCompletedProjectionCacheCostBounded() async {
+            let cache = CodexChatMarkdownCache(capacity: 10, maximumCost: 8)
+            let blocks: [CodexChatMarkdownRenderedBlock] = [.paragraph(AttributedString("value"))]
+
+            await cache.insert(blocks, for: "1234")
+            await cache.insert(blocks, for: "5678")
+            await cache.insert(blocks, for: "oversized")
+
+            #expect(await cache.cachedEntryCount() == 2)
+            #expect(await cache.cachedCost() == 8)
+            #expect(await cache.blocks(for: "oversized") == nil)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/CodexChatMarkdownParserTests.swift
+++ b/Tests/DahliaTests/CodexChatMarkdownParserTests.swift
@@ -3,7 +3,7 @@
     @testable import Dahlia
 
     struct CodexChatMarkdownParserTests {
-        @Test func preservesParagraphsAndUnorderedListItems() {
+        @Test func preservesParagraphsAndUnorderedListItems() throws {
             let authenticationDescription =
                 "GCP環境でログインがループする問題を調査。`.com`エイリアスとGoogle Workspaceの`.jp` IDの不一致が原因候補となり、" +
                 "過去事例を確認のうえ必要なら`.jp`で環境を作り直す方針です。"
@@ -25,7 +25,7 @@
                 "  \(pocDescription)",
             ].joined(separator: "\n")
 
-            #expect(CodexChatMarkdownParser.parse(markdown) == [
+            #expect(try CodexChatMarkdownParser.parse(markdown) == [
                 .paragraph("昨日（7月15日）の予定を確認します。"),
                 .paragraph("昨日（7月15日）は、DeNA／Databricks関連で3件ありました。"),
                 .unorderedList([
@@ -36,7 +36,7 @@
             ])
         }
 
-        @Test func parsesCommonBlockMarkdownAndLineBreaks() {
+        @Test func parsesCommonBlockMarkdownAndLineBreaks() throws {
             let markdown = [
                 "## Heading",
                 "soft",
@@ -55,7 +55,7 @@
                 "---",
             ].joined(separator: "\n")
 
-            #expect(CodexChatMarkdownParser.parse(markdown) == [
+            #expect(try CodexChatMarkdownParser.parse(markdown) == [
                 .heading(level: 2, text: "Heading"),
                 .paragraph("soft line\nhard"),
                 .orderedList([
@@ -66,6 +66,38 @@
                 .code(language: "swift", text: "let value = 1"),
                 .divider,
             ])
+        }
+
+        @Test func parsesIncompleteStreamingMarkdown() throws {
+            let markdown = [
+                "## Partial heading",
+                "",
+                "- **unfinished emphasis",
+                "",
+                "```swift",
+                "let value = 1",
+            ].joined(separator: "\n")
+
+            #expect(try CodexChatMarkdownParser.parse(markdown) == [
+                .heading(level: 2, text: "Partial heading"),
+                .unorderedList(["**unfinished emphasis"]),
+                .code(language: "swift", text: "let value = 1"),
+            ])
+        }
+
+        @Test func parsesLargeStreamingList() throws {
+            let markdown = (0 ..< 2_000)
+                .map { "- item \($0)" }
+                .joined(separator: "\n")
+
+            let blocks = try CodexChatMarkdownParser.parse(markdown)
+
+            guard case let .unorderedList(items) = blocks.first else {
+                Issue.record("Expected one unordered list")
+                return
+            }
+            #expect(blocks.count == 1)
+            #expect(items.count == 2_000)
         }
     }
 #endif

--- a/Tests/DahliaTests/CodexChatMarkdownProjectionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatMarkdownProjectionModelTests.swift
@@ -1,0 +1,130 @@
+#if canImport(Testing)
+    import Testing
+    @testable import Dahlia
+
+    @MainActor
+    struct CodexChatMarkdownProjectionModelTests {
+        @Test func coalescesPendingInputsAndPublishesOnlyLatestProjection() async {
+            let renderer = ControlledCodexChatMarkdownRenderer()
+            let model = CodexChatMarkdownProjectionModel(renderer: renderer)
+
+            model.submit(input("first"))
+            await waitForRequest("first", renderer: renderer)
+            model.submit(input("second"))
+            model.submit(input("third"))
+
+            #expect(await renderer.requestedMarkdown() == ["first"])
+            await renderer.complete("first")
+            await waitForRequest("third", renderer: renderer)
+            #expect(await renderer.requestedMarkdown() == ["first", "third"])
+
+            await renderer.complete("third")
+            await waitForProjection("third", model: model)
+            #expect(model.projection?.markdown == "third")
+        }
+
+        @Test func keepsAppendedRawSuffixVisibleWhileRendering() async {
+            let renderer = ControlledCodexChatMarkdownRenderer()
+            let model = CodexChatMarkdownProjectionModel(renderer: renderer)
+
+            model.submit(input("rendered"))
+            await waitForRequest("rendered", renderer: renderer)
+            await renderer.complete("rendered")
+            await waitForProjection("rendered", model: model)
+
+            model.submit(input("rendered tail"))
+
+            #expect(model.canDisplayProjection)
+            #expect(model.pendingSuffix == " tail")
+            model.cancel()
+            await renderer.complete("rendered tail")
+        }
+
+        @Test func completionCachesExistingProjectionWithoutRenderingAgain() async {
+            let renderer = ControlledCodexChatMarkdownRenderer()
+            let model = CodexChatMarkdownProjectionModel(renderer: renderer)
+
+            model.submit(input("complete"))
+            await waitForRequest("complete", renderer: renderer)
+            model.submit(CodexChatMarkdownInput(markdown: "complete", isStreaming: false))
+            await renderer.complete("complete")
+            await waitForProjection("complete", model: model)
+            await waitForCachedValue("complete", renderer: renderer)
+
+            #expect(await renderer.requestedMarkdown() == ["complete"])
+        }
+
+        @Test func nonPrefixReplacementFallsBackToRawMarkdown() async {
+            let renderer = ControlledCodexChatMarkdownRenderer()
+            let model = CodexChatMarkdownProjectionModel(renderer: renderer)
+
+            model.submit(input("original"))
+            await waitForRequest("original", renderer: renderer)
+            await renderer.complete("original")
+            await waitForProjection("original", model: model)
+
+            model.submit(input("replacement"))
+
+            #expect(!model.canDisplayProjection)
+            #expect(model.pendingSuffix == nil)
+            model.cancel()
+            await renderer.complete("replacement")
+        }
+
+        @Test func cancelledRenderCannotPublish() async {
+            let renderer = ControlledCodexChatMarkdownRenderer()
+            let model = CodexChatMarkdownProjectionModel(renderer: renderer)
+
+            model.submit(input("cancelled"))
+            await waitForRequest("cancelled", renderer: renderer)
+            model.cancel()
+            await renderer.complete("cancelled")
+            await Task.yield()
+
+            #expect(model.projection == nil)
+        }
+
+        private func input(_ markdown: String) -> CodexChatMarkdownInput {
+            CodexChatMarkdownInput(markdown: markdown, isStreaming: true)
+        }
+
+        private func waitForRequest(
+            _ markdown: String,
+            renderer: ControlledCodexChatMarkdownRenderer
+        ) async {
+            for _ in 0 ..< 1_000 {
+                if await renderer.requestedMarkdown().contains(markdown) {
+                    return
+                }
+                await Task.yield()
+            }
+            Issue.record("Renderer did not receive \(markdown)")
+        }
+
+        private func waitForProjection(
+            _ markdown: String,
+            model: CodexChatMarkdownProjectionModel
+        ) async {
+            for _ in 0 ..< 1_000 {
+                if model.projection?.markdown == markdown {
+                    return
+                }
+                await Task.yield()
+            }
+            Issue.record("Projection did not publish \(markdown)")
+        }
+
+        private func waitForCachedValue(
+            _ markdown: String,
+            renderer: ControlledCodexChatMarkdownRenderer
+        ) async {
+            for _ in 0 ..< 1_000 {
+                if await renderer.cachedValues().contains(markdown) {
+                    return
+                }
+                await Task.yield()
+            }
+            Issue.record("Renderer did not cache \(markdown)")
+        }
+    }
+#endif

--- a/Tests/DahliaTests/CodexChatMarkdownProjectionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatMarkdownProjectionModelTests.swift
@@ -1,4 +1,5 @@
 #if canImport(Testing)
+    import Foundation
     import Testing
     @testable import Dahlia
 
@@ -35,9 +36,54 @@
             model.submit(input("rendered tail"))
 
             #expect(model.canDisplayProjection)
+            #expect(model.canDisplayPendingSuffix)
             #expect(model.pendingSuffix == " tail")
             model.cancel()
             await renderer.complete("rendered tail")
+        }
+
+        @Test func fallsBackToRawTextWhenSuffixCrossesALineBoundary() async {
+            let renderer = ControlledCodexChatMarkdownRenderer()
+            let model = CodexChatMarkdownProjectionModel(renderer: renderer)
+
+            model.submit(input("paragraph"))
+            await waitForRequest("paragraph", renderer: renderer)
+            await renderer.complete("paragraph")
+            await waitForProjection("paragraph", model: model)
+
+            model.submit(input("paragraph\n\n# Heading"))
+
+            #expect(model.canDisplayProjection)
+            #expect(!model.canDisplayPendingSuffix)
+            model.cancel()
+            await renderer.complete("paragraph\n\n# Heading")
+        }
+
+        @Test func publishesCompletedPrefixRenderAfterInputAdvances() async {
+            let renderer = ControlledCodexChatMarkdownRenderer()
+            let model = CodexChatMarkdownProjectionModel(renderer: renderer)
+
+            model.submit(input("Hello"))
+            await waitForRequest("Hello", renderer: renderer)
+            model.submit(input("Hello world"))
+            await renderer.complete("Hello")
+            await waitForProjection("Hello", model: model)
+
+            #expect(model.canDisplayProjection)
+            #expect(model.pendingSuffix == " world")
+            model.cancel()
+            await renderer.complete("Hello world")
+        }
+
+        @Test func appendsPendingSuffixToTheLastRenderedBlock() {
+            let block = CodexChatMarkdownRenderedBlock.paragraph(AttributedString("Hello"))
+
+            guard case let .paragraph(text) = block.appendingPendingSuffix(" world") else {
+                Issue.record("Expected a paragraph with an appended suffix")
+                return
+            }
+
+            #expect(String(text.characters) == "Hello world")
         }
 
         @Test func completionCachesExistingProjectionWithoutRenderingAgain() async {

--- a/Tests/DahliaTests/ControlledCodexChatMarkdownRenderer.swift
+++ b/Tests/DahliaTests/ControlledCodexChatMarkdownRenderer.swift
@@ -1,0 +1,41 @@
+#if canImport(Testing)
+    import Foundation
+    @testable import Dahlia
+
+    actor ControlledCodexChatMarkdownRenderer: CodexChatMarkdownRendering {
+        private var requests: [String] = []
+        private var cachedMarkdown: [String] = []
+        private var continuations: [String: CheckedContinuation<[CodexChatMarkdownRenderedBlock], Never>] = [:]
+
+        func blocks(
+            for markdown: String,
+            cacheResult _: Bool
+        ) async -> [CodexChatMarkdownRenderedBlock] {
+            requests.append(markdown)
+            return await withCheckedContinuation { continuation in
+                continuations[markdown] = continuation
+            }
+        }
+
+        func cache(
+            _: [CodexChatMarkdownRenderedBlock],
+            for markdown: String
+        ) {
+            cachedMarkdown.append(markdown)
+        }
+
+        func complete(_ markdown: String) {
+            continuations.removeValue(forKey: markdown)?.resume(
+                returning: [.paragraph(AttributedString(markdown))]
+            )
+        }
+
+        func requestedMarkdown() -> [String] {
+            requests
+        }
+
+        func cachedValues() -> [String] {
+            cachedMarkdown
+        }
+    }
+#endif

--- a/docs/adr/0008-render-streaming-chat-markdown-as-bounded-projection.md
+++ b/docs/adr/0008-render-streaming-chat-markdown-as-bounded-projection.md
@@ -1,0 +1,51 @@
+# ADR-0008: ストリーミングチャット Markdown を bounded UI projection として描画する
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-19
+
+## Context
+
+Codex チャットは自由形式 Markdown の delta を逐次受信するが、従来は生成中だけプレーンテキストを表示し、turn 完了後に Markdown
+へ切り替えていた。生成中から同期的に Markdown を解析すると、応答が伸びるたびに MainActor 上で全文の block 解析とインライン装飾生成を
+繰り返し、録音中の UI や操作を停滞させる可能性がある。また、更新ごとの全文を共有キャッシュへ保存すると、内容がほぼ同じ長文で固定容量を
+埋め、不要なメモリ使用を招く。
+
+[ADR-0002](0002-isolate-recording-critical-path-from-main-actor.md) は重い表示処理を MainActor から分離し、再生成可能な UI 投影を有界にする
+方針を定めている。[ADR-0003](0003-use-a-shared-codex-app-server.md) は raw Markdown delta の逐次表示と `item/completed` による最終本文の
+整合を要求している。本 ADR は両方を維持しながら Markdown 表示を逐次適用する方法を定める。
+
+## Decision
+
+- 結合済みの raw Markdown を会話内容の正本とし、解析済み block は破棄・再生成可能な UI projection とする。
+- block 解析と `AttributedString` の Markdown 変換は Markdown view ごとの専用 actor で直列化し、MainActor では入力の集約、完成した projection の状態更新、レイアウトだけを行う。
+- view ごとの coordinator は実行中の描画を 1 件、待機中の入力を置換可能な最新 1 件だけ保持する。古い delta の projection を FIFO で再生せず、別のメッセージやウインドウの描画も同じ actor で待たせない。
+- パーサーは block と行の処理中に cancellation を確認し、不要になった長文解析を有限時間で終了できるようにする。
+- ストリーミング途中の全文は共有キャッシュへ保存しない。`item/completed` と整合した完了済み Markdown だけを、件数と raw UTF-8 byte 数の両方に上限を持つキャッシュへ保存する。
+- 解析中は直前の projection と未描画の raw suffix を同時に表示する。非 prefix の置換または初回 projection では raw text 全体を fallback として表示する。
+- 直前の parse 結果と一致する先頭 block の `AttributedString` は再利用し、更新中の末尾 block だけを再変換する。
+
+## Invariants
+
+- 描画の集約、キャンセル、キャッシュ eviction は raw Markdown を変更しない。
+- turn の停止または失敗時も受信済みの raw Markdown を残す。
+- Markdown 描画は app-server transport、録音 runtime、文字起こし永続化を待たせない。
+- チャット本文と projection を診断ログや Sentry context に含めない。
+
+## Consequences
+
+- 生成中から見出し、リスト、引用、コード、インライン装飾が段階的に表示され、完了時の全面的な表示切り替えがなくなる。
+- delta ごとに MainActor で全文解析せず、古い解析要求とキャッシュ項目が無制限に蓄積しない。
+- Markdown 記法が未完の間は記号が一時的に表示され、後続 delta で構文が完成した時点で局所的に装飾が変わる。
+- 初めて表示する履歴メッセージは非同期 projection の準備まで短時間 raw text で表示される場合がある。
+- Foundation の単一 `AttributedString` 変換自体は途中キャンセルできないが、view ごとの actor に隔離するため、他のメッセージの描画や MainActor を待たせない。
+
+## Tests
+
+- 未完の Markdown と長文を parser、projection renderer、cache のテストで確認する。
+- ストリーミング断片をキャッシュせず、完了済み projection の件数と総コストが上限内に収まることを確認する。
+- coordinator が中間入力を集約し、古い結果を反映せず、未描画 suffix を維持し、完了時に同一本文を再解析しないことを確認する。

--- a/docs/adr/0008-render-streaming-chat-markdown-as-bounded-projection.md
+++ b/docs/adr/0008-render-streaming-chat-markdown-as-bounded-projection.md
@@ -26,7 +26,7 @@ Codex チャットは自由形式 Markdown の delta を逐次受信するが、
 - view ごとの coordinator は実行中の描画を 1 件、待機中の入力を置換可能な最新 1 件だけ保持する。古い delta の projection を FIFO で再生せず、別のメッセージやウインドウの描画も同じ actor で待たせない。
 - パーサーは block と行の処理中に cancellation を確認し、不要になった長文解析を有限時間で終了できるようにする。
 - ストリーミング途中の全文は共有キャッシュへ保存しない。`item/completed` と整合した完了済み Markdown だけを、件数と raw UTF-8 byte 数の両方に上限を持つキャッシュへ保存する。
-- 解析中は直前の projection と未描画の raw suffix を同時に表示する。非 prefix の置換または初回 projection では raw text 全体を fallback として表示する。
+- 解析中に完成した入力が現在の raw Markdown の prefix なら、その projection を採用する。同一行に続く未描画の raw suffix は最終 block の末尾要素へプレーンテキストとして結合し、別の行へ積まない。改行を跨ぐ suffix、suffix を結合できない block、非 prefix の置換、初回 projection では raw text 全体を fallback として表示する。
 - 直前の parse 結果と一致する先頭 block の `AttributedString` は再利用し、更新中の末尾 block だけを再変換する。
 
 ## Invariants


### PR DESCRIPTION
## Summary

- render assistant responses and reasoning as Markdown while they are still streaming
- move Markdown parsing and inline rendering off the main actor
- coalesce updates to one active render plus the latest pending input
- reuse stable rendered blocks and bound the completed-response cache by entry count and UTF-8 size
- keep newly arrived raw text visible while a projection is being prepared
- document the bounded projection architecture in ADR-0008

## Why

Streaming responses were displayed as plain text until completion and then changed abruptly to rendered Markdown. Rendering synchronously or queueing every streaming update could also make the app unresponsive for long responses.

This change keeps the presentation natural during generation while bounding work and isolating expensive conversion from the main actor.

## Validation

- `swift build`
- `swift test --filter CodexChatMarkdown` — 12 tests in 3 suites passed
- `CI=true ./scripts/lint.sh` — SwiftFormat clean; existing non-blocking SwiftLint warnings remain
- `git diff --check`
- full Swift Testing run executed 679 tests; the pre-existing environment-dependent `GoogleCalendarConfigurationTests.clientSecretOverrideIsPreferredOverEnvironment` issue remains unrelated to this change
