### PR TITLE
Fix AI chat overlay minimize control

### DIFF
--- a/Sources/Dahlia/Models/CodexChatFloatingLayout.swift
+++ b/Sources/Dahlia/Models/CodexChatFloatingLayout.swift
@@ -40,6 +40,14 @@ struct CodexChatFloatingLayout: Equatable {
         )
     }
 
+    func resizeHandlePosition(in availableSize: CGSize, dragTranslation: CGSize = .zero) -> CGPoint {
+        let origin = origin(in: availableSize, dragTranslation: dragTranslation)
+        return CGPoint(
+            x: dockSide == .right ? origin.x : origin.x + size.width,
+            y: origin.y
+        )
+    }
+
     private static func clamped(_ size: CGSize, availableSize: CGSize) -> CGSize {
         CGSize(
             width: min(max(size.width, minimumSize.width), max(minimumSize.width, availableSize.width - margin * 2)),

--- a/Sources/Dahlia/Views/CodexChat/CodexChatFloatingView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatFloatingView.swift
@@ -26,6 +26,10 @@ struct CodexChatFloatingView: View {
     var body: some View {
         GeometryReader { geometry in
             let origin = layout.origin(in: geometry.size, dragTranslation: dragTranslation)
+            let resizeHandlePosition = layout.resizeHandlePosition(
+                in: geometry.size,
+                dragTranslation: dragTranslation
+            )
             ZStack(alignment: .topLeading) {
                 CodexChatView(
                     session: coordinator.floatingSession,
@@ -55,10 +59,7 @@ struct CodexChatFloatingView: View {
                 )
 
                 CodexChatResizeHandle(layout: $layout, availableSize: geometry.size)
-                    .position(
-                        x: layout.dockSide == .right ? origin.x + 12 : origin.x + layout.size.width - 12,
-                        y: origin.y + 12
-                    )
+                    .position(resizeHandlePosition)
             }
             .onChange(of: geometry.size) {
                 layout.clamp(to: geometry.size)

--- a/Tests/DahliaTests/CodexChatFloatingLayoutTests.swift
+++ b/Tests/DahliaTests/CodexChatFloatingLayoutTests.swift
@@ -40,5 +40,16 @@ import CoreGraphics
             #expect(origin.x == 464)
             #expect(origin.y == 224)
         }
+
+        @Test
+        func resizeHandleStaysOnOuterTopCorner() {
+            let available = CGSize(width: 1000, height: 800)
+
+            let rightDockedLayout = CodexChatFloatingLayout(dockSide: .right)
+            #expect(rightDockedLayout.resizeHandlePosition(in: available) == CGPoint(x: 464, y: 224))
+
+            let leftDockedLayout = CodexChatFloatingLayout(dockSide: .left)
+            #expect(leftDockedLayout.resizeHandlePosition(in: available) == CGPoint(x: 536, y: 224))
+        }
     }
 #endif


### PR DESCRIPTION
## Summary

- move the floating chat resize hit target onto the outer window corner
- keep the resize target from overlapping header controls on either dock side
- add regression coverage for left- and right-docked handle positions

## Root cause

The transparent 24-by-24 resize handle was positioned fully inside the chat overlay. Depending on the dock side, part of that hit target overlapped a header button, including the minimize button, and intercepted clicks.

## User impact

The AI chat overlay's minimize button and adjacent header controls now respond consistently while corner resizing remains available.

## Validation

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter CodexChatFloatingLayoutTests` (4 tests passed)
- `swift build`
- `CI=true ./scripts/lint.sh` (completed with existing non-blocking warnings)
