### PR TITLE
Improve Codex chat live mode

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>24</string>
+    <string>25</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.5.8</string>
+    <string>0.5.9</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/Models/CodexChatPendingInput.swift
+++ b/Sources/Dahlia/Models/CodexChatPendingInput.swift
@@ -1,4 +1,21 @@
 enum CodexChatPendingInput {
     case manual(String)
     case liveTranscript(String, wasTruncated: Bool)
+
+    var isLiveTranscript: Bool {
+        if case .liveTranscript = self {
+            return true
+        }
+        return false
+    }
+
+    var manualText: String? {
+        guard case let .manual(text) = self else { return nil }
+        return text
+    }
+
+    var liveTranscript: String? {
+        guard case let .liveTranscript(text, _) = self else { return nil }
+        return text
+    }
 }

--- a/Sources/Dahlia/Services/CodexAppServerError.swift
+++ b/Sources/Dahlia/Services/CodexAppServerError.swift
@@ -33,4 +33,9 @@ enum CodexAppServerError: LocalizedError, Equatable {
         case .emptyResponse: L10n.llmErrorEmptyResponse
         }
     }
+
+    var isNoActiveTurnToSteer: Bool {
+        guard case let .rpcError(_, message) = self else { return false }
+        return message.caseInsensitiveCompare("no active turn to steer") == .orderedSame
+    }
 }

--- a/Sources/Dahlia/Services/CodexChatPromptCodec.swift
+++ b/Sources/Dahlia/Services/CodexChatPromptCodec.swift
@@ -9,6 +9,7 @@ enum CodexChatPromptCodec {
     private static let liveModeDescription = "  Live mode is enabled. You are receiving finalized live transcription from Dahlia."
     private static let hiddenLiveTranscriptDescription = "  This turn contains one hidden live transcript block."
     private static let liveTranscriptStart = "<live_transcript>"
+    private static let dahliaLiveTranscriptStart = "<live_transcript source=\"dahlia\">"
     private static let liveTranscriptEnd = "</live_transcript>"
 
     static func encode(text: String, context: CodexChatContext?) -> String {
@@ -24,15 +25,15 @@ enum CodexChatPromptCodec {
     static func encodeTextBlocks(
         text: String?,
         context: CodexChatContext?,
-        isLiveMode: Bool,
+        includesLiveModeContext: Bool,
         liveTranscript: String? = nil
     ) -> [String] {
         let liveTranscript = liveTranscript?.nilIfBlank
         var blocks: [String] = []
-        if context != nil || isLiveMode {
+        if context != nil || includesLiveModeContext {
             blocks.append(encodeContext(
                 context,
-                isLiveMode: isLiveMode,
+                isLiveMode: includesLiveModeContext,
                 containsLiveTranscript: liveTranscript != nil
             ))
         }
@@ -97,19 +98,21 @@ enum CodexChatPromptCodec {
     }
 
     static func decodeTextBlocks(_ textBlocks: [String]) -> (text: String, context: CodexChatContext?) {
-        guard let firstText = textBlocks.first else { return ("", nil) }
+        guard !textBlocks.isEmpty else { return ("", nil) }
         if let decoded = decodeLiveModeTextBlocks(textBlocks) {
             return decoded
         }
-        if textBlocks.count == 2,
-           let context = canonicalContext(from: firstText) {
-            return (textBlocks[1], context)
+        let visibleBlocks = textBlocks.filter { !isDahliaLiveTranscriptBlock($0) }
+        guard let firstVisibleBlock = visibleBlocks.first else { return ("", nil) }
+        if visibleBlocks.count == 2,
+           let context = canonicalContext(from: firstVisibleBlock) {
+            return (visibleBlocks[1], context)
         }
-        return decodeUserText(textBlocks.joined(separator: "\n"))
+        return decodeUserText(visibleBlocks.joined(separator: "\n"))
     }
 
     static func visibleUserText(from text: String) -> String {
-        decodeUserText(text).text
+        decodeTextBlocks([text]).text
     }
 
     private static func decodeLiveModeTextBlocks(
@@ -119,39 +122,64 @@ enum CodexChatPromptCodec {
               first.hasPrefix("<context>\n" + liveModeDescription + "\n"),
               first.hasSuffix("\n</context>") else { return nil }
 
-        let containsLiveTranscript = first.contains("\n" + hiddenLiveTranscriptDescription + "\n")
         var contextBlock = first.replacing(liveModeDescription + "\n", with: "")
         contextBlock = contextBlock.replacing(hiddenLiveTranscriptDescription + "\n", with: "")
         let context = contextBlock == "<context>\n</context>" ? nil : canonicalContext(from: contextBlock)
         guard context != nil || contextBlock == "<context>\n</context>" else { return nil }
 
         var visibleBlocks = Array(textBlocks.dropFirst())
-        if containsLiveTranscript,
-           let firstVisible = visibleBlocks.first,
-           isCanonicalLiveTranscriptBlock(firstVisible) {
+        if first.contains("\n" + hiddenLiveTranscriptDescription + "\n"),
+           let transcript = visibleBlocks.first,
+           isCanonicalLiveTranscriptBlock(transcript) {
             visibleBlocks.removeFirst()
         }
+        visibleBlocks.removeAll(where: isDahliaLiveTranscriptBlock)
         return (visibleBlocks.joined(separator: "\n"), context)
     }
 
     private static func liveTranscriptBlock(_ text: String) -> String {
-        liveTranscriptStart + escape(text) + liveTranscriptEnd
+        dahliaLiveTranscriptStart + escape(text) + liveTranscriptEnd
     }
 
     private static func isCanonicalLiveTranscriptBlock(_ block: String) -> Bool {
-        guard block.hasPrefix(liveTranscriptStart), block.hasSuffix(liveTranscriptEnd) else { return false }
-        let valueStart = block.index(block.startIndex, offsetBy: liveTranscriptStart.count)
+        isLiveTranscriptBlock(block, start: liveTranscriptStart)
+    }
+
+    private static func isDahliaLiveTranscriptBlock(_ block: String) -> Bool {
+        isLiveTranscriptBlock(block, start: dahliaLiveTranscriptStart)
+    }
+
+    private static func isLiveTranscriptBlock(_ block: String, start: String) -> Bool {
+        guard block.hasPrefix(start), block.hasSuffix(liveTranscriptEnd) else { return false }
+        let valueStart = block.index(block.startIndex, offsetBy: start.count)
         let valueEnd = block.index(block.endIndex, offsetBy: -liveTranscriptEnd.count)
         let encoded = String(block[valueStart ..< valueEnd])
-        return unescape(encoded).map(liveTranscriptBlock) == block
+        guard let decoded = unescape(encoded) else { return false }
+        return start + escape(decoded) + liveTranscriptEnd == block
     }
 
     private static func decodeUserText(_ text: String) -> (text: String, context: CodexChatContext?) {
+        if let decoded = decodeLiveModePrefix(from: text) {
+            return decoded
+        }
         let decoded = decode(text)
         if decoded.context != nil {
             return decoded
         }
         return decodeContextPrefix(from: text) ?? decoded
+    }
+
+    private static func decodeLiveModePrefix(from text: String) -> (text: String, context: CodexChatContext?)? {
+        guard text.hasPrefix("<context>\n" + liveModeDescription + "\n"),
+              let closingRange = text.range(of: contextClosingTag)
+        else { return nil }
+        let contextBlock = String(text[..<closingRange.upperBound])
+        guard let decodedContext = decodeLiveModeTextBlocks([contextBlock]) else { return nil }
+        let remainder = String(text[closingRange.upperBound...])
+        let visibleText = isCanonicalLiveTranscriptBlock(remainder) || isDahliaLiveTranscriptBlock(remainder)
+            ? ""
+            : remainder
+        return (visibleText, decodedContext.context)
     }
 
     private static func decodeContextPrefix(from text: String) -> (text: String, context: CodexChatContext)? {

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -6,6 +6,12 @@ private enum CodexChatFailedSubmission {
     case liveTranscript(String)
 }
 
+private struct CodexChatLiveModeSubmissionState {
+    let isEnabled: Bool
+    let includesContext: Bool
+    let generation: UInt
+}
+
 @MainActor
 @Observable
 final class CodexChatSessionModel: Identifiable {
@@ -38,6 +44,11 @@ final class CodexChatSessionModel: Identifiable {
     private(set) var meetingReferencesByID: [UUID: CodexChatMeetingReference] = [:]
     private(set) var isLiveModeEnabled = false
 
+    var liveModeEnabled: Bool {
+        get { isLiveModeEnabled }
+        set { setLiveModeEnabled(newValue) }
+    }
+
     @ObservationIgnored private let service: any CodexChatServicing
     @ObservationIgnored private let settings: AppSettings
     @ObservationIgnored private let contextProvider: any CodexChatContextProviding
@@ -49,6 +60,9 @@ final class CodexChatSessionModel: Identifiable {
     @ObservationIgnored private var didTruncatePendingLiveTranscript = false
     @ObservationIgnored private var pendingManualInputs: [String] = []
     @ObservationIgnored private var isActiveTurnLiveTranscript = false
+    @ObservationIgnored private var didSendLiveModeContext = false
+    @ObservationIgnored private var liveModeGeneration: UInt = 0
+    @ObservationIgnored private var activeSteerIsLiveTranscript = false
     @ObservationIgnored private var activeSubmissionID: UUID?
     @ObservationIgnored private var activeResponseID: String?
     @ObservationIgnored private var turnTask: Task<Void, Never>?
@@ -229,7 +243,7 @@ private extension CodexChatSessionModel {
         liveTranscript: String?,
         context: CodexChatContext?,
         responseID: String,
-        isLiveModeSnapshot: Bool,
+        liveModeState: CodexChatLiveModeSubmissionState,
         submissionID: UUID
     ) async -> Bool {
         let accumulator = CodexChatTurnAccumulator()
@@ -250,17 +264,23 @@ private extension CodexChatSessionModel {
             )
             try ensureSubmissionCanContinue(submissionID, liveTranscript: liveTranscript)
 
+            let promptContext = liveModeState.isEnabled && !liveModeState.includesContext ? nil : context
             let stream = try await service.send(
                 threadID: backendThreadID,
                 textBlocks: CodexChatPromptCodec.encodeTextBlocks(
                     text: text,
-                    context: context,
-                    isLiveMode: isLiveModeSnapshot,
+                    context: promptContext,
+                    includesLiveModeContext: liveModeState.includesContext,
                     liveTranscript: liveTranscript
                 ),
                 model: selectedModelID.nilIfBlank,
                 effort: selectedEffort
             )
+            if liveModeState.includesContext,
+               isLiveModeEnabled,
+               liveModeGeneration == liveModeState.generation {
+                didSendLiveModeContext = true
+            }
             try ensureSubmissionCanContinue(submissionID, liveTranscript: liveTranscript)
             let turnCompleted = try await consumeTurnEvents(
                 stream,
@@ -569,6 +589,11 @@ private extension CodexChatSessionModel {
         errorMessage = nil
         isActiveTurnLiveTranscript = liveTranscript != nil
         let isLiveModeSnapshot = liveTranscript != nil || isLiveModeEnabled
+        let liveModeState = CodexChatLiveModeSubmissionState(
+            isEnabled: isLiveModeSnapshot,
+            includesContext: liveTranscript != nil && isLiveModeSnapshot && !didSendLiveModeContext,
+            generation: liveModeGeneration
+        )
         let submissionID = UUID.v7()
         activeSubmissionID = submissionID
 
@@ -579,7 +604,7 @@ private extension CodexChatSessionModel {
                 draftSnapshot: draftSnapshot ?? text,
                 referenceIDsSnapshot: referenceIDsSnapshot,
                 liveTranscript: liveTranscript,
-                isLiveModeSnapshot: isLiveModeSnapshot,
+                liveModeState: liveModeState,
                 submissionID: submissionID
             )
         }
@@ -591,16 +616,16 @@ private extension CodexChatSessionModel {
         draftSnapshot: String,
         referenceIDsSnapshot: [UUID],
         liveTranscript: String?,
-        isLiveModeSnapshot: Bool,
+        liveModeState: CodexChatLiveModeSubmissionState,
         submissionID: UUID
     ) async {
         defer {
             finishGeneration(submissionID: submissionID)
         }
+        let shouldResolveContext = !liveModeState.isEnabled || liveModeState.includesContext
         let context: CodexChatContext?
         do {
-            guard let vaultID else { throw CodexAppServerError.invalidProtocolResponse }
-            context = try await contextProvider.currentContext(vaultID: vaultID)
+            context = try await resolveContext(if: shouldResolveContext)
             try ensureSubmissionCanContinue(submissionID, liveTranscript: liveTranscript)
         } catch is CancellationError {
             return
@@ -633,7 +658,7 @@ private extension CodexChatSessionModel {
             liveTranscript: liveTranscript,
             context: context,
             responseID: responseID,
-            isLiveModeSnapshot: isLiveModeSnapshot,
+            liveModeState: liveModeState,
             submissionID: submissionID
         )
         if replacedLiveModePlaceholderTitle {
@@ -644,7 +669,12 @@ private extension CodexChatSessionModel {
     func setLiveModeEnabled(_ isEnabled: Bool) {
         guard isLiveModeEnabled != isEnabled else { return }
         isLiveModeEnabled = isEnabled
+        liveModeGeneration &+= 1
+        didSendLiveModeContext = false
         if !isEnabled {
+            if activeSteerIsLiveTranscript {
+                steerTask?.cancel()
+            }
             pendingLiveTranscript = nil
             failedLiveTranscript = nil
             failedSubmission = nil
@@ -702,8 +732,15 @@ private extension CodexChatSessionModel {
         guard let backendThreadID,
               let activeTurnID,
               let input = dequeuePendingSteerInput() else { return }
+        let liveModeGenerationSnapshot = liveModeGeneration
+        activeSteerIsLiveTranscript = input.isLiveTranscript
         steerTask = Task { [weak self] in
-            await self?.steer(input, threadID: backendThreadID, turnID: activeTurnID)
+            await self?.steer(
+                input,
+                threadID: backendThreadID,
+                turnID: activeTurnID,
+                liveModeGenerationSnapshot: liveModeGenerationSnapshot
+            )
         }
     }
 
@@ -720,53 +757,94 @@ private extension CodexChatSessionModel {
         return .liveTranscript(transcript, wasTruncated: wasTruncated)
     }
 
-    func steer(_ input: CodexChatPendingInput, threadID: String, turnID: String) async {
+    func steer(
+        _ input: CodexChatPendingInput,
+        threadID: String,
+        turnID: String,
+        liveModeGenerationSnapshot: UInt
+    ) async {
         defer {
             steerTask = nil
+            activeSteerIsLiveTranscript = false
             processPendingInputIfPossible()
         }
         do {
-            guard let vaultID else { throw CodexAppServerError.invalidProtocolResponse }
-            let context = try await contextProvider.currentContext(vaultID: vaultID)
+            guard !input.isLiveTranscript || isLiveModeEnabled else { return }
+            let text = input.manualText
+            let liveTranscript = input.liveTranscript
+            let isLiveModeSnapshot = isLiveModeEnabled
+            let includesLiveModeContext = liveTranscript != nil
+                && isLiveModeSnapshot
+                && liveModeGeneration == liveModeGenerationSnapshot
+                && !didSendLiveModeContext
+            let shouldResolveContext = !isLiveModeSnapshot || includesLiveModeContext
+            let context = try await resolveContext(if: shouldResolveContext)
             guard !Task.isCancelled,
                   isGenerating,
                   activeTurnID == turnID,
                   backendThreadID == threadID else {
-                requeue(input)
+                requeue(input, liveModeGenerationSnapshot: liveModeGenerationSnapshot)
                 return
             }
 
-            let text: String?
-            let liveTranscript: String?
-            switch input {
-            case let .manual(manualText):
-                text = manualText
-                liveTranscript = nil
-            case let .liveTranscript(transcript, _):
-                guard isLiveModeEnabled else { return }
-                text = nil
-                liveTranscript = transcript
-            }
+            let promptContext = isLiveModeSnapshot && !includesLiveModeContext ? nil : context
             try await service.steer(
                 threadID: threadID,
                 turnID: turnID,
                 textBlocks: CodexChatPromptCodec.encodeTextBlocks(
                     text: text,
-                    context: context,
-                    isLiveMode: isLiveModeEnabled,
+                    context: promptContext,
+                    includesLiveModeContext: includesLiveModeContext,
                     liveTranscript: liveTranscript
                 )
             )
-            await applySuccessfulSteer(input, context: context)
-        } catch is CancellationError {
-            requeue(input)
-        } catch {
-            if !isGenerating || activeTurnID != turnID {
-                requeue(input)
-            } else {
-                errorMessage = error.localizedDescription
-                recordSteerFailure(input)
+            if input.isLiveTranscript {
+                guard !Task.isCancelled,
+                      isLiveModeEnabled,
+                      liveModeGeneration == liveModeGenerationSnapshot else { return }
             }
+            if includesLiveModeContext {
+                didSendLiveModeContext = true
+            }
+            await applySuccessfulSteer(input, context: promptContext)
+        } catch is CancellationError {
+            requeue(input, liveModeGenerationSnapshot: liveModeGenerationSnapshot)
+        } catch {
+            handleSteerFailure(
+                error,
+                input: input,
+                turnID: turnID,
+                liveModeGenerationSnapshot: liveModeGenerationSnapshot
+            )
+        }
+    }
+
+    func resolveContext(if isRequired: Bool) async throws -> CodexChatContext? {
+        guard isRequired else { return nil }
+        guard let vaultID else { throw CodexAppServerError.invalidProtocolResponse }
+        return try await contextProvider.currentContext(vaultID: vaultID)
+    }
+
+    func handleSteerFailure(
+        _ error: any Error,
+        input: CodexChatPendingInput,
+        turnID: String,
+        liveModeGenerationSnapshot: UInt
+    ) {
+        if let serverError = error as? CodexAppServerError,
+           serverError.isNoActiveTurnToSteer,
+           isGenerating,
+           activeTurnID == turnID {
+            activeTurnID = nil
+            requeue(input, liveModeGenerationSnapshot: liveModeGenerationSnapshot)
+            turnTask?.cancel()
+            finalizeActiveResponseForCancellation()
+            finishGeneration(submissionID: activeSubmissionID)
+        } else if !isGenerating || activeTurnID != turnID {
+            requeue(input, liveModeGenerationSnapshot: liveModeGenerationSnapshot)
+        } else {
+            errorMessage = error.localizedDescription
+            recordSteerFailure(input)
         }
     }
 
@@ -791,12 +869,16 @@ private extension CodexChatSessionModel {
         }
     }
 
-    func requeue(_ input: CodexChatPendingInput) {
+    func requeue(_ input: CodexChatPendingInput, liveModeGenerationSnapshot: UInt? = nil) {
         guard !isReleased else { return }
         switch input {
         case let .manual(text):
             pendingManualInputs.insert(text, at: 0)
         case let .liveTranscript(text, wasTruncated):
+            if let liveModeGenerationSnapshot,
+               !isLiveModeEnabled || liveModeGeneration != liveModeGenerationSnapshot {
+                return
+            }
             let combined = pendingLiveTranscript.map { text + "\n" + $0 } ?? text
             pendingLiveTranscript = String(combined.suffix(Self.maximumPendingLiveTranscriptCharacters))
             didTruncatePendingLiveTranscript = wasTruncated

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -7,8 +7,7 @@ private enum CodexChatFailedSubmission {
 }
 
 private struct CodexChatLiveModeSubmissionState {
-    let isEnabled: Bool
-    let includesContext: Bool
+    let isEnabled: Bool, includesContext: Bool
     let generation: UInt
 }
 
@@ -810,7 +809,7 @@ private extension CodexChatSessionModel {
         } catch is CancellationError {
             requeue(input, liveModeGenerationSnapshot: liveModeGenerationSnapshot)
         } catch {
-            handleSteerFailure(
+            await handleSteerFailure(
                 error,
                 input: input,
                 turnID: turnID,
@@ -830,22 +829,31 @@ private extension CodexChatSessionModel {
         input: CodexChatPendingInput,
         turnID: String,
         liveModeGenerationSnapshot: UInt
-    ) {
+    ) async {
         if let serverError = error as? CodexAppServerError,
            serverError.isNoActiveTurnToSteer,
            isGenerating,
            activeTurnID == turnID {
-            activeTurnID = nil
             requeue(input, liveModeGenerationSnapshot: liveModeGenerationSnapshot)
-            turnTask?.cancel()
-            finalizeActiveResponseForCancellation()
-            finishGeneration(submissionID: activeSubmissionID)
+            await reloadCompletedTurnAndRestart(turnID: turnID)
         } else if !isGenerating || activeTurnID != turnID {
             requeue(input, liveModeGenerationSnapshot: liveModeGenerationSnapshot)
         } else {
             errorMessage = error.localizedDescription
             recordSteerFailure(input)
         }
+    }
+
+    func reloadCompletedTurnAndRestart(turnID: String) async {
+        guard let backendThreadID,
+              let thread = try? await service.loadThread(id: backendThreadID),
+              isGenerating,
+              activeTurnID == turnID else { return }
+        apply(thread)
+        activeTurnID = nil
+        turnTask?.cancel()
+        finalizeActiveResponseForCancellation()
+        finishGeneration(submissionID: activeSubmissionID)
     }
 
     func applySuccessfulSteer(_ input: CodexChatPendingInput, context: CodexChatContext?) async {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
@@ -36,20 +36,6 @@ struct CodexChatComposer: View {
                         )
                     }
 
-                Button(L10n.chatLiveMode, systemImage: "waveform", action: session.toggleLiveMode)
-                    .labelStyle(.iconOnly)
-                    .buttonStyle(.plain)
-                    .foregroundStyle(session.isLiveModeEnabled ? Color.accentColor : .secondary)
-                    .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
-                    .background(
-                        session.isLiveModeEnabled ? Color.accentColor.opacity(0.16) : Color.secondary.opacity(0.08),
-                        in: Circle()
-                    )
-                    .contentShape(Circle())
-                    .disabled(!session.isBoundToCurrentVault)
-                    .help(session.isLiveModeEnabled ? L10n.disableChatLiveMode : L10n.enableChatLiveMode)
-                    .accessibilityValue(session.isLiveModeEnabled ? L10n.chatLiveModeOn : L10n.chatLiveModeOff)
-
                 TextField(L10n.messageCodex, text: $session.draft, axis: .vertical)
                     .font(.body)
                     .textFieldStyle(.plain)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatDesign.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatDesign.swift
@@ -3,6 +3,11 @@ import CoreGraphics
 enum CodexChatDesign {
     static let headerHeight: CGFloat = 44
     static let headerHorizontalPadding: CGFloat = 14
+    static let liveModeStatusSpacing: CGFloat = 6
+    static let liveModeStatusHorizontalPadding: CGFloat = 10
+    static let liveModeStatusVerticalPadding: CGFloat = 3
+    static let liveModeStatusCornerRadius: CGFloat = 8
+    static let liveModeStatusBottomPadding: CGFloat = 4
     static let contentHorizontalPadding: CGFloat = 16
     static let composerHorizontalPadding: CGFloat = 8
     static let composerBottomPadding: CGFloat = 8

--- a/Sources/Dahlia/Views/CodexChat/CodexChatLiveModeStatusView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatLiveModeStatusView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct CodexChatLiveModeStatusView: View {
+    @Binding var isEnabled: Bool
+    let isAvailable: Bool
+
+    var body: some View {
+        HStack(spacing: CodexChatDesign.liveModeStatusSpacing) {
+            Label(statusText, systemImage: "waveform")
+                .font(.subheadline)
+                .foregroundStyle(isEnabled ? Color.accentColor : .secondary)
+                .accessibilityHidden(true)
+
+            Spacer(minLength: CodexChatDesign.liveModeStatusSpacing)
+
+            Toggle(L10n.chatLiveMode, isOn: $isEnabled)
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .disabled(!isAvailable)
+                .accessibilityLabel(L10n.chatLiveMode)
+                .accessibilityValue(statusText)
+                .help(isEnabled ? L10n.disableChatLiveMode : L10n.enableChatLiveMode)
+        }
+        .padding(.horizontal, CodexChatDesign.liveModeStatusHorizontalPadding)
+        .padding(.vertical, CodexChatDesign.liveModeStatusVerticalPadding)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: CodexChatDesign.liveModeStatusCornerRadius))
+    }
+
+    private var statusText: String {
+        isEnabled ? L10n.chatLiveModeOn : L10n.chatLiveModeOff
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatView.swift
@@ -77,6 +77,13 @@ struct CodexChatView: View {
                     .padding(.vertical, 6)
             }
 
+            CodexChatLiveModeStatusView(
+                isEnabled: $session.liveModeEnabled,
+                isAvailable: session.isBoundToCurrentVault
+            )
+            .padding(.horizontal, CodexChatDesign.composerHorizontalPadding)
+            .padding(.bottom, CodexChatDesign.liveModeStatusBottomPadding)
+
             CodexChatComposer(session: session)
                 .padding(.horizontal, CodexChatDesign.composerHorizontalPadding)
                 .padding(.bottom, CodexChatDesign.composerBottomPadding)

--- a/Tests/DahliaTests/CodexChatLiveModeSessionTests.swift
+++ b/Tests/DahliaTests/CodexChatLiveModeSessionTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct CodexChatLiveModeSessionTests {
+        @Test
+        func manualMessageOmitsContextBeforeTheFirstTranscript() async {
+            let service = TestCodexChatService(mode: .staleRollout)
+            let settings = AppSettings()
+            settings.currentVault = Self.testVault()
+            let session = Self.session(service: service, settings: settings)
+
+            session.toggleLiveMode()
+            session.draft = "Manual question"
+            session.sendDraft()
+            await waitUntil { !session.isGenerating }
+
+            #expect(await service.sentTextBlocks == [["Manual question"]])
+
+            session.receiveFinalizedLiveTranscript("First live speech")
+            await waitUntil { !session.isGenerating }
+
+            #expect(await service.sentTextBlocks.last == [
+                TestCodexChatFixtures.liveTranscriptContext,
+                "<live_transcript source=\"dahlia\">First live speech</live_transcript>",
+            ])
+        }
+
+        @Test
+        func contextIsResolvedOnlyForTheFirstTranscriptOfEachSession() async throws {
+            let service = TestCodexChatService(mode: .staleRollout)
+            let settings = AppSettings()
+            settings.currentVault = Self.testVault()
+            let context = CodexChatContext.meeting(
+                id: try #require(UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")),
+                name: "Current meeting",
+                calendarEvent: nil
+            )
+            let contextProvider = TestCodexChatContextProvider(context: context)
+            let session = Self.session(
+                service: service,
+                settings: settings,
+                contextProvider: contextProvider
+            )
+
+            session.toggleLiveMode()
+            session.draft = "Manual question"
+            session.sendDraft()
+            await waitUntil { !session.isGenerating }
+
+            #expect(contextProvider.requestCount == 0)
+            #expect(session.messages.first(where: { $0.role == .user })?.context == nil)
+
+            session.receiveFinalizedLiveTranscript("First transcript")
+            await waitUntil { !session.isGenerating }
+            session.receiveFinalizedLiveTranscript("Second transcript")
+            await waitUntil { !session.isGenerating }
+
+            #expect(contextProvider.requestCount == 1)
+            #expect(await service.sentTextBlocks.suffix(2).map { $0.first } == [
+                CodexChatPromptCodec.encodeTextBlocks(
+                    text: nil,
+                    context: context,
+                    includesLiveModeContext: true,
+                    liveTranscript: "First transcript"
+                ).first,
+                "<live_transcript source=\"dahlia\">Second transcript</live_transcript>",
+            ])
+
+            session.disableLiveMode()
+            session.toggleLiveMode()
+            session.receiveFinalizedLiveTranscript("New session transcript")
+            await waitUntil { !session.isGenerating }
+
+            #expect(contextProvider.requestCount == 2)
+            #expect(await service.sentTextBlocks.last?.first == CodexChatPromptCodec.encodeTextBlocks(
+                text: nil,
+                context: context,
+                includesLiveModeContext: true,
+                liveTranscript: "New session transcript"
+            ).first)
+        }
+
+        @Test
+        func staleSendCannotMarkANewSessionAsContextualized() async {
+            let service = TestCodexChatService(mode: .delayFirstSendIgnoringCancellation)
+            let settings = AppSettings()
+            settings.currentVault = Self.testVault()
+            let session = Self.session(service: service, settings: settings)
+
+            session.toggleLiveMode()
+            session.receiveFinalizedLiveTranscript("Old session")
+            await waitUntilAsync { await service.isSendWaiting }
+
+            session.disableLiveMode()
+            session.toggleLiveMode()
+            session.receiveFinalizedLiveTranscript("New session")
+            await waitUntilAsync { await service.sentTextBlocks.count == 2 }
+            await service.resumeDelayedSend()
+            await waitUntil { !session.isGenerating }
+
+            let sentTextBlocks = await service.sentTextBlocks
+            #expect(sentTextBlocks[0].first == TestCodexChatFixtures.liveTranscriptContext)
+            #expect(sentTextBlocks[1].first == TestCodexChatFixtures.liveTranscriptContext)
+        }
+
+        private static func session(
+            service: TestCodexChatService,
+            settings: AppSettings,
+            contextProvider: any CodexChatContextProviding = TestCodexChatContextProvider()
+        ) -> CodexChatSessionModel {
+            CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings,
+                contextProvider: contextProvider
+            )
+        }
+
+        private static func testVault() -> VaultRecord {
+            VaultRecord(
+                id: .v7(),
+                path: "/tmp/chat-live-mode-session-test-vault",
+                name: "Chat Live Mode Session Test",
+                createdAt: .now,
+                lastOpenedAt: .now
+            )
+        }
+
+        private func waitUntil(_ predicate: @MainActor () -> Bool) async {
+            for _ in 0 ..< 1000 {
+                if predicate() { return }
+                await Task.yield()
+            }
+            Issue.record("Timed out waiting for chat state")
+        }
+
+        private func waitUntilAsync(_ predicate: @escaping @Sendable () async -> Bool) async {
+            for _ in 0 ..< 1000 {
+                if await predicate() { return }
+                await Task.yield()
+            }
+            Issue.record("Timed out waiting for async chat state")
+        }
+    }
+#endif

--- a/Tests/DahliaTests/CodexChatPromptCodecTests.swift
+++ b/Tests/DahliaTests/CodexChatPromptCodecTests.swift
@@ -10,18 +10,13 @@ import Foundation
             let blocks = CodexChatPromptCodec.encodeTextBlocks(
                 text: nil,
                 context: nil,
-                isLiveMode: true,
+                includesLiveModeContext: true,
                 liveTranscript: "Speaker & <guest>\nNext line"
             )
 
             #expect(blocks == [
-                """
-                <context>
-                  Live mode is enabled. You are receiving finalized live transcription from Dahlia.
-                  This turn contains one hidden live transcript block.
-                </context>
-                """,
-                "<live_transcript>Speaker &amp; &lt;guest&gt;&#10;Next line</live_transcript>",
+                TestCodexChatFixtures.liveTranscriptContext,
+                "<live_transcript source=\"dahlia\">Speaker &amp; &lt;guest&gt;&#10;Next line</live_transcript>",
             ])
             let decoded = CodexChatPromptCodec.decodeTextBlocks(blocks)
             #expect(decoded.text.isEmpty)
@@ -29,18 +24,40 @@ import Foundation
         }
 
         @Test
-        func manualCanonicalLiveTranscriptTagRemainsVisible() {
-            let manualText = "<live_transcript>keep this visible</live_transcript>"
+        func standaloneLiveTranscriptBlockIsHidden() {
             let blocks = CodexChatPromptCodec.encodeTextBlocks(
-                text: manualText,
+                text: nil,
                 context: nil,
-                isLiveMode: true
+                includesLiveModeContext: false,
+                liveTranscript: "keep this hidden"
             )
 
             let decoded = CodexChatPromptCodec.decodeTextBlocks(blocks)
 
-            #expect(decoded.text == manualText)
+            #expect(blocks == ["<live_transcript source=\"dahlia\">keep this hidden</live_transcript>"])
+            #expect(decoded.text.isEmpty)
             #expect(decoded.context == nil)
+        }
+
+        @Test
+        func manualCanonicalLiveTranscriptTagRemainsVisible() {
+            let manualText = "<live_transcript>keep this visible</live_transcript>"
+
+            #expect(CodexChatPromptCodec.decodeTextBlocks([manualText]).text == manualText)
+            #expect(CodexChatPromptCodec.visibleUserText(from: manualText) == manualText)
+        }
+
+        @Test
+        func flattenedLiveModeContextAndTranscriptAreHidden() {
+            let flattened = CodexChatPromptCodec.encodeTextBlocks(
+                text: nil,
+                context: nil,
+                includesLiveModeContext: true,
+                liveTranscript: "Hidden speech"
+            ).joined()
+
+            #expect(CodexChatPromptCodec.decodeTextBlocks([flattened]).text.isEmpty)
+            #expect(CodexChatPromptCodec.visibleUserText(from: flattened).isEmpty)
         }
 
         @Test
@@ -48,7 +65,7 @@ import Foundation
             let blocks = CodexChatPromptCodec.encodeTextBlocks(
                 text: "Please summarize that",
                 context: nil,
-                isLiveMode: true
+                includesLiveModeContext: true
             )
 
             let decoded = CodexChatPromptCodec.decodeTextBlocks(blocks)

--- a/Tests/DahliaTests/CodexChatSessionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatSessionModelTests.swift
@@ -25,30 +25,25 @@ import Foundation
             #expect(session.messages.allSatisfy { $0.role == .assistant })
             #expect(await service.sentTextBlocks == [
                 [
-                    """
-                    <context>
-                      Live mode is enabled. You are receiving finalized live transcription from Dahlia.
-                      This turn contains one hidden live transcript block.
-                    </context>
-                    """,
-                    "<live_transcript>Finalized speech</live_transcript>",
+                    TestCodexChatFixtures.liveTranscriptContext,
+                    "<live_transcript source=\"dahlia\">Finalized speech</live_transcript>",
                 ],
             ])
             #expect(await service.threadNames == [L10n.chatLiveMode])
+
+            session.receiveFinalizedLiveTranscript("More finalized speech")
+            await waitUntil { !session.isGenerating }
+
+            #expect(await service.sentTextBlocks.last == [
+                "<live_transcript source=\"dahlia\">More finalized speech</live_transcript>",
+            ])
 
             session.draft = "A visible question"
             session.sendDraft()
             await waitUntil { !session.isGenerating }
 
             #expect(session.messages.filter { $0.role == .user }.map(\.text) == ["A visible question"])
-            #expect(await service.sentTextBlocks.last == [
-                """
-                <context>
-                  Live mode is enabled. You are receiving finalized live transcription from Dahlia.
-                </context>
-                """,
-                "A visible question",
-            ])
+            #expect(await service.sentTextBlocks.last == ["A visible question"])
             #expect(session.title == "A visible question")
             #expect(await service.threadNames == [L10n.chatLiveMode, "A visible question"])
         }
@@ -640,7 +635,7 @@ import Foundation
 
             let sentTextBlocks = await service.sentTextBlocks
             #expect(sentTextBlocks[1].last == "Manual recovery")
-            #expect(await service.steeredTextBlocks[0].last == "<live_transcript>Failed live speech</live_transcript>")
+            #expect(await service.steeredTextBlocks[0].last == "<live_transcript source=\"dahlia\">Failed live speech</live_transcript>")
             #expect(session.failedLiveTranscript == nil)
         }
 
@@ -710,22 +705,30 @@ import Foundation
             case staleRollout
             case rolloutWithoutReasoning
             case multipleMessages
+            case delayFirstSendIgnoringCancellation
         }
 
         let mode: Mode
+        private var steerErrors: [CodexAppServerError]
         private(set) var sentTextBlocks: [[String]] = []
         private(set) var steeredTextBlocks: [[String]] = []
         private(set) var threadNames: [String] = []
         private(set) var interruptCount = 0
         private(set) var unsubscribedThreadIDs: [String] = []
         private var blockedContinuation: AsyncThrowingStream<CodexChatTurnEvent, any Error>.Continuation?
+        private var delayedSendContinuation: CheckedContinuation<Void, Never>?
 
         var unsubscribeCount: Int {
             unsubscribedThreadIDs.count
         }
 
-        init(mode: Mode) {
+        var isSendWaiting: Bool {
+            delayedSendContinuation != nil
+        }
+
+        init(mode: Mode, steerErrors: [CodexAppServerError] = []) {
             self.mode = mode
+            self.steerErrors = steerErrors
         }
 
         func models(forceRefresh _: Bool) async throws -> [CodexModel] {
@@ -739,7 +742,8 @@ import Foundation
         func loadThread(id: String) async throws -> CodexChatThread {
             let assistantMessages: [CodexChatMessage] = switch mode {
             case .complete, .block, .burstThenBlock, .bufferedBurstThenInterrupt,
-                 .finishesWithoutTerminal, .interruptedThenBlock, .failThenComplete, .alwaysFail:
+                 .finishesWithoutTerminal, .interruptedThenBlock, .failThenComplete, .alwaysFail,
+                 .delayFirstSendIgnoringCancellation:
                 [CodexChatMessage(role: .assistant, text: "Final answer", reasoning: "Considered the question")]
             case .rolloutWithoutReasoning:
                 [CodexChatMessage(role: .assistant, text: "Final answer")]
@@ -789,6 +793,11 @@ import Foundation
             effort _: String
         ) async throws -> AsyncThrowingStream<CodexChatTurnEvent, any Error> {
             sentTextBlocks.append(textBlocks)
+            if mode == .delayFirstSendIgnoringCancellation, sentTextBlocks.count == 1 {
+                await withCheckedContinuation { continuation in
+                    delayedSendContinuation = continuation
+                }
+            }
             if mode == .failThenComplete, sentTextBlocks.count == 1 {
                 throw CodexAppServerError.invalidProtocolResponse
             }
@@ -798,7 +807,8 @@ import Foundation
             let (stream, continuation) = AsyncThrowingStream<CodexChatTurnEvent, any Error>.makeStream()
             continuation.yield(.started(turnID: "turn-1"))
             switch mode {
-            case .complete, .staleRollout, .rolloutWithoutReasoning, .failThenComplete, .alwaysFail:
+            case .complete, .staleRollout, .rolloutWithoutReasoning, .failThenComplete, .alwaysFail,
+                 .delayFirstSendIgnoringCancellation:
                 continuation.yield(.reasoningDelta(
                     itemID: "reasoning-1",
                     summaryIndex: 0,
@@ -849,12 +859,20 @@ import Foundation
 
         func steer(threadID _: String, turnID _: String, textBlocks: [String]) async throws {
             steeredTextBlocks.append(textBlocks)
+            if !steerErrors.isEmpty {
+                throw steerErrors.removeFirst()
+            }
         }
 
         func completeBlockedTurn() {
             blockedContinuation?.yield(.completed(itemID: nil, text: nil))
             blockedContinuation?.finish()
             blockedContinuation = nil
+        }
+
+        func resumeDelayedSend() {
+            delayedSendContinuation?.resume()
+            delayedSendContinuation = nil
         }
 
         func unsubscribe(threadID: String) async {
@@ -877,7 +895,7 @@ import Foundation
     }
 
     @MainActor
-    private final class TestCodexChatContextProvider: CodexChatContextProviding {
+    final class TestCodexChatContextProvider: CodexChatContextProviding {
         var context: CodexChatContext?
         var error: CodexAppServerError?
         var requestCount = 0

--- a/Tests/DahliaTests/CodexChatSteeringTests.swift
+++ b/Tests/DahliaTests/CodexChatSteeringTests.swift
@@ -19,9 +19,9 @@ import Foundation
 
             await waitUntilAsync { await service.steeredTextBlocks.count == 2 }
 
-            #expect(await service.steeredTextBlocks.map(\.last) == [
-                "<live_transcript>second</live_transcript>",
-                "<live_transcript>third</live_transcript>",
+            #expect(await service.steeredTextBlocks == [
+                ["<live_transcript source=\"dahlia\">second</live_transcript>"],
+                ["<live_transcript source=\"dahlia\">third</live_transcript>"],
             ])
             session.disableLiveMode()
             await waitUntil { !session.isGenerating }
@@ -67,8 +67,38 @@ import Foundation
             await waitUntilAsync { await service.steeredTextBlocks.count == 1 }
 
             #expect(session.draft == "Still editing")
-            #expect(await service.steeredTextBlocks[0].last == "<live_transcript>send immediately</live_transcript>")
+            #expect(await service.sentTextBlocks == [["Initial request"]])
+            #expect(await service.steeredTextBlocks[0] == [
+                TestCodexChatFixtures.liveTranscriptContext,
+                "<live_transcript source=\"dahlia\">send immediately</live_transcript>",
+            ])
             session.stop()
+            await waitUntil { !session.isGenerating }
+        }
+
+        @Test
+        func liveTranscriptStartsANewTurnWhenTheActiveTurnFinishedBeforeSteering() async {
+            let service = TestCodexChatService(
+                mode: .block,
+                steerErrors: [.rpcError(code: nil, message: "no active turn to steer")]
+            )
+            let session = makeSession(service: service)
+
+            session.toggleLiveMode()
+            session.receiveFinalizedLiveTranscript("first")
+            await waitUntil { session.activeTurnID != nil }
+
+            session.receiveFinalizedLiveTranscript("send on the next turn")
+            await waitUntilAsync { await service.steeredTextBlocks.count == 1 }
+            await waitUntilAsync { await service.sentTextBlocks.count == 2 }
+
+            #expect(await service.sentTextBlocks[1] == [
+                "<live_transcript source=\"dahlia\">send on the next turn</live_transcript>",
+            ])
+            #expect(session.isGenerating)
+            #expect(session.errorMessage == nil)
+
+            session.disableLiveMode()
             await waitUntil { !session.isGenerating }
         }
 

--- a/Tests/DahliaTests/CodexChatSteeringTests.swift
+++ b/Tests/DahliaTests/CodexChatSteeringTests.swift
@@ -95,6 +95,7 @@ import Foundation
             #expect(await service.sentTextBlocks[1] == [
                 "<live_transcript source=\"dahlia\">send on the next turn</live_transcript>",
             ])
+            #expect(session.messages.contains { $0.role == .assistant && $0.text == "Final answer" })
             #expect(session.isGenerating)
             #expect(session.errorMessage == nil)
 

--- a/Tests/DahliaTests/TestCodexChatFixtures.swift
+++ b/Tests/DahliaTests/TestCodexChatFixtures.swift
@@ -1,6 +1,13 @@
 @testable import Dahlia
 
 enum TestCodexChatFixtures {
+    static let liveTranscriptContext = """
+    <context>
+      Live mode is enabled. You are receiving finalized live transcription from Dahlia.
+      This turn contains one hidden live transcript block.
+    </context>
+    """
+
     private static let historyUserPrompt = """
     <context>
       You are viewing a meeting in the Dahlia App.


### PR DESCRIPTION
## Summary

- add a compact live mode status and toggle directly above the Codex chat composer
- send live mode context only with the first finalized transcript of each live session and omit it from manual input
- hide Dahlia-generated context and live transcript blocks without hiding manually entered canonical tags
- recover from `no active turn to steer` by starting the queued transcript in a new turn
- bump the app version to 0.5.9 (build 25)

## Why

Live mode prompt metadata was visible in chat, context was repeated more often than necessary, and the composer did not clearly communicate whether live mode was active. A steering race could also surface `no active turn to steer`, while stale asynchronous completions could incorrectly mark a newly restarted live session as already contextualized.

The prompt decoder previously could not distinguish Dahlia-generated transcript blocks from a user manually entering the same tag. Generated blocks now carry explicit Dahlia provenance so internal transcripts remain hidden without dropping user text.

## Validation

- `swift test --filter CodexChat` — 101 tests passed across 17 suites
- dedicated live mode session tests — 3 passed
- steering tests — 4 passed
- `swift build` — passed
- `git diff --check` — passed
- SwiftFormat — 0 files require formatting
- SwiftLint completed; only existing repository-wide non-blocking violations remain
