### PR TITLE
Handle expired Databricks authentication

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>25</string>
+    <string>26</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.5.9</string>
+    <string>0.5.10</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -738,7 +738,7 @@
 "Could not update the Codex configuration: %@" = "Could not update the Codex configuration: %@";
 "Codex is configured for Databricks" = "Codex is configured for Databricks";
 "The selected AI account is not ready. Open AI Connection in Settings and finish its configuration." = "The selected AI account is not ready. Open AI Connection in Settings and finish its configuration.";
-"Dahlia writes the selected profile to its Codex configuration. Tokens remain managed by Databricks CLI." = "Dahlia writes the selected profile to its Codex configuration. Tokens remain managed by Databricks CLI.";
+"Codex uses this Databricks CLI profile. Browser sign-in opens when authentication expires." = "Codex uses this Databricks CLI profile. Browser sign-in opens when authentication expires.";
 "Codex returned no available models. Try again." = "Codex returned no available models. Try again.";
 "Models are loaded from the bundled Codex app-server." = "Models are loaded from the bundled Codex app-server.";
 "The saved model is used when available; otherwise Codex's default model is selected." = "The saved model is used when available; otherwise Codex's default model is selected.";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -738,7 +738,7 @@
 "Could not update the Codex configuration: %@" = "Codex 設定を更新できませんでした: %@";
 "Codex is configured for Databricks" = "Codex を Databricks 用に設定しました";
 "The selected AI account is not ready. Open AI Connection in Settings and finish its configuration." = "選択した AI アカウントの準備が完了していません。設定の「AI 接続」を開き、設定を完了してください。";
-"Dahlia writes the selected profile to its Codex configuration. Tokens remain managed by Databricks CLI." = "Dahlia は、選択したプロファイルを専用 Codex 設定へ書き込みます。トークンは Databricks CLI が引き続き管理します。";
+"Codex uses this Databricks CLI profile. Browser sign-in opens when authentication expires." = "Codex はこの Databricks CLI プロファイルを使用します。認証の有効期限が切れた場合は、ブラウザでのサインインを開きます。";
 "Codex returned no available models. Try again." = "Codex から利用可能なモデルが返されませんでした。再試行してください。";
 "Models are loaded from the bundled Codex app-server." = "モデルは同梱 Codex app-server から取得します。";
 "The saved model is used when available; otherwise Codex's default model is selected." = "保存済みモデルが利用可能なら使用し、それ以外は Codex のデフォルトモデルを選択します。";

--- a/Sources/Dahlia/Services/CodexConfigurationManager.swift
+++ b/Sources/Dahlia/Services/CodexConfigurationManager.swift
@@ -22,10 +22,7 @@ struct CodexConfigurationManager {
 
     @discardableResult
     func configureDatabricks(profile: DatabricksCLIClient.Profile) throws -> Bool {
-        guard let profileName = profile.name.nilIfBlank else {
-            throw CodexConfigurationError.databricksProfileRequired
-        }
-        let workspaceURL = try normalizedWorkspaceURL(profile.host)
+        let (profileName, workspaceURL) = try validatedDatabricksValues(profile: profile)
         let baseURL = workspaceURL.appending(path: "ai-gateway/codex/v1").absoluteString
         let tokenCommand = "databricks auth token --profile \(shellQuote(profileName)) --output json "
             + "| /usr/bin/plutil -extract access_token raw -o - -"
@@ -45,6 +42,19 @@ struct CodexConfigurationManager {
         """ + "\n"
 
         return try writeIfChanged(Data(configuration.utf8))
+    }
+
+    func validateDatabricks(profile: DatabricksCLIClient.Profile) throws {
+        _ = try validatedDatabricksValues(profile: profile)
+    }
+
+    private func validatedDatabricksValues(
+        profile: DatabricksCLIClient.Profile
+    ) throws -> (profileName: String, workspaceURL: URL) {
+        guard let profileName = profile.name.nilIfBlank else {
+            throw CodexConfigurationError.databricksProfileRequired
+        }
+        return try (profileName, normalizedWorkspaceURL(profile.host))
     }
 
     private func normalizedWorkspaceURL(_ value: String?) throws -> URL {

--- a/Sources/Dahlia/Services/DatabricksCLIClient.swift
+++ b/Sources/Dahlia/Services/DatabricksCLIClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 struct DatabricksCLIClient {
     struct CommandOutput {
@@ -50,7 +51,11 @@ struct DatabricksCLIClient {
             guard let executableURL else {
                 throw DatabricksCLIError.cliNotInstalled
             }
-            return try await Self.execute(executableURL: executableURL, arguments: arguments)
+            return try await Self.execute(
+                executableURL: executableURL,
+                arguments: arguments,
+                capturesStandardOutput: arguments.prefix(2) != ["auth", "token"]
+            )
         }
     }
 
@@ -59,15 +64,13 @@ struct DatabricksCLIClient {
     }
 
     func profiles() async throws -> [Profile] {
-        let output = try await runCommand([
+        let output = try await runValidatedCommand([
             "auth",
             "profiles",
             "--skip-validate",
             "--output",
             "json",
         ])
-        try Task.checkCancellation()
-        try validate(output)
 
         guard let response = try? JSONDecoder().decode(ProfilesResponse.self, from: output.standardOutput) else {
             throw DatabricksCLIError.invalidProfilesResponse
@@ -77,23 +80,56 @@ struct DatabricksCLIClient {
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
     }
 
+    func ensureAuthenticated(profileName: String) async throws {
+        let tokenArguments = [
+            "auth",
+            "token",
+            "--profile",
+            profileName,
+            "--output",
+            "json",
+        ]
+        let tokenOutput = try await runCommand(tokenArguments)
+        try Task.checkCancellation()
+        guard tokenOutput.terminationStatus != 0 else { return }
+        guard requiresBrowserLogin(tokenOutput) else {
+            try validate(tokenOutput)
+            return
+        }
+
+        _ = try await runValidatedCommand([
+            "auth",
+            "login",
+            "--profile",
+            profileName,
+        ])
+        _ = try await runValidatedCommand(tokenArguments)
+    }
+
     static func locateExecutable(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL? {
         CommandLineToolLocator.executableURL(named: "databricks", environment: environment)
     }
 
-    private static func execute(executableURL: URL, arguments: [String]) async throws -> CommandOutput {
+    private static func execute(
+        executableURL: URL,
+        arguments: [String],
+        capturesStandardOutput: Bool
+    ) async throws -> CommandOutput {
         let process = Process()
-        let standardOutput = Pipe()
+        let launchState = OSAllocatedUnfairLock(initialState: false)
+        let standardOutput = capturesStandardOutput ? Pipe() : nil
         let standardError = Pipe()
         process.executableURL = executableURL
         process.arguments = arguments
-        process.standardOutput = standardOutput
+        process.standardOutput = standardOutput ?? FileHandle.nullDevice
         process.standardError = standardError
 
-        let standardOutputTask = Task { try await readToEnd(standardOutput.fileHandleForReading) }
+        let standardOutputTask = standardOutput.map { pipe in
+            Task { try await readToEnd(pipe.fileHandleForReading) }
+        }
         let standardErrorTask = Task { try await readToEnd(standardError.fileHandleForReading) }
         defer {
-            standardOutputTask.cancel()
+            standardOutputTask?.cancel()
             standardErrorTask.cancel()
         }
 
@@ -112,20 +148,31 @@ struct DatabricksCLIClient {
                     continuation.resume(returning: process.terminationStatus)
                 }
                 do {
-                    try process.run()
+                    let didLaunch = try launchState.withLock { isCancelled in
+                        guard !isCancelled else { return false }
+                        try process.run()
+                        return true
+                    }
+                    if !didLaunch {
+                        process.terminationHandler = nil
+                        continuation.resume(throwing: CancellationError())
+                    }
                 } catch {
                     process.terminationHandler = nil
                     continuation.resume(throwing: error)
                 }
             }
         } onCancel: {
-            if process.isRunning {
-                process.terminate()
+            launchState.withLock { isCancelled in
+                isCancelled = true
+                if process.isRunning {
+                    process.terminate()
+                }
             }
         }
         try Task.checkCancellation()
 
-        let outputData = try await standardOutputTask.value
+        let outputData = try await standardOutputTask?.value ?? Data()
         let errorData = try await standardErrorTask.value
         return CommandOutput(
             standardOutput: outputData,
@@ -135,10 +182,10 @@ struct DatabricksCLIClient {
     }
 
     private static func closeParentWriteHandles(
-        standardOutput: Pipe,
+        standardOutput: Pipe?,
         standardError: Pipe
     ) {
-        try? standardOutput.fileHandleForWriting.close()
+        try? standardOutput?.fileHandleForWriting.close()
         try? standardError.fileHandleForWriting.close()
     }
 
@@ -170,12 +217,29 @@ struct DatabricksCLIClient {
         return data
     }
 
+    private func runValidatedCommand(_ arguments: [String]) async throws -> CommandOutput {
+        let output = try await runCommand(arguments)
+        try Task.checkCancellation()
+        try validate(output)
+        return output
+    }
+
     private func validate(_ output: CommandOutput) throws {
         guard output.terminationStatus == 0 else {
             let detail = String(data: output.standardError, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             throw DatabricksCLIError.commandFailed(detail: detail?.nilIfBlank)
         }
+    }
+
+    private func requiresBrowserLogin(_ output: CommandOutput) -> Bool {
+        guard let detail = String(data: output.standardError, encoding: .utf8)?.lowercased() else {
+            return false
+        }
+        // These are Databricks CLI's explicit diagnostics for a missing cached login
+        // or an invalid refresh token. Other failures need their original error.
+        return detail.contains("refresh token is invalid")
+            || detail.contains("databricks oauth is not configured for this host")
     }
 
     private struct ProfilesResponse: Decodable {

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1238,7 +1238,7 @@ enum L10n {
         bundle: bundle
     ) }
     static var databricksCodexDescription: String { String(
-        localized: "Dahlia writes the selected profile to its Codex configuration. Tokens remain managed by Databricks CLI.",
+        localized: "Codex uses this Databricks CLI profile. Browser sign-in opens when authentication expires.",
         bundle: bundle
     ) }
     static var codexNoModels: String { String(localized: "Codex returned no available models. Try again.", bundle: bundle) }

--- a/Sources/Dahlia/ViewModels/DatabricksAccountController.swift
+++ b/Sources/Dahlia/ViewModels/DatabricksAccountController.swift
@@ -82,6 +82,7 @@ final class DatabricksAccountController {
 
         do {
             try Task.checkCancellation()
+            try configurationManager.validateDatabricks(profile: profile)
             try await client.ensureAuthenticated(profileName: profile.name)
             try Task.checkCancellation()
             configurationStore.invalidateCodexAccountConfiguration()

--- a/Sources/Dahlia/ViewModels/DatabricksAccountController.swift
+++ b/Sources/Dahlia/ViewModels/DatabricksAccountController.swift
@@ -82,6 +82,8 @@ final class DatabricksAccountController {
 
         do {
             try Task.checkCancellation()
+            try await client.ensureAuthenticated(profileName: profile.name)
+            try Task.checkCancellation()
             configurationStore.invalidateCodexAccountConfiguration()
             if try configurationManager.configureDatabricks(profile: profile) {
                 try await service.reloadConfiguration()

--- a/Tests/DahliaTests/DatabricksAccountControllerTests.swift
+++ b/Tests/DahliaTests/DatabricksAccountControllerTests.swift
@@ -136,6 +136,38 @@ import Foundation
             await service.shutdown()
         }
 
+        @Test
+        func invalidWorkspaceDoesNotStartBrowserLogin() async {
+            let rootURL = FileManager.default.temporaryDirectory
+                .appending(path: "dahlia-databricks-invalid-workspace-\(UUID().uuidString)", directoryHint: .isDirectory)
+            defer { try? FileManager.default.removeItem(at: rootURL) }
+            let profileResponse = Data(
+                #"{"profiles":[{"name":"DEFAULT","auth_type":"databricks-cli"}]}"#.utf8
+            )
+            let responder = ControllerAuthenticationResponder(profileResponse: profileResponse)
+            let client = DatabricksCLIClient { arguments in
+                await responder.run(arguments)
+            }
+            let service = CodexAppServerService {
+                TestCodexAppServerTransport(mode: .models)
+            }
+            let controller = DatabricksAccountController(
+                client: client,
+                configurationManager: CodexConfigurationManager(
+                    homeLocator: ApplicationSupportCodexHomeLocator(applicationSupportURL: rootURL)
+                ),
+                service: service,
+                configurationStore: TestCodexAccountConfigurationStore()
+            )
+
+            _ = await controller.prepare(profileName: "DEFAULT")
+
+            #expect(!controller.isConfigured)
+            #expect(controller.errorMessage == L10n.databricksWorkspaceURLInvalid)
+            #expect(await responder.commands.count == 1)
+            await service.shutdown()
+        }
+
         private actor ControllerAuthenticationResponder {
             private(set) var commands: [[String]] = []
             private let profileResponse: Data

--- a/Tests/DahliaTests/DatabricksAccountControllerTests.swift
+++ b/Tests/DahliaTests/DatabricksAccountControllerTests.swift
@@ -94,5 +94,75 @@ import Foundation
             #expect(configurationStore.configuredProviderRawValue == AIAccountProvider.databricks.rawValue)
             await service.shutdown()
         }
+
+        @Test
+        func failedBrowserLoginPreservesExistingConfiguration() async throws {
+            let rootURL = FileManager.default.temporaryDirectory
+                .appending(path: "dahlia-databricks-login-failure-\(UUID().uuidString)", directoryHint: .isDirectory)
+            defer { try? FileManager.default.removeItem(at: rootURL) }
+            let locator = ApplicationSupportCodexHomeLocator(applicationSupportURL: rootURL)
+            let configURL = try locator.homeURL().appending(path: "config.toml")
+            let originalConfiguration = Data("existing configuration".utf8)
+            try originalConfiguration.write(to: configURL)
+            let profileResponse = Data(
+                #"{"profiles":[{"name":"DEFAULT","host":"https://dbc.example.com","auth_type":"databricks-cli"}]}"#.utf8
+            )
+            let responder = ControllerAuthenticationResponder(profileResponse: profileResponse)
+            let client = DatabricksCLIClient { arguments in
+                await responder.run(arguments)
+            }
+            let service = CodexAppServerService {
+                TestCodexAppServerTransport(mode: .models)
+            }
+            let configurationStore = TestCodexAccountConfigurationStore(
+                configuredProvider: .databricks,
+                configuredDatabricksProfile: "DEFAULT"
+            )
+            let controller = DatabricksAccountController(
+                client: client,
+                configurationManager: CodexConfigurationManager(homeLocator: locator),
+                service: service,
+                configurationStore: configurationStore
+            )
+
+            _ = await controller.prepare(profileName: "DEFAULT")
+
+            #expect(FileManager.default.contents(atPath: configURL.path) == originalConfiguration)
+            #expect(configurationStore.configuredProviderRawValue == AIAccountProvider.databricks.rawValue)
+            #expect(configurationStore.configuredDatabricksProfile == "DEFAULT")
+            #expect(!controller.isConfigured)
+            #expect(controller.errorMessage?.contains("browser login timed out") == true)
+            #expect(await responder.commands.count == 3)
+            await service.shutdown()
+        }
+
+        private actor ControllerAuthenticationResponder {
+            private(set) var commands: [[String]] = []
+            private let profileResponse: Data
+
+            init(profileResponse: Data) {
+                self.profileResponse = profileResponse
+            }
+
+            func run(_ arguments: [String]) -> DatabricksCLIClient.CommandOutput {
+                commands.append(arguments)
+                return switch commands.count {
+                case 1:
+                    .init(standardOutput: profileResponse, standardError: Data(), terminationStatus: 0)
+                case 2:
+                    .init(
+                        standardOutput: Data(),
+                        standardError: Data("cache: databricks OAuth is not configured for this host".utf8),
+                        terminationStatus: 1
+                    )
+                default:
+                    .init(
+                        standardOutput: Data(),
+                        standardError: Data("browser login timed out".utf8),
+                        terminationStatus: 1
+                    )
+                }
+            }
+        }
     }
 #endif

--- a/Tests/DahliaTests/DatabricksCLIClientTests.swift
+++ b/Tests/DahliaTests/DatabricksCLIClientTests.swift
@@ -55,6 +55,153 @@ import Foundation
         }
 
         @Test
+        func validCachedCredentialsDoNotStartBrowserLogin() async throws {
+            let recorder = CommandRecorder()
+            let client = DatabricksCLIClient { arguments in
+                await recorder.record(arguments)
+                return .init(standardOutput: Data(), standardError: Data(), terminationStatus: 0)
+            }
+
+            try await client.ensureAuthenticated(profileName: "DEFAULT")
+
+            #expect(await recorder.commands == [
+                [
+                    "auth",
+                    "token",
+                    "--profile",
+                    "DEFAULT",
+                    "--output",
+                    "json",
+                ],
+            ])
+        }
+
+        @Test
+        func missingCredentialsStartBrowserLoginAndRecheckToken() async throws {
+            let responder = ScriptedCommandResponder(outputs: [
+                .failure("cache: databricks OAuth is not configured for this host"),
+                .success(),
+                .success(),
+            ])
+            let client = DatabricksCLIClient { arguments in
+                await responder.run(arguments)
+            }
+
+            try await client.ensureAuthenticated(profileName: "Team Profile")
+
+            #expect(await responder.commands == [
+                [
+                    "auth",
+                    "token",
+                    "--profile",
+                    "Team Profile",
+                    "--output",
+                    "json",
+                ],
+                [
+                    "auth",
+                    "login",
+                    "--profile",
+                    "Team Profile",
+                ],
+                [
+                    "auth",
+                    "token",
+                    "--profile",
+                    "Team Profile",
+                    "--output",
+                    "json",
+                ],
+            ])
+        }
+
+        @Test
+        func unrelatedTokenFailureDoesNotStartBrowserLogin() async {
+            let responder = ScriptedCommandResponder(outputs: [
+                .failure("TLS handshake failed"),
+            ])
+            let client = DatabricksCLIClient { arguments in
+                await responder.run(arguments)
+            }
+
+            await #expect(throws: DatabricksCLIError.self) {
+                try await client.ensureAuthenticated(profileName: "DEFAULT")
+            }
+            #expect(await responder.commands.count == 1)
+        }
+
+        @Test
+        func browserLoginFailureIsReportedWithoutRecheckingToken() async {
+            let responder = ScriptedCommandResponder(outputs: [
+                .failure("A new access token could not be retrieved because the refresh token is invalid."),
+                .failure("browser login timed out"),
+            ])
+            let client = DatabricksCLIClient { arguments in
+                await responder.run(arguments)
+            }
+
+            do {
+                try await client.ensureAuthenticated(profileName: "DEFAULT")
+                Issue.record("Expected browser login to fail")
+            } catch {
+                #expect(error.localizedDescription.contains("browser login timed out"))
+            }
+            #expect(await responder.commands.count == 2)
+        }
+
+        @Test
+        func tokenFailureAfterBrowserLoginIsReported() async {
+            let responder = ScriptedCommandResponder(outputs: [
+                .failure("A new access token could not be retrieved because the refresh token is invalid."),
+                .success(),
+                .failure("token still unavailable"),
+            ])
+            let client = DatabricksCLIClient { arguments in
+                await responder.run(arguments)
+            }
+
+            do {
+                try await client.ensureAuthenticated(profileName: "DEFAULT")
+                Issue.record("Expected token recheck to fail")
+            } catch {
+                #expect(error.localizedDescription.contains("token still unavailable"))
+            }
+            #expect(await responder.commands.count == 3)
+        }
+
+        @Test
+        func cancellingBrowserLoginDoesNotRecheckToken() async {
+            let loginStarted = AsyncStream.makeStream(of: Void.self)
+            let releaseLogin = AsyncStream.makeStream(of: Void.self)
+            let recorder = CommandRecorder()
+            let client = DatabricksCLIClient { arguments in
+                await recorder.record(arguments)
+                if arguments.prefix(2) == ["auth", "token"] {
+                    return .failure("A new access token could not be retrieved because the refresh token is invalid.")
+                }
+                loginStarted.continuation.yield()
+                for await _ in releaseLogin.stream {
+                    break
+                }
+                return .success()
+            }
+
+            let authentication = Task {
+                try await client.ensureAuthenticated(profileName: "DEFAULT")
+            }
+            for await _ in loginStarted.stream {
+                break
+            }
+            authentication.cancel()
+            releaseLogin.continuation.yield()
+
+            await #expect(throws: CancellationError.self) {
+                try await authentication.value
+            }
+            #expect(await recorder.commands.count == 2)
+        }
+
+        @Test
         func commandLineToolSearchPathIncludesHomebrewLocationsOnce() {
             let searchPath = CommandLineToolLocator.searchPath(environment: [
                 "PATH": "/usr/bin:/opt/homebrew/bin",
@@ -87,6 +234,30 @@ import Foundation
             func record(_ arguments: [String]) {
                 commands.append(arguments)
             }
+        }
+
+        private actor ScriptedCommandResponder {
+            private(set) var commands: [[String]] = []
+            private var outputs: [DatabricksCLIClient.CommandOutput]
+
+            init(outputs: [DatabricksCLIClient.CommandOutput]) {
+                self.outputs = outputs
+            }
+
+            func run(_ arguments: [String]) -> DatabricksCLIClient.CommandOutput {
+                commands.append(arguments)
+                return outputs.removeFirst()
+            }
+        }
+    }
+
+    private extension DatabricksCLIClient.CommandOutput {
+        static func success() -> Self {
+            .init(standardOutput: Data(), standardError: Data(), terminationStatus: 0)
+        }
+
+        static func failure(_ message: String) -> Self {
+            .init(standardOutput: Data(), standardError: Data(message.utf8), terminationStatus: 1)
         }
     }
 #endif


### PR DESCRIPTION
## Summary

- validate the selected Databricks CLI profile before applying Codex configuration
- open browser login only for missing or expired CLI credentials, then recheck the token
- make CLI process cancellation race-safe and avoid retaining token stdout
- add localized guidance and bump Dahlia to 0.5.10 (26)

## Root cause

Databricks profiles were listed with validation skipped, so expired OAuth credentials were only discovered later by Codex and surfaced as a misleading provider configuration error.

## Impact

Users with expired Databricks CLI credentials are prompted through `databricks auth login --profile <profile>` instead of seeing a configuration error. Other CLI, TLS, or profile failures retain their original diagnostics.

## Validation

- `swift test --filter DatabricksCLIClientTests` (10 tests passed)
- `swift test --filter DatabricksAccountControllerTests` (3 tests passed)
- `swift build`
- `CI=true ./scripts/lint.sh` (SwiftFormat clean; SwiftLint reported only existing non-blocking warnings)
- `plutil -lint Resources/Info.plist`
