### PR TITLE
Fix floating chat window interactions

### DIFF
--- a/Sources/Dahlia/Models/CodexChatFloatingLayout.swift
+++ b/Sources/Dahlia/Models/CodexChatFloatingLayout.swift
@@ -7,32 +7,68 @@ struct CodexChatFloatingLayout: Equatable {
 
     var size: CGSize
     var dockSide: CodexChatDockSide
+    private var undockedOriginX: CGFloat?
 
     init(size: CGSize = Self.defaultSize, dockSide: CodexChatDockSide = .right) {
         self.size = size
         self.dockSide = dockSide
     }
 
-    mutating func resize(translation: CGSize, availableSize: CGSize) {
-        let widthDelta = dockSide == .right ? -translation.width : translation.width
-        size = Self.clamped(
-            CGSize(width: size.width + widthDelta, height: size.height - translation.height),
-            availableSize: availableSize
-        )
+    mutating func resize(
+        from edge: CodexChatResizeEdge,
+        translation: CGSize,
+        availableSize: CGSize
+    ) {
+        let wasDocked = undockedOriginX == nil
+        let initialFrame = frame(in: availableSize)
+        var left = initialFrame.minX
+        var right = initialFrame.maxX
+        var top = initialFrame.minY
+
+        if edge.resizesLeft {
+            left = min(
+                max(Self.margin, initialFrame.minX + translation.width),
+                initialFrame.maxX - Self.minimumSize.width
+            )
+        } else if edge.resizesRight {
+            right = min(
+                max(initialFrame.minX + Self.minimumSize.width, initialFrame.maxX + translation.width),
+                max(initialFrame.minX + Self.minimumSize.width, availableSize.width - Self.margin)
+            )
+        }
+
+        if edge.resizesTop {
+            top = min(
+                max(Self.margin, initialFrame.minY + translation.height),
+                initialFrame.maxY - Self.minimumSize.height
+            )
+        }
+
+        size = CGSize(width: right - left, height: initialFrame.maxY - top)
+        if edge.resizesLeft || edge.resizesRight {
+            let preservesDock = wasDocked && (
+                dockSide == .left && edge.resizesRight ||
+                    dockSide == .right && edge.resizesLeft
+            )
+            undockedOriginX = preservesDock ? nil : left
+        }
     }
 
     mutating func snap(horizontalCenter: CGFloat, availableWidth: CGFloat) {
         dockSide = horizontalCenter < availableWidth / 2 ? .left : .right
+        undockedOriginX = nil
     }
 
     mutating func clamp(to availableSize: CGSize) {
         size = Self.clamped(size, availableSize: availableSize)
+        if let undockedOriginX {
+            let maximumX = max(Self.margin, availableSize.width - size.width - Self.margin)
+            self.undockedOriginX = min(max(Self.margin, undockedOriginX), maximumX)
+        }
     }
 
     func origin(in availableSize: CGSize, dragTranslation: CGSize = .zero) -> CGPoint {
-        let baseX = dockSide == .left
-            ? Self.margin
-            : max(Self.margin, availableSize.width - size.width - Self.margin)
+        let baseX = undockedOriginX ?? dockedOriginX(in: availableSize)
         let maximumX = max(Self.margin, availableSize.width - size.width - Self.margin)
         return CGPoint(
             x: min(max(Self.margin, baseX + dragTranslation.width), maximumX),
@@ -40,12 +76,14 @@ struct CodexChatFloatingLayout: Equatable {
         )
     }
 
-    func resizeHandlePosition(in availableSize: CGSize, dragTranslation: CGSize = .zero) -> CGPoint {
-        let origin = origin(in: availableSize, dragTranslation: dragTranslation)
-        return CGPoint(
-            x: dockSide == .right ? origin.x : origin.x + size.width,
-            y: origin.y
-        )
+    func frame(in availableSize: CGSize) -> CGRect {
+        CGRect(origin: origin(in: availableSize), size: size)
+    }
+
+    private func dockedOriginX(in availableSize: CGSize) -> CGFloat {
+        dockSide == .left
+            ? Self.margin
+            : max(Self.margin, availableSize.width - size.width - Self.margin)
     }
 
     private static func clamped(_ size: CGSize, availableSize: CGSize) -> CGSize {

--- a/Sources/Dahlia/Models/CodexChatFloatingLayout.swift
+++ b/Sources/Dahlia/Models/CodexChatFloatingLayout.swift
@@ -46,8 +46,10 @@ struct CodexChatFloatingLayout: Equatable {
 
         size = CGSize(width: right - left, height: initialFrame.maxY - top)
         if edge.resizesLeft || edge.resizesRight {
+            let horizontalEdgeMoved = left != initialFrame.minX || right != initialFrame.maxX
             let preservesDock = wasDocked && (
-                dockSide == .left && edge.resizesRight ||
+                !horizontalEdgeMoved ||
+                    dockSide == .left && edge.resizesRight ||
                     dockSide == .right && edge.resizesLeft
             )
             undockedOriginX = preservesDock ? nil : left

--- a/Sources/Dahlia/Models/CodexChatResizeEdge.swift
+++ b/Sources/Dahlia/Models/CodexChatResizeEdge.swift
@@ -1,0 +1,52 @@
+import AppKit
+
+enum CodexChatResizeEdge: CaseIterable, Hashable {
+    case top
+    case left
+    case right
+    case topLeft
+    case topRight
+
+    var cursor: NSCursor {
+        let position: NSCursor.FrameResizePosition = switch self {
+        case .top:
+            .top
+        case .left:
+            .left
+        case .right:
+            .right
+        case .topLeft:
+            .topLeft
+        case .topRight:
+            .topRight
+        }
+        return .frameResize(position: position, directions: .all)
+    }
+
+    var resizesTop: Bool {
+        switch self {
+        case .top, .topLeft, .topRight:
+            true
+        case .left, .right:
+            false
+        }
+    }
+
+    var resizesLeft: Bool {
+        switch self {
+        case .left, .topLeft:
+            true
+        case .top, .right, .topRight:
+            false
+        }
+    }
+
+    var resizesRight: Bool {
+        switch self {
+        case .right, .topRight:
+            true
+        case .top, .left, .topLeft:
+            false
+        }
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatDesign.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatDesign.swift
@@ -13,6 +13,11 @@ enum CodexChatDesign {
     static let composerBottomPadding: CGFloat = 8
     static let composerCornerRadius: CGFloat = 22
     static let controlSize: CGFloat = 30
+    static let headerControlSize: CGFloat = 28
+    static let resizeAccessibilityStep: CGFloat = 20
+    static let resizeHandleOutset: CGFloat = 8
+    static let resizeEdgeThickness: CGFloat = 8
+    static let resizeCornerSize: CGFloat = 12
     static let configurationPanelWidth: CGFloat = 252
     static let configurationPanelHeight: CGFloat = 278
     static let modelPanelWidth: CGFloat = 216

--- a/Sources/Dahlia/Views/CodexChat/CodexChatFloatingView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatFloatingView.swift
@@ -26,11 +26,9 @@ struct CodexChatFloatingView: View {
     var body: some View {
         GeometryReader { geometry in
             let origin = layout.origin(in: geometry.size, dragTranslation: dragTranslation)
-            let resizeHandlePosition = layout.resizeHandlePosition(
-                in: geometry.size,
-                dragTranslation: dragTranslation
-            )
-            ZStack(alignment: .topLeading) {
+            let restingOrigin = layout.origin(in: geometry.size)
+            let interactionSize = CodexChatResizeHandles.interactionSize(for: layout.size)
+            ZStack {
                 CodexChatView(
                     session: coordinator.floatingSession,
                     coordinator: coordinator,
@@ -42,28 +40,37 @@ struct CodexChatFloatingView: View {
                     onPopOut: popOut,
                     onHide: coordinator.hideFloating,
                     onOpenHistory: openHistory,
-                    onHeaderDragChanged: { dragTranslation = $0 },
+                    onHeaderDragChanged: updateDragging,
                     onHeaderDragEnded: { finishDragging($0, availableSize: geometry.size) }
                 )
                 .frame(width: layout.size.width, height: layout.size.height)
-                .clipShape(RoundedRectangle(cornerRadius: 24))
-                .contentShape(.interaction, RoundedRectangle(cornerRadius: 24))
+                .clipShape(.rect(cornerRadius: 24))
+                .contentShape(.interaction, .rect(cornerRadius: 24))
                 .overlay {
                     RoundedRectangle(cornerRadius: 24)
                         .stroke(.separator.opacity(0.6), lineWidth: 1)
                 }
                 .shadow(color: .black.opacity(0.18), radius: 22, y: 8)
-                .position(
-                    x: origin.x + layout.size.width / 2,
-                    y: origin.y + layout.size.height / 2
-                )
 
-                CodexChatResizeHandle(layout: $layout, availableSize: geometry.size)
-                    .position(resizeHandlePosition)
+                CodexChatResizeHandles(layout: $layout, availableSize: geometry.size)
             }
+            .frame(width: interactionSize.width, height: interactionSize.height)
+            .position(
+                x: restingOrigin.x + layout.size.width / 2,
+                y: restingOrigin.y + layout.size.height / 2
+            )
+            .offset(x: origin.x - restingOrigin.x)
             .onChange(of: geometry.size) {
                 layout.clamp(to: geometry.size)
             }
+        }
+    }
+
+    private func updateDragging(_ translation: CGSize) {
+        var transaction = Transaction()
+        transaction.animation = nil
+        withTransaction(transaction) {
+            dragTranslation = translation
         }
     }
 

--- a/Sources/Dahlia/Views/CodexChat/CodexChatIconButton.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatIconButton.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct CodexChatIconButton: View {
     let label: String
     let systemImage: String
-    var size: CGFloat = 28
+    var size = CodexChatDesign.headerControlSize
     let action: () -> Void
 
     @State private var isHovering = false

--- a/Sources/Dahlia/Views/CodexChat/CodexChatResizeHandle.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatResizeHandle.swift
@@ -3,27 +3,55 @@ import SwiftUI
 struct CodexChatResizeHandle: View {
     @Binding var layout: CodexChatFloatingLayout
     let availableSize: CGSize
+    let edge: CodexChatResizeEdge
 
     @State private var resizeStart: CodexChatFloatingLayout?
+    @State private var isHovering = false
 
     var body: some View {
         Color.clear
-            .frame(width: 24, height: 24)
             .contentShape(Rectangle())
             .gesture(
-                DragGesture()
+                DragGesture(minimumDistance: 0)
                     .onChanged(resize)
-                    .onEnded { _ in resizeStart = nil }
+                    .onEnded(endResize)
             )
-            .accessibilityLabel(L10n.resize)
+            .onHover(perform: updateHover)
+            .onDisappear(perform: resetCursor)
     }
 
     private func resize(_ value: DragGesture.Value) {
         if resizeStart == nil {
             resizeStart = layout
+            edge.cursor.set()
         }
         guard var resized = resizeStart else { return }
-        resized.resize(translation: value.translation, availableSize: availableSize)
-        layout = resized
+        resized.resize(from: edge, translation: value.translation, availableSize: availableSize)
+        var transaction = Transaction()
+        transaction.animation = nil
+        withTransaction(transaction) {
+            layout = resized
+        }
+    }
+
+    private func endResize(_: DragGesture.Value) {
+        resizeStart = nil
+        (isHovering ? edge.cursor : .arrow).set()
+    }
+
+    private func updateHover(_ hovering: Bool) {
+        guard hovering != isHovering else { return }
+        isHovering = hovering
+        if hovering {
+            edge.cursor.set()
+        } else if resizeStart == nil {
+            NSCursor.arrow.set()
+        }
+    }
+
+    private func resetCursor() {
+        if isHovering || resizeStart != nil {
+            NSCursor.arrow.set()
+        }
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatResizeHandles.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatResizeHandles.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+struct CodexChatResizeHandles: View {
+    @Binding var layout: CodexChatFloatingLayout
+    let availableSize: CGSize
+
+    var body: some View {
+        let interactionSize = Self.interactionSize(for: layout.size)
+
+        ZStack(alignment: .topLeading) {
+            ForEach(CodexChatResizeEdge.allCases, id: \.self) { edge in
+                let frame = Self.frame(for: edge, in: layout.size)
+                CodexChatResizeHandle(layout: $layout, availableSize: availableSize, edge: edge)
+                    .frame(width: frame.width, height: frame.height)
+                    .position(x: frame.midX, y: frame.midY)
+                    .accessibilityHidden(edge != .top)
+                    .accessibilityLabel(L10n.resize)
+                    .accessibilityValue(accessibilityValue)
+                    .accessibilityAdjustableAction { direction in
+                        guard edge == .top else { return }
+                        adjustSize(direction)
+                    }
+            }
+        }
+        .frame(width: interactionSize.width, height: interactionSize.height)
+    }
+
+    nonisolated static func frame(for edge: CodexChatResizeEdge, in size: CGSize) -> CGRect {
+        let outset = CodexChatDesign.resizeHandleOutset
+        let edgeThickness = CodexChatDesign.resizeEdgeThickness
+        let cornerSize = CodexChatDesign.resizeCornerSize
+        let cornerOffset = cornerSize / 2
+        return switch edge {
+        case .top:
+            CGRect(
+                x: outset + cornerOffset,
+                y: 0,
+                width: max(0, size.width - cornerSize),
+                height: edgeThickness
+            )
+        case .left:
+            CGRect(
+                x: 0,
+                y: outset + cornerOffset,
+                width: edgeThickness,
+                height: max(0, size.height - cornerOffset)
+            )
+        case .right:
+            CGRect(
+                x: outset + size.width,
+                y: outset + cornerOffset,
+                width: edgeThickness,
+                height: max(0, size.height - cornerOffset)
+            )
+        case .topLeft:
+            CGRect(x: outset - cornerOffset, y: outset - cornerOffset, width: cornerSize, height: cornerSize)
+        case .topRight:
+            CGRect(
+                x: outset + size.width - cornerOffset,
+                y: outset - cornerOffset,
+                width: cornerSize,
+                height: cornerSize
+            )
+        }
+    }
+
+    nonisolated static func interactionSize(for contentSize: CGSize) -> CGSize {
+        let inset = CodexChatDesign.resizeHandleOutset * 2
+        return CGSize(width: contentSize.width + inset, height: contentSize.height + inset)
+    }
+
+    nonisolated static func contentFrame(for contentSize: CGSize) -> CGRect {
+        let outset = CodexChatDesign.resizeHandleOutset
+        return CGRect(origin: CGPoint(x: outset, y: outset), size: contentSize)
+    }
+
+    private func adjustSize(_ direction: AccessibilityAdjustmentDirection) {
+        let multiplier: CGFloat
+        switch direction {
+        case .increment:
+            multiplier = 1
+        case .decrement:
+            multiplier = -1
+        @unknown default:
+            return
+        }
+        let step = CodexChatDesign.resizeAccessibilityStep * multiplier
+        let edge: CodexChatResizeEdge = layout.dockSide == .left ? .topRight : .topLeft
+        let horizontalTranslation = layout.dockSide == .left ? step : -step
+        var resized = layout
+        resized.resize(
+            from: edge,
+            translation: CGSize(width: horizontalTranslation, height: -step),
+            availableSize: availableSize
+        )
+        layout = resized
+    }
+
+    private var accessibilityValue: String {
+        "\(Int(layout.size.width.rounded())) × \(Int(layout.size.height.rounded()))"
+    }
+}

--- a/Tests/DahliaTests/CodexChatFloatingLayoutTests.swift
+++ b/Tests/DahliaTests/CodexChatFloatingLayoutTests.swift
@@ -21,11 +21,131 @@ import CoreGraphics
             var layout = CodexChatFloatingLayout(dockSide: .right)
             let available = CGSize(width: 900, height: 700)
 
-            layout.resize(translation: CGSize(width: 1000, height: 1000), availableSize: available)
+            layout.resize(
+                from: .topLeft,
+                translation: CGSize(width: 1000, height: 1000),
+                availableSize: available
+            )
             #expect(layout.size == CodexChatFloatingLayout.minimumSize)
 
-            layout.resize(translation: CGSize(width: -2000, height: -2000), availableSize: available)
+            layout.resize(
+                from: .topLeft,
+                translation: CGSize(width: -2000, height: -2000),
+                availableSize: available
+            )
             #expect(layout.size == CGSize(width: 868, height: 668))
+        }
+
+        @Test
+        func topResizeMovesOnlyTopEdge() {
+            var layout = CodexChatFloatingLayout(dockSide: .right)
+            let available = CGSize(width: 1000, height: 800)
+            let initialFrame = layout.frame(in: available)
+
+            layout.resize(from: .top, translation: CGSize(width: 200, height: 100), availableSize: available)
+            let resizedFrame = layout.frame(in: available)
+
+            #expect(resizedFrame.minX == initialFrame.minX)
+            #expect(resizedFrame.maxX == initialFrame.maxX)
+            #expect(resizedFrame.minY == initialFrame.minY + 100)
+            #expect(resizedFrame.maxY == initialFrame.maxY)
+        }
+
+        @Test
+        func topResizePreservesRightDockAcrossAvailableWidthChanges() {
+            var layout = CodexChatFloatingLayout(dockSide: .right)
+
+            layout.resize(
+                from: .top,
+                translation: CGSize(width: 0, height: 100),
+                availableSize: CGSize(width: 1000, height: 800)
+            )
+
+            let widerAvailableSize = CGSize(width: 1200, height: 800)
+            #expect(layout.origin(in: widerAvailableSize).x == 664)
+        }
+
+        @Test
+        func leftResizeMovesOnlyLeftEdge() {
+            var layout = CodexChatFloatingLayout(dockSide: .right)
+            let available = CGSize(width: 1000, height: 800)
+            let initialFrame = layout.frame(in: available)
+
+            layout.resize(from: .left, translation: CGSize(width: 100, height: 200), availableSize: available)
+            let resizedFrame = layout.frame(in: available)
+
+            #expect(resizedFrame.minX == initialFrame.minX + 100)
+            #expect(resizedFrame.maxX == initialFrame.maxX)
+            #expect(resizedFrame.minY == initialFrame.minY)
+            #expect(resizedFrame.maxY == initialFrame.maxY)
+        }
+
+        @Test
+        func rightResizeMovesOnlyRightEdge() {
+            var layout = CodexChatFloatingLayout(dockSide: .left)
+            let available = CGSize(width: 1000, height: 800)
+            let initialFrame = layout.frame(in: available)
+
+            layout.resize(from: .right, translation: CGSize(width: 100, height: 200), availableSize: available)
+            let resizedFrame = layout.frame(in: available)
+
+            #expect(resizedFrame.minX == initialFrame.minX)
+            #expect(resizedFrame.maxX == initialFrame.maxX + 100)
+            #expect(resizedFrame.minY == initialFrame.minY)
+            #expect(resizedFrame.maxY == initialFrame.maxY)
+        }
+
+        @Test
+        func innerEdgeResizePreservesDockAcrossAvailableWidthChanges() {
+            var rightDockedLayout = CodexChatFloatingLayout(dockSide: .right)
+            var leftDockedLayout = CodexChatFloatingLayout(dockSide: .left)
+            let initialAvailableSize = CGSize(width: 1000, height: 800)
+
+            rightDockedLayout.resize(
+                from: .left,
+                translation: CGSize(width: 100, height: 0),
+                availableSize: initialAvailableSize
+            )
+            leftDockedLayout.resize(
+                from: .right,
+                translation: CGSize(width: 100, height: 0),
+                availableSize: initialAvailableSize
+            )
+
+            let widerAvailableSize = CGSize(width: 1200, height: 800)
+            #expect(rightDockedLayout.origin(in: widerAvailableSize).x == 764)
+            #expect(leftDockedLayout.origin(in: widerAvailableSize).x == CodexChatFloatingLayout.margin)
+        }
+
+        @Test
+        func cornerResizeMovesBothRequestedEdges() {
+            var topLeftLayout = CodexChatFloatingLayout(dockSide: .right)
+            var topRightLayout = CodexChatFloatingLayout(dockSide: .left)
+            let available = CGSize(width: 1000, height: 800)
+            let topLeftInitialFrame = topLeftLayout.frame(in: available)
+            let topRightInitialFrame = topRightLayout.frame(in: available)
+
+            topLeftLayout.resize(
+                from: .topLeft,
+                translation: CGSize(width: 100, height: 100),
+                availableSize: available
+            )
+            topRightLayout.resize(
+                from: .topRight,
+                translation: CGSize(width: 100, height: 100),
+                availableSize: available
+            )
+            let topLeftFrame = topLeftLayout.frame(in: available)
+            let topRightFrame = topRightLayout.frame(in: available)
+
+            #expect(topLeftFrame.minX == topLeftInitialFrame.minX + 100)
+            #expect(topLeftFrame.maxX == topLeftInitialFrame.maxX)
+            #expect(topLeftFrame.minY == topLeftInitialFrame.minY + 100)
+            #expect(topLeftFrame.maxY == topLeftInitialFrame.maxY)
+            #expect(topRightFrame.minX == topRightInitialFrame.minX)
+            #expect(topRightFrame.maxX == topRightInitialFrame.maxX + 100)
+            #expect(topRightFrame.minY == topRightInitialFrame.minY + 100)
+            #expect(topRightFrame.maxY == topRightInitialFrame.maxY)
         }
 
         @Test
@@ -42,14 +162,46 @@ import CoreGraphics
         }
 
         @Test
-        func resizeHandleStaysOnOuterTopCorner() {
+        func snappingAfterOuterEdgeResizeRestoresDockedOrigin() {
             let available = CGSize(width: 1000, height: 800)
+            var layout = CodexChatFloatingLayout(dockSide: .right)
 
-            let rightDockedLayout = CodexChatFloatingLayout(dockSide: .right)
-            #expect(rightDockedLayout.resizeHandlePosition(in: available) == CGPoint(x: 464, y: 224))
+            layout.resize(from: .right, translation: CGSize(width: -100, height: 0), availableSize: available)
+            #expect(layout.origin(in: available).x == 464)
+            #expect(layout.origin(in: CGSize(width: 1200, height: 800)).x == 464)
 
-            let leftDockedLayout = CodexChatFloatingLayout(dockSide: .left)
-            #expect(leftDockedLayout.resizeHandlePosition(in: available) == CGPoint(x: 536, y: 224))
+            layout.snap(horizontalCenter: 200, availableWidth: available.width)
+            #expect(layout.dockSide == .left)
+            #expect(layout.origin(in: available).x == CodexChatFloatingLayout.margin)
+        }
+
+        @Test
+        func resizeHandlesDoNotOverlapMinimizeButton() {
+            let size = CodexChatFloatingLayout.defaultSize
+            let buttonSize = CodexChatDesign.headerControlSize
+            let contentFrame = CodexChatResizeHandles.contentFrame(for: size)
+            let minimizeButtonFrame = CGRect(
+                x: contentFrame.maxX - CodexChatDesign.headerHorizontalPadding - buttonSize,
+                y: contentFrame.minY + (CodexChatDesign.headerHeight - buttonSize) / 2,
+                width: buttonSize,
+                height: buttonSize
+            )
+
+            for edge in CodexChatResizeEdge.allCases {
+                let resizeFrame = CodexChatResizeHandles.frame(for: edge, in: size)
+                #expect(!resizeFrame.intersects(minimizeButtonFrame))
+            }
+        }
+
+        @Test
+        func straightResizeHandlesStayOutsideChatContent() {
+            let size = CodexChatFloatingLayout.defaultSize
+            let contentFrame = CodexChatResizeHandles.contentFrame(for: size)
+
+            for edge in [CodexChatResizeEdge.top, .left, .right] {
+                let resizeFrame = CodexChatResizeHandles.frame(for: edge, in: size)
+                #expect(!resizeFrame.intersects(contentFrame))
+            }
         }
     }
 #endif

--- a/Tests/DahliaTests/CodexChatFloatingLayoutTests.swift
+++ b/Tests/DahliaTests/CodexChatFloatingLayoutTests.swift
@@ -118,6 +118,28 @@ import CoreGraphics
         }
 
         @Test
+        func stationaryOuterEdgePreservesDockAcrossAvailableWidthChanges() {
+            var rightDockedLayout = CodexChatFloatingLayout(dockSide: .right)
+            var leftDockedLayout = CodexChatFloatingLayout(dockSide: .left)
+            let initialAvailableSize = CGSize(width: 1000, height: 800)
+
+            rightDockedLayout.resize(
+                from: .topRight,
+                translation: CGSize(width: 0, height: 100),
+                availableSize: initialAvailableSize
+            )
+            leftDockedLayout.resize(
+                from: .left,
+                translation: CGSize(width: -100, height: 0),
+                availableSize: initialAvailableSize
+            )
+
+            let widerAvailableSize = CGSize(width: 1200, height: 800)
+            #expect(rightDockedLayout.origin(in: widerAvailableSize).x == 664)
+            #expect(leftDockedLayout.origin(in: widerAvailableSize).x == CodexChatFloatingLayout.margin)
+        }
+
+        @Test
         func cornerResizeMovesBothRequestedEdges() {
             var topLeftLayout = CodexChatFloatingLayout(dockSide: .right)
             var topRightLayout = CodexChatFloatingLayout(dockSide: .left)


### PR DESCRIPTION
## Summary

- restore the floating chat minimize button hit area
- add resize cursors and drag handles for the top, left, right, top-left, and top-right edges
- make window movement and resizing smoother by removing implicit animation from drag updates
- preserve docked positioning during compatible resizes and keep resize handles from intercepting chat content
- expose an outside-only accessible resize control with current dimensions

## Root cause

The original resize handle overlapped header controls and only modeled a single corner. Drag updates also changed layout state without isolating them from animation, and resizing could convert a docked window into an absolute horizontal position.

## Impact

The floating AI chat can now be minimized reliably, clearly indicates every supported resize edge, and moves and resizes smoothly without blocking scrollbars or VoiceOver access to chat controls.

## Validation

- `swift test --filter CodexChatFloatingLayoutTests` — 12 tests passed
- SwiftFormat lint — 0 of 8 changed files require formatting
- SwiftLint on all changed files — passed
- `git diff --check` — passed
- deep review and SwiftUI accessibility re-review — no remaining actionable findings
