### PR TITLE
Add AI summary detail and language settings

### DIFF
--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -445,6 +445,7 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     @AppStorage("codexChatReasoningEffort") var codexChatReasoningEffort = CodexReasoningEffortOption.defaultValue
     @AppStorage("codexChatDockSide") var codexChatDockSideRawValue = CodexChatDockSide.right.rawValue
     @AppStorage("llmSummaryLanguage") var llmSummaryLanguageRawValue = SummaryLanguage.ja.rawValue
+    @AppStorage("summaryDetailLevel") var summaryDetailLevelRawValue = SummaryDetailLevel.defaultValue.rawValue
 
     var codexChatDockSide: CodexChatDockSide {
         get { CodexChatDockSide(rawValue: codexChatDockSideRawValue) ?? .right }
@@ -491,6 +492,11 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     var llmSummaryLanguage: SummaryLanguage {
         get { SummaryLanguage(rawValue: llmSummaryLanguageRawValue) ?? .ja }
         set { llmSummaryLanguageRawValue = newValue.rawValue }
+    }
+
+    var summaryDetailLevel: SummaryDetailLevel {
+        get { SummaryDetailLevel.fromPersistedValue(summaryDetailLevelRawValue) }
+        set { summaryDetailLevelRawValue = newValue.rawValue }
     }
 
     @AppStorage("llmSummaryPrompt") var llmSummaryPrompt: String = AppSettings.defaultSummaryPrompt

--- a/Sources/Dahlia/Models/SummaryDetailLevel.swift
+++ b/Sources/Dahlia/Models/SummaryDetailLevel.swift
@@ -1,0 +1,33 @@
+/// AI 要約に含める情報量。
+enum SummaryDetailLevel: String, CaseIterable, Identifiable {
+    case concise
+    case standard
+    case detailed
+
+    static let defaultValue = SummaryDetailLevel.detailed
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .concise: L10n.summaryDetailConcise
+        case .standard: L10n.summaryDetailStandard
+        case .detailed: L10n.summaryDetailDetailed
+        }
+    }
+
+    var instruction: String {
+        switch self {
+        case .concise:
+            "Keep the summary concise. Focus on important decisions, issues, and next actions, and omit minor details."
+        case .standard:
+            "Provide a balanced summary that covers the main topics with enough context to understand them."
+        case .detailed:
+            "Provide a comprehensive summary. Cover every substantive topic, relevant background and rationale, decisions, concerns, unresolved questions, and next steps. Avoid repetition and filler."
+        }
+    }
+
+    static func fromPersistedValue(_ value: String) -> SummaryDetailLevel {
+        SummaryDetailLevel(rawValue: value) ?? defaultValue
+    }
+}

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -326,6 +326,13 @@
 "AI Summary" = "AI Summary";
 "Reasoning Effort" = "Reasoning Effort";
 "Controls how much reasoning Codex uses for each summary." = "Controls how much reasoning Codex uses for each summary.";
+"Summary Output" = "Summary Output";
+"Detail Level" = "Detail Level";
+"Controls how much information is included in each summary." = "Controls how much information is included in each summary.";
+"Concise" = "Concise";
+"Detailed" = "Detailed";
+"Output Language" = "Output Language";
+"Select the language used for generated summaries." = "Select the language used for generated summaries.";
 "Minimal" = "Minimal";
 "Low" = "Low";
 "Medium" = "Medium";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -326,6 +326,13 @@
 "AI Summary" = "AI 要約";
 "Reasoning Effort" = "推論の強度";
 "Controls how much reasoning Codex uses for each summary." = "要約ごとに Codex が使用する推論の強度を設定します。";
+"Summary Output" = "要約の出力";
+"Detail Level" = "詳細度";
+"Controls how much information is included in each summary." = "要約に含める情報量を設定します。";
+"Concise" = "簡潔";
+"Detailed" = "詳細";
+"Output Language" = "出力言語";
+"Select the language used for generated summaries." = "生成する要約の言語を選択します。";
 "Minimal" = "最小";
 "Low" = "低";
 "Medium" = "中";

--- a/Sources/Dahlia/Services/SummaryService.swift
+++ b/Sources/Dahlia/Services/SummaryService.swift
@@ -19,19 +19,11 @@ enum SummaryService {
         repository: MeetingRepository? = nil
     ) async throws -> GeneratedSummary {
         let settings = AppSettings.shared
-        let prompt = resolvedSummaryPrompt(settings: settings, repository: repository)
-        let languageName = settings.llmSummaryLanguage.displayName
 
-        var systemPromptSections = [
-            prompt,
-            codexInputTrustInstruction,
-        ]
-        if !promptContext.previousMeetings.isEmpty {
-            systemPromptSections.append(codexPreviousMeetingsInstruction)
-        }
-        systemPromptSections.append("# Language\nWrite the summary in \(languageName).")
-        let systemPrompt = systemPromptSections.joined(separator: "\n\n")
-            + codexStructuredInstruction
+        let systemPrompt = summaryGenerationInstructions(
+            settings: settings,
+            includesPreviousMeetings: !promptContext.previousMeetings.isEmpty
+        )
         let inputs = await makeCodexInputs(.init(
             promptContext: promptContext,
             transcriptText: transcriptText,
@@ -288,29 +280,22 @@ enum SummaryService {
 
     // MARK: - Private Helpers
 
-    /// 選択中 instruction の内容を DB から解決する。
-    /// Auto モード時はデフォルトプロンプト全体を返す。
-    /// instruction 選択時は instruction 本文をそのまま使う。
     @MainActor
-    static func resolvedSummaryPrompt(
+    static func summaryGenerationInstructions(
         settings: AppSettings,
-        repository: MeetingRepository? = nil
+        includesPreviousMeetings: Bool
     ) -> String {
-        // Auto モード
-        guard let selectedInstructionID = settings.selectedInstructionID,
-              let vaultId = settings.currentVault?.id else {
-            return AppSettings.defaultSummaryPrompt
+        // カスタム instruction は一時的に無効化し、保存済みの選択にかかわらず既定値を使う。
+        var sections = [
+            AppSettings.defaultSummaryPrompt,
+            codexInputTrustInstruction,
+        ]
+        if includesPreviousMeetings {
+            sections.append(codexPreviousMeetingsInstruction)
         }
-
-        // カスタム instruction: DB から全文プロンプトを読み込む
-        if let instruction = try? repository?.fetchInstruction(id: selectedInstructionID),
-           instruction.vaultId == vaultId,
-           !instruction.content.isEmpty {
-            return instruction.content.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-
-        // フォールバック: デフォルト
-        return AppSettings.defaultSummaryPrompt
+        sections.append("# Detail Level\n\(settings.summaryDetailLevel.instruction)")
+        sections.append("# Language\nWrite the summary in \(settings.llmSummaryLanguage.displayName).")
+        return sections.joined(separator: "\n\n") + codexStructuredInstruction
     }
 
     private static func appendUniqueTags(_ candidates: [String], to tags: inout [String]) {

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1263,6 +1263,20 @@ enum L10n {
         localized: "The saved model is used when available; otherwise Codex's default model is selected.",
         bundle: bundle
     ) }
+    static var summaryOutput: String { String(localized: "Summary Output", bundle: bundle) }
+    static var summaryDetailLevel: String { String(localized: "Detail Level", bundle: bundle) }
+    static var summaryDetailLevelDescription: String { String(
+        localized: "Controls how much information is included in each summary.",
+        bundle: bundle
+    ) }
+    static var summaryDetailConcise: String { String(localized: "Concise", bundle: bundle) }
+    static var summaryDetailStandard: String { String(localized: "Standard", bundle: bundle) }
+    static var summaryDetailDetailed: String { String(localized: "Detailed", bundle: bundle) }
+    static var summaryOutputLanguage: String { String(localized: "Output Language", bundle: bundle) }
+    static var summaryOutputLanguageDescription: String { String(
+        localized: "Select the language used for generated summaries.",
+        bundle: bundle
+    ) }
     static var llmErrorEmptyResponse: String { String(localized: "Empty response from server", bundle: bundle) }
 
     // MARK: - Summary

--- a/Sources/Dahlia/Views/Settings/AISummarySettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/AISummarySettingsView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Codex model selection for AI summaries.
+/// Codex model and output settings for AI summaries.
 struct AISummarySettingsView: View {
     @ObservedObject private var settings = AppSettings.shared
     @State private var catalog = CodexModelCatalog()
@@ -52,6 +52,30 @@ struct AISummarySettingsView: View {
                 Text(L10n.aiSummary)
             } footer: {
                 Text(L10n.codexSummaryModelFooter)
+            }
+
+            Section {
+                Picker(selection: $settings.summaryDetailLevel) {
+                    ForEach(SummaryDetailLevel.allCases) { level in
+                        Text(level.displayName).tag(level)
+                    }
+                } label: {
+                    Text(L10n.summaryDetailLevel)
+                    Text(L10n.summaryDetailLevelDescription)
+                }
+                .pickerStyle(.menu)
+
+                Picker(selection: $settings.llmSummaryLanguage) {
+                    ForEach(SummaryLanguage.allCases) { language in
+                        Text(language.displayName).tag(language)
+                    }
+                } label: {
+                    Text(L10n.summaryOutputLanguage)
+                    Text(L10n.summaryOutputLanguageDescription)
+                }
+                .pickerStyle(.menu)
+            } header: {
+                Text(L10n.summaryOutput)
             }
         }
         .formStyle(.grouped)

--- a/Sources/Dahlia/Views/Settings/SettingsGroup.swift
+++ b/Sources/Dahlia/Views/Settings/SettingsGroup.swift
@@ -25,7 +25,7 @@ enum SettingsGroup: CaseIterable, Identifiable {
         case .app: [.general, .backups]
         case .recording: [.transcription, .screenshots]
         case .integrations: [.calendar, .cloudStorage]
-        case .ai: [.modelProvider, .aiSummary, .mcp, .instructions]
+        case .ai: [.modelProvider, .aiSummary, .mcp]
         case .advanced: [.developer, .audioDiagnostics]
         }
     }

--- a/Sources/Dahlia/Views/Settings/SettingsNavigation.swift
+++ b/Sources/Dahlia/Views/Settings/SettingsNavigation.swift
@@ -1,3 +1,7 @@
 enum SettingsNavigation {
     static let selectedCategoryDefaultsKey = "settingsSelectedCategory"
+
+    static func visibleSelection(_ selection: SettingsCategory) -> SettingsCategory {
+        selection == .instructions ? .aiSummary : selection
+    }
 }

--- a/Sources/Dahlia/Views/SettingsView.swift
+++ b/Sources/Dahlia/Views/SettingsView.swift
@@ -28,5 +28,8 @@ struct SettingsView: View {
             .navigationTitle(selection.label)
         }
         .frame(minWidth: 720, minHeight: 520)
+        .onAppear {
+            selection = SettingsNavigation.visibleSelection(selection)
+        }
     }
 }

--- a/Tests/DahliaTests/SettingsCategoryTests.swift
+++ b/Tests/DahliaTests/SettingsCategoryTests.swift
@@ -25,7 +25,16 @@
         @Test
         func groupsContainEveryCategoryOnce() {
             let groupedCategories = SettingsGroup.allCases.flatMap(\.categories)
-            #expect(groupedCategories == SettingsCategory.allCases)
+            let expectedCategories = SettingsCategory.allCases.filter { $0 != .instructions }
+
+            #expect(groupedCategories == expectedCategories)
+            #expect(!groupedCategories.contains(.instructions))
+        }
+
+        @Test
+        func hiddenInstructionsSelectionOpensAISummarySettings() {
+            #expect(SettingsNavigation.visibleSelection(.instructions) == .aiSummary)
+            #expect(SettingsNavigation.visibleSelection(.calendar) == .calendar)
         }
 
         @Test

--- a/Tests/DahliaTests/SummaryServiceTests.swift
+++ b/Tests/DahliaTests/SummaryServiceTests.swift
@@ -399,58 +399,77 @@ struct SummaryServiceTests {
     }
 
     @Test
-    func resolvedSummaryPromptUsesDefaultWhenAutoSelected() {
-        let previousInstructionID = AppSettings.shared.selectedInstructionID
-        let previousVault = AppSettings.shared.currentVault
-        defer {
-            AppSettings.shared.selectedInstructionID = previousInstructionID
-            AppSettings.shared.currentVault = previousVault
+    func summaryDetailLevelFallsBackToDetailed() {
+        let previousValue = AppSettings.shared.summaryDetailLevelRawValue
+        defer { AppSettings.shared.summaryDetailLevelRawValue = previousValue }
+
+        #expect(SummaryDetailLevel.defaultValue == .detailed)
+        for detailLevel in SummaryDetailLevel.allCases {
+            AppSettings.shared.summaryDetailLevelRawValue = detailLevel.rawValue
+            #expect(AppSettings.shared.summaryDetailLevel == detailLevel)
         }
 
-        AppSettings.shared.selectedInstructionID = nil
-        AppSettings.shared.currentVault = VaultRecord(
-            id: .v7(),
-            path: NSTemporaryDirectory(),
-            name: "Test Vault",
-            createdAt: Date(),
-            lastOpenedAt: Date()
-        )
-
-        let prompt = SummaryService.resolvedSummaryPrompt(settings: AppSettings.shared)
-
-        #expect(prompt == AppSettings.defaultSummaryPrompt)
+        AppSettings.shared.summaryDetailLevelRawValue = "unsupported"
+        #expect(AppSettings.shared.summaryDetailLevel == .detailed)
     }
 
     @Test
-    func resolvedSummaryPromptUsesSelectedInstructionFromDatabase() throws {
-        let previousInstructionID = AppSettings.shared.selectedInstructionID
-        let previousVault = AppSettings.shared.currentVault
+    func summaryGenerationInstructionsIncludeDetailAndLanguage() {
+        let settings = AppSettings.shared
+        let previousDetailLevel = settings.summaryDetailLevelRawValue
+        let previousLanguage = settings.llmSummaryLanguageRawValue
         defer {
-            AppSettings.shared.selectedInstructionID = previousInstructionID
-            AppSettings.shared.currentVault = previousVault
+            settings.summaryDetailLevelRawValue = previousDetailLevel
+            settings.llmSummaryLanguageRawValue = previousLanguage
         }
 
-        let database = try AppDatabaseManager(path: ":memory:")
-        let repository = MeetingRepository(dbQueue: database.dbQueue)
-        let vault = VaultRecord(
-            id: .v7(),
-            path: NSTemporaryDirectory(),
-            name: "Test Vault",
-            createdAt: Date(),
-            lastOpenedAt: Date()
-        )
-        try repository.insertVault(vault)
-        let instruction = try repository.createInstruction(
-            vaultId: vault.id,
-            name: "customer_meeting",
-            content: AppSettings.defaultSummaryPrompt + "\n\n# Extra\n- Follow up"
-        )
-        AppSettings.shared.currentVault = vault
-        AppSettings.shared.selectedInstructionID = instruction.id
+        settings.llmSummaryLanguage = .en
+        for detailLevel in SummaryDetailLevel.allCases {
+            settings.summaryDetailLevel = detailLevel
+            let instructions = SummaryService.summaryGenerationInstructions(
+                settings: settings,
+                includesPreviousMeetings: false
+            )
 
-        let prompt = SummaryService.resolvedSummaryPrompt(settings: AppSettings.shared, repository: repository)
+            #expect(instructions.hasPrefix(AppSettings.defaultSummaryPrompt))
+            #expect(instructions.contains(detailLevel.instruction))
+            #expect(instructions.contains("Write the summary in English."))
+        }
+    }
 
-        #expect(prompt == instruction.content.trimmingCharacters(in: .whitespacesAndNewlines))
+    @Test
+    func summaryGenerationInstructionsIgnoreSelectedCustomInstruction() {
+        let previousInstructionID = AppSettings.shared.selectedInstructionID
+        defer { AppSettings.shared.selectedInstructionID = previousInstructionID }
+
+        let settings = AppSettings.shared
+        settings.selectedInstructionID = nil
+        let autoInstructions = SummaryService.summaryGenerationInstructions(
+            settings: settings,
+            includesPreviousMeetings: false
+        )
+        settings.selectedInstructionID = .v7()
+        let selectedInstructions = SummaryService.summaryGenerationInstructions(
+            settings: settings,
+            includesPreviousMeetings: false
+        )
+
+        #expect(selectedInstructions == autoInstructions)
+    }
+
+    @Test
+    func summaryGenerationInstructionsIncludePreviousMeetingsOnlyWhenRequested() {
+        let withoutPreviousMeetings = SummaryService.summaryGenerationInstructions(
+            settings: AppSettings.shared,
+            includesPreviousMeetings: false
+        )
+        let withPreviousMeetings = SummaryService.summaryGenerationInstructions(
+            settings: AppSettings.shared,
+            includesPreviousMeetings: true
+        )
+
+        #expect(!withoutPreviousMeetings.contains(SummaryService.codexPreviousMeetingsInstruction))
+        #expect(withPreviousMeetings.components(separatedBy: SummaryService.codexPreviousMeetingsInstruction).count == 2)
     }
 
 }


### PR DESCRIPTION
## Summary

- add concise, standard, and detailed AI summary levels, defaulting invalid or missing values to detailed
- expose summary detail and output language controls in AI Summary settings
- always use the standard summary prompt while keeping saved custom Instructions data intact
- hide Instructions from the settings sidebar and redirect legacy selections to AI Summary settings

## Why

Codex app-server does not expose a numeric `max_tokens` equivalent for summary generation. These controls let users request broader or shorter coverage through explicit developer instructions and choose the output language from the existing supported set.

## Validation

- `swift test --filter SummaryServiceTests` — 19 tests passed
- settings category tests — 7 tests passed
- `swift build`
- `CI=true ./scripts/lint.sh` — SwiftFormat clean; existing repository-wide non-blocking SwiftLint violations remain
- deep review completed with no critical, security, concurrency, or performance findings
