### PR TITLE
Add image attachments to AI chat

### DIFF
--- a/Sources/Dahlia/Models/CodexChatImageAttachment.swift
+++ b/Sources/Dahlia/Models/CodexChatImageAttachment.swift
@@ -1,0 +1,36 @@
+import DahliaRuntimeSupport
+import Foundation
+
+struct CodexChatImageAttachment: Identifiable, Equatable, Sendable {
+    static let maximumAttachmentCount = 10
+    static let maximumInputByteCount = 25 * 1024 * 1024
+
+    let id: UUID
+    let data: Data
+    let mimeType: String
+    let dataURI: String
+
+    init(id: UUID = UUID.v7(), data: Data, mimeType: String) {
+        self.id = id
+        self.data = data
+        self.mimeType = mimeType
+        dataURI = "data:\(mimeType);base64,\(data.base64EncodedString())"
+    }
+
+    init?(id: UUID = UUID.v7(), dataURI: String) {
+        guard dataURI.utf8.count <= Self.maximumInputByteCount * 4 / 3 + 128,
+              dataURI.hasPrefix("data:image/"),
+              let separator = dataURI.range(of: ";base64,"),
+              separator.lowerBound > dataURI.startIndex,
+              dataURI.distance(from: separator.upperBound, to: dataURI.endIndex)
+              <= Self.maximumInputByteCount * 4 / 3 + 4,
+              let data = Data(base64Encoded: String(dataURI[separator.upperBound...])),
+              !data.isEmpty,
+              data.count <= Self.maximumInputByteCount,
+              let detectedMIMEType = ImageEncoder.mimeType(for: data) else { return nil }
+        self.id = id
+        self.data = data
+        self.dataURI = dataURI
+        mimeType = detectedMIMEType
+    }
+}

--- a/Sources/Dahlia/Models/CodexChatImageAttachment.swift
+++ b/Sources/Dahlia/Models/CodexChatImageAttachment.swift
@@ -8,13 +8,15 @@ struct CodexChatImageAttachment: Identifiable, Equatable, Sendable {
     let id: UUID
     let data: Data
     let mimeType: String
-    let dataURI: String
+
+    var dataURI: String {
+        "data:\(mimeType);base64,\(data.base64EncodedString())"
+    }
 
     init(id: UUID = UUID.v7(), data: Data, mimeType: String) {
         self.id = id
         self.data = data
         self.mimeType = mimeType
-        dataURI = "data:\(mimeType);base64,\(data.base64EncodedString())"
     }
 
     init?(id: UUID = UUID.v7(), dataURI: String) {
@@ -30,7 +32,6 @@ struct CodexChatImageAttachment: Identifiable, Equatable, Sendable {
               let detectedMIMEType = ImageEncoder.mimeType(for: data) else { return nil }
         self.id = id
         self.data = data
-        self.dataURI = dataURI
         mimeType = detectedMIMEType
     }
 }

--- a/Sources/Dahlia/Models/CodexChatManualSubmission.swift
+++ b/Sources/Dahlia/Models/CodexChatManualSubmission.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+struct CodexChatComposerSnapshot: Equatable, Sendable {
+    let draft: String
+    let referenceIDs: [UUID]
+    let images: [CodexChatImageAttachment]
+}
+
+struct CodexChatManualSubmission: Equatable, Sendable {
+    let text: String
+    let images: [CodexChatImageAttachment]
+    let composerSnapshot: CodexChatComposerSnapshot?
+
+    init(
+        text: String,
+        images: [CodexChatImageAttachment],
+        composerSnapshot: CodexChatComposerSnapshot? = nil
+    ) {
+        self.text = text
+        self.images = images
+        self.composerSnapshot = composerSnapshot
+    }
+}

--- a/Sources/Dahlia/Models/CodexChatMessage.swift
+++ b/Sources/Dahlia/Models/CodexChatMessage.swift
@@ -12,6 +12,7 @@ struct CodexChatMessage: Identifiable, Equatable {
     var reasoning: String
     var isStreaming: Bool
     var context: CodexChatContext?
+    var images: [CodexChatImageAttachment]
 
     init(
         id: String = UUID.v7().uuidString,
@@ -19,7 +20,8 @@ struct CodexChatMessage: Identifiable, Equatable {
         text: String,
         reasoning: String = "",
         isStreaming: Bool = false,
-        context: CodexChatContext? = nil
+        context: CodexChatContext? = nil,
+        images: [CodexChatImageAttachment] = []
     ) {
         self.id = id
         self.role = role
@@ -27,5 +29,6 @@ struct CodexChatMessage: Identifiable, Equatable {
         self.reasoning = reasoning
         self.isStreaming = isStreaming
         self.context = context
+        self.images = images
     }
 }

--- a/Sources/Dahlia/Models/CodexChatPendingInput.swift
+++ b/Sources/Dahlia/Models/CodexChatPendingInput.swift
@@ -1,5 +1,5 @@
 enum CodexChatPendingInput {
-    case manual(String)
+    case manual(CodexChatManualSubmission)
     case liveTranscript(String, wasTruncated: Bool)
 
     var isLiveTranscript: Bool {
@@ -9,9 +9,9 @@ enum CodexChatPendingInput {
         return false
     }
 
-    var manualText: String? {
-        guard case let .manual(text) = self else { return nil }
-        return text
+    var manualSubmission: CodexChatManualSubmission? {
+        guard case let .manual(submission) = self else { return nil }
+        return submission
     }
 
     var liveTranscript: String? {

--- a/Sources/Dahlia/Models/CodexChatTransferImage.swift
+++ b/Sources/Dahlia/Models/CodexChatTransferImage.swift
@@ -1,0 +1,13 @@
+import CoreTransferable
+import Foundation
+import UniformTypeIdentifiers
+
+struct CodexChatTransferImage: Transferable, Sendable {
+    let data: Data
+
+    static var transferRepresentation: some TransferRepresentation {
+        DataRepresentation(importedContentType: .image) { data in
+            Self(data: data)
+        }
+    }
+}

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -763,6 +763,16 @@
 "Stop generating" = "Stop generating";
 "Thinking" = "Thinking";
 "Message Codex" = "Message Codex";
+"Image" = "Image";
+"Attach images" = "Attach images";
+"Attached image" = "Attached image";
+"Attached images" = "Attached images";
+"Image unavailable" = "Image unavailable";
+"Remove attached image" = "Remove attached image";
+"Preparing images…" = "Preparing images…";
+"The selected model does not support images. Choose another model or remove the images." = "The selected model does not support images. Choose another model or remove the images.";
+"You can attach up to %lld images." = "You can attach up to %lld images.";
+"Could not attach %lld image(s)." = "Could not attach %lld image(s).";
 "Live mode" = "Live mode";
 "Turn on live mode" = "Turn on live mode";
 "Turn off live mode" = "Turn off live mode";

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -763,6 +763,7 @@
 "Stop generating" = "Stop generating";
 "Thinking" = "Thinking";
 "Message Codex" = "Message Codex";
+"Add to chat" = "Add to chat";
 "Image" = "Image";
 "Attach images" = "Attach images";
 "Attached image" = "Attached image";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -763,6 +763,7 @@
 "Stop generating" = "生成を停止";
 "Thinking" = "考えています";
 "Message Codex" = "Codex にメッセージ";
+"Add to chat" = "チャットに追加";
 "Image" = "画像";
 "Attach images" = "画像を添付";
 "Attached image" = "添付画像";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -763,6 +763,16 @@
 "Stop generating" = "生成を停止";
 "Thinking" = "考えています";
 "Message Codex" = "Codex にメッセージ";
+"Image" = "画像";
+"Attach images" = "画像を添付";
+"Attached image" = "添付画像";
+"Attached images" = "添付画像";
+"Image unavailable" = "画像を表示できません";
+"Remove attached image" = "添付画像を削除";
+"Preparing images…" = "画像を準備中…";
+"The selected model does not support images. Choose another model or remove the images." = "選択したモデルは画像に対応していません。別のモデルを選択するか、画像を削除してください。";
+"You can attach up to %lld images." = "画像は最大 %lld 枚まで添付できます。";
+"Could not attach %lld image(s)." = "%lld 枚の画像を添付できませんでした。";
 "Live mode" = "ライブモード";
 "Turn on live mode" = "ライブモードをオンにする";
 "Turn off live mode" = "ライブモードをオフにする";

--- a/Sources/Dahlia/Services/CodexAppServerInput.swift
+++ b/Sources/Dahlia/Services/CodexAppServerInput.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum CodexAppServerInput {
+enum CodexAppServerInput: Equatable, Sendable {
     case text(String)
     case imageMetadata(String)
     case imageDataURI(String)
@@ -13,6 +13,13 @@ enum CodexAppServerInput {
         switch self {
         case .imageMetadata, .imageDataURI: true
         case .text: false
+        }
+    }
+
+    var textValue: String? {
+        switch self {
+        case let .text(text), let .imageMetadata(text): text
+        case .imageDataURI: nil
         }
     }
 }

--- a/Sources/Dahlia/Services/CodexChatImageProcessor.swift
+++ b/Sources/Dahlia/Services/CodexChatImageProcessor.swift
@@ -1,0 +1,34 @@
+import DahliaRuntimeSupport
+import Foundation
+
+actor CodexChatImageProcessor {
+    static let shared = CodexChatImageProcessor()
+
+    private static let maximumLongEdge = 1024
+
+    func process(_ data: Data) -> CodexChatImageAttachment? {
+        guard data.count <= CodexChatImageAttachment.maximumInputByteCount,
+              let resized = ImageEncoder.resizedIfPossible(
+                  data,
+                  maxLongEdge: Self.maximumLongEdge
+              ), let mimeType = ImageEncoder.mimeType(for: resized) else { return nil }
+        return CodexChatImageAttachment(data: resized, mimeType: mimeType)
+    }
+
+    func process(_ dataItems: [Data]) -> [CodexChatImageAttachment?] {
+        dataItems.map { process($0) }
+    }
+
+    func process(_ url: URL) -> CodexChatImageAttachment? {
+        if let fileSize = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+           fileSize > CodexChatImageAttachment.maximumInputByteCount {
+            return nil
+        }
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return process(data)
+    }
+
+    func process(_ urls: [URL]) -> [CodexChatImageAttachment?] {
+        urls.map { process($0) }
+    }
+}

--- a/Sources/Dahlia/Services/CodexChatPasteboardImageReader.swift
+++ b/Sources/Dahlia/Services/CodexChatPasteboardImageReader.swift
@@ -1,0 +1,21 @@
+import AppKit
+import UniformTypeIdentifiers
+
+@MainActor
+enum CodexChatPasteboardImageReader {
+    private static let supportedTypes = [
+        UTType.png,
+        UTType.jpeg,
+        UTType.gif,
+        UTType.tiff,
+        UTType.webP,
+    ].map { NSPasteboard.PasteboardType($0.identifier) }
+
+    static func imageData(from pasteboard: NSPasteboard = .general) -> [Data] {
+        pasteboard.pasteboardItems?.compactMap(imageData(from:)) ?? []
+    }
+
+    private static func imageData(from item: NSPasteboardItem) -> Data? {
+        supportedTypes.lazy.compactMap { item.data(forType: $0) }.first
+    }
+}

--- a/Sources/Dahlia/Services/CodexChatService.swift
+++ b/Sources/Dahlia/Services/CodexChatService.swift
@@ -153,18 +153,13 @@ actor CodexChatService: CodexChatServicing {
 
     func send(
         threadID: String,
-        textBlocks: [String],
+        inputs: [CodexAppServerInput],
         model: String?,
         effort: String
     ) async throws -> AsyncThrowingStream<CodexChatTurnEvent, any Error> {
         var params: [String: JSONValue] = [
             "effort": .string(effort),
-            "input": .array(textBlocks.map { text in
-                .object([
-                    "type": .string("text"),
-                    "text": .string(text),
-                ])
-            }),
+            "input": .array(inputs.map(Self.jsonInput)),
             "summary": .string("auto"),
             "threadId": .string(threadID),
         ]
@@ -206,20 +201,24 @@ actor CodexChatService: CodexChatServicing {
         )
     }
 
-    func steer(threadID: String, turnID: String, textBlocks: [String]) async throws {
+    func steer(threadID: String, turnID: String, inputs: [CodexAppServerInput]) async throws {
         _ = try await appServer.request(
             method: "turn/steer",
             params: .object([
                 "expectedTurnId": .string(turnID),
-                "input": .array(textBlocks.map { text in
-                    .object([
-                        "type": .string("text"),
-                        "text": .string(text),
-                    ])
-                }),
+                "input": .array(inputs.map(Self.jsonInput)),
                 "threadId": .string(threadID),
             ])
         )
+    }
+
+    private nonisolated static func jsonInput(_ input: CodexAppServerInput) -> JSONValue {
+        switch input {
+        case let .text(text), let .imageMetadata(text):
+            .object(["type": .string("text"), "text": .string(text)])
+        case let .imageDataURI(uri):
+            .object(["type": .string("image"), "url": .string(uri)])
+        }
     }
 
     func interrupt(threadID: String, turnID: String) async {
@@ -329,20 +328,30 @@ private extension CodexChatService {
     }
 
     nonisolated static func parseUserMessages(_ object: [String: JSONValue], id: String) -> [CodexChatMessage] {
-        let textBlocks = object["content"]?.arrayValue?
+        guard let content = object["content"]?.arrayValue else { return [] }
+        let textBlocks = content
             .compactMap { input -> String? in
-                guard input.objectValue?["type"]?.stringValue == "text" else { return nil }
-                return input.objectValue?["text"]?.stringValue
+                guard let input = input.objectValue,
+                      input["type"]?.stringValue == "text" else { return nil }
+                return input["text"]?.stringValue
             }
-        guard let textBlocks, !textBlocks.isEmpty else { return [] }
+        var images: [CodexChatImageAttachment] = []
+        for input in content where images.count < CodexChatImageAttachment.maximumAttachmentCount {
+            guard let input = input.objectValue,
+                  input["type"]?.stringValue == "image",
+                  let dataURI = input["url"]?.stringValue,
+                  let image = CodexChatImageAttachment(dataURI: dataURI) else { continue }
+            images.append(image)
+        }
         let decoded = CodexChatPromptCodec.decodeTextBlocks(textBlocks)
-        guard decoded.text.nilIfBlank != nil else { return [] }
+        guard decoded.text.nilIfBlank != nil || !images.isEmpty else { return [] }
         return [
             CodexChatMessage(
                 id: id,
                 role: .user,
                 text: decoded.text,
-                context: decoded.context
+                context: decoded.context,
+                images: images
             ),
         ]
     }

--- a/Sources/Dahlia/Services/CodexChatServicing.swift
+++ b/Sources/Dahlia/Services/CodexChatServicing.swift
@@ -9,11 +9,11 @@ protocol CodexChatServicing: Sendable {
     func setThreadName(threadID: String, name: String) async
     func send(
         threadID: String,
-        textBlocks: [String],
+        inputs: [CodexAppServerInput],
         model: String?,
         effort: String
     ) async throws -> AsyncThrowingStream<CodexChatTurnEvent, any Error>
-    func steer(threadID: String, turnID: String, textBlocks: [String]) async throws
+    func steer(threadID: String, turnID: String, inputs: [CodexAppServerInput]) async throws
     func interrupt(threadID: String, turnID: String) async
     func unsubscribe(threadID: String) async
 }

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1525,6 +1525,25 @@ enum L10n {
     static var stopGenerating: String { String(localized: "Stop generating", bundle: bundle) }
     static var chatThinking: String { String(localized: "Thinking", bundle: bundle) }
     static var messageCodex: String { String(localized: "Message Codex", bundle: bundle) }
+    static var chatImage: String { String(localized: "Image", bundle: bundle) }
+    static var attachChatImages: String { String(localized: "Attach images", bundle: bundle) }
+    static var chatAttachedImage: String { String(localized: "Attached image", bundle: bundle) }
+    static var chatAttachedImages: String { String(localized: "Attached images", bundle: bundle) }
+    static var chatImageUnavailable: String { String(localized: "Image unavailable", bundle: bundle) }
+    static var removeChatAttachedImage: String { String(localized: "Remove attached image", bundle: bundle) }
+    static var chatPreparingImages: String { String(localized: "Preparing images…", bundle: bundle) }
+    static var chatModelDoesNotSupportImages: String {
+        String(localized: "The selected model does not support images. Choose another model or remove the images.", bundle: bundle)
+    }
+
+    static func chatImageLimitReached(_ count: Int) -> String {
+        String(localized: "You can attach up to \(count) images.", bundle: bundle)
+    }
+
+    static func chatImagesUnavailable(_ count: Int) -> String {
+        String(localized: "Could not attach \(count) image(s).", bundle: bundle)
+    }
+
     static var chatLiveMode: String { String(localized: "Live mode", bundle: bundle) }
     static var enableChatLiveMode: String { String(localized: "Turn on live mode", bundle: bundle) }
     static var disableChatLiveMode: String { String(localized: "Turn off live mode", bundle: bundle) }

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1525,6 +1525,7 @@ enum L10n {
     static var stopGenerating: String { String(localized: "Stop generating", bundle: bundle) }
     static var chatThinking: String { String(localized: "Thinking", bundle: bundle) }
     static var messageCodex: String { String(localized: "Message Codex", bundle: bundle) }
+    static var addToChat: String { String(localized: "Add to chat", bundle: bundle) }
     static var chatImage: String { String(localized: "Image", bundle: bundle) }
     static var attachChatImages: String { String(localized: "Attach images", bundle: bundle) }
     static var chatAttachedImage: String { String(localized: "Attached image", bundle: bundle) }

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import Observation
 
 private enum CodexChatFailedSubmission {
-    case manual(String)
+    case manual(CodexChatManualSubmission)
     case liveTranscript(String)
 }
 
@@ -36,6 +36,8 @@ final class CodexChatSessionModel: Identifiable {
     private(set) var noticeMessage: String?
     private(set) var activeTurnID: String?
     private(set) var lastSubmittedText: String?
+    private(set) var attachedImages: [CodexChatImageAttachment] = []
+    private(set) var pendingImagePreparationCount = 0
     private(set) var failedLiveTranscript: String?
     private(set) var availableMeetingReferences: [CodexChatMeetingReference] = []
     private(set) var selectedMeetingReferenceIDs: [UUID] = []
@@ -57,11 +59,13 @@ final class CodexChatSessionModel: Identifiable {
     @ObservationIgnored private var didUnsubscribe = false
     @ObservationIgnored private var pendingLiveTranscript: String?
     @ObservationIgnored private var didTruncatePendingLiveTranscript = false
-    @ObservationIgnored private var pendingManualInputs: [String] = []
+    @ObservationIgnored private var pendingManualInputs: [CodexChatManualSubmission] = []
+    @ObservationIgnored private var lastManualSubmission: CodexChatManualSubmission?
     @ObservationIgnored private var isActiveTurnLiveTranscript = false
     @ObservationIgnored private var didSendLiveModeContext = false
     @ObservationIgnored private var liveModeGeneration: UInt = 0
     @ObservationIgnored private var activeSteerIsLiveTranscript = false
+    @ObservationIgnored private var activeTurnSupportsImages: Bool?
     @ObservationIgnored private var activeSubmissionID: UUID?
     @ObservationIgnored private var activeResponseID: String?
     @ObservationIgnored private var turnTask: Task<Void, Never>?
@@ -142,6 +146,7 @@ final class CodexChatSessionModel: Identifiable {
         selectedModelID = modelID
         settings.codexChatModelID = modelID
         resolveEffort()
+        processPendingInputIfPossible()
     }
 
     func selectEffort(_ effort: String) {
@@ -153,23 +158,30 @@ final class CodexChatSessionModel: Identifiable {
         guard canSend else { return }
         let draftSnapshot = draft
         let referenceIDsSnapshot = selectedMeetingReferenceIDs
+        let imagesSnapshot = attachedImages
+        let composerSnapshot = CodexChatComposerSnapshot(
+            draft: draftSnapshot,
+            referenceIDs: referenceIDsSnapshot,
+            images: imagesSnapshot
+        )
         let text = CodexChatMeetingReference.serializedText(
             referenceIDs: referenceIDsSnapshot,
             draft: draftSnapshot
         )
+        let submission = CodexChatManualSubmission(
+            text: text,
+            images: imagesSnapshot,
+            composerSnapshot: composerSnapshot
+        )
         if isGenerating {
-            enqueueManualInput(
-                text,
-                draftSnapshot: draftSnapshot,
-                referenceIDsSnapshot: referenceIDsSnapshot
-            )
+            guard !pendingManualInputs.contains(where: { $0.composerSnapshot == composerSnapshot }) else { return }
+            enqueueManualInput(submission)
             return
         }
         submit(
             text,
-            clearsDraft: true,
-            draftSnapshot: draftSnapshot,
-            referenceIDsSnapshot: referenceIDsSnapshot
+            images: imagesSnapshot,
+            composerSnapshot: composerSnapshot
         )
     }
 
@@ -178,13 +190,12 @@ final class CodexChatSessionModel: Identifiable {
         case let .liveTranscript(failedLiveTranscript):
             self.failedLiveTranscript = nil
             failedSubmission = nil
-            submit("", clearsDraft: false, liveTranscript: failedLiveTranscript)
-        case let .manual(text):
-            failedSubmission = nil
-            retryManualSubmission(text)
+            submit("", liveTranscript: failedLiveTranscript)
+        case let .manual(submission):
+            retryManualSubmission(submission)
         case nil:
-            guard let lastSubmittedText else { return }
-            retryManualSubmission(lastSubmittedText)
+            guard let lastManualSubmission else { return }
+            retryManualSubmission(lastManualSubmission)
         }
     }
 
@@ -234,11 +245,61 @@ final class CodexChatSessionModel: Identifiable {
         }
         unsubscribeIfPossible()
     }
+
+    func addImageData(_ dataItems: [Data]) async {
+        guard !isReleased, !Task.isCancelled else { return }
+        let acceptedData = acceptedImageCandidates(from: dataItems)
+        guard !acceptedData.isEmpty else { return }
+
+        pendingImagePreparationCount += acceptedData.count
+        defer { pendingImagePreparationCount -= acceptedData.count }
+        let processedImages = await CodexChatImageProcessor.shared.process(acceptedData)
+        guard !isReleased, !Task.isCancelled else { return }
+        let images = processedImages.compactMap(\.self)
+        attachedImages.append(contentsOf: images)
+        let failedCount = acceptedData.count - images.count
+        if failedCount > 0 {
+            noticeMessage = L10n.chatImagesUnavailable(failedCount)
+        }
+    }
+
+    func addImageURLs(_ urls: [URL]) async {
+        guard !isReleased, !Task.isCancelled else { return }
+        let acceptedURLs = acceptedImageCandidates(from: urls)
+        guard !acceptedURLs.isEmpty else { return }
+
+        pendingImagePreparationCount += acceptedURLs.count
+        defer { pendingImagePreparationCount -= acceptedURLs.count }
+        let accessedURLs = acceptedURLs.filter { $0.startAccessingSecurityScopedResource() }
+        defer {
+            for url in accessedURLs {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+        let processedImages = await CodexChatImageProcessor.shared.process(acceptedURLs)
+        guard !isReleased, !Task.isCancelled else { return }
+        let images = processedImages.compactMap(\.self)
+        attachedImages.append(contentsOf: images)
+        let failedCount = acceptedURLs.count - images.count
+        if failedCount > 0 {
+            noticeMessage = L10n.chatImagesUnavailable(failedCount)
+        }
+    }
+
+    func removeAttachedImage(id: UUID) {
+        attachedImages.removeAll { $0.id == id }
+    }
+
+    func reportImageAttachmentFailure() {
+        noticeMessage = L10n.chatImagesUnavailable(1)
+    }
 }
 
 private extension CodexChatSessionModel {
     func runTurn(
         text: String?,
+        images: [CodexChatImageAttachment] = [],
+        composerSnapshot: CodexChatComposerSnapshot?,
         liveTranscript: String?,
         context: CodexChatContext?,
         responseID: String,
@@ -258,23 +319,49 @@ private extension CodexChatSessionModel {
             try ensureSubmissionCanContinue(submissionID, liveTranscript: liveTranscript)
             let backendThreadID = try await ensureBackendThread(
                 text: text,
+                images: images,
                 liveTranscript: liveTranscript,
                 submissionID: submissionID
             )
             try ensureSubmissionCanContinue(submissionID, liveTranscript: liveTranscript)
 
             let promptContext = liveModeState.isEnabled && !liveModeState.includesContext ? nil : context
+            guard images.isEmpty || selectedModelSupportsImages else {
+                noticeMessage = L10n.chatModelDoesNotSupportImages
+                recordFailedSubmission(text: text, images: images, liveTranscript: liveTranscript)
+                return false
+            }
+            activeTurnSupportsImages = selectedModelSupportsImages
+            let inputs = makeAppServerInputs(
+                text: text,
+                context: promptContext,
+                includesLiveModeContext: liveModeState.includesContext,
+                liveTranscript: liveTranscript,
+                images: images
+            )
             let stream = try await service.send(
                 threadID: backendThreadID,
-                textBlocks: CodexChatPromptCodec.encodeTextBlocks(
-                    text: text,
-                    context: promptContext,
-                    includesLiveModeContext: liveModeState.includesContext,
-                    liveTranscript: liveTranscript
-                ),
+                inputs: inputs,
                 model: selectedModelID.nilIfBlank,
                 effort: selectedEffort
             )
+            var replacedLiveModePlaceholderTitle = false
+            if liveTranscript == nil {
+                let submission = CodexChatManualSubmission(text: text ?? "", images: images)
+                clearComposer(ifMatching: composerSnapshot)
+                lastSubmittedText = submission.text
+                lastManualSubmission = submission
+                messages.append(CodexChatMessage(
+                    role: .user,
+                    text: submission.text,
+                    context: context,
+                    images: images
+                ))
+                let titleText = submission.text.nilIfBlank ?? L10n.chatImage
+                replacedLiveModePlaceholderTitle = await replaceLiveModePlaceholderTitleIfNeeded(with: titleText)
+            }
+            messages.append(CodexChatMessage(id: responseID, role: .assistant, text: "", isStreaming: true))
+            activeResponseID = responseID
             if liveModeState.includesContext,
                isLiveModeEnabled,
                liveModeGeneration == liveModeState.generation {
@@ -297,7 +384,10 @@ private extension CodexChatSessionModel {
                 )
             } else if !isStopRequested,
                       errorMessage != nil || liveTranscript != nil {
-                recordFailedSubmission(text: text, liveTranscript: liveTranscript)
+                recordFailedSubmission(text: text, images: images, liveTranscript: liveTranscript)
+            }
+            if replacedLiveModePlaceholderTitle {
+                title = text?.nilIfBlank ?? L10n.chatImage
             }
             return turnCompleted
         } catch is CancellationError {
@@ -307,7 +397,7 @@ private extension CodexChatSessionModel {
         } catch {
             guard activeSubmissionID == submissionID else { return false }
             errorMessage = error.localizedDescription
-            recordFailedSubmission(text: text, liveTranscript: liveTranscript)
+            recordFailedSubmission(text: text, images: images, liveTranscript: liveTranscript)
             updateLimiter.submit(force: true)
             completeTurnResponse(responseID: responseID)
             return false
@@ -452,6 +542,7 @@ private extension CodexChatSessionModel {
         activeTurnID = nil
         isStopRequested = false
         isActiveTurnLiveTranscript = false
+        activeTurnSupportsImages = nil
         activeSubmissionID = nil
         activeResponseID = nil
         turnTask = nil
@@ -463,6 +554,7 @@ private extension CodexChatSessionModel {
 
     func ensureBackendThread(
         text: String?,
+        images: [CodexChatImageAttachment],
         liveTranscript: String?,
         submissionID: UUID
     ) async throws -> String {
@@ -479,7 +571,15 @@ private extension CodexChatSessionModel {
         )
         try ensureSubmissionCanContinue(submissionID, liveTranscript: liveTranscript)
         apply(thread, preservingPendingMessages: true)
-        let threadTitle = liveTranscript == nil ? text ?? L10n.newChat : L10n.chatLiveMode
+        let threadTitle = if liveTranscript != nil {
+            L10n.chatLiveMode
+        } else if let text = text?.nilIfBlank {
+            text
+        } else if images.isEmpty {
+            L10n.newChat
+        } else {
+            L10n.chatImage
+        }
         title = threadTitle
         await service.setThreadName(threadID: thread.id, name: threadTitle)
         usesLiveModePlaceholderTitle = liveTranscript != nil
@@ -496,16 +596,25 @@ private extension CodexChatSessionModel {
         }
     }
 
-    func retryManualSubmission(_ text: String) {
+    func retryManualSubmission(_ submission: CodexChatManualSubmission) {
         let currentText = CodexChatMeetingReference.serializedText(
             referenceIDs: selectedMeetingReferenceIDs,
             draft: draft
         )
+        let composerSnapshot: CodexChatComposerSnapshot? = if currentText == submission.text,
+                                                              attachedImages == submission.images {
+            CodexChatComposerSnapshot(
+                draft: draft,
+                referenceIDs: selectedMeetingReferenceIDs,
+                images: attachedImages
+            )
+        } else {
+            nil
+        }
         submit(
-            text,
-            clearsDraft: currentText == text,
-            draftSnapshot: draft,
-            referenceIDsSnapshot: selectedMeetingReferenceIDs
+            submission.text,
+            images: submission.images,
+            composerSnapshot: composerSnapshot
         )
     }
 
@@ -517,12 +626,18 @@ private extension CodexChatSessionModel {
         failedSubmission = nil
     }
 
-    func recordFailedSubmission(text: String?, liveTranscript: String?) {
+    func recordFailedSubmission(
+        text: String?,
+        images: [CodexChatImageAttachment] = [],
+        liveTranscript: String?
+    ) {
         if let liveTranscript, isLiveModeEnabled {
             recordFailedLiveTranscript(liveTranscript)
-        } else if let text = text?.nilIfBlank {
-            lastSubmittedText = text
-            failedSubmission = .manual(text)
+        } else if text?.nilIfBlank != nil || !images.isEmpty {
+            let submission = CodexChatManualSubmission(text: text ?? "", images: images)
+            lastSubmittedText = submission.text
+            lastManualSubmission = submission
+            failedSubmission = .manual(submission)
         }
     }
 
@@ -573,16 +688,47 @@ private extension CodexChatSessionModel {
 }
 
 private extension CodexChatSessionModel {
+    func acceptedImageCandidates<Item>(from items: [Item]) -> [Item] {
+        let availableSlots = max(
+            0,
+            Self.maximumAttachedImages - attachedImages.count - pendingImagePreparationCount
+        )
+        let acceptedItems = Array(items.prefix(availableSlots))
+        if acceptedItems.count < items.count {
+            noticeMessage = L10n.chatImageLimitReached(Self.maximumAttachedImages)
+        }
+        return acceptedItems
+    }
+
+    func makeAppServerInputs(
+        text: String?,
+        context: CodexChatContext?,
+        includesLiveModeContext: Bool,
+        liveTranscript: String?,
+        images: [CodexChatImageAttachment]
+    ) -> [CodexAppServerInput] {
+        let textInputs = CodexChatPromptCodec.encodeTextBlocks(
+            text: text,
+            context: context,
+            includesLiveModeContext: includesLiveModeContext,
+            liveTranscript: liveTranscript
+        ).map(CodexAppServerInput.text)
+        return textInputs + images.map { .imageDataURI($0.dataURI) }
+    }
+
     func submit(
         _ text: String,
-        clearsDraft: Bool,
-        draftSnapshot: String? = nil,
-        referenceIDsSnapshot: [UUID] = [],
+        images: [CodexChatImageAttachment] = [],
+        composerSnapshot: CodexChatComposerSnapshot? = nil,
         liveTranscript: String? = nil
     ) {
         guard isBoundToCurrentVault,
               !isGenerating,
-              text.nilIfBlank != nil || liveTranscript?.nilIfBlank != nil else { return }
+              text.nilIfBlank != nil || !images.isEmpty || liveTranscript?.nilIfBlank != nil else { return }
+        guard images.isEmpty || models.isEmpty || selectedModelSupportsImages else {
+            noticeMessage = L10n.chatModelDoesNotSupportImages
+            return
+        }
         prepareFailureStateForSubmission(liveTranscript: liveTranscript)
         isGenerating = true
         errorMessage = nil
@@ -599,9 +745,8 @@ private extension CodexChatSessionModel {
         turnTask = Task { [weak self] in
             await self?.resolveContextAndRunTurn(
                 text: text,
-                clearsDraft: clearsDraft,
-                draftSnapshot: draftSnapshot ?? text,
-                referenceIDsSnapshot: referenceIDsSnapshot,
+                images: images,
+                composerSnapshot: composerSnapshot,
                 liveTranscript: liveTranscript,
                 liveModeState: liveModeState,
                 submissionID: submissionID
@@ -611,9 +756,8 @@ private extension CodexChatSessionModel {
 
     func resolveContextAndRunTurn(
         text: String,
-        clearsDraft: Bool,
-        draftSnapshot: String,
-        referenceIDsSnapshot: [UUID],
+        images: [CodexChatImageAttachment],
+        composerSnapshot: CodexChatComposerSnapshot?,
         liveTranscript: String?,
         liveModeState: CodexChatLiveModeSubmissionState,
         submissionID: UUID
@@ -630,39 +774,23 @@ private extension CodexChatSessionModel {
             return
         } catch {
             guard activeSubmissionID == submissionID else { return }
-            recordFailedSubmission(text: text, liveTranscript: liveTranscript)
+            recordFailedSubmission(text: text, images: images, liveTranscript: liveTranscript)
             errorMessage = error.localizedDescription
             return
         }
         guard !isReleased, isBoundToCurrentVault else { return }
-        if clearsDraft {
-            clearComposer(
-                draftSnapshot: draftSnapshot,
-                referenceIDsSnapshot: referenceIDsSnapshot
-            )
-        }
-        var replacedLiveModePlaceholderTitle = false
-        if liveTranscript == nil {
-            lastSubmittedText = text
-            messages.append(CodexChatMessage(role: .user, text: text, context: context))
-            replacedLiveModePlaceholderTitle = await replaceLiveModePlaceholderTitleIfNeeded(with: text)
-            guard activeSubmissionID == submissionID, !Task.isCancelled else { return }
-        }
         let responseID = "pending-\(UUID.v7().uuidString)"
-        messages.append(CodexChatMessage(id: responseID, role: .assistant, text: "", isStreaming: true))
-        activeResponseID = responseID
 
         _ = await runTurn(
             text: liveTranscript == nil ? text : nil,
+            images: liveTranscript == nil ? images : [],
+            composerSnapshot: composerSnapshot,
             liveTranscript: liveTranscript,
             context: context,
             responseID: responseID,
             liveModeState: liveModeState,
             submissionID: submissionID
         )
-        if replacedLiveModePlaceholderTitle {
-            title = text
-        }
     }
 
     func setLiveModeEnabled(_ isEnabled: Bool) {
@@ -686,29 +814,23 @@ private extension CodexChatSessionModel {
         liveModeChangeHandler?(isEnabled)
     }
 
-    func enqueueManualInput(
-        _ text: String,
-        draftSnapshot: String,
-        referenceIDsSnapshot: [UUID]
-    ) {
-        lastSubmittedText = text
-        pendingManualInputs.append(text)
-        clearComposer(
-            draftSnapshot: draftSnapshot,
-            referenceIDsSnapshot: referenceIDsSnapshot
-        )
+    func enqueueManualInput(_ submission: CodexChatManualSubmission) {
+        lastSubmittedText = submission.text
+        lastManualSubmission = submission
+        pendingManualInputs.append(submission)
         processPendingInputIfPossible()
     }
 
-    func clearComposer(
-        draftSnapshot: String,
-        referenceIDsSnapshot: [UUID]
-    ) {
-        if draft == draftSnapshot {
+    func clearComposer(ifMatching snapshot: CodexChatComposerSnapshot?) {
+        guard let snapshot else { return }
+        if draft == snapshot.draft {
             draft = ""
         }
-        if selectedMeetingReferenceIDs == referenceIDsSnapshot {
+        if selectedMeetingReferenceIDs == snapshot.referenceIDs {
             selectedMeetingReferenceIDs = []
+        }
+        if attachedImages == snapshot.images {
+            attachedImages = []
         }
     }
 
@@ -720,14 +842,27 @@ private extension CodexChatSessionModel {
         if isGenerating {
             startSteeringPendingInputIfPossible()
         } else if !pendingManualInputs.isEmpty {
-            let text = pendingManualInputs.removeFirst()
-            submit(text, clearsDraft: false)
+            guard pendingManualInputs[0].images.isEmpty || selectedModelSupportsImages else {
+                noticeMessage = L10n.chatModelDoesNotSupportImages
+                return
+            }
+            let submission = pendingManualInputs.removeFirst()
+            submit(
+                submission.text,
+                images: submission.images,
+                composerSnapshot: submission.composerSnapshot
+            )
         } else {
             sendNextLiveTranscriptIfPossible()
         }
     }
 
     func startSteeringPendingInputIfPossible() {
+        if let submission = pendingManualInputs.first,
+           !submission.images.isEmpty,
+           activeTurnSupportsImages != true {
+            return
+        }
         guard let backendThreadID,
               let activeTurnID,
               let input = dequeuePendingSteerInput() else { return }
@@ -769,7 +904,9 @@ private extension CodexChatSessionModel {
         }
         do {
             guard !input.isLiveTranscript || isLiveModeEnabled else { return }
-            let text = input.manualText
+            let submission = input.manualSubmission
+            let text = submission?.text
+            let images = submission?.images ?? []
             let liveTranscript = input.liveTranscript
             let isLiveModeSnapshot = isLiveModeEnabled
             let includesLiveModeContext = liveTranscript != nil
@@ -787,15 +924,17 @@ private extension CodexChatSessionModel {
             }
 
             let promptContext = isLiveModeSnapshot && !includesLiveModeContext ? nil : context
+            let inputs = makeAppServerInputs(
+                text: text,
+                context: promptContext,
+                includesLiveModeContext: includesLiveModeContext,
+                liveTranscript: liveTranscript,
+                images: images
+            )
             try await service.steer(
                 threadID: threadID,
                 turnID: turnID,
-                textBlocks: CodexChatPromptCodec.encodeTextBlocks(
-                    text: text,
-                    context: promptContext,
-                    includesLiveModeContext: includesLiveModeContext,
-                    liveTranscript: liveTranscript
-                )
+                inputs: inputs
             )
             if input.isLiveTranscript {
                 guard !Task.isCancelled,
@@ -858,9 +997,15 @@ private extension CodexChatSessionModel {
 
     func applySuccessfulSteer(_ input: CodexChatPendingInput, context: CodexChatContext?) async {
         switch input {
-        case let .manual(text):
-            messages.append(CodexChatMessage(role: .user, text: text, context: context))
-            _ = await replaceLiveModePlaceholderTitleIfNeeded(with: text)
+        case let .manual(submission):
+            clearComposer(ifMatching: submission.composerSnapshot)
+            messages.append(CodexChatMessage(
+                role: .user,
+                text: submission.text,
+                context: context,
+                images: submission.images
+            ))
+            _ = await replaceLiveModePlaceholderTitleIfNeeded(with: submission.text.nilIfBlank ?? L10n.chatImage)
         case let .liveTranscript(_, wasTruncated):
             if wasTruncated {
                 noticeMessage = L10n.chatLiveTranscriptBacklogTruncated
@@ -870,8 +1015,8 @@ private extension CodexChatSessionModel {
 
     func recordSteerFailure(_ input: CodexChatPendingInput) {
         switch input {
-        case let .manual(text):
-            recordFailedSubmission(text: text, liveTranscript: nil)
+        case let .manual(submission):
+            recordFailedSubmission(text: submission.text, images: submission.images, liveTranscript: nil)
         case let .liveTranscript(text, _):
             recordFailedSubmission(text: nil, liveTranscript: text)
         }
@@ -880,8 +1025,8 @@ private extension CodexChatSessionModel {
     func requeue(_ input: CodexChatPendingInput, liveModeGenerationSnapshot: UInt? = nil) {
         guard !isReleased else { return }
         switch input {
-        case let .manual(text):
-            pendingManualInputs.insert(text, at: 0)
+        case let .manual(submission):
+            pendingManualInputs.insert(submission, at: 0)
         case let .liveTranscript(text, wasTruncated):
             if let liveModeGenerationSnapshot,
                !isLiveModeEnabled || liveModeGeneration != liveModeGenerationSnapshot {
@@ -910,7 +1055,6 @@ private extension CodexChatSessionModel {
         didTruncatePendingLiveTranscript = false
         submit(
             "",
-            clearsDraft: false,
             liveTranscript: transcript
         )
         if wasTruncated {
@@ -929,6 +1073,7 @@ private extension CodexChatSessionModel {
     }
 
     static let maximumPendingLiveTranscriptCharacters = 100_000
+    static let maximumAttachedImages = CodexChatImageAttachment.maximumAttachmentCount
 }
 
 extension CodexChatSessionModel {
@@ -938,7 +1083,25 @@ extension CodexChatSessionModel {
 
     var canSend: Bool {
         isBoundToCurrentVault
-            && (draft.nilIfBlank != nil || !selectedMeetingReferenceIDs.isEmpty)
+            && pendingImagePreparationCount == 0
+            && (attachedImages.isEmpty || selectedModelSupportsImages)
+            && (draft.nilIfBlank != nil || !selectedMeetingReferenceIDs.isEmpty || !attachedImages.isEmpty)
+    }
+
+    var selectedModelSupportsImages: Bool {
+        models.first(where: { $0.model == selectedModelID })?.supportsImages == true
+    }
+
+    var attachmentValidationMessage: String? {
+        if pendingImagePreparationCount > 0 {
+            L10n.chatPreparingImages
+        } else if !attachedImages.isEmpty,
+                  models.contains(where: { $0.model == selectedModelID }),
+                  !selectedModelSupportsImages {
+            L10n.chatModelDoesNotSupportImages
+        } else {
+            nil
+        }
     }
 
     var hasRetryableSubmission: Bool {

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -65,6 +65,7 @@ final class CodexChatSessionModel: Identifiable {
     @ObservationIgnored private var didSendLiveModeContext = false
     @ObservationIgnored private var liveModeGeneration: UInt = 0
     @ObservationIgnored private var activeSteerIsLiveTranscript = false
+    @ObservationIgnored private var activeSteeringManualSubmission: CodexChatManualSubmission?
     @ObservationIgnored private var activeTurnSupportsImages: Bool?
     @ObservationIgnored private var activeSubmissionID: UUID?
     @ObservationIgnored private var activeResponseID: String?
@@ -174,7 +175,9 @@ final class CodexChatSessionModel: Identifiable {
             composerSnapshot: composerSnapshot
         )
         if isGenerating {
-            guard !pendingManualInputs.contains(where: { $0.composerSnapshot == composerSnapshot }) else { return }
+            let isDuplicate = activeSteeringManualSubmission?.composerSnapshot == composerSnapshot
+                || pendingManualInputs.contains(where: { $0.composerSnapshot == composerSnapshot })
+            guard !isDuplicate else { return }
             enqueueManualInput(submission)
             return
         }
@@ -844,6 +847,7 @@ private extension CodexChatSessionModel {
         } else if !pendingManualInputs.isEmpty {
             guard pendingManualInputs[0].images.isEmpty || selectedModelSupportsImages else {
                 noticeMessage = L10n.chatModelDoesNotSupportImages
+                sendNextLiveTranscriptIfPossible()
                 return
             }
             let submission = pendingManualInputs.removeFirst()
@@ -858,16 +862,12 @@ private extension CodexChatSessionModel {
     }
 
     func startSteeringPendingInputIfPossible() {
-        if let submission = pendingManualInputs.first,
-           !submission.images.isEmpty,
-           activeTurnSupportsImages != true {
-            return
-        }
         guard let backendThreadID,
               let activeTurnID,
-              let input = dequeuePendingSteerInput() else { return }
+              let input = nextPendingSteerInput() else { return }
         let liveModeGenerationSnapshot = liveModeGeneration
         activeSteerIsLiveTranscript = input.isLiveTranscript
+        activeSteeringManualSubmission = input.manualSubmission
         steerTask = Task { [weak self] in
             await self?.steer(
                 input,
@@ -878,10 +878,23 @@ private extension CodexChatSessionModel {
         }
     }
 
+    func nextPendingSteerInput() -> CodexChatPendingInput? {
+        if let submission = pendingManualInputs.first,
+           !submission.images.isEmpty,
+           activeTurnSupportsImages != true {
+            return dequeuePendingLiveTranscript()
+        }
+        return dequeuePendingSteerInput()
+    }
+
     func dequeuePendingSteerInput() -> CodexChatPendingInput? {
         if !pendingManualInputs.isEmpty {
             return .manual(pendingManualInputs.removeFirst())
         }
+        return dequeuePendingLiveTranscript()
+    }
+
+    func dequeuePendingLiveTranscript() -> CodexChatPendingInput? {
         guard isLiveModeEnabled,
               failedLiveTranscript == nil,
               let transcript = pendingLiveTranscript else { return nil }
@@ -900,6 +913,7 @@ private extension CodexChatSessionModel {
         defer {
             steerTask = nil
             activeSteerIsLiveTranscript = false
+            activeSteeringManualSubmission = nil
             processPendingInputIfPossible()
         }
         do {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatAddPanel.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatAddPanel.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct CodexChatAddPanel: View {
+    let showsMeetingPicker: Bool
+    let meetingReferences: [CodexChatMeetingReference]
+    let highlightedMeetingID: UUID?
+    let onAttachImages: () -> Void
+    let onAddMeetingReference: () -> Void
+    let onSelectMeeting: (CodexChatMeetingReference) -> Void
+
+    var body: some View {
+        Group {
+            if showsMeetingPicker {
+                CodexChatMeetingPicker(
+                    references: meetingReferences,
+                    highlightedID: highlightedMeetingID,
+                    onSelect: onSelectMeeting
+                )
+            } else {
+                VStack(alignment: .leading, spacing: 2) {
+                    CodexChatConfigurationRow(
+                        title: L10n.attachChatImages,
+                        isSelected: false,
+                        leadingSystemImage: "photo",
+                        action: onAttachImages
+                    )
+                    CodexChatConfigurationRow(
+                        title: L10n.addMeetingReference,
+                        isSelected: false,
+                        leadingSystemImage: "text.document",
+                        action: onAddMeetingReference
+                    )
+                }
+                .padding(10)
+                .frame(width: CodexChatDesign.addPanelWidth)
+            }
+        }
+        .codexChatPanelStyle()
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatAttachmentImage.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatAttachmentImage.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct CodexChatAttachmentImage: View {
+    let attachment: CodexChatImageAttachment
+    let size: CGFloat
+
+    @StateObject private var imageLoader = ScreenshotImageLoadModel()
+
+    var body: some View {
+        Group {
+            switch imageLoader.state {
+            case .idle, .loading:
+                ProgressView()
+                    .controlSize(.small)
+            case let .loaded(image):
+                Image(decorative: image, scale: 1)
+                    .resizable()
+                    .scaledToFill()
+            case .failed:
+                Image(systemName: "photo.badge.exclamationmark")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(width: size, height: size)
+        .background(.quaternary)
+        .clipShape(.rect(cornerRadius: 8))
+        .accessibilityElement()
+        .accessibilityLabel(accessibilityLabel)
+        .task(id: attachment.id) {
+            await imageLoader.load(
+                screenshotID: attachment.id,
+                data: attachment.data,
+                maxPixelSize: Int(size * 2)
+            )
+        }
+        .onDisappear(perform: imageLoader.unload)
+    }
+
+    private var accessibilityLabel: String {
+        if case .failed = imageLoader.state {
+            L10n.chatImageUnavailable
+        } else {
+            L10n.chatAttachedImage
+        }
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatAttachmentStrip.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatAttachmentStrip.swift
@@ -15,8 +15,8 @@ struct CodexChatAttachmentStrip: View {
                 }
             }
             .padding(.horizontal, 4)
-            .padding(.top, 4)
         }
+        .frame(height: CodexChatDesign.attachmentThumbnailSize)
         .scrollIndicators(.hidden)
         .accessibilityLabel(L10n.chatAttachedImages)
     }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatAttachmentStrip.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatAttachmentStrip.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct CodexChatAttachmentStrip: View {
+    let attachments: [CodexChatImageAttachment]
+    let onRemove: (UUID) -> Void
+
+    var body: some View {
+        ScrollView(.horizontal) {
+            LazyHStack(spacing: 8) {
+                ForEach(attachments) { attachment in
+                    CodexChatAttachmentThumbnail(
+                        attachment: attachment,
+                        onRemove: onRemove
+                    )
+                }
+            }
+            .padding(.horizontal, 4)
+            .padding(.top, 4)
+        }
+        .scrollIndicators(.hidden)
+        .accessibilityLabel(L10n.chatAttachedImages)
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatAttachmentThumbnail.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatAttachmentThumbnail.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct CodexChatAttachmentThumbnail: View {
+    let attachment: CodexChatImageAttachment
+    let onRemove: (UUID) -> Void
+
+    var body: some View {
+        CodexChatAttachmentImage(
+            attachment: attachment,
+            size: CodexChatDesign.attachmentThumbnailSize
+        )
+        .overlay(alignment: .topTrailing) {
+            Button(
+                L10n.removeChatAttachedImage,
+                systemImage: "xmark.circle.fill",
+                action: { onRemove(attachment.id) }
+            )
+            .labelStyle(.iconOnly)
+            .buttonStyle(.plain)
+            .symbolRenderingMode(.palette)
+            .foregroundStyle(.white, .black.opacity(0.65))
+            .padding(3)
+        }
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatAttachmentValidationView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatAttachmentValidationView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct CodexChatAttachmentValidationView: View {
+    let message: String
+
+    var body: some View {
+        Label(message, systemImage: "info.circle")
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
@@ -4,28 +4,29 @@ import UniformTypeIdentifiers
 
 struct CodexChatComposer: View {
     @Bindable var session: CodexChatSessionModel
-    @State private var isMeetingPickerPresented = false
+    @State private var showsMeetingPicker = false
     @State private var meetingQuery = ""
     @State private var highlightedMeetingID: UUID?
     @State private var suggestions: [CodexChatMeetingReference] = []
     @State private var consumesTrailingMentionOnSelection = false
     @State private var isImageImporterPresented = false
     @State private var isImageDropTargeted = false
+    @State private var showsAddPanel = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 6) {
+            if !session.attachedImages.isEmpty {
+                CodexChatAttachmentStrip(
+                    attachments: session.attachedImages,
+                    onRemove: session.removeAttachedImage
+                )
+            }
+
             if !session.selectedMeetingReferenceIDs.isEmpty {
                 CodexChatMeetingReferenceBar(
                     referenceIDs: session.selectedMeetingReferenceIDs,
                     referencesByID: session.meetingReferencesByID,
                     onRemove: session.removeMeetingReference
-                )
-            }
-
-            if !session.attachedImages.isEmpty {
-                CodexChatAttachmentStrip(
-                    attachments: session.attachedImages,
-                    onRemove: session.removeAttachedImage
                 )
             }
 
@@ -35,15 +36,18 @@ struct CodexChatComposer: View {
 
             CodexChatComposerInputRow(
                 session: session,
-                isMeetingPickerPresented: $isMeetingPickerPresented,
+                showsAddPanel: showsAddPanel,
+                showsMeetingPicker: showsMeetingPicker,
                 suggestions: suggestions,
                 highlightedMeetingID: highlightedMeetingID,
                 onShowImageImporter: showImageImporter,
+                onToggleAddPanel: toggleAddPanel,
                 onShowMeetingPicker: showMeetingPicker,
                 onSelectMeeting: selectMeeting,
+                onPasteImages: pasteImages,
                 onSubmit: handleSubmit,
                 onMoveCommand: handleMoveCommand,
-                onExitCommand: closeMeetingPicker,
+                onExitCommand: dismissAddPanel,
                 onHover: updateTextInputCursor
             )
         }
@@ -73,7 +77,20 @@ struct CodexChatComposer: View {
     }
 
     private func showImageImporter() {
+        dismissAddPanel()
         isImageImporterPresented = true
+    }
+
+    private func toggleAddPanel() {
+        guard !showsAddPanel else {
+            dismissAddPanel()
+            return
+        }
+        meetingQuery = ""
+        highlightedMeetingID = nil
+        consumesTrailingMentionOnSelection = false
+        showsMeetingPicker = false
+        showsAddPanel = true
     }
 
     private func handleImageImport(_ result: Result<[URL], any Error>) {
@@ -91,6 +108,13 @@ struct CodexChatComposer: View {
         Task { await session.addImageData(images.map(\.data)) }
     }
 
+    private func pasteImages() -> Bool {
+        let imageData = CodexChatPasteboardImageReader.imageData()
+        guard !imageData.isEmpty else { return false }
+        Task { await session.addImageData(imageData) }
+        return true
+    }
+
     private func updateDropTarget(_ dropSession: DropSession) {
         switch dropSession.phase {
         case .entering, .active:
@@ -103,7 +127,7 @@ struct CodexChatComposer: View {
     }
 
     private func handleSubmit() {
-        if isMeetingPickerPresented,
+        if showsMeetingPicker,
            let highlightedMeetingID,
            let reference = suggestions.first(where: { $0.id == highlightedMeetingID }) {
             selectMeeting(reference)
@@ -124,26 +148,29 @@ struct CodexChatComposer: View {
 
     private func handleDraftChange(_: String, _ newValue: String) {
         guard let query = CodexChatMeetingReference.trailingMentionQuery(in: newValue) else {
-            if isMeetingPickerPresented {
-                closeMeetingPicker()
+            if showsMeetingPicker {
+                dismissAddPanel()
             }
             return
         }
         meetingQuery = query
         consumesTrailingMentionOnSelection = true
-        isMeetingPickerPresented = true
+        showsMeetingPicker = true
+        showsAddPanel = true
         refreshSuggestions()
     }
 
     private func showMeetingPicker() {
         meetingQuery = ""
         consumesTrailingMentionOnSelection = false
-        isMeetingPickerPresented = true
+        showsMeetingPicker = true
+        showsAddPanel = true
         refreshSuggestions()
     }
 
-    private func closeMeetingPicker() {
-        isMeetingPickerPresented = false
+    private func dismissAddPanel() {
+        showsAddPanel = false
+        showsMeetingPicker = false
         meetingQuery = ""
         highlightedMeetingID = nil
         consumesTrailingMentionOnSelection = false
@@ -155,11 +182,11 @@ struct CodexChatComposer: View {
             consumesTrailingMention: consumesTrailingMentionOnSelection
         )
         session.addMeetingReference(reference)
-        closeMeetingPicker()
+        dismissAddPanel()
     }
 
     private func refreshSuggestionsIfPresented() {
-        guard isMeetingPickerPresented else { return }
+        guard showsMeetingPicker else { return }
         refreshSuggestions()
     }
 
@@ -178,7 +205,7 @@ struct CodexChatComposer: View {
     }
 
     private func handleMoveCommand(_ direction: MoveCommandDirection) {
-        guard isMeetingPickerPresented, !suggestions.isEmpty else { return }
+        guard showsMeetingPicker, !suggestions.isEmpty else { return }
         switch direction {
         case .up:
             highlightedMeetingID = CodexChatMeetingPickerSelection.moving(

--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct CodexChatComposer: View {
     @Bindable var session: CodexChatSessionModel
@@ -8,6 +9,8 @@ struct CodexChatComposer: View {
     @State private var highlightedMeetingID: UUID?
     @State private var suggestions: [CodexChatMeetingReference] = []
     @State private var consumesTrailingMentionOnSelection = false
+    @State private var isImageImporterPresented = false
+    @State private var isImageDropTargeted = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
@@ -19,70 +22,34 @@ struct CodexChatComposer: View {
                 )
             }
 
-            HStack(alignment: .bottom, spacing: 10) {
-                Button(L10n.addMeetingReference, systemImage: "plus", action: showMeetingPicker)
-                    .labelStyle(.iconOnly)
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
-                    .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
-                    .background(.quaternary, in: Circle())
-                    .contentShape(Circle())
-                    .help(L10n.addMeetingReference)
-                    .popover(isPresented: $isMeetingPickerPresented, arrowEdge: .top) {
-                        CodexChatMeetingPicker(
-                            references: suggestions,
-                            highlightedID: highlightedMeetingID,
-                            onSelect: selectMeeting
-                        )
-                    }
-
-                TextField(L10n.messageCodex, text: $session.draft, axis: .vertical)
-                    .font(.body)
-                    .textFieldStyle(.plain)
-                    .lineLimit(1 ... 5)
-                    .padding(.leading, 8)
-                    .padding(.vertical, 6)
-                    .contentShape(.rect)
-                    .onContinuousHover(perform: updateTextInputCursor)
-                    .accessibilityLabel(L10n.messageCodex)
-                    .onSubmit(handleSubmit)
-                    .onMoveCommand(perform: handleMoveCommand)
-                    .onExitCommand(perform: closeMeetingPicker)
-
-                if session.isLoading, session.models.isEmpty {
-                    ProgressView()
-                        .controlSize(.small)
-                        .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
-                        .accessibilityLabel(L10n.chatModelLoading)
-                } else if !session.models.isEmpty {
-                    CodexChatConfigurationButton(session: session)
-                }
-
-                if session.isGenerating, !session.canSend {
-                    CodexChatActionButton(
-                        label: L10n.stopGenerating,
-                        systemImage: "stop.fill",
-                        isEnabled: true,
-                        action: session.stop
-                    )
-                } else {
-                    CodexChatActionButton(
-                        label: L10n.sendMessage,
-                        systemImage: "arrow.up",
-                        isEnabled: session.canSend,
-                        action: session.sendDraft
-                    )
-                }
+            if !session.attachedImages.isEmpty {
+                CodexChatAttachmentStrip(
+                    attachments: session.attachedImages,
+                    onRemove: session.removeAttachedImage
+                )
             }
+
+            if let validationMessage = session.attachmentValidationMessage {
+                CodexChatAttachmentValidationView(message: validationMessage)
+            }
+
+            CodexChatComposerInputRow(
+                session: session,
+                isMeetingPickerPresented: $isMeetingPickerPresented,
+                suggestions: suggestions,
+                highlightedMeetingID: highlightedMeetingID,
+                onShowImageImporter: showImageImporter,
+                onShowMeetingPicker: showMeetingPicker,
+                onSelectMeeting: selectMeeting,
+                onSubmit: handleSubmit,
+                onMoveCommand: handleMoveCommand,
+                onExitCommand: closeMeetingPicker,
+                onHover: updateTextInputCursor
+            )
         }
         .padding(6)
         .background {
-            RoundedRectangle(cornerRadius: CodexChatDesign.composerCornerRadius)
-                .fill(.background)
-                .overlay {
-                    RoundedRectangle(cornerRadius: CodexChatDesign.composerCornerRadius)
-                        .stroke(.separator.opacity(0.55), lineWidth: 1)
-                }
+            CodexChatComposerBackground(isDropTargeted: isImageDropTargeted)
         }
         .shadow(color: .black.opacity(0.05), radius: 12, y: 3)
         .onChange(of: session.draft, handleDraftChange)
@@ -91,6 +58,47 @@ struct CodexChatComposer: View {
         }
         .onChange(of: session.selectedMeetingReferenceIDs) {
             refreshSuggestionsIfPresented()
+        }
+        .fileImporter(
+            isPresented: $isImageImporterPresented,
+            allowedContentTypes: [.image],
+            allowsMultipleSelection: true,
+            onCompletion: handleImageImport
+        )
+        .dropDestination(for: CodexChatTransferImage.self) { images, _ in
+            addTransferImages(images)
+        }
+        .onDropSessionUpdated(updateDropTarget)
+        .pasteDestination(for: CodexChatTransferImage.self, action: addTransferImages)
+    }
+
+    private func showImageImporter() {
+        isImageImporterPresented = true
+    }
+
+    private func handleImageImport(_ result: Result<[URL], any Error>) {
+        switch result {
+        case let .success(urls):
+            Task { await session.addImageURLs(urls) }
+        case let .failure(error):
+            let cocoaError = error as NSError
+            guard cocoaError.domain != NSCocoaErrorDomain || cocoaError.code != NSUserCancelledError else { return }
+            session.reportImageAttachmentFailure()
+        }
+    }
+
+    private func addTransferImages(_ images: [CodexChatTransferImage]) {
+        Task { await session.addImageData(images.map(\.data)) }
+    }
+
+    private func updateDropTarget(_ dropSession: DropSession) {
+        switch dropSession.phase {
+        case .entering, .active:
+            isImageDropTargeted = true
+        case .exiting, .ended, .dataTransferCompleted:
+            isImageDropTargeted = false
+        @unknown default:
+            isImageDropTargeted = false
         }
     }
 

--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposerBackground.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposerBackground.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct CodexChatComposerBackground: View {
+    let isDropTargeted: Bool
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: CodexChatDesign.composerCornerRadius)
+            .fill(.background)
+            .overlay {
+                RoundedRectangle(cornerRadius: CodexChatDesign.composerCornerRadius)
+                    .stroke(borderColor, lineWidth: isDropTargeted ? 2 : 1)
+            }
+    }
+
+    private var borderColor: Color {
+        isDropTargeted ? .accentColor : .secondary.opacity(0.3)
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+struct CodexChatComposerInputRow: View {
+    @Bindable var session: CodexChatSessionModel
+    @Binding var isMeetingPickerPresented: Bool
+    let suggestions: [CodexChatMeetingReference]
+    let highlightedMeetingID: UUID?
+    let onShowImageImporter: () -> Void
+    let onShowMeetingPicker: () -> Void
+    let onSelectMeeting: (CodexChatMeetingReference) -> Void
+    let onSubmit: () -> Void
+    let onMoveCommand: (MoveCommandDirection) -> Void
+    let onExitCommand: () -> Void
+    let onHover: (HoverPhase) -> Void
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 10) {
+            HStack(spacing: 4) {
+                Button(L10n.attachChatImages, systemImage: "paperclip", action: onShowImageImporter)
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
+                    .background(.quaternary, in: Circle())
+                    .contentShape(Circle())
+                    .help(L10n.attachChatImages)
+
+                Button(L10n.addMeetingReference, systemImage: "plus", action: onShowMeetingPicker)
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
+                    .background(.quaternary, in: Circle())
+                    .contentShape(Circle())
+                    .help(L10n.addMeetingReference)
+                    .popover(isPresented: $isMeetingPickerPresented, arrowEdge: .top) {
+                        CodexChatMeetingPicker(
+                            references: suggestions,
+                            highlightedID: highlightedMeetingID,
+                            onSelect: onSelectMeeting
+                        )
+                    }
+            }
+
+            TextField(L10n.messageCodex, text: $session.draft, axis: .vertical)
+                .font(.body)
+                .textFieldStyle(.plain)
+                .lineLimit(1 ... 5)
+                .padding(.leading, 8)
+                .padding(.vertical, 6)
+                .contentShape(.rect)
+                .onContinuousHover(perform: onHover)
+                .accessibilityLabel(L10n.messageCodex)
+                .onSubmit(onSubmit)
+                .onMoveCommand(perform: onMoveCommand)
+                .onExitCommand(perform: onExitCommand)
+
+            if session.isLoading, session.models.isEmpty {
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
+                    .accessibilityLabel(L10n.chatModelLoading)
+            } else if !session.models.isEmpty {
+                CodexChatConfigurationButton(session: session)
+            }
+
+            if session.isGenerating, !session.canSend {
+                CodexChatActionButton(
+                    label: L10n.stopGenerating,
+                    systemImage: "stop.fill",
+                    isEnabled: true,
+                    action: session.stop
+                )
+            } else {
+                CodexChatActionButton(
+                    label: L10n.sendMessage,
+                    systemImage: "arrow.up",
+                    isEnabled: session.canSend,
+                    action: session.sendDraft
+                )
+            }
+        }
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
@@ -2,12 +2,15 @@ import SwiftUI
 
 struct CodexChatComposerInputRow: View {
     @Bindable var session: CodexChatSessionModel
-    @Binding var isMeetingPickerPresented: Bool
+    let showsAddPanel: Bool
+    let showsMeetingPicker: Bool
     let suggestions: [CodexChatMeetingReference]
     let highlightedMeetingID: UUID?
     let onShowImageImporter: () -> Void
+    let onToggleAddPanel: () -> Void
     let onShowMeetingPicker: () -> Void
     let onSelectMeeting: (CodexChatMeetingReference) -> Void
+    let onPasteImages: () -> Bool
     let onSubmit: () -> Void
     let onMoveCommand: (MoveCommandDirection) -> Void
     let onExitCommand: () -> Void
@@ -15,32 +18,30 @@ struct CodexChatComposerInputRow: View {
 
     var body: some View {
         HStack(alignment: .bottom, spacing: 10) {
-            HStack(spacing: 4) {
-                Button(L10n.attachChatImages, systemImage: "paperclip", action: onShowImageImporter)
-                    .labelStyle(.iconOnly)
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
-                    .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
-                    .background(.quaternary, in: Circle())
-                    .contentShape(Circle())
-                    .help(L10n.attachChatImages)
-
-                Button(L10n.addMeetingReference, systemImage: "plus", action: onShowMeetingPicker)
-                    .labelStyle(.iconOnly)
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
-                    .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
-                    .background(.quaternary, in: Circle())
-                    .contentShape(Circle())
-                    .help(L10n.addMeetingReference)
-                    .popover(isPresented: $isMeetingPickerPresented, arrowEdge: .top) {
-                        CodexChatMeetingPicker(
-                            references: suggestions,
-                            highlightedID: highlightedMeetingID,
-                            onSelect: onSelectMeeting
+            Button(L10n.addToChat, systemImage: "plus", action: onToggleAddPanel)
+                .labelStyle(.iconOnly)
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
+                .background(.quaternary, in: Circle())
+                .contentShape(Circle())
+                .help(L10n.addToChat)
+                .overlay(alignment: .bottomLeading) {
+                    if showsAddPanel {
+                        CodexChatAddPanel(
+                            showsMeetingPicker: showsMeetingPicker,
+                            meetingReferences: suggestions,
+                            highlightedMeetingID: highlightedMeetingID,
+                            onAttachImages: onShowImageImporter,
+                            onAddMeetingReference: onShowMeetingPicker,
+                            onSelectMeeting: onSelectMeeting
                         )
+                        .offset(y: -(CodexChatDesign.controlSize + 8))
+                        .zIndex(1)
                     }
-            }
+                }
+                .onExitCommand(perform: onExitCommand)
+                .zIndex(showsAddPanel ? 1 : 0)
 
             TextField(L10n.messageCodex, text: $session.draft, axis: .vertical)
                 .font(.body)
@@ -54,6 +55,10 @@ struct CodexChatComposerInputRow: View {
                 .onSubmit(onSubmit)
                 .onMoveCommand(perform: onMoveCommand)
                 .onExitCommand(perform: onExitCommand)
+                .onKeyPress("v", phases: .down) { keyPress in
+                    guard keyPress.modifiers.contains(.command), onPasteImages() else { return .ignored }
+                    return .handled
+                }
 
             if session.isLoading, session.models.isEmpty {
                 ProgressView()

--- a/Sources/Dahlia/Views/CodexChat/CodexChatConfigurationPanel.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatConfigurationPanel.swift
@@ -48,15 +48,7 @@ struct CodexChatConfigurationPanel: View {
                 alignment: .topLeading
             )
         }
-        .fixedSize()
-        .background(.background, in: RoundedRectangle(cornerRadius: 18))
-        .clipShape(RoundedRectangle(cornerRadius: 18))
-        .overlay {
-            RoundedRectangle(cornerRadius: 18)
-                .stroke(.separator.opacity(0.65), lineWidth: 1)
-        }
-        .shadow(color: .black.opacity(0.16), radius: 18, y: 8)
-        .accessibilityElement(children: .contain)
+        .codexChatPanelStyle()
     }
 
     private var selectedModelName: String {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatConfigurationRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatConfigurationRow.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct CodexChatConfigurationRow: View {
     let title: String
     let isSelected: Bool
+    var leadingSystemImage: String?
     var trailingSystemImage: String?
     let action: () -> Void
 
@@ -11,6 +12,12 @@ struct CodexChatConfigurationRow: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 4) {
+                if let leadingSystemImage {
+                    Image(systemName: leadingSystemImage)
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+                }
+
                 Text(title)
                     .font(.callout)
                     .foregroundStyle(.primary)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatDesign.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatDesign.swift
@@ -20,6 +20,7 @@ enum CodexChatDesign {
     static let resizeCornerSize: CGFloat = 12
     static let attachmentThumbnailSize: CGFloat = 64
     static let messageImageSize: CGFloat = 120
+    static let addPanelWidth: CGFloat = 220
     static let configurationPanelWidth: CGFloat = 252
     static let configurationPanelHeight: CGFloat = 278
     static let modelPanelWidth: CGFloat = 216

--- a/Sources/Dahlia/Views/CodexChat/CodexChatDesign.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatDesign.swift
@@ -18,6 +18,8 @@ enum CodexChatDesign {
     static let resizeHandleOutset: CGFloat = 8
     static let resizeEdgeThickness: CGFloat = 8
     static let resizeCornerSize: CGFloat = 12
+    static let attachmentThumbnailSize: CGFloat = 64
+    static let messageImageSize: CGFloat = 120
     static let configurationPanelWidth: CGFloat = 252
     static let configurationPanelHeight: CGFloat = 278
     static let modelPanelWidth: CGFloat = 216

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMessageImageGrid.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMessageImageGrid.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct CodexChatMessageImageGrid: View {
+    let attachments: [CodexChatImageAttachment]
+
+    var body: some View {
+        FlowLayout(spacing: 6, rowSpacing: 6) {
+            ForEach(attachments) { attachment in
+                CodexChatAttachmentImage(
+                    attachment: attachment,
+                    size: CodexChatDesign.messageImageSize
+                )
+            }
+        }
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
@@ -18,6 +18,7 @@ struct CodexChatMessageRow: View {
                 VStack(alignment: .trailing, spacing: 4) {
                     CodexChatUserMessageContent(
                         rawText: visibleText,
+                        images: message.images,
                         meetingNamesByID: meetingNamesByID,
                         meetingReferencesByID: meetingReferencesByID
                     )
@@ -25,7 +26,9 @@ struct CodexChatMessageRow: View {
                     .padding(.vertical, 8)
                     .background(.quaternary, in: RoundedRectangle(cornerRadius: 14))
 
-                    CodexChatCopyButton(text: displayText)
+                    if !displayText.isEmpty {
+                        CodexChatCopyButton(text: displayText)
+                    }
                 }
             } else {
                 VStack(alignment: .leading, spacing: 10) {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatPanelStyle.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatPanelStyle.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+extension View {
+    func codexChatPanelStyle() -> some View {
+        fixedSize()
+            .background(.background, in: RoundedRectangle(cornerRadius: 18))
+            .clipShape(RoundedRectangle(cornerRadius: 18))
+            .overlay {
+                RoundedRectangle(cornerRadius: 18)
+                    .stroke(.separator.opacity(0.65), lineWidth: 1)
+            }
+            .shadow(color: .black.opacity(0.16), radius: 18, y: 8)
+            .accessibilityElement(children: .contain)
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatUserMessageContent.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatUserMessageContent.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CodexChatUserMessageContent: View {
     let rawText: String
+    let images: [CodexChatImageAttachment]
     let meetingNamesByID: [UUID: String]
     let meetingReferencesByID: [UUID: CodexChatMeetingReference]
 
@@ -13,6 +14,10 @@ struct CodexChatUserMessageContent: View {
         )
 
         VStack(alignment: .leading, spacing: 6) {
+            if !images.isEmpty {
+                CodexChatMessageImageGrid(attachments: images)
+            }
+
             if !content.referenceIDs.isEmpty {
                 FlowLayout(spacing: 6, rowSpacing: 6) {
                     ForEach(content.referenceIDs.indices, id: \.self) { index in

--- a/Tests/DahliaTests/CodexChatCoordinatorTests.swift
+++ b/Tests/DahliaTests/CodexChatCoordinatorTests.swift
@@ -243,14 +243,14 @@ import Foundation
 
         func send(
             threadID _: String,
-            textBlocks _: [String],
+            inputs _: [CodexAppServerInput],
             model _: String?,
             effort _: String
         ) async throws -> AsyncThrowingStream<CodexChatTurnEvent, any Error> {
             AsyncThrowingStream { $0.finish() }
         }
 
-        func steer(threadID _: String, turnID _: String, textBlocks _: [String]) async throws {}
+        func steer(threadID _: String, turnID _: String, inputs _: [CodexAppServerInput]) async throws {}
         func interrupt(threadID _: String, turnID _: String) async {}
         func unsubscribe(threadID _: String) async {}
 
@@ -309,15 +309,15 @@ import Foundation
 
         func send(
             threadID _: String,
-            textBlocks: [String],
+            inputs: [CodexAppServerInput],
             model _: String?,
             effort _: String
         ) async throws -> AsyncThrowingStream<CodexChatTurnEvent, any Error> {
-            sentTextBlocks.append(textBlocks)
+            sentTextBlocks.append(inputs.compactMap(\.textValue))
             return AsyncThrowingStream<CodexChatTurnEvent, any Error> { $0.finish() }
         }
 
-        func steer(threadID _: String, turnID _: String, textBlocks _: [String]) async throws {}
+        func steer(threadID _: String, turnID _: String, inputs _: [CodexAppServerInput]) async throws {}
         func interrupt(threadID _: String, turnID _: String) async {}
 
         func unsubscribe(threadID: String) async {

--- a/Tests/DahliaTests/CodexChatImageProcessorTests.swift
+++ b/Tests/DahliaTests/CodexChatImageProcessorTests.swift
@@ -1,0 +1,53 @@
+import CoreGraphics
+import DahliaRuntimeSupport
+import Foundation
+import ImageIO
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct CodexChatImageProcessorTests {
+        @Test
+        func imageIsResizedToMaximumLongEdge() async throws {
+            let context = try #require(CGContext(
+                data: nil,
+                width: 2048,
+                height: 1024,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ))
+            let sourceImage = try #require(context.makeImage())
+            let sourceData = try #require(ImageEncoder.encode(sourceImage, quality: 0.9))
+
+            let attachment = try #require(await CodexChatImageProcessor.shared.process(sourceData))
+            let imageSource = try #require(CGImageSourceCreateWithData(attachment.data as CFData, nil))
+            let properties = try #require(CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil) as? [CFString: Any])
+            let width = try #require(properties[kCGImagePropertyPixelWidth] as? Int)
+            let height = try #require(properties[kCGImagePropertyPixelHeight] as? Int)
+
+            #expect(max(width, height) == 1024)
+            #expect(attachment.mimeType.hasPrefix("image/"))
+        }
+
+        @Test
+        func invalidImageIsRejected() async {
+            let attachment = await CodexChatImageProcessor.shared.process(Data("not an image".utf8))
+            #expect(attachment == nil)
+        }
+
+        @Test
+        func oversizedInputIsRejectedBeforeDecoding() async {
+            let data = Data(count: CodexChatImageAttachment.maximumInputByteCount + 1)
+            let attachment = await CodexChatImageProcessor.shared.process(data)
+            #expect(attachment == nil)
+        }
+
+        @Test
+        func corruptHistoryDataURIIsRejected() {
+            #expect(CodexChatImageAttachment(dataURI: "data:image/jpeg;base64,AA==") == nil)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/CodexChatImageSessionTests.swift
+++ b/Tests/DahliaTests/CodexChatImageSessionTests.swift
@@ -1,0 +1,306 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct CodexChatImageSessionTests {
+        @Test
+        func failedImageOnlySubmissionRetainsComposerAndRetryClearsAfterSuccess() async throws {
+            let service = ImageChatService(supportsImages: true, sendBehavior: .failFirst)
+            let session = makeSession(service: service)
+            let png = try testPNGData()
+
+            await session.prepare()
+            await session.addImageData([png])
+            #expect(session.attachedImages.count == 1)
+            #expect(session.canSend)
+
+            session.sendDraft()
+            await waitUntil { !session.isGenerating }
+
+            #expect(session.attachedImages.count == 1)
+            let firstInputs = await service.sentInputs
+            #expect(firstInputs.count == 1)
+            guard case .imageDataURI = firstInputs[0][0] else {
+                Issue.record("Expected an image-only Codex input")
+                return
+            }
+            #expect(await service.threadNames == [L10n.chatImage])
+
+            session.retry()
+            await waitUntil { !session.isGenerating }
+            #expect(session.attachedImages.isEmpty)
+            let retriedInputs = await service.sentInputs
+            #expect(retriedInputs.count == 2)
+            #expect(retriedInputs[1] == retriedInputs[0])
+        }
+
+        @Test
+        func composerChangesDuringTurnStartAreNotCleared() async throws {
+            let service = ImageChatService(supportsImages: true, sendBehavior: .delayFirst)
+            let session = makeSession(service: service)
+            let png = try testPNGData()
+
+            await session.prepare()
+            session.draft = "Original"
+            await session.addImageData([png])
+            session.sendDraft()
+            await waitUntilAsync { await service.isSendWaiting }
+
+            session.draft = "New draft"
+            await session.addImageData([png])
+            await service.resumeDelayedSend()
+            await waitUntil { !session.isGenerating }
+
+            #expect(session.draft == "New draft")
+            #expect(session.attachedImages.count == 2)
+        }
+
+        @Test
+        func imageSubmissionSteersActiveTurnAndClearsAfterSuccess() async throws {
+            let service = ImageChatService(supportsImages: true, sendBehavior: .block)
+            let session = makeSession(service: service)
+            let png = try testPNGData()
+
+            await session.prepare()
+            session.draft = "Start"
+            session.sendDraft()
+            await waitUntil { session.activeTurnID != nil }
+
+            session.draft = "Follow up"
+            await session.addImageData([png])
+            session.sendDraft()
+            await waitUntilAsync { await service.steeredInputs.count == 1 }
+
+            let steeredInputs = await service.steeredInputs[0]
+            #expect(steeredInputs.last?.isImage == true)
+            #expect(session.draft.isEmpty)
+            #expect(session.attachedImages.isEmpty)
+            await service.completeBlockedTurn()
+            await waitUntil { !session.isGenerating }
+        }
+
+        @Test
+        func meetingReferenceTextPrecedesMultipleImages() async throws {
+            let service = ImageChatService(supportsImages: true)
+            let session = makeSession(service: service)
+            let png = try testPNGData()
+            let meetingID = UUID.v7()
+
+            await session.prepare()
+            session.addMeetingReference(CodexChatMeetingReference(
+                id: meetingID,
+                name: "Planning",
+                createdAt: .now
+            ))
+            session.draft = "Explain these"
+            await session.addImageData([png, png])
+            session.sendDraft()
+            await waitUntil { !session.isGenerating }
+
+            let inputs = await service.sentInputs[0]
+            #expect(inputs.count == 3)
+            #expect(inputs[0] == .text("meeting:\(meetingID.uuidString.lowercased()) Explain these"))
+            #expect(inputs[1].isImage)
+            #expect(inputs[2].isImage)
+        }
+
+        @Test
+        func imageLimitAndTextOnlyModelBlockSending() async throws {
+            let service = ImageChatService(supportsImages: false)
+            let session = makeSession(service: service)
+            let png = try testPNGData()
+
+            await session.addImageData(Array(repeating: png, count: 11))
+            #expect(!session.canSend)
+            await session.prepare()
+
+            #expect(session.attachedImages.count == 10)
+            #expect(!session.canSend)
+            #expect(session.attachmentValidationMessage == L10n.chatModelDoesNotSupportImages)
+        }
+
+        @Test
+        func retryStopsAfterSwitchingToTextOnlyModel() async throws {
+            let service = ImageChatService(supportsImages: true, sendBehavior: .failFirst)
+            let session = makeSession(service: service)
+            let png = try testPNGData()
+
+            await session.prepare()
+            await session.addImageData([png])
+            session.sendDraft()
+            await waitUntil { !session.isGenerating }
+
+            session.selectModel("text-only-model")
+            session.retry()
+            await Task.yield()
+
+            #expect(await service.sentInputs.count == 1)
+            #expect(session.attachedImages.count == 1)
+            #expect(session.attachmentValidationMessage == L10n.chatModelDoesNotSupportImages)
+        }
+
+        private func makeSession(service: ImageChatService) -> CodexChatSessionModel {
+            let settings = AppSettings()
+            settings.currentVault = VaultRecord(
+                id: .v7(),
+                path: "/tmp/chat-image-test-vault",
+                name: "Chat Image Test",
+                createdAt: .now,
+                lastOpenedAt: .now
+            )
+            return CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings
+            )
+        }
+
+        private func testPNGData() throws -> Data {
+            try #require(Data(base64Encoded:
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Zl2sAAAAASUVORK5CYII="
+            ))
+        }
+
+        private func waitUntil(_ predicate: @MainActor () -> Bool) async {
+            for _ in 0 ..< 1000 {
+                if predicate() { return }
+                await Task.yield()
+            }
+            Issue.record("Timed out waiting for chat image state")
+        }
+
+        private func waitUntilAsync(_ predicate: @escaping @Sendable () async -> Bool) async {
+            for _ in 0 ..< 1000 {
+                if await predicate() { return }
+                await Task.yield()
+            }
+            Issue.record("Timed out waiting for async chat image state")
+        }
+    }
+
+    private actor ImageChatService: CodexChatServicing {
+        enum SendBehavior {
+            case complete
+            case failFirst
+            case delayFirst
+            case block
+        }
+
+        let supportsImages: Bool
+        let sendBehavior: SendBehavior
+        private(set) var sentInputs: [[CodexAppServerInput]] = []
+        private(set) var steeredInputs: [[CodexAppServerInput]] = []
+        private(set) var threadNames: [String] = []
+        private var delayedSendContinuation: CheckedContinuation<Void, Never>?
+        private var blockedTurnContinuation: AsyncThrowingStream<CodexChatTurnEvent, any Error>.Continuation?
+
+        var isSendWaiting: Bool { delayedSendContinuation != nil }
+
+        init(supportsImages: Bool, sendBehavior: SendBehavior = .complete) {
+            self.supportsImages = supportsImages
+            self.sendBehavior = sendBehavior
+        }
+
+        func models(forceRefresh _: Bool) async throws -> [CodexModel] {
+            let selectedModel = CodexModel(
+                id: "default",
+                model: "default-model",
+                displayName: "Default",
+                description: "",
+                hidden: false,
+                isDefault: true,
+                supportedReasoningEfforts: [],
+                defaultReasoningEffort: "medium",
+                inputModalities: supportsImages ? ["text", "image"] : ["text"]
+            )
+            guard supportsImages else { return [selectedModel] }
+            return [
+                selectedModel,
+                CodexModel(
+                    id: "text-only",
+                    model: "text-only-model",
+                    displayName: "Text only",
+                    description: "",
+                    hidden: false,
+                    isDefault: false,
+                    supportedReasoningEfforts: [],
+                    defaultReasoningEffort: "medium",
+                    inputModalities: ["text"]
+                ),
+            ]
+        }
+
+        func listThreads(cursor _: String?, vaultID _: UUID) async throws -> CodexChatThreadPage {
+            CodexChatThreadPage(threads: [], nextCursor: nil)
+        }
+
+        func loadThread(id: String) async throws -> CodexChatThread {
+            CodexChatThread(id: id, title: L10n.chatImage, messages: [], model: nil, reasoningEffort: nil)
+        }
+
+        func resumeThread(id: String, vaultID _: UUID) async throws -> CodexChatThread {
+            try await loadThread(id: id)
+        }
+
+        func startThread(model _: String?, effort: String, vaultID _: UUID) async throws -> CodexChatThread {
+            CodexChatThread(
+                id: "thread-image",
+                title: "",
+                messages: [],
+                model: "default-model",
+                reasoningEffort: effort
+            )
+        }
+
+        func setThreadName(threadID _: String, name: String) async {
+            threadNames.append(name)
+        }
+
+        func send(
+            threadID _: String,
+            inputs: [CodexAppServerInput],
+            model _: String?,
+            effort _: String
+        ) async throws -> AsyncThrowingStream<CodexChatTurnEvent, any Error> {
+            sentInputs.append(inputs)
+            if sendBehavior == .failFirst, sentInputs.count == 1 {
+                throw CodexAppServerError.invalidProtocolResponse
+            }
+            if sendBehavior == .delayFirst, sentInputs.count == 1 {
+                await withCheckedContinuation { continuation in
+                    delayedSendContinuation = continuation
+                }
+            }
+            let (stream, continuation) = AsyncThrowingStream<CodexChatTurnEvent, any Error>.makeStream()
+            continuation.yield(.started(turnID: "turn-image"))
+            if sendBehavior == .block {
+                blockedTurnContinuation = continuation
+            } else {
+                continuation.yield(.completed(itemID: nil, text: nil))
+                continuation.finish()
+            }
+            return stream
+        }
+
+        func steer(threadID _: String, turnID _: String, inputs: [CodexAppServerInput]) async throws {
+            steeredInputs.append(inputs)
+        }
+        func interrupt(threadID _: String, turnID _: String) async {}
+        func unsubscribe(threadID _: String) async {}
+
+        func resumeDelayedSend() {
+            delayedSendContinuation?.resume()
+            delayedSendContinuation = nil
+        }
+
+        func completeBlockedTurn() {
+            blockedTurnContinuation?.yield(.completed(itemID: nil, text: nil))
+            blockedTurnContinuation?.finish()
+            blockedTurnContinuation = nil
+        }
+    }
+#endif

--- a/Tests/DahliaTests/CodexChatImageSessionTests.swift
+++ b/Tests/DahliaTests/CodexChatImageSessionTests.swift
@@ -83,6 +83,67 @@ import Foundation
         }
 
         @Test
+        func repeatedSendDoesNotDuplicateManualSubmissionWhileSteering() async throws {
+            let service = ImageChatService(supportsImages: true, sendBehavior: .blockSteer)
+            let session = makeSession(service: service)
+            let png = try testPNGData()
+
+            await session.prepare()
+            session.draft = "Start"
+            session.sendDraft()
+            await waitUntil { session.activeTurnID != nil }
+
+            session.draft = "Follow up"
+            await session.addImageData([png])
+            session.sendDraft()
+            await waitUntilAsync { await service.isSteerWaiting }
+
+            session.sendDraft()
+            await service.resumeDelayedSteer()
+            await waitUntilAsync { await service.steeredInputs.count == 1 }
+            for _ in 0 ..< 10 {
+                await Task.yield()
+            }
+
+            #expect(await service.steeredInputs.count == 1)
+            await service.completeBlockedTurn()
+            await waitUntil { !session.isGenerating }
+        }
+
+        @Test
+        func incompatiblePendingImageDoesNotBlockLiveTranscript() async throws {
+            let service = ImageChatService(supportsImages: true, sendBehavior: .delayFirstWithoutTurn)
+            let session = makeSession(service: service)
+            let png = try testPNGData()
+
+            await session.prepare()
+            session.toggleLiveMode()
+            session.draft = "Start"
+            session.sendDraft()
+            await waitUntilAsync { await service.isSendWaiting }
+
+            session.draft = "Image pending"
+            await session.addImageData([png])
+            session.sendDraft()
+            session.selectModel("text-only-model")
+            session.receiveFinalizedLiveTranscript("Live speech")
+            await service.resumeDelayedSend()
+
+            await waitUntilAsync { await service.sentInputs.count == 2 }
+            await waitUntil { !session.isGenerating }
+            let liveInputs = await service.sentInputs[1]
+            #expect(liveInputs.contains { input in
+                input.textValue?.contains("Live speech") == true
+            })
+            #expect(!liveInputs.contains { $0.isImage })
+
+            session.selectModel("default-model")
+            await waitUntilAsync { await service.sentInputs.count == 3 }
+            await waitUntil { !session.isGenerating }
+            #expect(await service.sentInputs[2].contains { $0.isImage })
+        }
+
+        @Test
         func meetingReferenceTextPrecedesMultipleImages() async throws {
             let service = ImageChatService(supportsImages: true)
             let session = makeSession(service: service)
@@ -187,7 +248,9 @@ import Foundation
             case complete
             case failFirst
             case delayFirst
+            case delayFirstWithoutTurn
             case block
+            case blockSteer
         }
 
         let supportsImages: Bool
@@ -196,9 +259,11 @@ import Foundation
         private(set) var steeredInputs: [[CodexAppServerInput]] = []
         private(set) var threadNames: [String] = []
         private var delayedSendContinuation: CheckedContinuation<Void, Never>?
+        private var delayedSteerContinuation: CheckedContinuation<Void, Never>?
         private var blockedTurnContinuation: AsyncThrowingStream<CodexChatTurnEvent, any Error>.Continuation?
 
         var isSendWaiting: Bool { delayedSendContinuation != nil }
+        var isSteerWaiting: Bool { delayedSteerContinuation != nil }
 
         init(supportsImages: Bool, sendBehavior: SendBehavior = .complete) {
             self.supportsImages = supportsImages
@@ -270,14 +335,16 @@ import Foundation
             if sendBehavior == .failFirst, sentInputs.count == 1 {
                 throw CodexAppServerError.invalidProtocolResponse
             }
-            if sendBehavior == .delayFirst, sentInputs.count == 1 {
+            if (sendBehavior == .delayFirst || sendBehavior == .delayFirstWithoutTurn), sentInputs.count == 1 {
                 await withCheckedContinuation { continuation in
                     delayedSendContinuation = continuation
                 }
             }
             let (stream, continuation) = AsyncThrowingStream<CodexChatTurnEvent, any Error>.makeStream()
-            continuation.yield(.started(turnID: "turn-image"))
-            if sendBehavior == .block {
+            if sendBehavior != .delayFirstWithoutTurn || sentInputs.count != 1 {
+                continuation.yield(.started(turnID: "turn-image"))
+            }
+            if sendBehavior == .block || sendBehavior == .blockSteer {
                 blockedTurnContinuation = continuation
             } else {
                 continuation.yield(.completed(itemID: nil, text: nil))
@@ -288,6 +355,11 @@ import Foundation
 
         func steer(threadID _: String, turnID _: String, inputs: [CodexAppServerInput]) async throws {
             steeredInputs.append(inputs)
+            if sendBehavior == .blockSteer {
+                await withCheckedContinuation { continuation in
+                    delayedSteerContinuation = continuation
+                }
+            }
         }
         func interrupt(threadID _: String, turnID _: String) async {}
         func unsubscribe(threadID _: String) async {}
@@ -295,6 +367,11 @@ import Foundation
         func resumeDelayedSend() {
             delayedSendContinuation?.resume()
             delayedSendContinuation = nil
+        }
+
+        func resumeDelayedSteer() {
+            delayedSteerContinuation?.resume()
+            delayedSteerContinuation = nil
         }
 
         func completeBlockedTurn() {

--- a/Tests/DahliaTests/CodexChatPasteboardImageReaderTests.swift
+++ b/Tests/DahliaTests/CodexChatPasteboardImageReaderTests.swift
@@ -1,0 +1,43 @@
+#if canImport(Testing)
+import AppKit
+import Testing
+import UniformTypeIdentifiers
+@testable import Dahlia
+
+@MainActor
+struct CodexChatPasteboardImageReaderTests {
+    @Test
+    func readsOnePreferredRepresentationPerImage() {
+        let pasteboard = makePasteboard()
+        let firstPNG = Data([1, 2, 3])
+        let firstTIFF = Data([4, 5, 6])
+        let secondTIFF = Data([7, 8, 9])
+        let firstItem = NSPasteboardItem()
+        firstItem.setData(firstTIFF, forType: type(for: .tiff))
+        firstItem.setData(firstPNG, forType: type(for: .png))
+        let secondItem = NSPasteboardItem()
+        secondItem.setData(secondTIFF, forType: type(for: .tiff))
+        pasteboard.writeObjects([firstItem, secondItem])
+
+        #expect(CodexChatPasteboardImageReader.imageData(from: pasteboard) == [firstPNG, secondTIFF])
+    }
+
+    @Test
+    func ignoresTextOnlyPasteboardContents() {
+        let pasteboard = makePasteboard()
+        pasteboard.setString("Keep normal text paste working", forType: .string)
+
+        #expect(CodexChatPasteboardImageReader.imageData(from: pasteboard).isEmpty)
+    }
+
+    private func makePasteboard() -> NSPasteboard {
+        let pasteboard = NSPasteboard(name: .init("CodexChatPasteboardImageReaderTests-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        return pasteboard
+    }
+
+    private func type(for contentType: UTType) -> NSPasteboard.PasteboardType {
+        NSPasteboard.PasteboardType(contentType.identifier)
+    }
+}
+#endif

--- a/Tests/DahliaTests/CodexChatServiceTests.swift
+++ b/Tests/DahliaTests/CodexChatServiceTests.swift
@@ -21,7 +21,7 @@ import Foundation
             let thread = try await service.startThread(model: "default-model", effort: "medium", vaultID: vaultID)
             let stream = try await service.send(
                 threadID: thread.id,
-                textBlocks: ["Meeting context", "Hi"],
+                inputs: [.text("Meeting context"), .text("Hi")],
                 model: "default-model",
                 effort: "high"
             )
@@ -99,10 +99,11 @@ import Foundation
                 workspaceLocator: TestCodexChatWorkspaceLocator(url: URL(filePath: "/tmp/dahlia-chat-tests"))
             )
 
+            let dataURI = TestCodexChatFixtures.historyImageDataURI
             try await service.steer(
                 threadID: "thread-1",
                 turnID: "turn-1",
-                textBlocks: ["Live context", "New instruction"]
+                inputs: [.text("Live context"), .imageDataURI(dataURI)]
             )
 
             let params = try #require(await transport.messages().first {
@@ -116,10 +117,42 @@ import Foundation
                     "text": .string("Live context"),
                 ]),
                 .object([
-                    "type": .string("text"),
-                    "text": .string("New instruction"),
+                    "type": .string("image"),
+                    "url": .string(dataURI),
                 ]),
             ]))
+            await appServer.shutdown()
+        }
+
+        @Test
+        func imageInputsAreSentAndRestoredFromHistory() async throws {
+            let transport = TestCodexChatAppServerTransport()
+            let appServer = CodexAppServerService(transportFactory: { transport })
+            let service = CodexChatService(
+                appServer: appServer,
+                workspaceLocator: TestCodexChatWorkspaceLocator(url: URL(filePath: "/tmp/dahlia-chat-images"))
+            )
+            let dataURI = TestCodexChatFixtures.historyImageDataURI
+
+            _ = try await service.send(
+                threadID: "thread-1",
+                inputs: [.text("Describe this"), .imageDataURI(dataURI)],
+                model: "default-model",
+                effort: "medium"
+            )
+            let params = try #require(await transport.messages().first {
+                $0.objectValue?["method"]?.stringValue == "turn/start"
+            }?.objectValue?["params"]?.objectValue)
+            #expect(params["input"] == .array([
+                .object(["type": .string("text"), "text": .string("Describe this")]),
+                .object(["type": .string("image"), "url": .string(dataURI)]),
+            ]))
+
+            let loaded = try await service.loadThread(id: "thread-history")
+            #expect(loaded.messages[0].images.count == 1)
+            #expect(loaded.messages[0].images[0].dataURI == dataURI)
+            #expect(loaded.messages[1].text.isEmpty)
+            #expect(loaded.messages[1].images.count == 1)
             await appServer.shutdown()
         }
 
@@ -150,7 +183,7 @@ import Foundation
             )
             let stream = try await service.send(
                 threadID: "thread-1",
-                textBlocks: ["Disconnect"],
+                inputs: [.text("Disconnect")],
                 model: "default-model",
                 effort: "medium"
             )
@@ -183,9 +216,9 @@ import Foundation
 
             #expect(page.threads.map(\.id) == ["thread-history"])
             #expect(page.nextCursor == "next-page")
-            #expect(loaded.messages.map(\.text) == ["Question", "Answer", ""])
-            #expect(loaded.messages[1].reasoning == "Reviewed the question\n\nPrepared the answer")
-            #expect(loaded.messages[2].reasoning == "Reasoning without an answer")
+            #expect(loaded.messages.map(\.text) == ["Question", "", "Answer", ""])
+            #expect(loaded.messages[2].reasoning == "Reviewed the question\n\nPrepared the answer")
+            #expect(loaded.messages[3].reasoning == "Reasoning without an answer")
             #expect(resumed.model == "default-model")
             #expect(resumed.reasoningEffort == "high")
             guard case let .meeting(meetingID, meetingName, calendarEvent) = loaded.messages[0].context else {
@@ -221,7 +254,7 @@ import Foundation
             )
             let stream = try await service.send(
                 threadID: "thread-1",
-                textBlocks: ["Test"],
+                inputs: [.text("Test")],
                 model: "default-model",
                 effort: "medium"
             )

--- a/Tests/DahliaTests/CodexChatSessionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatSessionModelTests.swift
@@ -788,10 +788,11 @@ import Foundation
 
         func send(
             threadID _: String,
-            textBlocks: [String],
+            inputs: [CodexAppServerInput],
             model _: String?,
             effort _: String
         ) async throws -> AsyncThrowingStream<CodexChatTurnEvent, any Error> {
+            let textBlocks = inputs.compactMap(\.textValue)
             sentTextBlocks.append(textBlocks)
             if mode == .delayFirstSendIgnoringCancellation, sentTextBlocks.count == 1 {
                 await withCheckedContinuation { continuation in
@@ -857,7 +858,8 @@ import Foundation
             blockedContinuation = nil
         }
 
-        func steer(threadID _: String, turnID _: String, textBlocks: [String]) async throws {
+        func steer(threadID _: String, turnID _: String, inputs: [CodexAppServerInput]) async throws {
+            let textBlocks = inputs.compactMap(\.textValue)
             steeredTextBlocks.append(textBlocks)
             if !steerErrors.isEmpty {
                 throw steerErrors.removeFirst()

--- a/Tests/DahliaTests/TestCodexChatFixtures.swift
+++ b/Tests/DahliaTests/TestCodexChatFixtures.swift
@@ -17,6 +17,16 @@ enum TestCodexChatFixtures {
     </context>Question
     """
 
+    nonisolated static let historyImageDataURI =
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Zl2sAAAAASUVORK5CYII="
+
+    private nonisolated static var historyImageInput: JSONValue {
+        .object([
+            "type": .string("image"),
+            "url": .string(historyImageDataURI),
+        ])
+    }
+
     nonisolated static var modelList: JSONValue {
         .object([
             "data": .array([
@@ -62,7 +72,13 @@ enum TestCodexChatFixtures {
                                     "type": .string("text"),
                                     "text": .string(historyUserPrompt),
                                 ]),
+                                historyImageInput,
                             ]),
+                        ]),
+                        .object([
+                            "id": .string("user-image-only"),
+                            "type": .string("userMessage"),
+                            "content": .array([historyImageInput]),
                         ]),
                         .object([
                             "id": .string("agent-1"),


### PR DESCRIPTION
## Summary

- Add multiple AI chat image attachments through file selection, drag and drop, and clipboard paste.
- Validate and resize images to a 1024 px longest edge, then send them as Codex App Server image inputs.
- Preserve image submissions through steer, queue, cancellation, failure, and retry flows, and restore persisted images in chat history.
- Add localized validation for attachment limits, unreadable images, and image-incompatible models.

## Why

AI chat previously accepted text-only submissions. This adds image-only and mixed text/image messages while keeping the existing Codex thread as the persistence source and avoiding database or dependency changes.

## Validation

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build`
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` — 709 Swift Testing tests across 124 suites, plus 3 XCTest tests passed
- Targeted image attachment tests — 10 tests passed
- `CI=true ./scripts/lint.sh` — passed; existing SwiftLint warnings remain
- `git diff --check`
