### PR TITLE
Fix screenshot collection app hang

### DIFF
--- a/Sources/Dahlia/Services/ErrorReportingService.swift
+++ b/Sources/Dahlia/Services/ErrorReportingService.swift
@@ -53,6 +53,18 @@ enum ErrorReportingService {
         }
     }
 
+    static func recordScreenshotCollectionState(countBucket: Int, minimumWidthBucket: Int) {
+        guard isEnabled else { return }
+        let breadcrumb = Breadcrumb(level: .info, category: "ui.screenshot_grid")
+        breadcrumb.type = "state"
+        breadcrumb.data = [
+            "backend": "nscollectionview",
+            "count_bucket": String(countBucket),
+            "minimum_width_bucket": String(minimumWidthBucket),
+        ]
+        SentrySDK.addBreadcrumb(breadcrumb)
+    }
+
     static func resolveDSN(infoDictionary: [String: Any], isDebugBuild: Bool) -> String? {
         guard !isDebugBuild else { return nil }
         return trimmedString(for: dsnInfoKey, in: infoDictionary)

--- a/Sources/Dahlia/Utilities/ScreenshotImageLoader.swift
+++ b/Sources/Dahlia/Utilities/ScreenshotImageLoader.swift
@@ -93,7 +93,7 @@ final class ScreenshotImageLoadModel: ObservableObject {
         state = image.map(State.loaded) ?? .failed
     }
 
-    /// Lazy grid が保持している画面外 View からデコード済み画像を解放する。
+    /// 画面外になった表示要素からデコード済み画像を解放する。
     func unload() {
         loadGeneration &+= 1
         state = .idle

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -80,144 +80,6 @@ private struct ScreenshotOverlayView: View {
     }
 }
 
-/// スクリーンショットのサムネイル表示。
-private struct ScreenshotThumbnailView: View {
-    let screenshot: MeetingScreenshotRecord
-    let timestamp: String
-    let viewModel: CaptionViewModel
-    let isSelecting: Bool
-    let isReferencedBySummary: Bool
-    @Binding var expandedScreenshot: MeetingScreenshotRecord?
-    @Binding var selectedScreenshotIds: Set<UUID>
-    @StateObject private var imageLoader = ScreenshotImageLoadModel()
-
-    private var isSelected: Bool {
-        selectedScreenshotIds.contains(screenshot.id)
-    }
-
-    var body: some View {
-        VStack(spacing: 4) {
-            Button(action: handleImageAction) {
-                Group {
-                    if case let .loaded(thumbnailImage) = imageLoader.state {
-                        Image(decorative: thumbnailImage, scale: 1)
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .clipShape(RoundedRectangle(cornerRadius: 6))
-                            .shadow(color: .black.opacity(0.1), radius: 2, y: 1)
-                    } else {
-                        RoundedRectangle(cornerRadius: 6)
-                            .fill(Color.primary.opacity(0.05))
-                            .aspectRatio(16 / 9, contentMode: .fit)
-                    }
-                }
-                .overlay(alignment: .topTrailing) {
-                    if isSelecting {
-                        Image(systemName: selectionIndicatorSystemImage)
-                            .font(.title2)
-                            .symbolRenderingMode(.palette)
-                            .foregroundStyle(selectionIndicatorColor, .black.opacity(0.45))
-                            .padding(8)
-                    }
-                }
-            }
-            .buttonStyle(.plain)
-            .pointerStyle(.link)
-            .disabled(isSelecting && isReferencedBySummary)
-            .accessibilityLabel(imageActionAccessibilityLabel)
-            .accessibilityValue(isSelected ? L10n.selected : "")
-            HStack {
-                Text(timestamp)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Spacer()
-                if isReferencedBySummary {
-                    Image(systemName: "lock.fill")
-                        .foregroundStyle(.secondary)
-                        .help(L10n.screenshotUsedInSummary)
-                }
-                if !isSelecting {
-                    Button(L10n.download, systemImage: "arrow.down.circle") {
-                        viewModel.downloadScreenshot(screenshot)
-                    }
-                    .labelStyle(.iconOnly)
-                    .buttonStyle(.plain)
-                    .pointerStyle(.link)
-                    .foregroundStyle(.secondary)
-                    .help(L10n.download)
-
-                    Button(L10n.delete, systemImage: "trash", role: .destructive) {
-                        viewModel.deleteScreenshot(screenshot)
-                    }
-                    .labelStyle(.iconOnly)
-                    .buttonStyle(.plain)
-                    .pointerStyle(.link)
-                    .foregroundStyle(.secondary)
-                    .disabled(isReferencedBySummary || viewModel.isSummaryGenerating || viewModel.isDeletingScreenshots)
-                    .help(isReferencedBySummary ? L10n.screenshotUsedInSummary : L10n.delete)
-                }
-            }
-        }
-        .padding(6)
-        .background(Color.primary.opacity(0.05), in: RoundedRectangle(cornerRadius: 8))
-        .task(id: screenshot.id) {
-            await imageLoader.load(
-                screenshotID: screenshot.id,
-                data: screenshot.imageData,
-                maxPixelSize: ScreenshotGridSizing.maximumThumbnailPixelSize
-            )
-        }
-        .onDisappear {
-            imageLoader.unload()
-        }
-    }
-
-    private func handleImageAction() {
-        if isSelecting {
-            guard !isReferencedBySummary else { return }
-            if isSelected {
-                selectedScreenshotIds.remove(screenshot.id)
-            } else {
-                selectedScreenshotIds.insert(screenshot.id)
-            }
-        } else {
-            withAnimation(.easeOut(duration: 0.15)) {
-                expandedScreenshot = screenshot
-            }
-        }
-    }
-
-    private var imageActionAccessibilityLabel: String {
-        if isSelecting, isReferencedBySummary {
-            L10n.screenshotUsedInSummary
-        } else if isSelecting {
-            L10n.select
-        } else {
-            L10n.open
-        }
-    }
-
-    private var selectionIndicatorSystemImage: String {
-        if isReferencedBySummary {
-            "lock.circle.fill"
-        } else if isSelected {
-            "checkmark.circle.fill"
-        } else {
-            "circle"
-        }
-    }
-
-    private var selectionIndicatorColor: Color {
-        if isReferencedBySummary {
-            .secondary
-        } else if isSelected {
-            .accentColor
-        } else {
-            .white
-        }
-    }
-}
-
 /// ミーティング詳細のタイトル。クリックでインライン編集できる。
 private struct MeetingNameHeader: View {
     let title: String
@@ -712,33 +574,27 @@ struct ControlPanelView: View {
 
                 Divider()
 
-                ScrollView {
-                    LazyVGrid(
-                        columns: [GridItem(.adaptive(minimum: screenshotMinimumWidth), spacing: 12)],
-                        spacing: 12
-                    ) {
-                        let timeBase = screenshotTimeBase
-                        let recordingSessions = viewModel.store.recordingSessions
-                        ForEach(viewModel.screenshots, id: \.id) { screenshot in
-                            ScreenshotThumbnailView(
-                                screenshot: screenshot,
-                                timestamp: Formatters.elapsedHHmmss(
-                                    at: screenshot.capturedAt,
-                                    sessionId: screenshot.sessionId,
-                                    sessions: recordingSessions,
-                                    fallbackTimeBase: timeBase
-                                ),
-                                viewModel: viewModel,
-                                isSelecting: isSelectingScreenshots,
-                                isReferencedBySummary: referencedScreenshotIds.contains(screenshot.id),
-                                expandedScreenshot: $expandedScreenshot,
-                                selectedScreenshotIds: $selectedScreenshotIds
-                            )
-                        }
-                    }
-                    .padding(12)
-                }
+                ScreenshotCollectionView(
+                    meetingID: viewModel.screenshots[0].meetingId,
+                    screenshots: viewModel.screenshots,
+                    recordingSessions: viewModel.store.recordingSessions,
+                    fallbackTimeBase: screenshotTimeBase,
+                    minimumItemWidth: screenshotMinimumWidth,
+                    isSelecting: isSelectingScreenshots,
+                    referencedScreenshotIDs: referencedScreenshotIds,
+                    isDeletionDisabled: viewModel.isSummaryGenerating || viewModel.isDeletingScreenshots,
+                    selectedScreenshotIDs: $selectedScreenshotIds,
+                    open: openScreenshot,
+                    download: viewModel.downloadScreenshot,
+                    delete: viewModel.deleteScreenshot
+                )
             }
+        }
+    }
+
+    private func openScreenshot(_ screenshot: MeetingScreenshotRecord) {
+        withAnimation(.easeOut(duration: 0.15)) {
+            expandedScreenshot = screenshot
         }
     }
 

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -575,7 +575,7 @@ struct ControlPanelView: View {
                 Divider()
 
                 ScreenshotCollectionView(
-                    meetingID: viewModel.screenshots[0].meetingId,
+                    meetingID: viewModel.currentMeetingId,
                     screenshots: viewModel.screenshots,
                     recordingSessions: viewModel.store.recordingSessions,
                     fallbackTimeBase: screenshotTimeBase,

--- a/Sources/Dahlia/Views/ScreenshotCollectionLayout.swift
+++ b/Sources/Dahlia/Views/ScreenshotCollectionLayout.swift
@@ -1,0 +1,71 @@
+import AppKit
+
+final class ScreenshotCollectionLayout: NSCollectionViewFlowLayout {
+    struct Metrics: Equatable {
+        let columnCount: Int
+        let itemSize: NSSize
+    }
+
+    static let sectionPadding: CGFloat = 12
+    static let itemSpacing: CGFloat = 12
+    static let metadataHeight: CGFloat = 36
+
+    var minimumItemWidth = CGFloat(ScreenshotGridSizing.defaultMinimumWidth) {
+        didSet {
+            guard minimumItemWidth != oldValue else { return }
+            invalidateLayout()
+        }
+    }
+
+    override init() {
+        super.init()
+        scrollDirection = .vertical
+        minimumInteritemSpacing = Self.itemSpacing
+        minimumLineSpacing = Self.itemSpacing
+        sectionInset = NSEdgeInsets(
+            top: Self.sectionPadding,
+            left: Self.sectionPadding,
+            bottom: Self.sectionPadding,
+            right: Self.sectionPadding
+        )
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepare() {
+        guard let collectionView else {
+            super.prepare()
+            return
+        }
+
+        let viewportWidth = collectionView.enclosingScrollView?.contentSize.width ?? collectionView.bounds.width
+        let metrics = Self.metrics(containerWidth: viewportWidth, minimumItemWidth: minimumItemWidth)
+        if itemSize != metrics.itemSize {
+            itemSize = metrics.itemSize
+        }
+        super.prepare()
+    }
+
+    override func shouldInvalidateLayout(forBoundsChange newBounds: NSRect) -> Bool {
+        guard let collectionView else { return false }
+        return newBounds.width != collectionView.bounds.width
+    }
+
+    static func metrics(containerWidth: CGFloat, minimumItemWidth: CGFloat) -> Metrics {
+        let horizontalPadding = sectionPadding * 2
+        let availableWidth = max(containerWidth - horizontalPadding, 1)
+        let resolvedMinimumWidth = max(minimumItemWidth, 1)
+        let columnCount = max(1, Int((availableWidth + itemSpacing) / (resolvedMinimumWidth + itemSpacing)))
+        let totalSpacing = CGFloat(columnCount - 1) * itemSpacing
+        let itemWidth = max(1, ((availableWidth - totalSpacing) / CGFloat(columnCount)).rounded(.down))
+        let thumbnailWidth = max(1, itemWidth - 12)
+        let thumbnailHeight = (thumbnailWidth * 9 / 16).rounded(.down)
+        return Metrics(
+            columnCount: columnCount,
+            itemSize: NSSize(width: itemWidth, height: thumbnailHeight + metadataHeight)
+        )
+    }
+}

--- a/Sources/Dahlia/Views/ScreenshotCollectionLayout.swift
+++ b/Sources/Dahlia/Views/ScreenshotCollectionLayout.swift
@@ -41,7 +41,7 @@ final class ScreenshotCollectionLayout: NSCollectionViewFlowLayout {
             return
         }
 
-        let viewportWidth = collectionView.enclosingScrollView?.contentSize.width ?? collectionView.bounds.width
+        let viewportWidth = collectionView.bounds.width
         let metrics = Self.metrics(containerWidth: viewportWidth, minimumItemWidth: minimumItemWidth)
         if itemSize != metrics.itemSize {
             itemSize = metrics.itemSize

--- a/Sources/Dahlia/Views/ScreenshotCollectionView.swift
+++ b/Sources/Dahlia/Views/ScreenshotCollectionView.swift
@@ -1,0 +1,365 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+struct ScreenshotCollectionView: NSViewRepresentable {
+    let meetingID: UUID
+    let screenshots: [MeetingScreenshotRecord]
+    let recordingSessions: [RecordingSessionTimeline]
+    let fallbackTimeBase: Date
+    let minimumItemWidth: Double
+    let isSelecting: Bool
+    let referencedScreenshotIDs: Set<UUID>
+    let isDeletionDisabled: Bool
+    @Binding var selectedScreenshotIDs: Set<UUID>
+    let open: (MeetingScreenshotRecord) -> Void
+    let download: (MeetingScreenshotRecord) -> Void
+    let delete: (MeetingScreenshotRecord) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let layout = ScreenshotCollectionLayout()
+        layout.minimumItemWidth = minimumItemWidth
+
+        let collectionView = NSCollectionView()
+        collectionView.autoresizingMask = [.width]
+        collectionView.collectionViewLayout = layout
+        collectionView.isSelectable = false
+        collectionView.backgroundColors = [.clear]
+        collectionView.register(
+            ScreenshotCollectionViewItem.self,
+            forItemWithIdentifier: ScreenshotCollectionViewItem.reuseIdentifier
+        )
+        collectionView.delegate = context.coordinator
+
+        let scrollView = NSScrollView()
+        scrollView.drawsBackground = false
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        collectionView.frame = scrollView.contentView.bounds
+        scrollView.documentView = collectionView
+
+        context.coordinator.installDataSource(on: collectionView)
+        context.coordinator.update(parent: self, collectionView: collectionView, layout: layout)
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        guard let collectionView = scrollView.documentView as? NSCollectionView,
+              let layout = collectionView.collectionViewLayout as? ScreenshotCollectionLayout else { return }
+        context.coordinator.update(parent: self, collectionView: collectionView, layout: layout)
+    }
+
+    static func dismantleNSView(_ scrollView: NSScrollView, coordinator: Coordinator) {
+        guard let collectionView = scrollView.documentView as? NSCollectionView else { return }
+        coordinator.dismantle(collectionView: collectionView)
+    }
+}
+
+extension ScreenshotCollectionView {
+    @MainActor
+    final class Coordinator: NSObject, NSCollectionViewDelegate {
+        private var parent: ScreenshotCollectionView
+        private var dataSource: NSCollectionViewDiffableDataSource<Int, UUID>?
+        private var currentScreenshotIDs: [UUID] = []
+        private var currentScreenshotMetadata: [ScreenshotMetadata] = []
+        private var timestampByID: [UUID: String] = [:]
+        private var timestampContext: TimestampContext?
+        private var lastPresentationState: PresentationState?
+        private var currentMeetingID: UUID?
+        private var lastBreadcrumbState: BreadcrumbState?
+        private var snapshotGeneration: UInt64 = 0
+        private(set) var timestampCacheGeneration: UInt64 = 0
+        private(set) var isDismantled = false
+
+        var snapshotItemIdentifiers: [UUID] {
+            dataSource?.snapshot().itemIdentifiers ?? []
+        }
+
+        init(parent: ScreenshotCollectionView) {
+            self.parent = parent
+        }
+
+        func installDataSource(on collectionView: NSCollectionView) {
+            dataSource = NSCollectionViewDiffableDataSource<Int, UUID>(collectionView: collectionView) { [weak self] collectionView, indexPath, id in
+                MainActor.assumeIsolated {
+                    guard let self,
+                          !self.isDismantled,
+                          let item = collectionView.makeItem(
+                              withIdentifier: ScreenshotCollectionViewItem.reuseIdentifier,
+                              for: indexPath
+                          ) as? ScreenshotCollectionViewItem else { return nil }
+                    self.configure(item, id: id)
+                    return item
+                }
+            }
+        }
+
+        func update(
+            parent: ScreenshotCollectionView,
+            collectionView: NSCollectionView,
+            layout: ScreenshotCollectionLayout
+        ) {
+            guard !isDismantled else { return }
+            self.parent = parent
+            layout.minimumItemWidth = parent.minimumItemWidth
+
+            let screenshots = parent.screenshots
+            let ids = screenshots.map(\.id)
+            let screenshotMetadata = screenshots.map(ScreenshotMetadata.init)
+            let meetingChanged = currentMeetingID != parent.meetingID
+            let identifiersChanged = Self.requiresSnapshotUpdate(
+                currentIDs: currentScreenshotIDs,
+                newIDs: ids
+            )
+            let metadataChanged = currentScreenshotMetadata != screenshotMetadata
+            currentMeetingID = parent.meetingID
+            currentScreenshotIDs = ids
+            currentScreenshotMetadata = screenshotMetadata
+
+            let currentTimestampContext = TimestampContext(
+                recordingSessions: parent.recordingSessions,
+                fallbackTimeBase: parent.fallbackTimeBase
+            )
+            if meetingChanged || metadataChanged || timestampContext != currentTimestampContext {
+                timestampByID = Dictionary(uniqueKeysWithValues: screenshots.map { ($0.id, timestamp(for: $0)) })
+                timestampContext = currentTimestampContext
+                timestampCacheGeneration &+= 1
+            }
+
+            applySnapshotIfNeeded(
+                ids: ids,
+                collectionView: collectionView,
+                identifiersChanged: identifiersChanged,
+                resetsScrollPosition: meetingChanged
+            )
+
+            let presentationState = PresentationState(
+                isSelecting: parent.isSelecting,
+                selectedScreenshotIDs: parent.selectedScreenshotIDs,
+                referencedScreenshotIDs: parent.referencedScreenshotIDs,
+                isDeletionDisabled: parent.isDeletionDisabled,
+                timestampCacheGeneration: timestampCacheGeneration
+            )
+            if Self.requiresVisibleItemUpdate(previous: lastPresentationState, current: presentationState) {
+                reconfigureVisibleItems(in: collectionView)
+                lastPresentationState = presentationState
+            }
+            recordBreadcrumbIfNeeded(count: screenshots.count)
+        }
+
+        func dismantle(collectionView: NSCollectionView) {
+            isDismantled = true
+            snapshotGeneration &+= 1
+            for item in collectionView.visibleItems() {
+                (item as? ScreenshotCollectionViewItem)?.didEndDisplaying()
+            }
+            collectionView.delegate = nil
+            collectionView.dataSource = nil
+            dataSource = nil
+            currentScreenshotIDs.removeAll()
+            currentScreenshotMetadata.removeAll()
+            timestampByID.removeAll()
+        }
+
+        func collectionView(
+            _: NSCollectionView,
+            willDisplay item: NSCollectionViewItem,
+            forRepresentedObjectAt indexPath: IndexPath
+        ) {
+            guard let item = item as? ScreenshotCollectionViewItem,
+                  let id = dataSource?.itemIdentifier(for: indexPath) else { return }
+            configure(item, id: id)
+        }
+
+        func collectionView(
+            _: NSCollectionView,
+            didEndDisplaying item: NSCollectionViewItem,
+            forRepresentedObjectAt _: IndexPath
+        ) {
+            (item as? ScreenshotCollectionViewItem)?.didEndDisplaying()
+        }
+
+        private func applySnapshotIfNeeded(
+            ids: [UUID],
+            collectionView: NSCollectionView,
+            identifiersChanged: Bool,
+            resetsScrollPosition: Bool
+        ) {
+            guard let dataSource else { return }
+            guard identifiersChanged else {
+                if resetsScrollPosition {
+                    Self.scrollToTop(collectionView)
+                }
+                return
+            }
+
+            let preservedOrigin = collectionView.enclosingScrollView?.contentView.bounds.origin
+            let appliedMeetingID = currentMeetingID
+            snapshotGeneration &+= 1
+            let appliedSnapshotGeneration = snapshotGeneration
+            var snapshot = NSDiffableDataSourceSnapshot<Int, UUID>()
+            snapshot.appendSections([0])
+            snapshot.appendItems(ids, toSection: 0)
+            dataSource.apply(snapshot, animatingDifferences: false) { [weak self, weak collectionView] in
+                guard let self,
+                      let collectionView,
+                      !self.isDismantled,
+                      self.currentMeetingID == appliedMeetingID,
+                      self.snapshotGeneration == appliedSnapshotGeneration else { return }
+                if resetsScrollPosition {
+                    Self.scrollToTop(collectionView)
+                } else if let preservedOrigin {
+                    Self.scroll(collectionView, to: preservedOrigin)
+                }
+            }
+        }
+
+        private func reconfigureVisibleItems(in collectionView: NSCollectionView) {
+            let visibleItems = collectionView.visibleItems().compactMap { $0 as? ScreenshotCollectionViewItem }
+            for item in visibleItems {
+                guard let id = item.representedScreenshotID else { continue }
+                configure(item, id: id)
+            }
+        }
+
+        private func configure(_ item: ScreenshotCollectionViewItem, id: UUID) {
+            guard let screenshot = screenshot(for: id), let timestamp = timestampByID[id] else { return }
+            item.configure(
+                .init(
+                    screenshot: screenshot,
+                    timestamp: timestamp,
+                    isSelecting: parent.isSelecting,
+                    isSelected: parent.selectedScreenshotIDs.contains(id),
+                    isReferencedBySummary: parent.referencedScreenshotIDs.contains(id),
+                    isDeletionDisabled: parent.isDeletionDisabled
+                ),
+                actions: .init(
+                    activate: { [weak self] in self?.activate(id: id) },
+                    download: { [weak self] in self?.download(id: id) },
+                    delete: { [weak self] in self?.delete(id: id) }
+                )
+            )
+        }
+
+        private func activate(id: UUID) {
+            guard let screenshot = screenshot(for: id) else { return }
+            if parent.isSelecting {
+                guard !parent.referencedScreenshotIDs.contains(id) else { return }
+                if parent.selectedScreenshotIDs.contains(id) {
+                    parent.selectedScreenshotIDs.remove(id)
+                } else {
+                    parent.selectedScreenshotIDs.insert(id)
+                }
+            } else {
+                parent.open(screenshot)
+            }
+        }
+
+        private func download(id: UUID) {
+            guard let screenshot = screenshot(for: id) else { return }
+            parent.download(screenshot)
+        }
+
+        private func delete(id: UUID) {
+            guard let screenshot = screenshot(for: id) else { return }
+            parent.delete(screenshot)
+        }
+
+        private func screenshot(for id: UUID) -> MeetingScreenshotRecord? {
+            parent.screenshots.first { $0.id == id }
+        }
+
+        private func timestamp(for screenshot: MeetingScreenshotRecord) -> String {
+            Formatters.elapsedHHmmss(
+                at: screenshot.capturedAt,
+                sessionId: screenshot.sessionId,
+                sessions: parent.recordingSessions,
+                fallbackTimeBase: parent.fallbackTimeBase
+            )
+        }
+
+        private func recordBreadcrumbIfNeeded(count: Int) {
+            let state = BreadcrumbState(
+                countBucket: Self.countBucket(for: count),
+                minimumWidthBucket: Self.minimumWidthBucket(for: parent.minimumItemWidth)
+            )
+            guard state != lastBreadcrumbState else { return }
+            lastBreadcrumbState = state
+            ErrorReportingService.recordScreenshotCollectionState(
+                countBucket: state.countBucket,
+                minimumWidthBucket: state.minimumWidthBucket
+            )
+        }
+
+        private static func scrollToTop(_ collectionView: NSCollectionView) {
+            scroll(collectionView, to: .zero)
+        }
+
+        private static func scroll(_ collectionView: NSCollectionView, to origin: NSPoint) {
+            guard let scrollView = collectionView.enclosingScrollView else { return }
+            scrollView.contentView.scroll(to: origin)
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+        }
+
+        static func countBucket(for count: Int) -> Int {
+            switch count {
+            case ..<1: 0
+            case 1 ..< 10: 1
+            case 10 ..< 25: 10
+            case 25 ..< 50: 25
+            case 50 ..< 100: 50
+            default: (count / 100) * 100
+            }
+        }
+
+        static func minimumWidthBucket(for width: Double) -> Int {
+            Int((width / 10).rounded()) * 10
+        }
+
+        static func requiresSnapshotUpdate(currentIDs: [UUID], newIDs: [UUID]) -> Bool {
+            currentIDs != newIDs
+        }
+
+        static func requiresVisibleItemUpdate(
+            previous: PresentationState?,
+            current: PresentationState
+        ) -> Bool {
+            previous != current
+        }
+
+        struct PresentationState: Equatable {
+            let isSelecting: Bool
+            let selectedScreenshotIDs: Set<UUID>
+            let referencedScreenshotIDs: Set<UUID>
+            let isDeletionDisabled: Bool
+            let timestampCacheGeneration: UInt64
+        }
+
+        private struct TimestampContext: Equatable {
+            let recordingSessions: [RecordingSessionTimeline]
+            let fallbackTimeBase: Date
+        }
+
+        private struct ScreenshotMetadata: Equatable {
+            let id: UUID
+            let sessionID: UUID?
+            let capturedAt: Date
+
+            init(_ screenshot: MeetingScreenshotRecord) {
+                id = screenshot.id
+                sessionID = screenshot.sessionId
+                capturedAt = screenshot.capturedAt
+            }
+        }
+
+        private struct BreadcrumbState: Equatable {
+            let countBucket: Int
+            let minimumWidthBucket: Int
+        }
+    }
+}

--- a/Sources/Dahlia/Views/ScreenshotCollectionView.swift
+++ b/Sources/Dahlia/Views/ScreenshotCollectionView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 @MainActor
 struct ScreenshotCollectionView: NSViewRepresentable {
-    let meetingID: UUID
+    let meetingID: UUID?
     let screenshots: [MeetingScreenshotRecord]
     let recordingSessions: [RecordingSessionTimeline]
     let fallbackTimeBase: Date
@@ -66,6 +66,7 @@ extension ScreenshotCollectionView {
         private var parent: ScreenshotCollectionView
         private var dataSource: NSCollectionViewDiffableDataSource<Int, UUID>?
         private var currentScreenshotIDs: [UUID] = []
+        private var screenshotIndexByID: [UUID: Int] = [:]
         private var currentScreenshotMetadata: [ScreenshotMetadata] = []
         private var timestampByID: [UUID: String] = [:]
         private var timestampContext: TimestampContext?
@@ -116,6 +117,11 @@ extension ScreenshotCollectionView {
                 currentIDs: currentScreenshotIDs,
                 newIDs: ids
             )
+            if identifiersChanged {
+                screenshotIndexByID = Dictionary(
+                    uniqueKeysWithValues: ids.enumerated().map { ($0.element, $0.offset) }
+                )
+            }
             let metadataChanged = currentScreenshotMetadata != screenshotMetadata
             currentMeetingID = parent.meetingID
             currentScreenshotIDs = ids
@@ -162,6 +168,7 @@ extension ScreenshotCollectionView {
             collectionView.dataSource = nil
             dataSource = nil
             currentScreenshotIDs.removeAll()
+            screenshotIndexByID.removeAll()
             currentScreenshotMetadata.removeAll()
             timestampByID.removeAll()
         }
@@ -271,7 +278,10 @@ extension ScreenshotCollectionView {
         }
 
         private func screenshot(for id: UUID) -> MeetingScreenshotRecord? {
-            parent.screenshots.first { $0.id == id }
+            guard let index = screenshotIndexByID[id],
+                  parent.screenshots.indices.contains(index),
+                  parent.screenshots[index].id == id else { return nil }
+            return parent.screenshots[index]
         }
 
         private func timestamp(for screenshot: MeetingScreenshotRecord) -> String {

--- a/Sources/Dahlia/Views/ScreenshotCollectionViewItem.swift
+++ b/Sources/Dahlia/Views/ScreenshotCollectionViewItem.swift
@@ -1,0 +1,291 @@
+import AppKit
+import CoreGraphics
+
+@MainActor
+private final class PassthroughImageView: NSImageView {
+    override func hitTest(_: NSPoint) -> NSView? {
+        nil
+    }
+}
+
+@MainActor
+private final class ScreenshotThumbnailButton: NSButton {
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateBackgroundColor()
+    }
+
+    func updateBackgroundColor() {
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            layer?.backgroundColor = NSColor.labelColor.withAlphaComponent(0.05).cgColor
+        }
+    }
+}
+
+@MainActor
+final class ScreenshotCollectionViewItem: NSCollectionViewItem {
+    typealias ThumbnailProvider = @Sendable (UUID, Data, Int) async -> CGImage?
+
+    struct Configuration {
+        let screenshot: MeetingScreenshotRecord
+        let timestamp: String
+        let isSelecting: Bool
+        let isSelected: Bool
+        let isReferencedBySummary: Bool
+        let isDeletionDisabled: Bool
+    }
+
+    struct Actions {
+        let activate: () -> Void
+        let download: () -> Void
+        let delete: () -> Void
+    }
+
+    struct RenderedState: Equatable {
+        let isThumbnailEnabled: Bool
+        let isLockVisible: Bool
+        let selectionSymbolName: String?
+        let isDeleteHidden: Bool
+        let isDeleteEnabled: Bool
+    }
+
+    nonisolated static let reuseIdentifier = NSUserInterfaceItemIdentifier("ScreenshotCollectionViewItem")
+
+    private let thumbnailButton = ScreenshotThumbnailButton()
+    private let timestampLabel = NSTextField(labelWithString: "")
+    private let lockImageView = NSImageView()
+    private let selectionImageView = PassthroughImageView()
+    private let downloadButton = NSButton()
+    private let deleteButton = NSButton()
+    private var thumbnailTask: Task<Void, Never>?
+    private var loadGeneration: UInt64 = 0
+    private var activationHandler: (() -> Void)?
+    private var downloadHandler: (() -> Void)?
+    private var deleteHandler: (() -> Void)?
+    private var representedImageData: Data?
+
+    private(set) var representedScreenshotID: UUID?
+    private(set) var renderedState: RenderedState?
+    var loadedThumbnailSize: NSSize? { thumbnailButton.image?.size }
+    var isLoadingThumbnail: Bool { thumbnailTask != nil }
+    var hasCallbacks: Bool { activationHandler != nil || downloadHandler != nil || deleteHandler != nil }
+    var selectionIndicatorAcceptsHitTesting: Bool { selectionImageView.hitTest(.zero) != nil }
+    var selectionIndicatorIsAccessibilityElement: Bool { selectionImageView.isAccessibilityElement() }
+
+    override func loadView() {
+        let rootView = NSBox()
+        rootView.boxType = .custom
+        rootView.borderWidth = 0
+        rootView.cornerRadius = 8
+        rootView.fillColor = NSColor.labelColor.withAlphaComponent(0.05)
+        rootView.contentViewMargins = NSSize(width: 6, height: 6)
+
+        configureThumbnailButton()
+        configureMetadataControls()
+
+        let metadataStack = NSStackView(views: [timestampLabel, lockImageView, downloadButton, deleteButton])
+        metadataStack.orientation = .horizontal
+        metadataStack.alignment = .centerY
+        metadataStack.spacing = 6
+        timestampLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        timestampLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let contentStack = NSStackView(views: [thumbnailButton, metadataStack])
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        contentStack.orientation = .vertical
+        contentStack.alignment = .leading
+        contentStack.spacing = 4
+        contentStack.distribution = .fill
+
+        selectionImageView.translatesAutoresizingMaskIntoConstraints = false
+        selectionImageView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 20, weight: .semibold)
+        selectionImageView.setAccessibilityElement(false)
+
+        rootView.addSubview(contentStack)
+        rootView.addSubview(selectionImageView)
+        NSLayoutConstraint.activate([
+            contentStack.leadingAnchor.constraint(equalTo: rootView.leadingAnchor, constant: 6),
+            contentStack.trailingAnchor.constraint(equalTo: rootView.trailingAnchor, constant: -6),
+            contentStack.topAnchor.constraint(equalTo: rootView.topAnchor, constant: 6),
+            contentStack.bottomAnchor.constraint(equalTo: rootView.bottomAnchor, constant: -6),
+            thumbnailButton.widthAnchor.constraint(equalTo: contentStack.widthAnchor),
+            thumbnailButton.heightAnchor.constraint(equalTo: thumbnailButton.widthAnchor, multiplier: 9 / 16),
+            metadataStack.widthAnchor.constraint(equalTo: contentStack.widthAnchor),
+            selectionImageView.topAnchor.constraint(equalTo: thumbnailButton.topAnchor, constant: 8),
+            selectionImageView.trailingAnchor.constraint(equalTo: thumbnailButton.trailingAnchor, constant: -8),
+        ])
+        view = rootView
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        releaseRepresentedContent()
+    }
+
+    func didEndDisplaying() {
+        releaseRepresentedContent()
+    }
+
+    private func releaseRepresentedContent() {
+        releaseThumbnail()
+        representedScreenshotID = nil
+        representedImageData = nil
+        renderedState = nil
+        activationHandler = nil
+        downloadHandler = nil
+        deleteHandler = nil
+        timestampLabel.stringValue = ""
+        lockImageView.isHidden = true
+        selectionImageView.isHidden = true
+        selectionImageView.image = nil
+    }
+
+    func configure(
+        _ configuration: Configuration,
+        thumbnailProvider: @escaping ThumbnailProvider = defaultThumbnailProvider,
+        actions: Actions
+    ) {
+        loadViewIfNeeded()
+        let screenshot = configuration.screenshot
+        let shouldStartThumbnailLoad = representedScreenshotID != screenshot.id
+            || representedImageData != screenshot.imageData
+            || (thumbnailButton.image == nil && thumbnailTask == nil)
+        representedScreenshotID = screenshot.id
+        representedImageData = screenshot.imageData
+        timestampLabel.stringValue = configuration.timestamp
+        timestampLabel.toolTip = configuration.timestamp
+        activationHandler = actions.activate
+        downloadHandler = actions.download
+        deleteHandler = actions.delete
+
+        thumbnailButton.isEnabled = !configuration.isSelecting || !configuration.isReferencedBySummary
+        let accessibilityLabel = if configuration.isSelecting, configuration.isReferencedBySummary {
+            L10n.screenshotUsedInSummary
+        } else if configuration.isSelecting {
+            L10n.select
+        } else {
+            L10n.open
+        }
+        thumbnailButton.setAccessibilityLabel(accessibilityLabel)
+        thumbnailButton.setAccessibilityValue(configuration.isSelected ? L10n.selected : "")
+
+        lockImageView.isHidden = !configuration.isReferencedBySummary
+        selectionImageView.isHidden = !configuration.isSelecting
+        var selectionSymbolName: String?
+        if configuration.isSelecting {
+            let symbolName = if configuration.isReferencedBySummary {
+                "lock.circle.fill"
+            } else if configuration.isSelected {
+                "checkmark.circle.fill"
+            } else {
+                "circle"
+            }
+            selectionSymbolName = symbolName
+            selectionImageView.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
+            selectionImageView.contentTintColor = configuration.isReferencedBySummary || !configuration.isSelected
+                ? .secondaryLabelColor
+                : .controlAccentColor
+        }
+
+        downloadButton.isHidden = configuration.isSelecting
+        deleteButton.isHidden = configuration.isSelecting
+        deleteButton.isEnabled = !configuration.isReferencedBySummary && !configuration.isDeletionDisabled
+        deleteButton.toolTip = configuration.isReferencedBySummary ? L10n.screenshotUsedInSummary : L10n.delete
+        renderedState = RenderedState(
+            isThumbnailEnabled: thumbnailButton.isEnabled,
+            isLockVisible: !lockImageView.isHidden,
+            selectionSymbolName: selectionSymbolName,
+            isDeleteHidden: deleteButton.isHidden,
+            isDeleteEnabled: deleteButton.isEnabled
+        )
+        if shouldStartThumbnailLoad {
+            startThumbnailLoad(for: screenshot, provider: thumbnailProvider)
+        }
+    }
+
+    private func releaseThumbnail() {
+        thumbnailTask?.cancel()
+        thumbnailTask = nil
+        loadGeneration &+= 1
+        thumbnailButton.image = nil
+    }
+
+    private func configureThumbnailButton() {
+        thumbnailButton.translatesAutoresizingMaskIntoConstraints = false
+        thumbnailButton.isBordered = false
+        thumbnailButton.imagePosition = .imageOnly
+        thumbnailButton.imageScaling = .scaleProportionallyUpOrDown
+        thumbnailButton.target = self
+        thumbnailButton.action = #selector(activateThumbnail)
+        thumbnailButton.wantsLayer = true
+        thumbnailButton.layer?.cornerRadius = 6
+        thumbnailButton.layer?.masksToBounds = true
+        thumbnailButton.updateBackgroundColor()
+    }
+
+    private func configureMetadataControls() {
+        timestampLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        timestampLabel.textColor = .secondaryLabelColor
+        timestampLabel.lineBreakMode = .byTruncatingTail
+
+        lockImageView.image = NSImage(systemSymbolName: "lock.fill", accessibilityDescription: L10n.screenshotUsedInSummary)
+        lockImageView.contentTintColor = .secondaryLabelColor
+        lockImageView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 12, weight: .regular)
+
+        configureIconButton(downloadButton, symbolName: "arrow.down.circle", label: L10n.download, action: #selector(downloadScreenshot))
+        configureIconButton(deleteButton, symbolName: "trash", label: L10n.delete, action: #selector(deleteScreenshot))
+        deleteButton.contentTintColor = .secondaryLabelColor
+    }
+
+    private func configureIconButton(_ button: NSButton, symbolName: String, label: String, action: Selector) {
+        button.isBordered = false
+        button.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: label)
+        button.imagePosition = .imageOnly
+        button.target = self
+        button.action = action
+        button.toolTip = label
+        button.setAccessibilityLabel(label)
+    }
+
+    private func startThumbnailLoad(for screenshot: MeetingScreenshotRecord, provider: @escaping ThumbnailProvider) {
+        releaseThumbnail()
+        let generation = loadGeneration
+        let screenshotID = screenshot.id
+        thumbnailTask = Task { [weak self] in
+            let image = await provider(
+                screenshotID,
+                screenshot.imageData,
+                ScreenshotGridSizing.maximumThumbnailPixelSize
+            )
+            guard let self,
+                  self.loadGeneration == generation,
+                  self.representedScreenshotID == screenshotID else { return }
+            self.thumbnailTask = nil
+            guard !Task.isCancelled, let image else { return }
+            self.thumbnailButton.image = NSImage(
+                cgImage: image,
+                size: NSSize(width: image.width, height: image.height)
+            )
+        }
+    }
+
+    private static let defaultThumbnailProvider: ThumbnailProvider = { screenshotID, data, maxPixelSize in
+        await ScreenshotImageLoader.shared.image(
+            screenshotID: screenshotID,
+            data: data,
+            maxPixelSize: maxPixelSize
+        )
+    }
+
+    @objc private func activateThumbnail() {
+        activationHandler?()
+    }
+
+    @objc private func downloadScreenshot() {
+        downloadHandler?()
+    }
+
+    @objc private func deleteScreenshot() {
+        deleteHandler?()
+    }
+}

--- a/Sources/Dahlia/Views/ScreenshotCollectionViewItem.swift
+++ b/Sources/Dahlia/Views/ScreenshotCollectionViewItem.swift
@@ -26,6 +26,13 @@ private final class ScreenshotThumbnailButton: NSButton {
 final class ScreenshotCollectionViewItem: NSCollectionViewItem {
     typealias ThumbnailProvider = @Sendable (UUID, Data, Int) async -> CGImage?
 
+    private enum ThumbnailLoadState {
+        case idle
+        case loading
+        case loaded
+        case failed
+    }
+
     struct Configuration {
         let screenshot: MeetingScreenshotRecord
         let timestamp: String
@@ -58,6 +65,7 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
     private let downloadButton = NSButton()
     private let deleteButton = NSButton()
     private var thumbnailTask: Task<Void, Never>?
+    private var thumbnailLoadState = ThumbnailLoadState.idle
     private var loadGeneration: UInt64 = 0
     private var activationHandler: (() -> Void)?
     private var downloadHandler: (() -> Void)?
@@ -149,7 +157,7 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
         let screenshot = configuration.screenshot
         let shouldStartThumbnailLoad = representedScreenshotID != screenshot.id
             || representedImageData != screenshot.imageData
-            || (thumbnailButton.image == nil && thumbnailTask == nil)
+            || thumbnailLoadState == .idle
         representedScreenshotID = screenshot.id
         representedImageData = screenshot.imageData
         timestampLabel.stringValue = configuration.timestamp
@@ -206,6 +214,7 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
     private func releaseThumbnail() {
         thumbnailTask?.cancel()
         thumbnailTask = nil
+        thumbnailLoadState = .idle
         loadGeneration &+= 1
         thumbnailButton.image = nil
     }
@@ -249,6 +258,7 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
 
     private func startThumbnailLoad(for screenshot: MeetingScreenshotRecord, provider: @escaping ThumbnailProvider) {
         releaseThumbnail()
+        thumbnailLoadState = .loading
         let generation = loadGeneration
         let screenshotID = screenshot.id
         thumbnailTask = Task { [weak self] in
@@ -261,7 +271,12 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
                   self.loadGeneration == generation,
                   self.representedScreenshotID == screenshotID else { return }
             self.thumbnailTask = nil
-            guard !Task.isCancelled, let image else { return }
+            guard !Task.isCancelled else { return }
+            guard let image else {
+                self.thumbnailLoadState = .failed
+                return
+            }
+            self.thumbnailLoadState = .loaded
             self.thumbnailButton.image = NSImage(
                 cgImage: image,
                 size: NSSize(width: image.width, height: image.height)

--- a/Tests/DahliaTests/ScreenshotCollectionViewIntegrationTests.swift
+++ b/Tests/DahliaTests/ScreenshotCollectionViewIntegrationTests.swift
@@ -1,0 +1,267 @@
+import AppKit
+import Foundation
+import SwiftUI
+@testable import Dahlia
+
+#if canImport(Testing)
+import Testing
+
+@MainActor
+extension ScreenshotCollectionViewTests {
+    @Test
+    func coordinatorAppliesSnapshotsPreservesUpdatesAndResetsMeetingScroll() async {
+        let firstMeetingID = UUID.v7()
+        let secondMeetingID = UUID.v7()
+        let initialScreenshots = makeScreenshots(count: 80, meetingID: firstMeetingID)
+        let initialInput = makeCollectionInput(meetingID: firstMeetingID, screenshots: initialScreenshots)
+        let harness = ScreenshotCollectionHarness(parent: initialInput)
+
+        await integrationWaitUntil { harness.coordinator.snapshotItemIdentifiers == initialScreenshots.map(\.id) }
+        harness.layoutViews()
+        harness.scroll(toY: 240)
+        let preservedOrigin = harness.scrollView.contentView.bounds.origin.y
+        #expect(preservedOrigin > 0)
+
+        let appendedScreenshots = initialScreenshots + makeScreenshots(count: 1, meetingID: firstMeetingID)
+        harness.update(parent: makeCollectionInput(meetingID: firstMeetingID, screenshots: appendedScreenshots))
+        await integrationWaitUntil { harness.coordinator.snapshotItemIdentifiers == appendedScreenshots.map(\.id) }
+        await integrationWaitUntil { harness.scrollView.contentView.bounds.origin.y == preservedOrigin }
+
+        let deletedScreenshots = Array(appendedScreenshots.dropFirst())
+        harness.update(parent: makeCollectionInput(meetingID: firstMeetingID, screenshots: deletedScreenshots))
+        await integrationWaitUntil { harness.coordinator.snapshotItemIdentifiers == deletedScreenshots.map(\.id) }
+        await integrationWaitUntil { harness.scrollView.contentView.bounds.origin.y == preservedOrigin }
+
+        harness.scroll(toY: 320)
+        let secondMeetingScreenshots = makeScreenshots(count: 30, meetingID: secondMeetingID)
+        harness.update(parent: makeCollectionInput(meetingID: secondMeetingID, screenshots: secondMeetingScreenshots))
+        await integrationWaitUntil { harness.coordinator.snapshotItemIdentifiers == secondMeetingScreenshots.map(\.id) }
+        await integrationWaitUntil { harness.scrollView.contentView.bounds.origin.y == 0 }
+    }
+
+    @Test
+    func coordinatorSkipsTimestampRebuildForUnrelatedAndSelectionUpdates() {
+        let meetingID = UUID.v7()
+        let screenshots = makeScreenshots(count: 20, meetingID: meetingID)
+        let initialInput = makeCollectionInput(meetingID: meetingID, screenshots: screenshots)
+        let harness = ScreenshotCollectionHarness(parent: initialInput)
+        let initialGeneration = harness.coordinator.timestampCacheGeneration
+
+        harness.update(parent: initialInput)
+        #expect(harness.coordinator.timestampCacheGeneration == initialGeneration)
+
+        harness.update(parent: makeCollectionInput(
+            meetingID: meetingID,
+            screenshots: screenshots,
+            selectedScreenshotIDs: [screenshots[0].id]
+        ))
+        #expect(harness.coordinator.timestampCacheGeneration == initialGeneration)
+
+        let session = RecordingSessionTimeline(
+            id: .v7(),
+            startedAt: .now,
+            endedAt: nil,
+            offsetSeconds: 0
+        )
+        harness.update(parent: makeCollectionInput(
+            meetingID: meetingID,
+            screenshots: screenshots,
+            recordingSessions: [session]
+        ))
+        #expect(harness.coordinator.timestampCacheGeneration == initialGeneration + 1)
+    }
+
+    @Test
+    func sameIdentifierRecordUpdateRefreshesTimestampAndActionRecord() async throws {
+        let meetingID = UUID.v7()
+        let actionRecorder = CollectionActionRecorder()
+        let original = makeScreenshots(count: 1, meetingID: meetingID)[0]
+        let harness = ScreenshotCollectionHarness(parent: makeCollectionInput(
+            meetingID: meetingID,
+            screenshots: [original],
+            actionRecorder: actionRecorder
+        ))
+        let initialGeneration = harness.coordinator.timestampCacheGeneration
+
+        var updated = original
+        updated.capturedAt = original.capturedAt.addingTimeInterval(60)
+        updated.imageData = Data([1, 2, 3])
+        harness.update(parent: makeCollectionInput(
+            meetingID: meetingID,
+            screenshots: [updated],
+            actionRecorder: actionRecorder
+        ))
+
+        #expect(harness.coordinator.timestampCacheGeneration == initialGeneration + 1)
+        await integrationWaitUntil { harness.collectionView.item(at: IndexPath(item: 0, section: 0)) != nil }
+        let item = try #require(
+            harness.collectionView.item(at: IndexPath(item: 0, section: 0)) as? ScreenshotCollectionViewItem
+        )
+        let openButton = try #require(
+            integrationDescendantViews(of: item.view)
+                .compactMap { $0 as? NSButton }
+                .first { $0.accessibilityLabel() == L10n.open }
+        )
+        openButton.performClick(nil)
+
+        #expect(actionRecorder.openedScreenshot?.capturedAt == updated.capturedAt)
+        #expect(actionRecorder.openedScreenshot?.imageData == updated.imageData)
+    }
+
+    @Test
+    func fiveHundredScreenshotsCreateOnlyVisibleItems() async {
+        let meetingID = UUID.v7()
+        let screenshots = makeScreenshots(count: 500, meetingID: meetingID)
+        let harness = ScreenshotCollectionHarness(
+            parent: makeCollectionInput(meetingID: meetingID, screenshots: screenshots)
+        )
+
+        await integrationWaitUntil { harness.coordinator.snapshotItemIdentifiers.count == 500 }
+        harness.layoutViews()
+        await integrationWaitUntil { !harness.collectionView.visibleItems().isEmpty }
+
+        #expect(harness.collectionView.visibleItems().count < 50)
+    }
+
+    @Test
+    func dismantlingCollectionInvalidatesPendingUpdatesAndReleasesVisibleItems() async {
+        let meetingID = UUID.v7()
+        let screenshots = makeScreenshots(count: 100, meetingID: meetingID)
+        let harness = ScreenshotCollectionHarness(
+            parent: makeCollectionInput(meetingID: meetingID, screenshots: screenshots)
+        )
+        await integrationWaitUntil { !harness.collectionView.visibleItems().isEmpty }
+        let visibleItems = harness.collectionView.visibleItems().compactMap { $0 as? ScreenshotCollectionViewItem }
+
+        ScreenshotCollectionView.dismantleNSView(harness.scrollView, coordinator: harness.coordinator)
+
+        #expect(harness.coordinator.isDismantled)
+        #expect(harness.coordinator.snapshotItemIdentifiers.isEmpty)
+        #expect(harness.collectionView.delegate == nil)
+        #expect(harness.collectionView.dataSource == nil)
+        #expect(visibleItems.allSatisfy { $0.representedScreenshotID == nil && !$0.isLoadingThumbnail })
+    }
+
+    private func makeCollectionInput(
+        meetingID: UUID,
+        screenshots: [MeetingScreenshotRecord],
+        recordingSessions: [RecordingSessionTimeline] = [],
+        selectedScreenshotIDs: Set<UUID> = [],
+        actionRecorder: CollectionActionRecorder? = nil
+    ) -> ScreenshotCollectionView {
+        let selection = SelectionBox(selectedScreenshotIDs)
+        return ScreenshotCollectionView(
+            meetingID: meetingID,
+            screenshots: screenshots,
+            recordingSessions: recordingSessions,
+            fallbackTimeBase: Date(timeIntervalSince1970: 0),
+            minimumItemWidth: ScreenshotGridSizing.defaultMinimumWidth,
+            isSelecting: !selectedScreenshotIDs.isEmpty,
+            referencedScreenshotIDs: [],
+            isDeletionDisabled: false,
+            selectedScreenshotIDs: Binding(
+                get: { selection.value },
+                set: { selection.value = $0 }
+            ),
+            open: { actionRecorder?.openedScreenshot = $0 },
+            download: { actionRecorder?.downloadedScreenshot = $0 },
+            delete: { actionRecorder?.deletedScreenshot = $0 }
+        )
+    }
+
+    private func makeScreenshots(count: Int, meetingID: UUID) -> [MeetingScreenshotRecord] {
+        (0 ..< count).map { index in
+            MeetingScreenshotRecord(
+                id: .v7(),
+                meetingId: meetingID,
+                capturedAt: Date(timeIntervalSince1970: Double(index)),
+                imageData: Data(),
+                mimeType: "image/png"
+            )
+        }
+    }
+
+    private func integrationWaitUntil(_ predicate: @MainActor () -> Bool) async {
+        for _ in 0 ..< 1_000 {
+            if predicate() { return }
+            await Task.yield()
+        }
+        Issue.record("Timed out waiting for MainActor state")
+    }
+
+    private func integrationDescendantViews(of view: NSView) -> [NSView] {
+        view.subviews + view.subviews.flatMap(integrationDescendantViews)
+    }
+}
+
+@MainActor
+private final class ScreenshotCollectionHarness {
+    let coordinator: ScreenshotCollectionView.Coordinator
+    let collectionView: NSCollectionView
+    let scrollView: NSScrollView
+    private let collectionLayout: ScreenshotCollectionLayout
+    private let window: NSWindow
+
+    init(parent: ScreenshotCollectionView) {
+        coordinator = parent.makeCoordinator()
+        collectionLayout = ScreenshotCollectionLayout()
+        collectionView = NSCollectionView()
+        scrollView = NSScrollView(
+            frame: NSRect(x: 0, y: 0, width: 640, height: 360)
+        )
+        window = NSWindow(
+            contentRect: scrollView.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+
+        collectionView.frame = scrollView.contentView.bounds
+        collectionView.autoresizingMask = [.width]
+        collectionView.collectionViewLayout = collectionLayout
+        collectionView.register(
+            ScreenshotCollectionViewItem.self,
+            forItemWithIdentifier: ScreenshotCollectionViewItem.reuseIdentifier
+        )
+        collectionView.delegate = coordinator
+        scrollView.hasVerticalScroller = true
+        scrollView.documentView = collectionView
+        window.contentView = scrollView
+
+        coordinator.installDataSource(on: collectionView)
+        update(parent: parent)
+    }
+
+    func update(parent: ScreenshotCollectionView) {
+        coordinator.update(parent: parent, collectionView: collectionView, layout: collectionLayout)
+        layoutViews()
+    }
+
+    func layoutViews() {
+        collectionLayout.invalidateLayout()
+        window.contentView?.layoutSubtreeIfNeeded()
+        collectionView.layoutSubtreeIfNeeded()
+    }
+
+    func scroll(toY y: CGFloat) {
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: y))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+    }
+}
+
+@MainActor
+private final class SelectionBox {
+    var value: Set<UUID>
+
+    init(_ value: Set<UUID>) {
+        self.value = value
+    }
+}
+
+@MainActor
+private final class CollectionActionRecorder {
+    var openedScreenshot: MeetingScreenshotRecord?
+    var downloadedScreenshot: MeetingScreenshotRecord?
+    var deletedScreenshot: MeetingScreenshotRecord?
+}
+#endif

--- a/Tests/DahliaTests/ScreenshotCollectionViewIntegrationTests.swift
+++ b/Tests/DahliaTests/ScreenshotCollectionViewIntegrationTests.swift
@@ -9,6 +9,30 @@ import Testing
 @MainActor
 extension ScreenshotCollectionViewTests {
     @Test
+    func layoutPreparationAndInvalidationUseCollectionBoundsWidth() {
+        let layout = ScreenshotCollectionLayout()
+        let collectionView = NSCollectionView(frame: NSRect(x: 0, y: 0, width: 700, height: 360))
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 640, height: 360))
+        collectionView.collectionViewLayout = layout
+        scrollView.documentView = collectionView
+        collectionView.frame.size.width = 700
+
+        layout.prepare()
+
+        #expect(layout.itemSize == ScreenshotCollectionLayout.metrics(
+            containerWidth: collectionView.bounds.width,
+            minimumItemWidth: layout.minimumItemWidth
+        ).itemSize)
+        #expect(!layout.shouldInvalidateLayout(forBoundsChange: collectionView.bounds))
+        #expect(layout.shouldInvalidateLayout(forBoundsChange: NSRect(
+            x: 0,
+            y: 0,
+            width: collectionView.bounds.width + 1,
+            height: collectionView.bounds.height
+        )))
+    }
+
+    @Test
     func coordinatorAppliesSnapshotsPreservesUpdatesAndResetsMeetingScroll() async {
         let firstMeetingID = UUID.v7()
         let secondMeetingID = UUID.v7()

--- a/Tests/DahliaTests/ScreenshotCollectionViewTests.swift
+++ b/Tests/DahliaTests/ScreenshotCollectionViewTests.swift
@@ -1,0 +1,368 @@
+import AppKit
+import CoreGraphics
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+import Testing
+
+@MainActor
+struct ScreenshotCollectionViewTests {
+    @Test
+    func layoutUsesAdaptiveColumnsAndStableAspectRatio() {
+        let metrics = ScreenshotCollectionLayout.metrics(containerWidth: 1_000, minimumItemWidth: 200)
+
+        #expect(metrics.columnCount == 4)
+        #expect(metrics.itemSize.width == 235)
+        #expect(metrics.itemSize.height == 161)
+    }
+
+    @Test
+    func layoutSupportsSmallTilesAndNarrowContainers() {
+        let smallTiles = ScreenshotCollectionLayout.metrics(containerWidth: 1_000, minimumItemWidth: 110)
+        let narrowContainer = ScreenshotCollectionLayout.metrics(containerWidth: 80, minimumItemWidth: 200)
+
+        #expect(smallTiles.columnCount == 8)
+        #expect(smallTiles.itemSize.width == 111)
+        #expect(narrowContainer.columnCount == 1)
+        #expect(narrowContainer.itemSize.width == 56)
+        #expect(narrowContainer.itemSize.height > ScreenshotCollectionLayout.metadataHeight)
+    }
+
+    @Test
+    func snapshotUpdatesOnlyWhenIdentifiersChange() {
+        let first = UUID.v7()
+        let second = UUID.v7()
+        let otherMeeting = UUID.v7()
+
+        #expect(ScreenshotCollectionView.Coordinator.requiresSnapshotUpdate(currentIDs: [], newIDs: [first]))
+        #expect(!ScreenshotCollectionView.Coordinator.requiresSnapshotUpdate(currentIDs: [first], newIDs: [first]))
+        #expect(ScreenshotCollectionView.Coordinator.requiresSnapshotUpdate(currentIDs: [first], newIDs: [first, second]))
+        #expect(ScreenshotCollectionView.Coordinator.requiresSnapshotUpdate(currentIDs: [first, second], newIDs: [second]))
+        #expect(ScreenshotCollectionView.Coordinator.requiresSnapshotUpdate(currentIDs: [first, second], newIDs: [otherMeeting]))
+    }
+
+    @Test
+    func sameIdentifierStateChangesOnlyReconfigureVisibleItems() {
+        let screenshotID = UUID.v7()
+        let unchanged = ScreenshotCollectionView.Coordinator.PresentationState(
+            isSelecting: false,
+            selectedScreenshotIDs: [],
+            referencedScreenshotIDs: [],
+            isDeletionDisabled: false,
+            timestampCacheGeneration: 1
+        )
+        let selected = ScreenshotCollectionView.Coordinator.PresentationState(
+            isSelecting: true,
+            selectedScreenshotIDs: [screenshotID],
+            referencedScreenshotIDs: [],
+            isDeletionDisabled: false,
+            timestampCacheGeneration: 1
+        )
+
+        #expect(!ScreenshotCollectionView.Coordinator.requiresVisibleItemUpdate(previous: unchanged, current: unchanged))
+        #expect(ScreenshotCollectionView.Coordinator.requiresVisibleItemUpdate(previous: unchanged, current: selected))
+    }
+
+    @Test
+    func breadcrumbCountsUseBoundedBuckets() {
+        #expect(ScreenshotCollectionView.Coordinator.countBucket(for: 0) == 0)
+        #expect(ScreenshotCollectionView.Coordinator.countBucket(for: 9) == 1)
+        #expect(ScreenshotCollectionView.Coordinator.countBucket(for: 24) == 10)
+        #expect(ScreenshotCollectionView.Coordinator.countBucket(for: 99) == 50)
+        #expect(ScreenshotCollectionView.Coordinator.countBucket(for: 245) == 200)
+        #expect(ScreenshotCollectionView.Coordinator.minimumWidthBucket(for: 110) == 110)
+        #expect(ScreenshotCollectionView.Coordinator.minimumWidthBucket(for: 164) == 160)
+        #expect(ScreenshotCollectionView.Coordinator.minimumWidthBucket(for: 200) == 200)
+    }
+
+    @Test
+    func preparingForReuseReleasesLoadedThumbnail() async throws {
+        let item = ScreenshotCollectionViewItem()
+        let screenshot = makeScreenshot()
+        let image = try #require(makeImage(width: 32, height: 18))
+
+        configure(item, screenshot: screenshot) { _, _, _ in image }
+        await waitUntil { item.loadedThumbnailSize != nil }
+        #expect(item.loadedThumbnailSize == NSSize(width: 32, height: 18))
+
+        item.prepareForReuse()
+
+        #expect(item.representedScreenshotID == nil)
+        #expect(item.loadedThumbnailSize == nil)
+    }
+
+    @Test
+    func endingDisplayReleasesImageIdentifierAndCallbacks() async throws {
+        let item = ScreenshotCollectionViewItem()
+        let screenshot = makeScreenshot()
+        let image = try #require(makeImage(width: 32, height: 18))
+
+        configure(item, screenshot: screenshot) { _, _, _ in image }
+        await waitUntil { item.loadedThumbnailSize != nil }
+
+        item.didEndDisplaying()
+
+        #expect(item.loadedThumbnailSize == nil)
+        #expect(item.representedScreenshotID == nil)
+        #expect(!item.hasCallbacks)
+    }
+
+    @Test
+    func reusedCellAppliesSelectionLockAndDeletionState() {
+        let item = ScreenshotCollectionViewItem()
+        let first = makeScreenshot()
+        let second = makeScreenshot()
+        let provider: ScreenshotCollectionViewItem.ThumbnailProvider = { _, _, _ in nil }
+
+        configure(
+            item,
+            screenshot: first,
+            state: .init(isSelecting: true, isReferencedBySummary: true),
+            provider: provider
+        )
+        #expect(!item.selectionIndicatorAcceptsHitTesting)
+        #expect(!item.selectionIndicatorIsAccessibilityElement)
+        #expect(item.renderedState == .init(
+            isThumbnailEnabled: false,
+            isLockVisible: true,
+            selectionSymbolName: "lock.circle.fill",
+            isDeleteHidden: true,
+            isDeleteEnabled: false
+        ))
+
+        item.prepareForReuse()
+        configure(
+            item,
+            screenshot: second,
+            state: .init(isSelecting: true, isSelected: true),
+            provider: provider
+        )
+        #expect(item.renderedState == .init(
+            isThumbnailEnabled: true,
+            isLockVisible: false,
+            selectionSymbolName: "checkmark.circle.fill",
+            isDeleteHidden: true,
+            isDeleteEnabled: true
+        ))
+
+        configure(
+            item,
+            screenshot: second,
+            state: .init(isDeletionDisabled: true),
+            provider: provider
+        )
+        #expect(item.renderedState == .init(
+            isThumbnailEnabled: true,
+            isLockVisible: false,
+            selectionSymbolName: nil,
+            isDeleteHidden: false,
+            isDeleteEnabled: false
+        ))
+    }
+
+    @Test
+    func nativeButtonsRouteOpenDownloadAndDeleteActions() throws {
+        let item = ScreenshotCollectionViewItem()
+        let screenshot = makeScreenshot()
+        var invokedActions: [String] = []
+        item.configure(
+            .init(
+                screenshot: screenshot,
+                timestamp: "00:00:01",
+                isSelecting: false,
+                isSelected: false,
+                isReferencedBySummary: false,
+                isDeletionDisabled: false
+            ),
+            thumbnailProvider: { _, _, _ in nil },
+            actions: .init(
+                activate: { invokedActions.append("open") },
+                download: { invokedActions.append("download") },
+                delete: { invokedActions.append("delete") }
+            )
+        )
+
+        let buttons = descendantViews(of: item.view).compactMap { $0 as? NSButton }
+        let openButton = try #require(buttons.first { $0.accessibilityLabel() == L10n.open })
+        let downloadButton = try #require(buttons.first { $0.accessibilityLabel() == L10n.download })
+        let deleteButton = try #require(buttons.first { $0.accessibilityLabel() == L10n.delete })
+
+        openButton.performClick(nil)
+        downloadButton.performClick(nil)
+        deleteButton.performClick(nil)
+
+        #expect(invokedActions == ["open", "download", "delete"])
+    }
+
+    @Test
+    func staleDecodeResultCannotReplaceReusedCellImage() async throws {
+        let item = ScreenshotCollectionViewItem()
+        let first = makeScreenshot()
+        let second = makeScreenshot()
+        let provider = ControlledThumbnailProvider()
+        let firstImage = try #require(makeImage(width: 40, height: 20))
+        let secondImage = try #require(makeImage(width: 24, height: 12))
+
+        configure(item, screenshot: first, provider: provider.image)
+        await waitUntilAsync { await provider.hasRequest(for: first.id) }
+
+        configure(item, screenshot: second, provider: provider.image)
+        await waitUntilAsync { await provider.hasRequest(for: second.id) }
+        await provider.resolve(id: second.id, image: secondImage)
+        await waitUntil { item.loadedThumbnailSize == NSSize(width: 24, height: 12) }
+
+        await provider.resolve(id: first.id, image: firstImage)
+        await Task.yield()
+
+        #expect(item.representedScreenshotID == second.id)
+        #expect(item.loadedThumbnailSize == NSSize(width: 24, height: 12))
+    }
+
+    @Test
+    func failedDecodeCanRetryForTheSameScreenshot() async throws {
+        let item = ScreenshotCollectionViewItem()
+        let screenshot = makeScreenshot()
+        let image = try #require(makeImage(width: 30, height: 15))
+        let provider = SequencedThumbnailProvider(successfulImage: image)
+        let provideThumbnail: ScreenshotCollectionViewItem.ThumbnailProvider = { id, data, maxPixelSize in
+            await provider.image(id: id, data: data, maxPixelSize: maxPixelSize)
+        }
+
+        configure(item, screenshot: screenshot, provider: provideThumbnail)
+        await waitUntilAsync { await provider.callCount == 1 }
+        await waitUntil { !item.isLoadingThumbnail }
+
+        configure(item, screenshot: screenshot, provider: provideThumbnail)
+        await waitUntilAsync { await provider.callCount == 2 }
+        await waitUntil { item.loadedThumbnailSize == NSSize(width: 30, height: 15) }
+
+        #expect(item.representedScreenshotID == screenshot.id)
+    }
+
+    @Test
+    func changedImageDataReloadsThumbnailForTheSameIdentifier() async throws {
+        let item = ScreenshotCollectionViewItem()
+        let original = makeScreenshot()
+        var updated = original
+        updated.imageData = Data([1])
+        let originalImage = try #require(makeImage(width: 32, height: 18))
+        let updatedImage = try #require(makeImage(width: 40, height: 20))
+        let originalData = original.imageData
+        let provider: ScreenshotCollectionViewItem.ThumbnailProvider = { _, data, _ in
+            data == originalData ? originalImage : updatedImage
+        }
+
+        configure(item, screenshot: original, provider: provider)
+        await waitUntil { item.loadedThumbnailSize == NSSize(width: 32, height: 18) }
+
+        configure(item, screenshot: updated, provider: provider)
+        await waitUntil { item.loadedThumbnailSize == NSSize(width: 40, height: 20) }
+
+        #expect(item.representedScreenshotID == original.id)
+    }
+
+    private func configure(
+        _ item: ScreenshotCollectionViewItem,
+        screenshot: MeetingScreenshotRecord,
+        state: TestControlState = .init(),
+        provider: @escaping ScreenshotCollectionViewItem.ThumbnailProvider
+    ) {
+        item.configure(
+            .init(
+                screenshot: screenshot,
+                timestamp: "00:00:01",
+                isSelecting: state.isSelecting,
+                isSelected: state.isSelected,
+                isReferencedBySummary: state.isReferencedBySummary,
+                isDeletionDisabled: state.isDeletionDisabled
+            ),
+            thumbnailProvider: provider,
+            actions: .init(activate: {}, download: {}, delete: {})
+        )
+    }
+
+    private func descendantViews(of view: NSView) -> [NSView] {
+        view.subviews + view.subviews.flatMap(descendantViews)
+    }
+
+    private struct TestControlState {
+        var isSelecting = false
+        var isSelected = false
+        var isReferencedBySummary = false
+        var isDeletionDisabled = false
+    }
+
+    private func makeScreenshot() -> MeetingScreenshotRecord {
+        MeetingScreenshotRecord(
+            id: .v7(),
+            meetingId: .v7(),
+            capturedAt: .now,
+            imageData: Data([0]),
+            mimeType: "image/png"
+        )
+    }
+
+    private func makeImage(width: Int, height: Int) -> CGImage? {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+        return CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        )?.makeImage()
+    }
+
+    private func waitUntil(_ predicate: @MainActor () -> Bool) async {
+        for _ in 0 ..< 1_000 {
+            if predicate() { return }
+            await Task.yield()
+        }
+        Issue.record("Timed out waiting for MainActor state")
+    }
+
+    private func waitUntilAsync(_ predicate: @escaping @Sendable () async -> Bool) async {
+        for _ in 0 ..< 1_000 {
+            if await predicate() { return }
+            await Task.yield()
+        }
+        Issue.record("Timed out waiting for asynchronous state")
+    }
+}
+
+private actor ControlledThumbnailProvider {
+    private var continuations: [UUID: CheckedContinuation<CGImage?, Never>] = [:]
+
+    func image(id: UUID, data _: Data, maxPixelSize _: Int) async -> CGImage? {
+        await withCheckedContinuation { continuation in
+            continuations[id] = continuation
+        }
+    }
+
+    func hasRequest(for id: UUID) -> Bool {
+        continuations[id] != nil
+    }
+
+    func resolve(id: UUID, image: CGImage?) {
+        continuations.removeValue(forKey: id)?.resume(returning: image)
+    }
+}
+
+private actor SequencedThumbnailProvider {
+    private let successfulImage: CGImage
+    private(set) var callCount = 0
+
+    init(successfulImage: CGImage) {
+        self.successfulImage = successfulImage
+    }
+
+    func image(id _: UUID, data _: Data, maxPixelSize _: Int) -> CGImage? {
+        callCount += 1
+        return callCount == 1 ? nil : successfulImage
+    }
+}
+#endif

--- a/Tests/DahliaTests/ScreenshotCollectionViewTests.swift
+++ b/Tests/DahliaTests/ScreenshotCollectionViewTests.swift
@@ -220,7 +220,7 @@ struct ScreenshotCollectionViewTests {
     }
 
     @Test
-    func failedDecodeCanRetryForTheSameScreenshot() async throws {
+    func failedDecodeDoesNotRetryUntilTheCellIsRedisplayed() async throws {
         let item = ScreenshotCollectionViewItem()
         let screenshot = makeScreenshot()
         let image = try #require(makeImage(width: 30, height: 15))
@@ -233,6 +233,16 @@ struct ScreenshotCollectionViewTests {
         await waitUntilAsync { await provider.callCount == 1 }
         await waitUntil { !item.isLoadingThumbnail }
 
+        configure(
+            item,
+            screenshot: screenshot,
+            state: .init(isSelecting: true),
+            provider: provideThumbnail
+        )
+        await Task.yield()
+        #expect(await provider.callCount == 1)
+
+        item.didEndDisplaying()
         configure(item, screenshot: screenshot, provider: provideThumbnail)
         await waitUntilAsync { await provider.callCount == 2 }
         await waitUntil { item.loadedThumbnailSize == NSSize(width: 30, height: 15) }


### PR DESCRIPTION
## Summary

- replace the SwiftUI screenshot `LazyVGrid` with a reusable native `NSCollectionView`
- keep only visible thumbnail surfaces alive and release image tasks, images, identifiers, and callbacks when cells leave the viewport or are reused
- apply UUID-based diffable snapshots while preserving scroll position for same-meeting changes and resetting it when switching meetings
- add non-PII Sentry breadcrumbs for the collection backend, screenshot-count bucket, and thumbnail-size bucket
- add layout, cell-reuse, stale-decode, action-routing, diff-update, teardown, and 500-item virtualization coverage

## Root cause

Recent `0.5.10 (26)` hang events stopped the main thread in `CA::Render::Context::wait_for_synchronize` / `RB::SharedSurfaceGroup::wait_for_allocations` while the screenshot list was visible. The SwiftUI grid retained enough image, clipping, and shadow rendering surfaces during continuous scrolling to exhaust RenderBox allocation capacity.

This change bounds rendered image ownership to reusable visible collection items while keeping the existing serialized 400-pixel thumbnail loader and user-facing screenshot actions.

Sentry issue: https://dahlia-app.sentry.io/issues/7607221669/

## Validation

- `swift test --filter ScreenshotCollectionViewTests` — 17 tests passed
- `swift test --filter ScreenshotImageLoaderTests` — 3 tests passed
- `swift build` — passed
- `swift test` — 742 Swift Testing tests and 3 XCTest tests passed
- `CI=true ./scripts/lint.sh` — SwiftFormat clean; repository-wide pre-existing SwiftLint violations remain non-blocking
- `git diff --check` — passed

## Manual verification

The automated AppKit integration suite verifies 500-item virtualization. Long-running real-app scrolling and active/inactive stress testing remains to be performed before release.
