### PR TITLE
Dismiss AI chat popups on outside click

### DIFF
--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
@@ -36,6 +36,7 @@ struct CodexChatComposerInputRow: View {
                             onAddMeetingReference: onShowMeetingPicker,
                             onSelectMeeting: onSelectMeeting
                         )
+                        .codexChatDismissOnOutsideClick(perform: onExitCommand)
                         .offset(y: -(CodexChatDesign.controlSize + 8))
                         .zIndex(1)
                     }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatConfigurationButton.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatConfigurationButton.swift
@@ -28,6 +28,7 @@ struct CodexChatConfigurationButton: View {
                         showsModels: $showsModels,
                         onDismiss: dismissConfiguration
                     )
+                    .codexChatDismissOnOutsideClick(perform: dismissConfiguration)
                     .offset(
                         x: CodexChatDesign.controlSize,
                         y: -(CodexChatDesign.controlSize + 8)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatOutsideClickMonitor.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatOutsideClickMonitor.swift
@@ -1,0 +1,68 @@
+import AppKit
+import SwiftUI
+
+extension View {
+    func codexChatDismissOnOutsideClick(perform action: @escaping () -> Void) -> some View {
+        background {
+            CodexChatOutsideClickMonitor(onOutsideClick: action)
+        }
+    }
+}
+
+struct CodexChatOutsideClickMonitor: NSViewRepresentable {
+    let onOutsideClick: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onOutsideClick: onOutsideClick)
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        context.coordinator.startMonitoring(view: view)
+        return view
+    }
+
+    func updateNSView(_: NSView, context: Context) {
+        context.coordinator.onOutsideClick = onOutsideClick
+    }
+
+    static func dismantleNSView(_: NSView, coordinator: Coordinator) {
+        coordinator.stopMonitoring()
+    }
+
+    @MainActor
+    final class Coordinator {
+        var onOutsideClick: () -> Void
+
+        private var eventMonitor: Any?
+
+        init(onOutsideClick: @escaping () -> Void) {
+            self.onOutsideClick = onOutsideClick
+        }
+
+        func startMonitoring(view: NSView) {
+            eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { [weak self, weak view] event in
+                guard let self, let view else { return event }
+                return handle(event, in: view)
+            }
+        }
+
+        func handle(_ event: NSEvent, in view: NSView) -> NSEvent {
+            guard event.window === view.window else { return event }
+
+            let location = view.convert(event.locationInWindow, from: nil)
+            guard !view.bounds.contains(location) else { return event }
+
+            Task { @MainActor [weak self] in
+                self?.onOutsideClick()
+            }
+            return event
+        }
+
+        func stopMonitoring() {
+            guard let eventMonitor else { return }
+            NSEvent.removeMonitor(eventMonitor)
+            self.eventMonitor = nil
+        }
+    }
+}

--- a/Tests/DahliaTests/CodexChatOutsideClickMonitorTests.swift
+++ b/Tests/DahliaTests/CodexChatOutsideClickMonitorTests.swift
@@ -1,0 +1,97 @@
+#if canImport(Testing)
+import AppKit
+import Testing
+@testable import Dahlia
+
+@MainActor
+struct CodexChatOutsideClickMonitorTests {
+    @Test
+    func clickInsidePanelIsForwardedWithoutDismissal() async throws {
+        let fixture = try makeFixture(eventLocation: CGPoint(x: 50, y: 50))
+        var dismissCount = 0
+        let coordinator = CodexChatOutsideClickMonitor.Coordinator {
+            dismissCount += 1
+        }
+
+        let handledEvent = coordinator.handle(fixture.event, in: fixture.view)
+
+        #expect(dismissCount == 0)
+        await Task.yield()
+
+        #expect(handledEvent === fixture.event)
+        #expect(dismissCount == 0)
+    }
+
+    @Test
+    func clickOutsidePanelIsForwardedAndDismisses() async throws {
+        let fixture = try makeFixture(eventLocation: CGPoint(x: 150, y: 150))
+        var dismissCount = 0
+        let coordinator = CodexChatOutsideClickMonitor.Coordinator {
+            dismissCount += 1
+        }
+
+        let handledEvent = coordinator.handle(fixture.event, in: fixture.view)
+
+        #expect(dismissCount == 0)
+        await Task.yield()
+
+        #expect(handledEvent === fixture.event)
+        #expect(dismissCount == 1)
+    }
+
+    @Test
+    func clickInAnotherWindowIsForwardedWithoutDismissal() async throws {
+        let fixture = try makeFixture(eventLocation: CGPoint(x: 150, y: 150))
+        let otherWindow = NSWindow(
+            contentRect: CGRect(x: 0, y: 0, width: 200, height: 200),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        let otherEvent = try #require(NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: CGPoint(x: 150, y: 150),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: otherWindow.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 0
+        ))
+        var dismissCount = 0
+        let coordinator = CodexChatOutsideClickMonitor.Coordinator {
+            dismissCount += 1
+        }
+
+        let handledEvent = coordinator.handle(otherEvent, in: fixture.view)
+        await Task.yield()
+
+        #expect(handledEvent === otherEvent)
+        #expect(dismissCount == 0)
+    }
+
+    private func makeFixture(eventLocation: CGPoint) throws -> (event: NSEvent, view: NSView, window: NSWindow) {
+        let window = NSWindow(
+            contentRect: CGRect(x: 0, y: 0, width: 200, height: 200),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        let view = NSView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        window.contentView?.addSubview(view)
+        let event = try #require(NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: eventLocation,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 0
+        ))
+        return (event, view, window)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- close the AI chat attachment and model configuration popups when clicking elsewhere in the chat window
- preserve the clicked control's action by forwarding the mouse event before dismissing the popup
- keep the click-monitoring region aligned with the visually offset popup
- add regression coverage for inside, outside, and other-window clicks

## Root cause

The custom popup panels were rendered as SwiftUI overlays rather than native popovers, so they did not inherit automatic outside-click dismissal behavior. The initial event monitor also needed to account for SwiftUI offset transforms and avoid consuming the destination click.

## User impact

Users can dismiss attachment and model-selection popups by clicking another area, and the destination control responds on the first click.

## Validation

- `swift test --disable-sandbox --filter CodexChatOutsideClickMonitorTests` — 3 tests passed
- `swift build --disable-sandbox`
- `CI=true ./scripts/lint.sh` — SwiftFormat passed; SwiftLint reported only existing non-blocking warnings
- `git diff --check`