### PR TITLE
Add retained batch audio retranscription

### DIFF
--- a/Sources/Dahlia/Database/RecordingSessionRecord.swift
+++ b/Sources/Dahlia/Database/RecordingSessionRecord.swift
@@ -26,4 +26,10 @@ struct RecordingSessionRecord: Codable, FetchableRecord, PersistableRecord, Equa
     var batchLanguageDetectionMode: BatchLanguageDetectionMode = .manual
     var batchSelectedLocaleIdentifier: String?
     var batchAutomaticLanguageCandidatesJSON: String?
+
+    /// A completed transcript is being rebuilt while the previous successful result remains available.
+    var isBatchRetranscriptionPending: Bool {
+        guard let batchCompletedAt, let batchLastAttemptAt else { return false }
+        return batchLastAttemptAt > batchCompletedAt
+    }
 }

--- a/Sources/Dahlia/Models/BatchTranscriptionConfirmation.swift
+++ b/Sources/Dahlia/Models/BatchTranscriptionConfirmation.swift
@@ -1,12 +1,19 @@
 import Foundation
 
 struct BatchTranscriptionConfirmation: Identifiable, Equatable {
+    enum Purpose: Equatable {
+        case initialOrRetry
+        case retranscription(sessionIds: [UUID])
+    }
+
     let sessionId: UUID
     let meetingId: UUID
     let suggestedLocaleIdentifier: String
     let retainAudioAfterBatch: Bool
     let initialLanguageSelection: BatchTranscriptionLanguageSelection
     let automaticLanguageCandidateSnapshot: BatchLanguageDetectionCandidateSnapshot?
+    let purpose: Purpose
+    let initiallyGeneratesSummary: Bool
 
     init(
         sessionId: UUID,
@@ -14,8 +21,13 @@ struct BatchTranscriptionConfirmation: Identifiable, Equatable {
         suggestedLocaleIdentifier: String,
         retainAudioAfterBatch: Bool,
         initialLanguageSelection: BatchTranscriptionLanguageSelection? = nil,
-        automaticLanguageCandidateSnapshot: BatchLanguageDetectionCandidateSnapshot? = nil
+        automaticLanguageCandidateSnapshot: BatchLanguageDetectionCandidateSnapshot? = nil,
+        purpose: Purpose = .initialOrRetry,
+        initiallyGeneratesSummary: Bool = false
     ) {
+        if case let .retranscription(sessionIds) = purpose {
+            precondition(!sessionIds.isEmpty && sessionIds.contains(sessionId))
+        }
         self.sessionId = sessionId
         self.meetingId = meetingId
         self.suggestedLocaleIdentifier = suggestedLocaleIdentifier
@@ -23,7 +35,13 @@ struct BatchTranscriptionConfirmation: Identifiable, Equatable {
         self.initialLanguageSelection = initialLanguageSelection
             ?? .manual(localeIdentifier: suggestedLocaleIdentifier)
         self.automaticLanguageCandidateSnapshot = automaticLanguageCandidateSnapshot
+        self.purpose = purpose
+        self.initiallyGeneratesSummary = initiallyGeneratesSummary
     }
 
     var id: UUID { sessionId }
+
+    var isRetranscription: Bool {
+        if case .retranscription = purpose { true } else { false }
+    }
 }

--- a/Sources/Dahlia/Models/BatchTranscriptionState.swift
+++ b/Sources/Dahlia/Models/BatchTranscriptionState.swift
@@ -8,6 +8,7 @@ enum BatchTranscriptionState: Equatable {
     case running(sessionId: UUID)
     case completed(sessionId: UUID)
     case failed(sessionId: UUID, message: String)
+    case retranscriptionFailed(sessionId: UUID, message: String)
 
     var sessionId: UUID {
         switch self {
@@ -16,14 +17,15 @@ enum BatchTranscriptionState: Equatable {
              let .queued(sessionId),
              let .running(sessionId),
              let .completed(sessionId),
-             let .failed(sessionId, _):
+             let .failed(sessionId, _),
+             let .retranscriptionFailed(sessionId, _):
             sessionId
         }
     }
 
     var blocksSummaryGeneration: Bool {
         switch self {
-        case .recording, .awaitingConfirmation, .queued, .running, .failed:
+        case .recording, .awaitingConfirmation, .queued, .running, .failed, .retranscriptionFailed:
             true
         case .completed:
             false
@@ -33,14 +35,17 @@ enum BatchTranscriptionState: Equatable {
     static func derive(from session: RecordingSessionRecord, isRunning: Bool = false) -> Self? {
         guard session.transcriptionMode == .batch,
               session.batchDiscardedAt == nil else { return nil }
-        if session.batchCompletedAt != nil {
-            return .completed(sessionId: session.id)
-        }
+        let isRetranscription = session.isBatchRetranscriptionPending
         if isRunning {
             return .running(sessionId: session.id)
         }
+        if session.batchCompletedAt != nil, !isRetranscription {
+            return .completed(sessionId: session.id)
+        }
         if let error = session.batchLastError?.nilIfBlank {
-            return .failed(sessionId: session.id, message: error)
+            return isRetranscription
+                ? .retranscriptionFailed(sessionId: session.id, message: error)
+                : .failed(sessionId: session.id, message: error)
         }
         if session.endedAt == nil {
             return .recording(sessionId: session.id)

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -614,8 +614,12 @@
 "High-accuracy transcription completed." = "High-accuracy transcription completed.";
 "Batch transcription failed: %@" = "Batch transcription failed: %@";
 "Retry Batch Transcription" = "Retry Batch Transcription";
+"Keep Current Transcript" = "Keep Current Transcript";
+"Retranscribe" = "Retranscribe";
 "Start batch transcription?" = "Start batch transcription?";
 "Choose a transcription language. Audio is kept until transcription succeeds." = "Choose a transcription language. Audio is kept until transcription succeeds.";
+"Retranscribe the saved recording?" = "Retranscribe the saved recording?";
+"The current transcript remains available while processing and is replaced only after retranscription succeeds." = "The current transcript remains available while processing and is replaced only after retranscription succeeds.";
 "Multilingual meetings" = "Multilingual meetings";
 "Detects the language of each recording, allowing transcription when multiple languages are used." = "Detects the language of each recording, allowing transcription when multiple languages are used.";
 "Languages to detect" = "Languages to detect";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -614,8 +614,12 @@
 "High-accuracy transcription completed." = "高精度な文字起こしが完了しました。";
 "Batch transcription failed: %@" = "バッチ文字起こしに失敗しました: %@";
 "Retry Batch Transcription" = "バッチ文字起こしを再試行";
+"Keep Current Transcript" = "現在の文字起こしを維持";
+"Retranscribe" = "文字起こしをやり直す";
 "Start batch transcription?" = "バッチ文字起こしを開始しますか？";
 "Choose a transcription language. Audio is kept until transcription succeeds." = "文字起こし言語を選択してください。文字起こしが成功するまで音声データは保持されます。";
+"Retranscribe the saved recording?" = "保存した録音を再文字起こししますか？";
+"The current transcript remains available while processing and is replaced only after retranscription succeeds." = "処理中は現在の文字起こしを保持し、再文字起こしに成功した場合のみ新しい内容に置き換えます。";
 "Multilingual meetings" = "複数言語に対応";
 "Detects the language of each recording, allowing transcription when multiple languages are used." = "録音ごとに言語を判定し、複数の言語が混在するミーティングを文字起こしできます。";
 "Languages to detect" = "判定する言語";

--- a/Sources/Dahlia/Services/BatchTranscriptionConfirmationService.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionConfirmationService.swift
@@ -22,15 +22,9 @@ enum BatchTranscriptionConfirmationService {
         retainAudioAfterBatch: Bool,
         dbQueue: DatabaseQueue
     ) async throws -> Result {
-        let selectedLocaleIdentifier = try selectedLocaleIdentifier(from: languageSelection)
-        let automaticLanguageCandidatesJSON = try automaticLanguageCandidatesJSON(
-            from: languageSelection,
-            candidates: automaticLanguageCandidates
-        )
-        let persistenceOptions = PersistenceOptions(
-            languageDetectionMode: languageSelection.detectionMode,
-            selectedLocaleIdentifier: selectedLocaleIdentifier,
-            automaticLanguageCandidatesJSON: automaticLanguageCandidatesJSON,
+        let persistenceOptions = try persistenceOptions(
+            languageSelection: languageSelection,
+            automaticLanguageCandidates: automaticLanguageCandidates,
             retainAudioAfterBatch: retainAudioAfterBatch
         )
 
@@ -50,7 +44,7 @@ enum BatchTranscriptionConfirmationService {
             let confirmedAt = Date.now
             for unconfirmedSession in sessions {
                 try requireAudioRanges(sessionId: unconfirmedSession.id, db: db)
-                if let selectedLocaleIdentifier {
+                if let selectedLocaleIdentifier = persistenceOptions.selectedLocaleIdentifier {
                     try updateSingleRecordedLocale(
                         sessionId: unconfirmedSession.id,
                         localeIdentifier: selectedLocaleIdentifier,
@@ -68,6 +62,101 @@ enum BatchTranscriptionConfirmationService {
             return Result(meetingId: session.meetingId, sessionIds: sessions.map(\.id))
         }
     }
+}
+
+extension BatchTranscriptionConfirmationService {
+    /// Requeues completed sessions without removing their last successful transcript.
+    static func confirmRetranscription(
+        sessionIds: [UUID],
+        languageSelection: BatchTranscriptionLanguageSelection,
+        automaticLanguageCandidates: BatchLanguageDetectionCandidateSnapshot?,
+        retainAudioAfterBatch: Bool,
+        dbQueue: DatabaseQueue
+    ) async throws -> Result {
+        let options = try persistenceOptions(
+            languageSelection: languageSelection,
+            automaticLanguageCandidates: automaticLanguageCandidates,
+            retainAudioAfterBatch: retainAudioAfterBatch
+        )
+
+        return try await dbQueue.write { db in
+            let uniqueSessionIds = Array(Set(sessionIds))
+            guard !uniqueSessionIds.isEmpty else { throw CocoaError(.fileNoSuchFile) }
+            let sessions = try RecordingSessionRecord
+                .filter(uniqueSessionIds.contains(Column("id")))
+                .order(Column("startedAt").asc)
+                .fetchAll(db)
+            guard sessions.count == uniqueSessionIds.count,
+                  let meetingId = sessions.first?.meetingId,
+                  sessions.allSatisfy({ session in
+                      session.meetingId == meetingId
+                          && session.transcriptionMode == .batch
+                          && session.endedAt != nil
+                          && session.batchCompletedAt != nil
+                          && session.batchDiscardedAt == nil
+                          && (session.retainAudioAfterBatch || session.isBatchRetranscriptionPending)
+                  }) else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+
+            guard let latestCompletion = sessions.compactMap(\.batchCompletedAt).max() else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            // The timestamp ordering is also the persisted pending marker. Keep it valid if the
+            // system clock moved backwards after the previous transcription completed.
+            let confirmedAt = max(Date.now, latestCompletion.addingTimeInterval(0.001))
+            for session in sessions {
+                try requireTranscribableAudio(sessionId: session.id, db: db)
+                if let selectedLocaleIdentifier = options.selectedLocaleIdentifier {
+                    try updateSingleRecordedLocale(
+                        sessionId: session.id,
+                        localeIdentifier: selectedLocaleIdentifier,
+                        updatedAt: confirmedAt,
+                        db: db
+                    )
+                }
+                try markRetranscriptionConfirmed(
+                    sessionId: session.id,
+                    options: options,
+                    confirmedAt: confirmedAt,
+                    db: db
+                )
+            }
+            return Result(meetingId: meetingId, sessionIds: sessions.map(\.id))
+        }
+    }
+
+    /// Stops a failed retranscription and restores the last successful transcript as the active result.
+    static func cancelRetranscription(sessionIds: [UUID], dbQueue: DatabaseQueue) async throws -> UUID {
+        try await dbQueue.write { db in
+            let uniqueSessionIds = Array(Set(sessionIds))
+            guard !uniqueSessionIds.isEmpty else { throw CocoaError(.fileNoSuchFile) }
+            let sessions = try RecordingSessionRecord
+                .filter(uniqueSessionIds.contains(Column("id")))
+                .fetchAll(db)
+            guard sessions.count == uniqueSessionIds.count,
+                  let meetingId = sessions.first?.meetingId,
+                  sessions.allSatisfy({ $0.meetingId == meetingId && $0.isBatchRetranscriptionPending }) else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+
+            let cancelledAt = Date.now
+            var arguments: StatementArguments = [RecordingAudioRetentionPolicy.keepInApp.rawValue, cancelledAt]
+            arguments += StatementArguments(uniqueSessionIds)
+            try db.execute(
+                sql: """
+                UPDATE recording_sessions
+                SET retainAudioAfterBatch = 1, audioRetentionPolicy = ?,
+                    batchLastAttemptAt = batchCompletedAt, batchAttemptCount = 0,
+                    batchLastError = NULL, batchFailureKind = NULL, updatedAt = ?
+                WHERE id IN (\(databasePlaceholders(count: uniqueSessionIds.count)))
+                """,
+                arguments: arguments
+            )
+            guard db.changesCount == uniqueSessionIds.count else { throw CocoaError(.fileNoSuchFile) }
+            return meetingId
+        }
+    }
 
     private static func selectedLocaleIdentifier(
         from selection: BatchTranscriptionLanguageSelection
@@ -78,6 +167,22 @@ enum BatchTranscriptionConfirmationService {
             throw CocoaError(.validationMissingMandatoryProperty)
         }
         return normalized
+    }
+
+    private static func persistenceOptions(
+        languageSelection: BatchTranscriptionLanguageSelection,
+        automaticLanguageCandidates: BatchLanguageDetectionCandidateSnapshot?,
+        retainAudioAfterBatch: Bool
+    ) throws -> PersistenceOptions {
+        try PersistenceOptions(
+            languageDetectionMode: languageSelection.detectionMode,
+            selectedLocaleIdentifier: selectedLocaleIdentifier(from: languageSelection),
+            automaticLanguageCandidatesJSON: automaticLanguageCandidatesJSON(
+                from: languageSelection,
+                candidates: automaticLanguageCandidates
+            ),
+            retainAudioAfterBatch: retainAudioAfterBatch
+        )
     }
 
     private static func automaticLanguageCandidatesJSON(
@@ -137,6 +242,34 @@ enum BatchTranscriptionConfirmationService {
         guard rangeCount > 0 else {
             throw CocoaError(.fileNoSuchFile)
         }
+    }
+
+    private static func requireTranscribableAudio(sessionId: UUID, db: Database) throws {
+        let segmentCount = try RecordingAudioSegmentRecord
+            .filter(Column("recordingSessionId") == sessionId)
+            .fetchCount(db)
+        let transcribableSegmentCount = try Int.fetchOne(
+            db,
+            sql: """
+            SELECT COUNT(*)
+            FROM recording_audio_segments AS segments
+            WHERE segments.recordingSessionId = ?
+              AND segments.state = ?
+              AND segments.purgedAt IS NULL
+              AND EXISTS (
+                  SELECT 1 FROM recording_audio_segment_ranges AS ranges
+                  WHERE ranges.audioSegmentId = segments.id
+              )
+            """,
+            arguments: [sessionId, RecordingAudioSegmentState.ready.rawValue]
+        ) ?? 0
+        guard segmentCount > 0, transcribableSegmentCount == segmentCount else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+    }
+
+    private static func databasePlaceholders(count: Int) -> String {
+        Array(repeating: "?", count: count).joined(separator: ", ")
     }
 
     private static func updateSingleRecordedLocale(
@@ -199,5 +332,38 @@ enum BatchTranscriptionConfirmationService {
                 sessionId,
             ]
         )
+    }
+
+    private static func markRetranscriptionConfirmed(
+        sessionId: UUID,
+        options: PersistenceOptions,
+        confirmedAt: Date,
+        db: Database
+    ) throws {
+        try db.execute(
+            sql: """
+            UPDATE recording_sessions
+            SET retainAudioAfterBatch = ?, audioRetentionPolicy = ?,
+                batchLanguageDetectionMode = ?, batchSelectedLocaleIdentifier = ?,
+                batchAutomaticLanguageCandidatesJSON = ?, batchLastAttemptAt = ?,
+                batchAttemptCount = 0, batchLastError = NULL, batchFailureKind = NULL, updatedAt = ?
+            WHERE id = ?
+              AND batchCompletedAt IS NOT NULL
+              AND batchDiscardedAt IS NULL
+            """,
+            arguments: [
+                options.retainAudioAfterBatch,
+                options.retainAudioAfterBatch
+                    ? RecordingAudioRetentionPolicy.keepInApp.rawValue
+                    : RecordingAudioRetentionPolicy.deleteAfterTranscription.rawValue,
+                options.languageDetectionMode.rawValue,
+                options.selectedLocaleIdentifier,
+                options.automaticLanguageCandidatesJSON,
+                confirmedAt,
+                confirmedAt,
+                sessionId,
+            ]
+        )
+        guard db.changesCount == 1 else { throw CocoaError(.fileNoSuchFile) }
     }
 }

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator+Scheduling.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator+Scheduling.swift
@@ -7,7 +7,7 @@ extension BatchTranscriptionCoordinator: BatchTranscriptionScheduling {
 
     static func shouldAutomaticallyRetry(_ session: RecordingSessionRecord) -> Bool {
         guard session.transcriptionMode == .batch,
-              session.batchCompletedAt == nil,
+              session.batchCompletedAt == nil || session.isBatchRetranscriptionPending,
               session.batchDiscardedAt == nil else { return false }
         guard session.batchFailureKind != .recordingRecovery,
               session.batchFailureKind != .recordingAudioPermanent else { return false }

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -103,10 +103,11 @@ actor BatchTranscriptionCoordinator {
 
     func recoverAndEnqueue() async {
         _ = await recordingAudioStore?.reconcileStartup()
+        await recoverCompletedAudioPurges()
         let sessionIds = await (try? dbQueue.read { db in
             try RecordingSessionRecord
                 .filter(Column("transcriptionMode") == TranscriptionMode.batch.rawValue)
-                .filter(Column("batchCompletedAt") == nil)
+                .filter(sql: "batchCompletedAt IS NULL OR batchLastAttemptAt > batchCompletedAt")
                 .filter(Column("batchDiscardedAt") == nil)
                 .order(Column("startedAt").asc)
                 .fetchAll(db)
@@ -116,25 +117,6 @@ actor BatchTranscriptionCoordinator {
 
         for sessionId in sessionIds {
             await enqueue(sessionId: sessionId)
-        }
-    }
-
-    func confirmAndEnqueue(
-        sessionId: UUID,
-        languageSelection: BatchTranscriptionLanguageSelection,
-        automaticLanguageCandidates: BatchLanguageDetectionCandidateSnapshot?,
-        retainAudioAfterBatch: Bool
-    ) async throws {
-        let result = try await BatchTranscriptionConfirmationService.confirm(
-            sessionId: sessionId,
-            languageSelection: languageSelection,
-            automaticLanguageCandidates: automaticLanguageCandidates,
-            retainAudioAfterBatch: retainAudioAfterBatch,
-            dbQueue: dbQueue
-        )
-        for confirmedSessionId in result.sessionIds {
-            await notify(meetingId: result.meetingId, state: .queued(sessionId: confirmedSessionId))
-            await enqueue(sessionId: confirmedSessionId)
         }
     }
 
@@ -232,13 +214,17 @@ actor BatchTranscriptionCoordinator {
             try db.execute(
                 sql: """
                 UPDATE recording_sessions
-                SET batchLastAttemptAt = ?, batchAttemptCount = batchAttemptCount + 1,
+                SET batchLastAttemptAt = CASE
+                        WHEN batchLastAttemptAt IS NULL OR ? > batchLastAttemptAt THEN ?
+                        ELSE batchLastAttemptAt
+                    END,
+                    batchAttemptCount = batchAttemptCount + 1,
                     batchLastError = NULL, batchFailureKind = NULL, updatedAt = ?
                 WHERE id = ?
-                  AND batchCompletedAt IS NULL
+                  AND (batchCompletedAt IS NULL OR batchLastAttemptAt > batchCompletedAt)
                   AND batchDiscardedAt IS NULL
                 """,
-                arguments: [attemptDate, attemptDate, sessionId]
+                arguments: [attemptDate, attemptDate, attemptDate, sessionId]
             )
             guard db.changesCount == 1 else { throw CancellationError() }
         }
@@ -254,7 +240,7 @@ actor BatchTranscriptionCoordinator {
                     batchLastError = NULL, batchFailureKind = NULL, updatedAt = ?
                 WHERE id = ?
                   AND transcriptionMode = ?
-                  AND batchCompletedAt IS NULL
+                  AND (batchCompletedAt IS NULL OR batchLastAttemptAt > batchCompletedAt)
                   AND batchDiscardedAt IS NULL
                 """,
                 arguments: [now, now, sessionId, TranscriptionMode.batch.rawValue]
@@ -560,9 +546,102 @@ actor BatchTranscriptionCoordinator {
             )
             return db.changesCount == 1
         }) ?? false
-        if didPersist, let meetingId = try? meetingId(for: sessionId) {
-            await notify(meetingId: meetingId, state: .failed(sessionId: sessionId, message: message))
+        if didPersist, let result = try? failureNotificationContext(for: sessionId) {
+            let state: BatchTranscriptionState = result.isRetranscription
+                ? .retranscriptionFailed(sessionId: sessionId, message: message)
+                : .failed(sessionId: sessionId, message: message)
+            await notify(meetingId: result.meetingId, state: state)
         }
     }
 
+}
+
+extension BatchTranscriptionCoordinator {
+    /// Resumes the delete-after-transcription policy if the app stopped after committing a result.
+    private func recoverCompletedAudioPurges() async {
+        guard let recordingAudioStore else { return }
+        let sessionIds = await (try? dbQueue.read { db in
+            try UUID.fetchAll(
+                db,
+                sql: """
+                SELECT sessions.id
+                FROM recording_sessions AS sessions
+                WHERE sessions.transcriptionMode = ?
+                  AND sessions.batchCompletedAt IS NOT NULL
+                  AND sessions.batchDiscardedAt IS NULL
+                  AND sessions.audioRetentionPolicy = ?
+                  AND EXISTS (
+                      SELECT 1 FROM recording_audio_segments AS segments
+                      WHERE segments.recordingSessionId = sessions.id
+                        AND segments.state != ?
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1 FROM recording_audio_segments AS segments
+                      WHERE segments.recordingSessionId = sessions.id
+                        AND segments.state = ?
+                  )
+                """,
+                arguments: [
+                    TranscriptionMode.batch.rawValue,
+                    RecordingAudioRetentionPolicy.deleteAfterTranscription.rawValue,
+                    RecordingAudioSegmentState.purged.rawValue,
+                    RecordingAudioSegmentState.failed.rawValue,
+                ]
+            )
+        }) ?? []
+        for sessionId in sessionIds {
+            do {
+                try await recordingAudioStore.requestPurge(sessionId: sessionId)
+            } catch {
+                ErrorReportingService.capture(error, context: ["source": "batchAudioPurgeRecovery"])
+            }
+        }
+    }
+
+    func confirmAndEnqueue(
+        sessionId: UUID,
+        languageSelection: BatchTranscriptionLanguageSelection,
+        automaticLanguageCandidates: BatchLanguageDetectionCandidateSnapshot?,
+        retainAudioAfterBatch: Bool
+    ) async throws {
+        let result = try await BatchTranscriptionConfirmationService.confirm(
+            sessionId: sessionId,
+            languageSelection: languageSelection,
+            automaticLanguageCandidates: automaticLanguageCandidates,
+            retainAudioAfterBatch: retainAudioAfterBatch,
+            dbQueue: dbQueue
+        )
+        for confirmedSessionId in result.sessionIds {
+            await notify(meetingId: result.meetingId, state: .queued(sessionId: confirmedSessionId))
+            await enqueue(sessionId: confirmedSessionId)
+        }
+    }
+
+    func confirmRetranscriptionAndEnqueue(
+        sessionIds: [UUID],
+        languageSelection: BatchTranscriptionLanguageSelection,
+        automaticLanguageCandidates: BatchLanguageDetectionCandidateSnapshot?,
+        retainAudioAfterBatch: Bool
+    ) async throws {
+        let result = try await BatchTranscriptionConfirmationService.confirmRetranscription(
+            sessionIds: sessionIds,
+            languageSelection: languageSelection,
+            automaticLanguageCandidates: automaticLanguageCandidates,
+            retainAudioAfterBatch: retainAudioAfterBatch,
+            dbQueue: dbQueue
+        )
+        for sessionId in result.sessionIds {
+            await notify(meetingId: result.meetingId, state: .queued(sessionId: sessionId))
+            await enqueue(sessionId: sessionId)
+        }
+    }
+
+    private func failureNotificationContext(for sessionId: UUID) throws -> (meetingId: UUID, isRetranscription: Bool) {
+        try dbQueue.read { db in
+            guard let session = try RecordingSessionRecord.fetchOne(db, key: sessionId) else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            return (session.meetingId, session.isBatchRetranscriptionPending)
+        }
+    }
 }

--- a/Sources/Dahlia/Services/BatchTranscriptionPersistence.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionPersistence.swift
@@ -11,10 +11,11 @@ enum BatchTranscriptionPersistence {
         dbQueue: DatabaseQueue
     ) throws {
         try dbQueue.write { db in
-            guard try RecordingSessionRecord.fetchOne(db, key: sessionId) != nil,
+            guard let session = try RecordingSessionRecord.fetchOne(db, key: sessionId),
                   try MeetingRecord.fetchOne(db, key: meetingId) != nil else {
                 throw CocoaError(.fileNoSuchFile)
             }
+            let persistedCompletedAt = max(completedAt, session.batchLastAttemptAt ?? completedAt)
             _ = try TranscriptSegmentRecord
                 .filter(Column("sessionId") == sessionId)
                 .deleteAll(db)
@@ -28,11 +29,11 @@ enum BatchTranscriptionPersistence {
                     batchFailureKind = NULL, updatedAt = ?
                 WHERE id = ?
                 """,
-                arguments: [completedAt, completedAt, sessionId]
+                arguments: [persistedCompletedAt, persistedCompletedAt, sessionId]
             )
             try db.execute(
                 sql: "UPDATE meetings SET status = ?, updatedAt = ? WHERE id = ?",
-                arguments: [MeetingStatus.ready.rawValue, completedAt, meetingId]
+                arguments: [MeetingStatus.ready.rawValue, persistedCompletedAt, meetingId]
             )
         }
     }

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -522,9 +522,16 @@ enum L10n {
     }
 
     static var retryBatchTranscription: String { String(localized: "Retry Batch Transcription", bundle: bundle) }
+    static var keepCurrentTranscript: String { String(localized: "Keep Current Transcript", bundle: bundle) }
+    static var retranscribe: String { String(localized: "Retranscribe", bundle: bundle) }
     static var batchTranscriptionConfirmationTitle: String { String(localized: "Start batch transcription?", bundle: bundle) }
     static var batchTranscriptionConfirmationDescription: String { String(
         localized: "Choose a transcription language. Audio is kept until transcription succeeds.",
+        bundle: bundle
+    ) }
+    static var batchRetranscriptionConfirmationTitle: String { String(localized: "Retranscribe the saved recording?", bundle: bundle) }
+    static var batchRetranscriptionConfirmationDescription: String { String(
+        localized: "The current transcript remains available while processing and is replaced only after retranscription succeeds.",
         bundle: bundle
     ) }
     static var automaticDetectionMultilingualTitle: String { String(

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -113,6 +113,7 @@ final class CaptionViewModel: ObservableObject {
     @Published var isPreparingAnalyzer = false
     @Published private(set) var activeTranscriptionMode: TranscriptionMode?
     @Published private(set) var batchTranscriptionState: BatchTranscriptionState?
+    @Published private(set) var retranscribableBatchSessionIds: [UUID] = []
     @Published var pendingBatchTranscriptionConfirmation: BatchTranscriptionConfirmation?
     @Published var errorMessage: String?
     @Published var availableMicrophones: [MicrophoneDevice] = []
@@ -154,6 +155,11 @@ final class CaptionViewModel: ObservableObject {
     @Published var lastSummaryURL: URL?
     @Published var currentSummaryGoogleFileId: String?
     @Published var currentSummaryDocument: SummaryDocument?
+
+    var canRetranscribeBatchAudio: Bool {
+        !retranscribableBatchSessionIds.isEmpty && batchTranscriptionState == nil && !isListening
+    }
+
     /// Summary タブへの切り替えをリクエストするフラグ。
     @Published var requestShowSummaryTab = false
     /// 要約生成の進捗トースト状態。
@@ -507,13 +513,68 @@ final class CaptionViewModel: ObservableObject {
     }
 
     func retryBatchTranscription() {
-        guard case let .failed(sessionId, _) = batchTranscriptionState,
-              let meetingId = currentMeetingId else { return }
-        presentBatchTranscriptionConfirmation(
+        switch batchTranscriptionState {
+        case let .failed(sessionId, _):
+            guard let meetingId = currentMeetingId else { return }
+            presentBatchTranscriptionConfirmation(
+                sessionId: sessionId,
+                meetingId: meetingId,
+                suggestedLocaleIdentifier: selectedLocale,
+                dbQueue: currentDbQueue
+            )
+        case let .retranscriptionFailed(sessionId, _):
+            guard let meetingId = currentMeetingId,
+                  let dbQueue = currentDbQueue else { return }
+            Task {
+                guard let sessionIds = await Self.pendingBatchRetranscriptionSessionIds(
+                    meetingId: meetingId,
+                    dbQueue: dbQueue
+                ),
+                    !sessionIds.isEmpty,
+                    currentMeetingId == meetingId,
+                    case .retranscriptionFailed = batchTranscriptionState else { return }
+                presentBatchRetranscriptionConfirmation(
+                    sessionId: sessionId,
+                    sessionIds: sessionIds,
+                    meetingId: meetingId
+                )
+            }
+        default:
+            return
+        }
+    }
+
+    func presentBatchRetranscriptionConfirmation() {
+        guard canRetranscribeBatchAudio,
+              let meetingId = currentMeetingId,
+              let sessionId = retranscribableBatchSessionIds.last else { return }
+        presentBatchRetranscriptionConfirmation(
             sessionId: sessionId,
-            meetingId: meetingId,
+            sessionIds: retranscribableBatchSessionIds,
+            meetingId: meetingId
+        )
+    }
+
+    private func presentBatchRetranscriptionConfirmation(
+        sessionId: UUID,
+        sessionIds: [UUID],
+        meetingId: UUID
+    ) {
+        let preferences = batchConfirmationPreferences(
+            sessionId: sessionId,
             suggestedLocaleIdentifier: selectedLocale,
             dbQueue: currentDbQueue
+        )
+        pendingBatchTranscriptionConfirmation = BatchTranscriptionConfirmation(
+            sessionId: sessionId,
+            meetingId: meetingId,
+            suggestedLocaleIdentifier: preferences.localeIdentifier,
+            retainAudioAfterBatch: preferences.retainsAudio,
+            initialLanguageSelection: preferences.languageSelection,
+            automaticLanguageCandidateSnapshot: preferences.automaticLanguageCandidateSnapshot,
+            purpose: .retranscription(sessionIds: sessionIds),
+            initiallyGeneratesSummary: hasCurrentMeetingSummary
+                || AppSettings.shared.generateSummaryAfterBatchTranscription
         )
     }
 
@@ -574,26 +635,31 @@ final class CaptionViewModel: ObservableObject {
 
     func confirmBatchTranscription(
         languageSelection: BatchTranscriptionLanguageSelection,
-        retainAudioAfterBatch: Bool
+        retainAudioAfterBatch: Bool,
+        summaryGenerationOptions: SummaryGenerationOptions?
     ) {
         guard let confirmation = pendingBatchTranscriptionConfirmation,
               let coordinator = batchTranscriptionCoordinator else { return }
         let automaticLanguageCandidates = batchTranscriptionAutomaticLanguageCandidates(
             snapshot: confirmation.automaticLanguageCandidateSnapshot
         )
+        let selectedAutomaticLanguageCandidates = languageSelection == .automatic
+            ? automaticLanguageCandidates.snapshot
+            : nil
         let retryConfirmation = BatchTranscriptionConfirmation(
             sessionId: confirmation.sessionId,
             meetingId: confirmation.meetingId,
             suggestedLocaleIdentifier: confirmation.suggestedLocaleIdentifier,
             retainAudioAfterBatch: retainAudioAfterBatch,
             initialLanguageSelection: languageSelection,
-            automaticLanguageCandidateSnapshot: automaticLanguageCandidates.snapshot
+            automaticLanguageCandidateSnapshot: automaticLanguageCandidates.snapshot,
+            purpose: confirmation.purpose,
+            initiallyGeneratesSummary: summaryGenerationOptions != nil
         )
-        let settings = AppSettings.shared
-        if settings.generateSummaryAfterBatchTranscription {
+        if let summaryGenerationOptions {
             pendingBatchSummaryRequestsBySessionId[confirmation.sessionId] = (
                 meetingId: confirmation.meetingId,
-                options: settings.batchSummaryGenerationOptions
+                options: summaryGenerationOptions
             )
         } else {
             pendingBatchSummaryRequestsBySessionId.removeValue(forKey: confirmation.sessionId)
@@ -601,21 +667,36 @@ final class CaptionViewModel: ObservableObject {
         pendingBatchTranscriptionConfirmation = nil
         if currentMeetingId == confirmation.meetingId {
             batchTranscriptionState = .queued(sessionId: confirmation.sessionId)
+            retranscribableBatchSessionIds = []
         }
 
         Task {
             do {
-                try await coordinator.confirmAndEnqueue(
-                    sessionId: confirmation.sessionId,
-                    languageSelection: languageSelection,
-                    automaticLanguageCandidates: languageSelection == .automatic
-                        ? automaticLanguageCandidates.snapshot
-                        : nil,
-                    retainAudioAfterBatch: retainAudioAfterBatch
-                )
+                switch confirmation.purpose {
+                case .initialOrRetry:
+                    try await coordinator.confirmAndEnqueue(
+                        sessionId: confirmation.sessionId,
+                        languageSelection: languageSelection,
+                        automaticLanguageCandidates: selectedAutomaticLanguageCandidates,
+                        retainAudioAfterBatch: retainAudioAfterBatch
+                    )
+                case let .retranscription(sessionIds):
+                    try await coordinator.confirmRetranscriptionAndEnqueue(
+                        sessionIds: sessionIds,
+                        languageSelection: languageSelection,
+                        automaticLanguageCandidates: selectedAutomaticLanguageCandidates,
+                        retainAudioAfterBatch: retainAudioAfterBatch
+                    )
+                }
             } catch {
                 if currentMeetingId == confirmation.meetingId {
-                    batchTranscriptionState = .awaitingConfirmation(sessionId: confirmation.sessionId)
+                    switch confirmation.purpose {
+                    case .initialOrRetry:
+                        batchTranscriptionState = .awaitingConfirmation(sessionId: confirmation.sessionId)
+                    case let .retranscription(sessionIds):
+                        batchTranscriptionState = nil
+                        retranscribableBatchSessionIds = sessionIds
+                    }
                 }
                 errorMessage = error.localizedDescription
                 pendingBatchTranscriptionConfirmation = retryConfirmation
@@ -634,6 +715,30 @@ final class CaptionViewModel: ObservableObject {
                 guard try await repository.discardFailedBatchSessionSafely(id: sessionId) else { return }
                 pendingBatchSummaryRequestsBySessionId.removeValue(forKey: sessionId)
                 try refreshBatchTranscriptionState(meetingId: meetingId, dbQueue: dbQueue)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    func cancelFailedBatchRetranscription() {
+        guard case .retranscriptionFailed = batchTranscriptionState,
+              let meetingId = currentMeetingId,
+              let dbQueue = currentDbQueue else { return }
+        Task {
+            do {
+                guard let sessionIds = await Self.pendingBatchRetranscriptionSessionIds(
+                    meetingId: meetingId,
+                    dbQueue: dbQueue
+                ),
+                    !sessionIds.isEmpty else { return }
+                _ = try await BatchTranscriptionConfirmationService.cancelRetranscription(
+                    sessionIds: sessionIds,
+                    dbQueue: dbQueue
+                )
+                guard currentMeetingId == meetingId else { return }
+                batchTranscriptionState = nil
+                retranscribableBatchSessionIds = sessionIds
             } catch {
                 errorMessage = error.localizedDescription
             }
@@ -792,6 +897,7 @@ final class CaptionViewModel: ObservableObject {
         let googleFileId: String?
         let lastSummaryURL: URL?
         let note: MeetingNoteRecord?
+        let retranscribableBatchSessionIds: [UUID]
     }
 
     private nonisolated static func fetchLoadedMeetingData(
@@ -819,6 +925,47 @@ final class CaptionViewModel: ObservableObject {
             nil
         }
 
+        let retranscribableBatchSessionIds = try dbQueue.read { db in
+            try UUID.fetchAll(
+                db,
+                sql: """
+                SELECT DISTINCT sessions.id
+                FROM recording_sessions AS sessions
+                JOIN recording_audio_segments AS segments
+                  ON segments.recordingSessionId = sessions.id
+                JOIN recording_audio_segment_ranges AS ranges
+                  ON ranges.audioSegmentId = segments.id
+                WHERE sessions.meetingId = ?
+                  AND sessions.transcriptionMode = ?
+                  AND sessions.batchCompletedAt IS NOT NULL
+                  AND sessions.batchDiscardedAt IS NULL
+                  AND sessions.retainAudioAfterBatch = 1
+                  AND (sessions.batchLastAttemptAt IS NULL OR sessions.batchLastAttemptAt <= sessions.batchCompletedAt)
+                  AND segments.state = ?
+                  AND segments.purgedAt IS NULL
+                  AND NOT EXISTS (
+                      SELECT 1 FROM recording_audio_segments AS candidate
+                      WHERE candidate.recordingSessionId = sessions.id
+                        AND (
+                            candidate.state != ?
+                            OR candidate.purgedAt IS NOT NULL
+                            OR NOT EXISTS (
+                                SELECT 1 FROM recording_audio_segment_ranges AS candidateRanges
+                                WHERE candidateRanges.audioSegmentId = candidate.id
+                            )
+                        )
+                  )
+                ORDER BY sessions.startedAt
+                """,
+                arguments: [
+                    meetingId,
+                    TranscriptionMode.batch.rawValue,
+                    RecordingAudioSegmentState.ready.rawValue,
+                    RecordingAudioSegmentState.ready.rawValue,
+                ]
+            )
+        }
+
         return try LoadedMeetingData(
             createdAt: detail.meeting?.createdAt,
             recordingSessionRecords: detail.recordingSessions,
@@ -829,7 +976,8 @@ final class CaptionViewModel: ObservableObject {
             summaryDocument: detail.summary?.loadDocument(),
             googleFileId: googleDocsExport?.googleDocumentID,
             lastSummaryURL: lastSummaryURL,
-            note: detail.note
+            note: detail.note,
+            retranscribableBatchSessionIds: retranscribableBatchSessionIds
         )
     }
 
@@ -1119,6 +1267,7 @@ final class CaptionViewModel: ObservableObject {
         currentVaultURL = nil
         draftMeeting = nil
         batchTranscriptionState = nil
+        retranscribableBatchSessionIds = []
     }
 
     /// 録音対象のトランスクリプトに表示を復帰する。
@@ -1137,6 +1286,7 @@ final class CaptionViewModel: ObservableObject {
         currentVaultURL = ctx.vaultURL
         currentDbQueue = ctx.dbQueue
         batchTranscriptionState = ctx.batchTranscriptionState
+        retranscribableBatchSessionIds = []
         draftMeeting = nil
 
         store = ctx.store
@@ -1189,6 +1339,7 @@ final class CaptionViewModel: ObservableObject {
             .reversed()
             .compactMap { BatchTranscriptionState.derive(from: $0) }
             .first(where: \.blocksSummaryGeneration)
+        retranscribableBatchSessionIds = loaded.retranscribableBatchSessionIds
         setupNoteAutoSave()
 
         guard let coordinator = batchTranscriptionCoordinator,
@@ -1229,6 +1380,7 @@ final class CaptionViewModel: ObservableObject {
         resetSummaryState()
         draftMeeting = nil
         batchTranscriptionState = nil
+        retranscribableBatchSessionIds = []
     }
 
     private func resetSummaryState() {
@@ -2034,7 +2186,8 @@ final class CaptionViewModel: ObservableObject {
             suggestedLocaleIdentifier: preferences.localeIdentifier,
             retainAudioAfterBatch: preferences.retainsAudio,
             initialLanguageSelection: preferences.languageSelection,
-            automaticLanguageCandidateSnapshot: preferences.automaticLanguageCandidateSnapshot
+            automaticLanguageCandidateSnapshot: preferences.automaticLanguageCandidateSnapshot,
+            initiallyGeneratesSummary: AppSettings.shared.generateSummaryAfterBatchTranscription
         )
         MainWindowOpener.shared.openMainWindow()
     }
@@ -2076,8 +2229,9 @@ final class CaptionViewModel: ObservableObject {
             )
         }
         let localeIdentifier = session.batchSelectedLocaleIdentifier ?? stored.1 ?? suggestedLocaleIdentifier
-        let isRetry = session.batchLastError?.nilIfBlank != nil && session.batchAttemptCount > 0
-        let languageSelection: BatchTranscriptionLanguageSelection = if isRetry,
+        let preservesStoredSelection = session.batchCompletedAt != nil
+            || (session.batchLastError?.nilIfBlank != nil && session.batchAttemptCount > 0)
+        let languageSelection: BatchTranscriptionLanguageSelection = if preservesStoredSelection,
                                                                         session.batchLanguageDetectionMode == .automatic {
             .automatic
         } else {
@@ -2086,6 +2240,21 @@ final class CaptionViewModel: ObservableObject {
         let automaticLanguageCandidateSnapshot = session.batchAutomaticLanguageCandidatesJSON
             .flatMap { try? BatchLanguageDetectionCandidateSnapshot.decode($0) }
         return (localeIdentifier, session.retainAudioAfterBatch, languageSelection, automaticLanguageCandidateSnapshot)
+    }
+
+    private nonisolated static func pendingBatchRetranscriptionSessionIds(
+        meetingId: UUID,
+        dbQueue: DatabaseQueue
+    ) async -> [UUID]? {
+        try? await dbQueue.read { db in
+            try RecordingSessionRecord
+                .filter(Column("meetingId") == meetingId)
+                .filter(Column("batchCompletedAt") != nil)
+                .filter(sql: "batchLastAttemptAt > batchCompletedAt")
+                .order(Column("startedAt").asc)
+                .fetchAll(db)
+                .map(\.id)
+        }
     }
 
     private func completeBatchRecording(

--- a/Sources/Dahlia/Views/BatchTranscriptionConfirmationView.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionConfirmationView.swift
@@ -4,11 +4,16 @@ struct BatchTranscriptionConfirmationView: View {
     let locales: [Locale]
     let automaticLanguageLocales: [Locale]
     let displayLocale: Locale
-    let onStart: (BatchTranscriptionLanguageSelection, Bool) -> Void
+    let isRetranscription: Bool
+    let onStart: (BatchTranscriptionLanguageSelection, Bool, SummaryGenerationOptions?) -> Void
     let onPostpone: () -> Void
 
     @State private var languageSelection: BatchTranscriptionLanguageSelection
     @State private var deleteAudioAfterTranscription: Bool
+    @State private var generateSummaryAfterBatchTranscription: Bool
+    @State private var exportBatchSummaryToVault: Bool
+    @State private var exportBatchSummaryToGoogleDocs: Bool
+    @State private var previousMeetingCount: Int
 
     init(
         locales: [Locale],
@@ -16,7 +21,10 @@ struct BatchTranscriptionConfirmationView: View {
         displayLocale: Locale,
         initialLanguageSelection: BatchTranscriptionLanguageSelection,
         initiallyRetainsAudioAfterBatch: Bool,
-        onStart: @escaping (BatchTranscriptionLanguageSelection, Bool) -> Void,
+        initiallyGeneratesSummary: Bool,
+        summaryGenerationOptions: SummaryGenerationOptions,
+        isRetranscription: Bool,
+        onStart: @escaping (BatchTranscriptionLanguageSelection, Bool, SummaryGenerationOptions?) -> Void,
         onPostpone: @escaping () -> Void
     ) {
         self.locales = locales
@@ -24,17 +32,24 @@ struct BatchTranscriptionConfirmationView: View {
         self.displayLocale = displayLocale
         self.onStart = onStart
         self.onPostpone = onPostpone
+        self.isRetranscription = isRetranscription
         _languageSelection = State(initialValue: initialLanguageSelection)
         _deleteAudioAfterTranscription = State(initialValue: !initiallyRetainsAudioAfterBatch)
+        _generateSummaryAfterBatchTranscription = State(initialValue: initiallyGeneratesSummary)
+        _exportBatchSummaryToVault = State(initialValue: summaryGenerationOptions.exportOptions.exportsToVault)
+        _exportBatchSummaryToGoogleDocs = State(initialValue: summaryGenerationOptions.exportOptions.exportsToGoogleDocs)
+        _previousMeetingCount = State(initialValue: summaryGenerationOptions.previousMeetingCount)
     }
 
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 6) {
-                Text(L10n.batchTranscriptionConfirmationTitle)
+                Text(isRetranscription ? L10n.batchRetranscriptionConfirmationTitle : L10n.batchTranscriptionConfirmationTitle)
                     .font(.headline)
 
-                Text(L10n.batchTranscriptionConfirmationDescription)
+                Text(isRetranscription
+                    ? L10n.batchRetranscriptionConfirmationDescription
+                    : L10n.batchTranscriptionConfirmationDescription)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -47,7 +62,11 @@ struct BatchTranscriptionConfirmationView: View {
                 automaticLanguageLocales: automaticLanguageLocales,
                 displayLocale: displayLocale,
                 languageSelection: $languageSelection,
-                deleteAudioAfterTranscription: $deleteAudioAfterTranscription
+                deleteAudioAfterTranscription: $deleteAudioAfterTranscription,
+                generateSummaryAfterBatchTranscription: $generateSummaryAfterBatchTranscription,
+                exportBatchSummaryToVault: $exportBatchSummaryToVault,
+                exportBatchSummaryToGoogleDocs: $exportBatchSummaryToGoogleDocs,
+                previousMeetingCount: $previousMeetingCount
             )
 
             Divider()
@@ -56,16 +75,43 @@ struct BatchTranscriptionConfirmationView: View {
                 Spacer()
                 Button(L10n.later, action: onPostpone)
                     .keyboardShortcut(.cancelAction)
-                Button(L10n.startTranscription, action: startTranscription)
-                    .keyboardShortcut(.defaultAction)
-                    .disabled(languageSelection == .automatic && automaticLanguageLocales.isEmpty)
+                if isRetranscription {
+                    Button(L10n.retranscribe, action: startTranscription)
+                        .disabled(languageSelection == .automatic && automaticLanguageLocales.isEmpty)
+                } else {
+                    Button(L10n.startTranscription, action: startTranscription)
+                        .keyboardShortcut(.defaultAction)
+                        .disabled(languageSelection == .automatic && automaticLanguageLocales.isEmpty)
+                }
             }
             .padding(20)
         }
         .frame(minWidth: 500, idealWidth: 520, minHeight: 440, idealHeight: 500)
+        .onChange(of: generateSummaryAfterBatchTranscription) { _, _ in persistSummaryPreferencesIfNeeded() }
+        .onChange(of: exportBatchSummaryToVault) { _, _ in persistSummaryPreferencesIfNeeded() }
+        .onChange(of: exportBatchSummaryToGoogleDocs) { _, _ in persistSummaryPreferencesIfNeeded() }
+        .onChange(of: previousMeetingCount) { _, _ in persistSummaryPreferencesIfNeeded() }
     }
 
     private func startTranscription() {
-        onStart(languageSelection, !deleteAudioAfterTranscription)
+        let summaryOptions = generateSummaryAfterBatchTranscription
+            ? SummaryGenerationOptions(
+                previousMeetingCount: AppSettings.normalizedSummaryPreviousMeetingCount(previousMeetingCount),
+                exportOptions: SummaryExportOptions(
+                    exportsToVault: exportBatchSummaryToVault,
+                    exportsToGoogleDocs: exportBatchSummaryToGoogleDocs
+                )
+            )
+            : nil
+        onStart(languageSelection, !deleteAudioAfterTranscription, summaryOptions)
+    }
+
+    private func persistSummaryPreferencesIfNeeded() {
+        guard !isRetranscription else { return }
+        let settings = AppSettings.shared
+        settings.generateSummaryAfterBatchTranscription = generateSummaryAfterBatchTranscription
+        settings.exportBatchSummaryToVault = exportBatchSummaryToVault
+        settings.exportBatchSummaryToGoogleDocs = exportBatchSummaryToGoogleDocs
+        settings.summaryPreviousMeetingCount = previousMeetingCount
     }
 }

--- a/Sources/Dahlia/Views/BatchTranscriptionOptionsForm.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionOptionsForm.swift
@@ -6,15 +6,10 @@ struct BatchTranscriptionOptionsForm: View {
     let displayLocale: Locale
     @Binding var languageSelection: BatchTranscriptionLanguageSelection
     @Binding var deleteAudioAfterTranscription: Bool
-
-    @AppStorage(AppSettings.generateSummaryAfterBatchTranscriptionUserDefaultsKey)
-    private var generateSummaryAfterBatchTranscription = false
-    @AppStorage(AppSettings.exportBatchSummaryToVaultUserDefaultsKey)
-    private var exportBatchSummaryToVault = true
-    @AppStorage(AppSettings.exportBatchSummaryToGoogleDocsUserDefaultsKey)
-    private var exportBatchSummaryToGoogleDocs = false
-    @AppStorage(AppSettings.summaryPreviousMeetingCountUserDefaultsKey)
-    private var previousMeetingCount = AppSettings.defaultSummaryPreviousMeetingCount
+    @Binding var generateSummaryAfterBatchTranscription: Bool
+    @Binding var exportBatchSummaryToVault: Bool
+    @Binding var exportBatchSummaryToGoogleDocs: Bool
+    @Binding var previousMeetingCount: Int
 
     var body: some View {
         Form {

--- a/Sources/Dahlia/Views/BatchTranscriptionStatusView.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionStatusView.swift
@@ -35,7 +35,6 @@ struct BatchTranscriptionStatusView: View {
                 Label(L10n.batchTranscriptionFailed(message), systemImage: "exclamationmark.triangle.fill")
                     .foregroundStyle(.orange)
                 Spacer()
-                Button(L10n.keepCurrentTranscript, action: cancelRetranscription)
                 Button(L10n.retryBatchTranscription, action: retry)
                 Button(
                     L10n.discardFailedBatchRecording,
@@ -46,6 +45,7 @@ struct BatchTranscriptionStatusView: View {
                 Label(L10n.batchTranscriptionFailed(message), systemImage: "exclamationmark.triangle.fill")
                     .foregroundStyle(.orange)
                 Spacer()
+                Button(L10n.keepCurrentTranscript, action: cancelRetranscription)
                 Button(L10n.retryBatchTranscription, action: retry)
             }
         }

--- a/Sources/Dahlia/Views/BatchTranscriptionStatusView.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionStatusView.swift
@@ -4,6 +4,7 @@ struct BatchTranscriptionStatusView: View {
     let state: BatchTranscriptionState
     let confirm: () -> Void
     let retry: () -> Void
+    let cancelRetranscription: () -> Void
     let discard: () -> Void
 
     @State private var isShowingDiscardConfirmation = false
@@ -34,12 +35,18 @@ struct BatchTranscriptionStatusView: View {
                 Label(L10n.batchTranscriptionFailed(message), systemImage: "exclamationmark.triangle.fill")
                     .foregroundStyle(.orange)
                 Spacer()
+                Button(L10n.keepCurrentTranscript, action: cancelRetranscription)
                 Button(L10n.retryBatchTranscription, action: retry)
                 Button(
                     L10n.discardFailedBatchRecording,
                     role: .destructive,
                     action: showDiscardConfirmation
                 )
+            case let .retranscriptionFailed(_, message):
+                Label(L10n.batchTranscriptionFailed(message), systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Spacer()
+                Button(L10n.retryBatchTranscription, action: retry)
             }
         }
         .font(.callout)

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -87,6 +87,9 @@ struct ContentView: View {
                 displayLocale: AppSettings.shared.appLanguage.locale,
                 initialLanguageSelection: confirmation.initialLanguageSelection,
                 initiallyRetainsAudioAfterBatch: confirmation.retainAudioAfterBatch,
+                initiallyGeneratesSummary: confirmation.initiallyGeneratesSummary,
+                summaryGenerationOptions: AppSettings.shared.batchSummaryGenerationOptions,
+                isRetranscription: confirmation.isRetranscription,
                 onStart: viewModel.confirmBatchTranscription,
                 onPostpone: viewModel.postponeBatchTranscription
             )

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -162,6 +162,14 @@ private struct MeetingActionsMenu: View {
                 SummaryOpenMenu(viewModel: viewModel)
             }
 
+            if viewModel.canRetranscribeBatchAudio {
+                Button(
+                    L10n.retranscribe,
+                    systemImage: "arrow.clockwise",
+                    action: viewModel.presentBatchRetranscriptionConfirmation
+                )
+            }
+
             Divider()
 
             Button(role: .destructive) {
@@ -353,6 +361,7 @@ struct ControlPanelView: View {
                         batchTranscriptionState: viewModel.batchTranscriptionState,
                         confirmBatchTranscription: viewModel.presentBatchTranscriptionConfirmation,
                         retryBatchTranscription: viewModel.retryBatchTranscription,
+                        cancelFailedBatchRetranscription: viewModel.cancelFailedBatchRetranscription,
                         discardFailedBatchTranscription: viewModel.discardFailedBatchTranscription,
                         retryInitialMeetingLoad: viewModel.retryInitialMeetingLoad
                     )

--- a/Sources/Dahlia/Views/TranscriptTabView.swift
+++ b/Sources/Dahlia/Views/TranscriptTabView.swift
@@ -10,6 +10,7 @@ struct TranscriptTabView: View {
     let batchTranscriptionState: BatchTranscriptionState?
     let confirmBatchTranscription: () -> Void
     let retryBatchTranscription: () -> Void
+    let cancelFailedBatchRetranscription: () -> Void
     let discardFailedBatchTranscription: () -> Void
     let retryInitialMeetingLoad: () -> Void
 
@@ -24,6 +25,7 @@ struct TranscriptTabView: View {
                     state: batchTranscriptionState,
                     confirm: confirmBatchTranscription,
                     retry: retryBatchTranscription,
+                    cancelRetranscription: cancelFailedBatchRetranscription,
                     discard: discardFailedBatchTranscription
                 )
             }

--- a/Tests/DahliaTests/BatchAudioTestFixture.swift
+++ b/Tests/DahliaTests/BatchAudioTestFixture.swift
@@ -1,3 +1,4 @@
+@preconcurrency import AVFoundation
 import Foundation
 import GRDB
 @testable import Dahlia
@@ -63,6 +64,34 @@ import GRDB
 
         func removeFiles() {
             try? FileManager.default.removeItem(at: testRootURL)
+        }
+
+        func recordMicrophoneAudio(localeIdentifier: String = "ja_JP") async throws {
+            let recorder = try BatchAudioRecordingSession(
+                dbQueue: database.dbQueue,
+                managedRootURL: managedRootURL,
+                meetingId: meeting.id,
+                recordingSessionId: session.id,
+                recordingStartTime: now,
+                sampleRate: 16000,
+                configuration: RecordingAudioStore.Configuration(
+                    targetSegmentDuration: .seconds(30),
+                    maximumFinalizingSegmentCountPerSource: 2,
+                    maximumActiveSegmentDuration: .seconds(600),
+                    maximumActiveSegmentByteCount: 64 * 1024 * 1024,
+                    minimumAvailableCapacity: 0,
+                    capacityCheckInterval: .seconds(5)
+                )
+            )
+            let writer = try await recorder.beginRange(
+                source: .microphone,
+                locale: Locale(identifier: localeIdentifier),
+                at: now
+            )
+            let buffer = try #require(AVAudioPCMBuffer(pcmFormat: recorder.targetFormat, frameCapacity: 160))
+            buffer.frameLength = 160
+            writer.appendBuffer(buffer)
+            try await recorder.finish()
         }
     }
 #endif

--- a/Tests/DahliaTests/BatchTranscriptionConfirmationServiceTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionConfirmationServiceTests.swift
@@ -86,15 +86,20 @@ import GRDB
                 sessionId: fixture.session.id,
                 meetingId: fixture.meeting.id,
                 records: [replacement],
-                completedAt: persisted.0?.batchLastAttemptAt?.addingTimeInterval(1) ?? Date.now,
+                completedAt: fixture.now.addingTimeInterval(120),
                 dbQueue: fixture.database.dbQueue
             )
-            let completedTranscripts = try await fixture.database.dbQueue.read { db in
-                try TranscriptSegmentRecord
-                    .filter(Column("sessionId") == fixture.session.id)
-                    .fetchAll(db)
+            let completedResult = try await fixture.database.dbQueue.read { db in
+                try (
+                    RecordingSessionRecord.fetchOne(db, key: fixture.session.id),
+                    TranscriptSegmentRecord
+                        .filter(Column("sessionId") == fixture.session.id)
+                        .fetchAll(db)
+                )
             }
-            #expect(completedTranscripts.map(\.text) == ["replacement transcript"])
+            #expect(completedResult.0?.isBatchRetranscriptionPending == false)
+            #expect(completedResult.0?.batchCompletedAt == persisted.0?.batchLastAttemptAt)
+            #expect(completedResult.1.map(\.text) == ["replacement transcript"])
         }
 
         @Test
@@ -197,7 +202,7 @@ import GRDB
                 sessionId: fixture.session.id,
                 meetingId: fixture.meeting.id,
                 records: [],
-                completedAt: try #require(pending?.batchLastAttemptAt).addingTimeInterval(1),
+                completedAt: #require(pending?.batchLastAttemptAt).addingTimeInterval(1),
                 dbQueue: fixture.database.dbQueue
             )
 

--- a/Tests/DahliaTests/BatchTranscriptionConfirmationServiceTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionConfirmationServiceTests.swift
@@ -9,6 +9,215 @@ import GRDB
     @MainActor
     struct BatchTranscriptionConfirmationServiceTests {
         @Test
+        func retranscriptionKeepsPreviousTranscriptUntilSuccessfulCompletion() async throws {
+            let completedAt = Date(timeIntervalSince1970: 4_000_000_000)
+            let fixture = try BatchAudioTestFixture(
+                name: "RetranscriptionConfirmation",
+                endedAt: Date(timeIntervalSince1970: 1_776_384_030),
+                duration: 30,
+                retainAudioAfterBatch: true,
+                batchCompletedAt: completedAt
+            )
+            defer { fixture.removeFiles() }
+            try await fixture.recordMicrophoneAudio()
+            let previousTranscript = TranscriptSegmentRecord(
+                id: .v7(),
+                meetingId: fixture.meeting.id,
+                sessionId: fixture.session.id,
+                startTime: fixture.now,
+                endTime: fixture.now.addingTimeInterval(1),
+                text: "previous transcript",
+                translatedText: nil,
+                isConfirmed: true,
+                speakerLabel: "mic"
+            )
+            try await fixture.database.dbQueue.write { db in
+                try previousTranscript.insert(db)
+            }
+
+            let result = try await BatchTranscriptionConfirmationService.confirmRetranscription(
+                sessionIds: [fixture.session.id],
+                languageSelection: .manual(localeIdentifier: "en_US"),
+                automaticLanguageCandidates: nil,
+                retainAudioAfterBatch: false,
+                dbQueue: fixture.database.dbQueue
+            )
+            let firstAttempt = try await fixture.database.dbQueue.read { db in
+                try RecordingSessionRecord.fetchOne(db, key: fixture.session.id)
+            }
+            #expect(firstAttempt?.retainAudioAfterBatch == false)
+            #expect(firstAttempt?.isBatchRetranscriptionPending == true)
+
+            _ = try await BatchTranscriptionConfirmationService.confirmRetranscription(
+                sessionIds: [fixture.session.id],
+                languageSelection: .manual(localeIdentifier: "en_US"),
+                automaticLanguageCandidates: nil,
+                retainAudioAfterBatch: true,
+                dbQueue: fixture.database.dbQueue
+            )
+            let persisted = try await fixture.database.dbQueue.read { db in
+                try (
+                    RecordingSessionRecord.fetchOne(db, key: fixture.session.id),
+                    TranscriptSegmentRecord.fetchOne(db, key: previousTranscript.id),
+                    RecordingAudioSegmentRangeRecord.fetchAll(db)
+                )
+            }
+
+            #expect(result.meetingId == fixture.meeting.id)
+            #expect(result.sessionIds == [fixture.session.id])
+            #expect(persisted.0?.batchCompletedAt == completedAt)
+            #expect(persisted.0?.isBatchRetranscriptionPending == true)
+            #expect(persisted.0?.batchAttemptCount == 0)
+            #expect(persisted.1?.text == "previous transcript")
+            #expect(persisted.2.map(\.localeIdentifier) == ["en_US"])
+
+            let replacement = TranscriptSegmentRecord(
+                id: .v7(),
+                meetingId: fixture.meeting.id,
+                sessionId: fixture.session.id,
+                startTime: fixture.now,
+                endTime: fixture.now.addingTimeInterval(1),
+                text: "replacement transcript",
+                translatedText: nil,
+                isConfirmed: true,
+                speakerLabel: "mic"
+            )
+            try BatchTranscriptionPersistence.complete(
+                sessionId: fixture.session.id,
+                meetingId: fixture.meeting.id,
+                records: [replacement],
+                completedAt: persisted.0?.batchLastAttemptAt?.addingTimeInterval(1) ?? Date.now,
+                dbQueue: fixture.database.dbQueue
+            )
+            let completedTranscripts = try await fixture.database.dbQueue.read { db in
+                try TranscriptSegmentRecord
+                    .filter(Column("sessionId") == fixture.session.id)
+                    .fetchAll(db)
+            }
+            #expect(completedTranscripts.map(\.text) == ["replacement transcript"])
+        }
+
+        @Test
+        func retranscriptionRejectsIncompleteRetainedAudio() async throws {
+            let completedAt = Date(timeIntervalSince1970: 1_776_384_060)
+            let fixture = try BatchAudioTestFixture(
+                name: "RetranscriptionIncompleteAudio",
+                endedAt: completedAt.addingTimeInterval(-30),
+                duration: 30,
+                retainAudioAfterBatch: true,
+                batchCompletedAt: completedAt
+            )
+            defer { fixture.removeFiles() }
+            try await fixture.recordMicrophoneAudio()
+            try await fixture.database.dbQueue.write { db in
+                try db.execute(
+                    sql: "UPDATE recording_audio_segments SET state = ? WHERE recordingSessionId = ?",
+                    arguments: [RecordingAudioSegmentState.failed.rawValue, fixture.session.id]
+                )
+            }
+
+            await #expect(throws: CocoaError.self) {
+                try await BatchTranscriptionConfirmationService.confirmRetranscription(
+                    sessionIds: [fixture.session.id],
+                    languageSelection: .manual(localeIdentifier: "en_US"),
+                    automaticLanguageCandidates: nil,
+                    retainAudioAfterBatch: true,
+                    dbQueue: fixture.database.dbQueue
+                )
+            }
+        }
+
+        @Test
+        func cancellingRetranscriptionRestoresRetainedCompletedState() async throws {
+            let completedAt = Date(timeIntervalSince1970: 1_776_384_060)
+            let fixture = try BatchAudioTestFixture(
+                name: "CancelRetranscription",
+                endedAt: completedAt.addingTimeInterval(-30),
+                duration: 30,
+                retainAudioAfterBatch: true,
+                batchCompletedAt: completedAt
+            )
+            defer { fixture.removeFiles() }
+            try await fixture.recordMicrophoneAudio()
+            _ = try await BatchTranscriptionConfirmationService.confirmRetranscription(
+                sessionIds: [fixture.session.id],
+                languageSelection: .manual(localeIdentifier: "en_US"),
+                automaticLanguageCandidates: nil,
+                retainAudioAfterBatch: false,
+                dbQueue: fixture.database.dbQueue
+            )
+            try await fixture.database.dbQueue.write { db in
+                try db.execute(
+                    sql: "UPDATE recording_sessions SET batchLastError = ? WHERE id = ?",
+                    arguments: ["failed", fixture.session.id]
+                )
+            }
+
+            let meetingId = try await BatchTranscriptionConfirmationService.cancelRetranscription(
+                sessionIds: [fixture.session.id],
+                dbQueue: fixture.database.dbQueue
+            )
+            let session = try await fixture.database.dbQueue.read { db in
+                try RecordingSessionRecord.fetchOne(db, key: fixture.session.id)
+            }
+
+            #expect(meetingId == fixture.meeting.id)
+            #expect(session?.isBatchRetranscriptionPending == false)
+            #expect(session?.retainAudioAfterBatch == true)
+            #expect(session?.audioRetentionPolicy == .keepInApp)
+            #expect(session?.batchLastError == nil)
+            #expect(session.flatMap { BatchTranscriptionState.derive(from: $0) } == .completed(
+                sessionId: fixture.session.id
+            ))
+        }
+
+        @Test
+        func startupRecoveryFinishesDeferredAudioDeletion() async throws {
+            let completedAt = Date(timeIntervalSince1970: 1_776_384_060)
+            let fixture = try BatchAudioTestFixture(
+                name: "DeferredAudioDeletion",
+                endedAt: completedAt.addingTimeInterval(-30),
+                duration: 30,
+                retainAudioAfterBatch: true,
+                batchCompletedAt: completedAt
+            )
+            defer { fixture.removeFiles() }
+            try await fixture.recordMicrophoneAudio()
+            _ = try await BatchTranscriptionConfirmationService.confirmRetranscription(
+                sessionIds: [fixture.session.id],
+                languageSelection: .manual(localeIdentifier: "en_US"),
+                automaticLanguageCandidates: nil,
+                retainAudioAfterBatch: false,
+                dbQueue: fixture.database.dbQueue
+            )
+            let pending = try await fixture.database.dbQueue.read { db in
+                try RecordingSessionRecord.fetchOne(db, key: fixture.session.id)
+            }
+            try BatchTranscriptionPersistence.complete(
+                sessionId: fixture.session.id,
+                meetingId: fixture.meeting.id,
+                records: [],
+                completedAt: try #require(pending?.batchLastAttemptAt).addingTimeInterval(1),
+                dbQueue: fixture.database.dbQueue
+            )
+
+            let coordinator = BatchTranscriptionCoordinator(
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL,
+                onStateChange: { _ in }
+            )
+            await coordinator.recoverAndEnqueue()
+            let segmentStates = try await fixture.database.dbQueue.read { db in
+                try RecordingAudioSegmentRecord
+                    .filter(Column("recordingSessionId") == fixture.session.id)
+                    .fetchAll(db)
+                    .map(\.state)
+            }
+
+            #expect(segmentStates == [.purged])
+        }
+
+        @Test
         func automaticConfirmationRejectsEmptyCandidates() async throws {
             let queue = try DatabaseQueue(path: ":memory:")
 
@@ -207,5 +416,6 @@ import GRDB
             #expect(candidates.identifierSet == ["en", "ja"])
             #expect(result.1.map(\.localeIdentifier) == ["ja_JP"])
         }
+
     }
 #endif

--- a/Tests/DahliaTests/BatchTranscriptionStateTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionStateTests.swift
@@ -35,6 +35,17 @@ import Foundation
             session.batchCompletedAt = now.addingTimeInterval(20)
             #expect(BatchTranscriptionState.derive(from: session) == .completed(sessionId: session.id))
 
+            session.batchLastAttemptAt = now.addingTimeInterval(21)
+            session.batchLastError = nil
+            #expect(session.isBatchRetranscriptionPending)
+            #expect(BatchTranscriptionState.derive(from: session) == .queued(sessionId: session.id))
+
+            session.batchLastError = "retry failed"
+            #expect(BatchTranscriptionState.derive(from: session) == .retranscriptionFailed(
+                sessionId: session.id,
+                message: "retry failed"
+            ))
+
             session.batchDiscardedAt = now.addingTimeInterval(30)
             #expect(BatchTranscriptionState.derive(from: session) == nil)
         }

--- a/Tests/DahliaTests/CaptionViewModelBatchRetryTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelBatchRetryTests.swift
@@ -8,6 +8,46 @@ import GRDB
     @MainActor
     struct CaptionViewModelBatchRetryTests {
         @Test
+        func retainedCompletedAudioOffersRetranscription() async throws {
+            let batch = try BatchAudioTestFixture(
+                name: "retained-completed-audio",
+                endedAt: Date(timeIntervalSince1970: 1_776_384_001),
+                duration: 1,
+                retainAudioAfterBatch: true,
+                batchCompletedAt: Date(timeIntervalSince1970: 1_776_384_002)
+            )
+            defer { batch.removeFiles() }
+            try await batch.recordMicrophoneAudio()
+
+            let viewModel = CaptionViewModel()
+            viewModel.configureBatchTranscription(
+                dbQueue: batch.database.dbQueue,
+                managedRootURL: batch.managedRootURL,
+                recoverExistingSessions: false
+            )
+            viewModel.loadMeeting(
+                batch.meeting.id,
+                dbQueue: batch.database.dbQueue,
+                projectURL: nil,
+                projectId: nil,
+                vaultURL: batch.vaultURL
+            )
+            #expect(await waitUntil { viewModel.canRetranscribeBatchAudio })
+
+            viewModel.presentBatchRetranscriptionConfirmation()
+
+            let confirmation = try #require(viewModel.pendingBatchTranscriptionConfirmation)
+            #expect(confirmation.isRetranscription)
+            #expect(confirmation.sessionId == batch.session.id)
+            #expect(confirmation.retainAudioAfterBatch)
+            guard case let .retranscription(sessionIds) = confirmation.purpose else {
+                Issue.record("Expected a retranscription confirmation")
+                return
+            }
+            #expect(sessionIds == [batch.session.id])
+        }
+
+        @Test
         func newConfirmationDefaultsToManualSelectedLanguage() {
             let confirmation = BatchTranscriptionConfirmation(
                 sessionId: .v7(),

--- a/Tests/DahliaTests/CaptionViewModelBatchUpdateTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelBatchUpdateTests.swift
@@ -179,7 +179,8 @@ import GRDB
             )
             viewModel.confirmBatchTranscription(
                 languageSelection: .manual(localeIdentifier: "ja_JP"),
-                retainAudioAfterBatch: false
+                retainAudioAfterBatch: false,
+                summaryGenerationOptions: nil
             )
             #expect(await waitUntil {
                 if case .failed = viewModel.batchTranscriptionState {


### PR DESCRIPTION
## Summary

- add a Retranscribe action for completed batch sessions whose audio was retained
- preserve the current transcript until retranscription completes successfully
- support retrying or abandoning a failed retranscription without blocking the existing transcript and summary
- keep summary-generation options local to the retranscription confirmation flow

## Root cause

Completed batch sessions were treated as terminal. The app did not discover retained, transcribable audio for those sessions or expose a route back into the batch transcription coordinator.

## Reliability and safety

- reject incomplete, failed, or purged retained audio before retranscription can replace a transcript
- keep retranscription timestamps monotonic across system clock changes
- recover deferred delete-after-transcription audio purges during startup
- restrict startup recovery queries to sessions that can actually require processing
- move retry database reads off the main actor
- add a non-destructive Keep Current Transcript action after retranscription failure

## User impact

Users who kept a batch recording can run transcription again with a different language or summary configuration. Existing transcript data remains available throughout processing and is replaced atomically only after success.

## Validation

- `swift build`
- `swift test` — 817 tests in 138 Swift Testing suites passed, plus 3 XCTest cases
- `CI=true ./scripts/lint.sh` — SwiftFormat reported 0 files requiring changes; SwiftLint completed with the repository's non-blocking warnings
- `git diff --check`
