### PR TITLE
Move Vault summaries with meetings

### DIFF
--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -6,6 +6,47 @@ import GRDB
 // Query methods share one MainActor-isolated database boundary.
 // swiftlint:disable:next type_body_length
 final class MeetingRepository {
+    struct MeetingMoveCandidate {
+        let meetingId: UUID
+        let projectId: UUID?
+        let hasVaultExport: Bool
+        let vaultRelativePath: String?
+    }
+
+    struct MeetingVaultExportUpdate {
+        let meetingId: UUID
+        let relativePath: String?
+    }
+
+    private static func updateVaultExports(
+        _ updates: [MeetingVaultExportUpdate],
+        forMeetingIds meetingIds: Set<UUID>,
+        in db: Database
+    ) throws {
+        let existingRecords = try SummaryExportRecord
+            .filter(meetingIds.contains(Column("meetingId")))
+            .filter(Column("type") == SummaryExportType.vault)
+            .fetchAll(db)
+        let existingByMeetingId = Dictionary(uniqueKeysWithValues: existingRecords.map { ($0.meetingId, $0) })
+        let updatedAt = Date.now
+
+        for update in updates where meetingIds.contains(update.meetingId) {
+            guard let url = update.relativePath.flatMap(SummaryExportRecord.vaultURL(relativePath:)) else {
+                if let existing = existingByMeetingId[update.meetingId] {
+                    _ = try existing.delete(db)
+                }
+                continue
+            }
+            try SummaryExportRecord(
+                meetingId: update.meetingId,
+                type: .vault,
+                url: url,
+                createdAt: existingByMeetingId[update.meetingId]?.createdAt ?? updatedAt,
+                updatedAt: updatedAt
+            ).save(db)
+        }
+    }
+
     struct AppendRecordingContext {
         let meetingCreatedAt: Date?
         let firstSegmentStartTime: Date?
@@ -264,22 +305,77 @@ final class MeetingRepository {
         try deleteMeetings(ids: ids)
     }
 
-    func moveMeeting(id: UUID, toProjectId: UUID?) throws {
-        try dbQueue.write { db in
-            if var record = try MeetingRecord.fetchOne(db, key: id) {
-                record.projectId = toProjectId
-                try record.update(db)
+    func fetchMeetingMoveCandidates(ids: Set<UUID>, vaultId: UUID) throws -> [MeetingMoveCandidate] {
+        guard !ids.isEmpty else { return [] }
+        return try dbQueue.read { db in
+            let meetings = try MeetingRecord
+                .filter(ids.contains(Column("id")))
+                .filter(Column("vaultId") == vaultId)
+                .fetchAll(db)
+            let vaultExports = try SummaryExportRecord
+                .filter(ids.contains(Column("meetingId")))
+                .filter(Column("type") == SummaryExportType.vault)
+                .fetchAll(db)
+            let vaultExportsByMeetingId = Dictionary(uniqueKeysWithValues: vaultExports.map { ($0.meetingId, $0) })
+
+            return meetings.map { meeting in
+                let vaultExport = vaultExportsByMeetingId[meeting.id]
+                return MeetingMoveCandidate(
+                    meetingId: meeting.id,
+                    projectId: meeting.projectId,
+                    hasVaultExport: vaultExport != nil,
+                    vaultRelativePath: vaultExport?.vaultRelativePath
+                )
             }
         }
     }
 
-    /// 複数のミーティングを一括移動する。
-    func moveMeetings(ids: Set<UUID>, toProjectId: UUID?) throws {
+    func sharedVaultSummaryPaths(relativePaths: Set<String>, vaultId: UUID) throws -> Set<String> {
+        let pathsByURL = Dictionary(uniqueKeysWithValues: relativePaths.compactMap { relativePath in
+            SummaryExportRecord.vaultURL(relativePath: relativePath).map { ($0, relativePath) }
+        })
+        guard !pathsByURL.isEmpty else { return [] }
+        return try dbQueue.read { db in
+            let sharedURLs = try String.fetchSet(
+                db,
+                sql: """
+                SELECT summary_exports.url
+                FROM summary_exports
+                JOIN meetings ON meetings.id = summary_exports.meetingId
+                WHERE summary_exports.type = ?
+                  AND meetings.vaultId = ?
+                GROUP BY summary_exports.url
+                HAVING COUNT(*) > 1
+                """,
+                arguments: [SummaryExportType.vault, vaultId]
+            )
+            return Set(sharedURLs.compactMap { pathsByURL[$0] })
+        }
+    }
+
+    func commitMeetingMove(
+        ids: Set<UUID>,
+        toProjectId: UUID?,
+        vaultId: UUID,
+        vaultExportUpdates: [MeetingVaultExportUpdate]
+    ) throws {
         guard !ids.isEmpty else { return }
         try dbQueue.write { db in
+            if let toProjectId {
+                guard let destination = try ProjectRecord.fetchOne(db, key: toProjectId),
+                      destination.vaultId == vaultId,
+                      !destination.missingOnDisk
+                else {
+                    throw ProjectWorkspaceError.invalidMoveDestination
+                }
+            }
+
             _ = try MeetingRecord
                 .filter(ids.contains(Column("id")))
+                .filter(Column("vaultId") == vaultId)
                 .updateAll(db, Column("projectId").set(to: toProjectId))
+
+            try Self.updateVaultExports(vaultExportUpdates, forMeetingIds: ids, in: db)
         }
     }
 
@@ -813,6 +909,18 @@ extension MeetingRepository {
         }
     }
 
+    func meetingIds(projectHierarchy name: String, vaultId: UUID) throws -> Set<UUID> {
+        try dbQueue.read { db in
+            let projectIds = try ProjectRecord.hierarchy(prefix: name, vaultId: vaultId, in: db).map(\.id)
+            guard !projectIds.isEmpty else { return [] }
+            return try UUID.fetchSet(
+                db,
+                sql: "SELECT id FROM meetings WHERE projectId IN (\(projectIds.map { _ in "?" }.joined(separator: ",")))",
+                arguments: StatementArguments(projectIds)
+            )
+        }
+    }
+
     func fetchProject(id: UUID) throws -> ProjectRecord? {
         try dbQueue.read { db in
             try ProjectRecord.fetchOne(db, key: id)
@@ -890,7 +998,8 @@ extension MeetingRepository {
     func deleteProjectHierarchy(
         name: String,
         vaultId: UUID,
-        meetingDisposition: ProjectMeetingDisposition
+        meetingDisposition: ProjectMeetingDisposition,
+        vaultExportUpdates: [MeetingVaultExportUpdate] = []
     ) throws {
         let meetingIds = try dbQueue.read { db in
             let projectIds = try ProjectRecord.hierarchy(prefix: name, vaultId: vaultId, in: db).map(\.id)
@@ -927,11 +1036,7 @@ extension MeetingRepository {
                     _ = try MeetingRecord
                         .filter(meetingIds.contains(Column("id")))
                         .updateAll(db, Column("projectId").set(to: destinationId))
-                    try SummaryExportRecord.clearVaultPaths(
-                        meetingIds: meetingIds,
-                        underProjectPrefix: name,
-                        in: db
-                    )
+                    try Self.updateVaultExports(vaultExportUpdates, forMeetingIds: meetingIds, in: db)
                 }
             case .deleteMeetings:
                 if !meetingIds.isEmpty {

--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -330,26 +330,42 @@ final class MeetingRepository {
         }
     }
 
-    func sharedVaultSummaryPaths(relativePaths: Set<String>, vaultId: UUID) throws -> Set<String> {
-        let pathsByURL = Dictionary(uniqueKeysWithValues: relativePaths.compactMap { relativePath in
-            SummaryExportRecord.vaultURL(relativePath: relativePath).map { ($0, relativePath) }
-        })
+    func externallySharedVaultSummaryPaths(
+        relativePaths: Set<String>,
+        movingMeetingIds: Set<UUID>,
+        vaultId: UUID
+    ) throws -> Set<String> {
+        let pathsByURL = Dictionary(grouping: relativePaths.compactMap { relativePath in
+            SummaryExportRecord.vaultURL(relativePath: relativePath).map { ($0.lowercased(), relativePath) }
+        }, by: \.0)
         guard !pathsByURL.isEmpty else { return [] }
         return try dbQueue.read { db in
-            let sharedURLs = try String.fetchSet(
+            let normalizedURLs = Array(pathsByURL.keys)
+            let placeholders = normalizedURLs.map { _ in "?" }.joined(separator: ",")
+            var arguments: StatementArguments = [SummaryExportType.vault, vaultId]
+            arguments += StatementArguments(normalizedURLs)
+            let records = try SummaryExportRecord.fetchAll(
                 db,
                 sql: """
-                SELECT summary_exports.url
+                SELECT summary_exports.*
                 FROM summary_exports
                 JOIN meetings ON meetings.id = summary_exports.meetingId
                 WHERE summary_exports.type = ?
                   AND meetings.vaultId = ?
-                GROUP BY summary_exports.url
-                HAVING COUNT(*) > 1
+                  AND LOWER(summary_exports.url) IN (\(placeholders))
                 """,
-                arguments: [SummaryExportType.vault, vaultId]
+                arguments: arguments
             )
-            return Set(sharedURLs.compactMap { pathsByURL[$0] })
+            let externallySharedURLs = Set(records.compactMap { record -> String? in
+                let key = record.url.lowercased()
+                guard pathsByURL[key] != nil,
+                      !movingMeetingIds.contains(record.meetingId)
+                else { return nil }
+                return key
+            })
+            return Set(externallySharedURLs.flatMap { key in
+                pathsByURL[key, default: []].map(\.1)
+            })
         }
     }
 

--- a/Sources/Dahlia/Database/SummaryExportRecord.swift
+++ b/Sources/Dahlia/Database/SummaryExportRecord.swift
@@ -144,19 +144,4 @@ struct SummaryExportRecord: Codable, FetchableRecord, PersistableRecord, Equatab
         )
     }
 
-    static func clearVaultPaths(
-        meetingIds: Set<UUID>,
-        underProjectPrefix projectPrefix: String,
-        in db: Database
-    ) throws {
-        guard !meetingIds.isEmpty else { return }
-        let records = try filter(meetingIds.contains(Column("meetingId")))
-            .filter(Column("type") == SummaryExportType.vault)
-            .fetchAll(db)
-        for record in records where record.vaultRelativePath.map({
-            ProjectRecord.belongsToHierarchy($0, prefix: projectPrefix)
-        }) == true {
-            _ = try record.delete(db)
-        }
-    }
 }

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -201,6 +201,8 @@
 "The project folder must exist before it can be renamed." = "The project folder must exist before it can be renamed.";
 "The project folder could not be moved to a recoverable Trash location." = "The project folder could not be moved to a recoverable Trash location.";
 "Choose an available project outside the hierarchy being deleted." = "Choose an available project outside the hierarchy being deleted.";
+"A summary file named %@ already exists in the destination." = "A summary file named %@ already exists in the destination.";
+"The summary file %@ is linked to multiple meetings and cannot be moved safely." = "The summary file %@ is linked to multiple meetings and cannot be moved safely.";
 "The project operation failed (%@), and Dahlia could not restore the folder (%@)." = "The project operation failed (%@), and Dahlia could not restore the folder (%@).";
 "Select a project to manage summary destinations and instructions." = "Select a project to manage summary destinations and instructions.";
 "Open a vault before managing project settings." = "Open a vault before managing project settings.";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -201,6 +201,8 @@
 "The project folder must exist before it can be renamed." = "名前を変更するにはプロジェクトフォルダが必要です。";
 "The project folder could not be moved to a recoverable Trash location." = "復元可能なゴミ箱の場所へプロジェクトフォルダを移動できませんでした。";
 "Choose an available project outside the hierarchy being deleted." = "削除対象の階層外にある利用可能なプロジェクトを選択してください。";
+"A summary file named %@ already exists in the destination." = "移動先には「%@」という要約ファイルがすでにあります。";
+"The summary file %@ is linked to multiple meetings and cannot be moved safely." = "要約ファイル「%@」は複数のmeetingから参照されているため、安全に移動できません。";
 "The project operation failed (%@), and Dahlia could not restore the folder (%@)." = "プロジェクト操作に失敗し（%@）、フォルダも復元できませんでした（%@）。";
 "Select a project to manage summary destinations and instructions." = "要約の書き出し先と instruction を管理するプロジェクトを選択してください。";
 "Open a vault before managing project settings." = "プロジェクト設定を管理するには保管庫を開いてください。";

--- a/Sources/Dahlia/Services/ProjectWorkspaceError.swift
+++ b/Sources/Dahlia/Services/ProjectWorkspaceError.swift
@@ -10,6 +10,8 @@ enum ProjectWorkspaceError: LocalizedError, Equatable {
     case folderMissing
     case trashLocationUnavailable
     case invalidMoveDestination
+    case summaryFileAlreadyExists(String)
+    case summaryFileShared(String)
     case rollbackFailed(operation: String, rollback: String)
 
     var errorDescription: String? {
@@ -32,6 +34,10 @@ enum ProjectWorkspaceError: LocalizedError, Equatable {
             L10n.projectTrashLocationUnavailable
         case .invalidMoveDestination:
             L10n.invalidProjectMoveDestination
+        case let .summaryFileAlreadyExists(name):
+            L10n.summaryFileAlreadyExists(name)
+        case let .summaryFileShared(name):
+            L10n.summaryFileShared(name)
         case let .rollbackFailed(operation, rollback):
             L10n.projectRollbackFailed(operation: operation, rollback: rollback)
         }

--- a/Sources/Dahlia/Services/ProjectWorkspaceService.swift
+++ b/Sources/Dahlia/Services/ProjectWorkspaceService.swift
@@ -240,19 +240,20 @@ extension ProjectWorkspaceService {
         let candidates = try repository.fetchMeetingMoveCandidates(ids: ids, vaultId: vault.id)
             .filter { $0.projectId != toProjectId }
         let meetingIds = Set(candidates.map(\.meetingId))
-        let sharedSummaryPaths = try repository.sharedVaultSummaryPaths(
+        let sharedSummaryPaths = try repository.externallySharedVaultSummaryPaths(
             relativePaths: Set(candidates.compactMap(\.vaultRelativePath)),
+            movingMeetingIds: meetingIds,
             vaultId: vault.id
         )
         var relocations: [SummaryRelocation] = []
         var updates: [MeetingRepository.MeetingVaultExportUpdate] = []
         var destinationPaths: Set<String> = []
+        var destinationBySourcePath: [String: URL] = [:]
 
         for candidate in candidates where candidate.hasVaultExport {
             guard let sourceURL = try summaryFileResolver(candidate.vaultRelativePath, vault.url),
                   isInsideVaultAfterResolvingSymlinks(sourceURL)
             else {
-                updates.append(.init(meetingId: candidate.meetingId, relativePath: nil))
                 continue
             }
             if let relativePath = candidate.vaultRelativePath, sharedSummaryPaths.contains(relativePath) {
@@ -274,10 +275,19 @@ extension ProjectWorkspaceService {
             updates.append(.init(meetingId: candidate.meetingId, relativePath: relativePath))
             guard standardizedSourceURL != destinationURL else { continue }
 
+            let sourceKey = standardizedSourceURL.path.lowercased()
+            if let plannedDestination = destinationBySourcePath[sourceKey] {
+                guard plannedDestination == destinationURL else {
+                    throw ProjectWorkspaceError.summaryFileAlreadyExists(destinationURL.lastPathComponent)
+                }
+                continue
+            }
+
             let destinationKey = destinationURL.path.lowercased()
             if !destinationPaths.insert(destinationKey).inserted || fileManager.fileExists(atPath: destinationURL.path) {
                 throw ProjectWorkspaceError.summaryFileAlreadyExists(destinationURL.lastPathComponent)
             }
+            destinationBySourcePath[sourceKey] = destinationURL
             relocations.append(.init(sourceURL: standardizedSourceURL, destinationURL: destinationURL))
         }
 

--- a/Sources/Dahlia/Services/ProjectWorkspaceService.swift
+++ b/Sources/Dahlia/Services/ProjectWorkspaceService.swift
@@ -3,25 +3,40 @@ import Foundation
 @MainActor
 final class ProjectWorkspaceService {
     typealias TrashHandler = @MainActor (URL) throws -> URL
+    typealias SummaryFileResolver = @MainActor (String?, URL) throws -> URL?
+
+    private struct SummaryRelocation {
+        let sourceURL: URL
+        let destinationURL: URL
+    }
+
+    private struct MeetingMovePlan {
+        let meetingIds: Set<UUID>
+        let relocations: [SummaryRelocation]
+        let vaultExportUpdates: [MeetingRepository.MeetingVaultExportUpdate]
+    }
 
     private let repository: MeetingRepository
     private let vault: VaultRecord
     private let managedAudioRootURL: URL
     private let fileManager: FileManager
     private let trashHandler: TrashHandler
+    private let summaryFileResolver: SummaryFileResolver
 
     init(
         repository: MeetingRepository,
         vault: VaultRecord,
         managedAudioRootURL: URL = BatchAudioStorage.managedRootURL,
         fileManager: FileManager = .default,
-        trashHandler: @escaping TrashHandler = ProjectWorkspaceService.moveToTrash
+        trashHandler: @escaping TrashHandler = ProjectWorkspaceService.moveToTrash,
+        summaryFileResolver: @escaping SummaryFileResolver = ProjectWorkspaceService.resolveSummaryFile
     ) {
         self.repository = repository
         self.vault = vault
         self.managedAudioRootURL = managedAudioRootURL
         self.fileManager = fileManager
         self.trashHandler = trashHandler
+        self.summaryFileResolver = summaryFileResolver
     }
 
     func createProject(leafName: String, parentProjectId: UUID?) throws -> ProjectRecord {
@@ -92,11 +107,30 @@ final class ProjectWorkspaceService {
         return renamed
     }
 
+    func moveMeeting(id: UUID, toProjectId: UUID?) throws {
+        try moveMeetings(ids: [id], toProjectId: toProjectId)
+    }
+
+    func moveMeetings(ids: Set<UUID>, toProjectId: UUID?) throws {
+        let plan = try makeMeetingMovePlan(ids: ids, toProjectId: toProjectId)
+        guard !plan.meetingIds.isEmpty else { return }
+
+        try performSummaryRelocations(plan.relocations) {
+            try repository.commitMeetingMove(
+                ids: plan.meetingIds,
+                toProjectId: toProjectId,
+                vaultId: vault.id,
+                vaultExportUpdates: plan.vaultExportUpdates
+            )
+        }
+    }
+
     func deleteProjectHierarchy(id: UUID, meetingDisposition: ProjectMeetingDisposition) async throws {
         guard let project = try repository.fetchProject(id: id), project.vaultId == vault.id else {
             throw ProjectWorkspaceError.projectNotFound
         }
 
+        let movePlan: MeetingMovePlan?
         if case let .move(destinationId) = meetingDisposition {
             guard let destination = try repository.fetchProject(id: destinationId),
                   destination.vaultId == vault.id,
@@ -105,6 +139,10 @@ final class ProjectWorkspaceService {
             else {
                 throw ProjectWorkspaceError.invalidMoveDestination
             }
+            let hierarchyMeetingIds = try repository.meetingIds(projectHierarchy: project.name, vaultId: vault.id)
+            movePlan = try makeMeetingMovePlan(ids: hierarchyMeetingIds, toProjectId: destinationId)
+        } else {
+            movePlan = nil
         }
 
         if meetingDisposition == .deleteMeetings {
@@ -115,30 +153,34 @@ final class ProjectWorkspaceService {
             )
         }
 
-        let originalURL = projectURL(name: project.name)
-        let trashedURL: URL? = if fileManager.fileExists(atPath: originalURL.path) {
-            try trashHandler(originalURL)
-        } else {
-            nil
-        }
-
-        do {
-            try repository.deleteProjectHierarchy(
-                name: project.name,
-                vaultId: vault.id,
-                meetingDisposition: meetingDisposition
-            )
-        } catch {
-            guard let trashedURL else { throw error }
-            do {
-                try fileManager.moveItem(at: trashedURL, to: originalURL)
-            } catch let rollbackError {
-                throw ProjectWorkspaceError.rollbackFailed(
-                    operation: error.localizedDescription,
-                    rollback: rollbackError.localizedDescription
-                )
+        let relocations = movePlan?.relocations ?? []
+        try performSummaryRelocations(relocations) {
+            let originalURL = projectURL(name: project.name)
+            let trashedURL: URL? = if fileManager.fileExists(atPath: originalURL.path) {
+                try trashHandler(originalURL)
+            } else {
+                nil
             }
-            throw error
+
+            do {
+                try repository.deleteProjectHierarchy(
+                    name: project.name,
+                    vaultId: vault.id,
+                    meetingDisposition: meetingDisposition,
+                    vaultExportUpdates: movePlan?.vaultExportUpdates ?? []
+                )
+            } catch {
+                guard let trashedURL else { throw error }
+                do {
+                    try fileManager.moveItem(at: trashedURL, to: originalURL)
+                } catch let rollbackError {
+                    throw ProjectWorkspaceError.rollbackFailed(
+                        operation: error.localizedDescription,
+                        rollback: rollbackError.localizedDescription
+                    )
+                }
+                throw error
+            }
         }
     }
 
@@ -158,7 +200,9 @@ final class ProjectWorkspaceService {
         guard name.utf8.count <= 255 else { throw ProjectWorkspaceError.nameTooLong }
         return name
     }
+}
 
+extension ProjectWorkspaceService {
     private func ensureProjectDoesNotExist(name: String, excludingProjectId: UUID?) throws {
         let projects = try repository.fetchAllProjects(vaultId: vault.id)
         if projects.contains(where: {
@@ -185,6 +229,142 @@ final class ProjectWorkspaceService {
 
     private func projectURL(name: String) -> URL {
         vault.url.appending(path: name, directoryHint: .isDirectory)
+    }
+
+    private func makeMeetingMovePlan(ids: Set<UUID>, toProjectId: UUID?) throws -> MeetingMovePlan {
+        guard !ids.isEmpty else {
+            return MeetingMovePlan(meetingIds: [], relocations: [], vaultExportUpdates: [])
+        }
+
+        let destinationDirectory = try summaryDestinationDirectory(toProjectId: toProjectId)
+        let candidates = try repository.fetchMeetingMoveCandidates(ids: ids, vaultId: vault.id)
+            .filter { $0.projectId != toProjectId }
+        let meetingIds = Set(candidates.map(\.meetingId))
+        let sharedSummaryPaths = try repository.sharedVaultSummaryPaths(
+            relativePaths: Set(candidates.compactMap(\.vaultRelativePath)),
+            vaultId: vault.id
+        )
+        var relocations: [SummaryRelocation] = []
+        var updates: [MeetingRepository.MeetingVaultExportUpdate] = []
+        var destinationPaths: Set<String> = []
+
+        for candidate in candidates where candidate.hasVaultExport {
+            guard let sourceURL = try summaryFileResolver(candidate.vaultRelativePath, vault.url),
+                  isInsideVaultAfterResolvingSymlinks(sourceURL)
+            else {
+                updates.append(.init(meetingId: candidate.meetingId, relativePath: nil))
+                continue
+            }
+            if let relativePath = candidate.vaultRelativePath, sharedSummaryPaths.contains(relativePath) {
+                throw ProjectWorkspaceError.summaryFileShared(sourceURL.lastPathComponent)
+            }
+
+            let destinationURL = destinationDirectory
+                .appending(path: sourceURL.lastPathComponent, directoryHint: .notDirectory)
+                .standardizedFileURL
+            let standardizedSourceURL = sourceURL.standardizedFileURL
+            guard let relativePath = VaultSummaryFileLocator.relativePath(
+                for: destinationURL,
+                vaultURL: vault.url
+            ) else {
+                updates.append(.init(meetingId: candidate.meetingId, relativePath: nil))
+                continue
+            }
+
+            updates.append(.init(meetingId: candidate.meetingId, relativePath: relativePath))
+            guard standardizedSourceURL != destinationURL else { continue }
+
+            let destinationKey = destinationURL.path.lowercased()
+            if !destinationPaths.insert(destinationKey).inserted || fileManager.fileExists(atPath: destinationURL.path) {
+                throw ProjectWorkspaceError.summaryFileAlreadyExists(destinationURL.lastPathComponent)
+            }
+            relocations.append(.init(sourceURL: standardizedSourceURL, destinationURL: destinationURL))
+        }
+
+        return MeetingMovePlan(
+            meetingIds: meetingIds,
+            relocations: relocations,
+            vaultExportUpdates: updates
+        )
+    }
+
+    private func summaryDestinationDirectory(toProjectId: UUID?) throws -> URL {
+        let destinationDirectory: URL
+        if let toProjectId {
+            guard let destination = try repository.fetchProject(id: toProjectId),
+                  destination.vaultId == vault.id,
+                  !destination.missingOnDisk
+            else {
+                throw ProjectWorkspaceError.invalidMoveDestination
+            }
+            destinationDirectory = projectURL(name: destination.name)
+        } else {
+            destinationDirectory = vault.url
+        }
+        guard isDirectoryInsideVault(destinationDirectory) else {
+            throw ProjectWorkspaceError.invalidMoveDestination
+        }
+        return destinationDirectory
+    }
+
+    private func isDirectoryInsideVault(_ url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+            && isInsideVaultAfterResolvingSymlinks(url)
+    }
+
+    private func isInsideVaultAfterResolvingSymlinks(_ url: URL) -> Bool {
+        let vaultPath = vault.url.resolvingSymlinksInPath().standardizedFileURL.path
+        let candidatePath = url.resolvingSymlinksInPath().standardizedFileURL.path
+        let prefix = vaultPath.hasSuffix("/") ? vaultPath : vaultPath + "/"
+        return candidatePath == vaultPath || candidatePath.hasPrefix(prefix)
+    }
+
+    static func resolveSummaryFile(storedRelativePath: String?, vaultURL: URL) throws -> URL? {
+        guard let storedRelativePath,
+              let fileURL = VaultSummaryFileLocator.fileURL(for: storedRelativePath, vaultURL: vaultURL),
+              fileURL.pathExtension.lowercased() == "md"
+        else { return nil }
+
+        do {
+            let values = try fileURL.resourceValues(forKeys: [.isRegularFileKey])
+            return values.isRegularFile == true ? fileURL : nil
+        } catch let error as CocoaError where error.code == .fileNoSuchFile || error.code == .fileReadNoSuchFile {
+            return nil
+        } catch let error as POSIXError where error.code == .ENOENT {
+            return nil
+        }
+    }
+
+    /// File system and SQLite operations cannot share a transaction. Runtime failures are compensated here;
+    /// process termination follows the same existing limitation as project folder rename and deletion.
+    private func performSummaryRelocations(
+        _ relocations: [SummaryRelocation],
+        operation: () throws -> Void
+    ) throws {
+        var completed: [SummaryRelocation] = []
+        do {
+            for relocation in relocations {
+                try fileManager.moveItem(at: relocation.sourceURL, to: relocation.destinationURL)
+                completed.append(relocation)
+            }
+            try operation()
+        } catch {
+            var rollbackError: (any Error)?
+            for relocation in completed.reversed() {
+                do {
+                    try fileManager.moveItem(at: relocation.destinationURL, to: relocation.sourceURL)
+                } catch {
+                    rollbackError = rollbackError ?? error
+                }
+            }
+            if let rollbackError {
+                throw ProjectWorkspaceError.rollbackFailed(
+                    operation: error.localizedDescription,
+                    rollback: rollbackError.localizedDescription
+                )
+            }
+            throw error
+        }
     }
 
     private func moveProjectFolder(from sourceURL: URL, to destinationURL: URL) throws {

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -385,6 +385,14 @@ enum L10n {
         bundle: bundle
     ) }
 
+    static func summaryFileAlreadyExists(_ name: String) -> String {
+        String(localized: "A summary file named \(name) already exists in the destination.", bundle: bundle)
+    }
+
+    static func summaryFileShared(_ name: String) -> String {
+        String(localized: "The summary file \(name) is linked to multiple meetings and cannot be moved safely.", bundle: bundle)
+    }
+
     static func projectRollbackFailed(operation: String, rollback: String) -> String {
         String(
             localized: "The project operation failed (\(operation)), and Dahlia could not restore the folder (\(rollback)).",

--- a/Sources/Dahlia/ViewModels/SidebarViewModel.swift
+++ b/Sources/Dahlia/ViewModels/SidebarViewModel.swift
@@ -542,18 +542,20 @@ final class SidebarViewModel {
     }
 
     func moveMeeting(id: UUID, toProjectId: UUID?) {
-        guard let repository = meetingRepository else { return }
+        guard let projectWorkspaceService else { return }
         do {
-            try repository.moveMeeting(id: id, toProjectId: toProjectId)
+            try projectWorkspaceService.moveMeeting(id: id, toProjectId: toProjectId)
+            lastError = nil
         } catch {
             lastError = error.localizedDescription
         }
     }
 
     func moveMeetings(ids: Set<UUID>, toProjectId: UUID?) {
-        guard let repository = meetingRepository, !ids.isEmpty else { return }
+        guard let projectWorkspaceService, !ids.isEmpty else { return }
         do {
-            try repository.moveMeetings(ids: ids, toProjectId: toProjectId)
+            try projectWorkspaceService.moveMeetings(ids: ids, toProjectId: toProjectId)
+            lastError = nil
         } catch {
             lastError = error.localizedDescription
         }

--- a/Sources/Dahlia/ViewModels/SidebarViewModel.swift
+++ b/Sources/Dahlia/ViewModels/SidebarViewModel.swift
@@ -541,23 +541,29 @@ final class SidebarViewModel {
         }
     }
 
-    func moveMeeting(id: UUID, toProjectId: UUID?) {
-        guard let projectWorkspaceService else { return }
+    @discardableResult
+    func moveMeeting(id: UUID, toProjectId: UUID?) -> Bool {
+        guard let projectWorkspaceService else { return false }
         do {
             try projectWorkspaceService.moveMeeting(id: id, toProjectId: toProjectId)
             lastError = nil
+            return true
         } catch {
             lastError = error.localizedDescription
+            return false
         }
     }
 
-    func moveMeetings(ids: Set<UUID>, toProjectId: UUID?) {
-        guard let projectWorkspaceService, !ids.isEmpty else { return }
+    @discardableResult
+    func moveMeetings(ids: Set<UUID>, toProjectId: UUID?) -> Bool {
+        guard let projectWorkspaceService, !ids.isEmpty else { return false }
         do {
             try projectWorkspaceService.moveMeetings(ids: ids, toProjectId: toProjectId)
             lastError = nil
+            return true
         } catch {
             lastError = error.localizedDescription
+            return false
         }
     }
 }

--- a/Sources/Dahlia/Views/MeetingMetadataBar.swift
+++ b/Sources/Dahlia/Views/MeetingMetadataBar.swift
@@ -430,11 +430,11 @@ struct MeetingProjectPicker: View {
     private func clearProject() {
         let existingMeetingId = viewModel.currentMeetingId
         let removesPersistedProject = viewModel.currentProjectId != nil
-        viewModel.setExplicitProjectContext(projectURL: nil, projectId: nil, projectName: nil)
         if removesPersistedProject, let existingMeetingId {
-            sidebarViewModel.moveMeeting(id: existingMeetingId, toProjectId: nil)
+            guard sidebarViewModel.moveMeeting(id: existingMeetingId, toProjectId: nil) else { return }
             sidebarViewModel.selectMeeting(existingMeetingId)
         }
+        viewModel.setExplicitProjectContext(projectURL: nil, projectId: nil, projectName: nil)
         projectInput = ""
         showProjectPopover = false
     }
@@ -447,8 +447,9 @@ struct MeetingProjectPicker: View {
             projectName: projectName
         ) else { return }
 
-        if projectId != viewModel.currentProjectId {
-            sidebarViewModel.moveMeeting(id: meetingId, toProjectId: projectId)
+        if projectId != viewModel.currentProjectId,
+           !sidebarViewModel.moveMeeting(id: meetingId, toProjectId: projectId) {
+            return
         }
         viewModel.setExplicitProjectContext(
             projectURL: projectURL,

--- a/Tests/DahliaTests/ProjectWorkspaceServiceTests.swift
+++ b/Tests/DahliaTests/ProjectWorkspaceServiceTests.swift
@@ -161,6 +161,297 @@ import GRDB
             #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Original").path))
             #expect(!FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Renamed").path))
         }
+    }
+
+    extension ProjectWorkspaceServiceTests {
+        @Test
+        func movesStoredSummaryWithMeeting() throws {
+            let context = try makeContext()
+            defer { try? FileManager.default.removeItem(at: context.rootURL) }
+
+            let source = try context.service.createProject(leafName: "Source", parentProjectId: nil)
+            let destination = try context.service.createProject(leafName: "Destination", parentProjectId: nil)
+            let meeting = try insertMeeting(projectId: source.id, context: context)
+            try insertSummary(
+                meetingId: meeting.id,
+                path: "Source/Summary.md",
+                context: context,
+                writeFile: true
+            )
+            try context.repository.updateSummaryGoogleFileId(
+                forMeetingId: meeting.id,
+                googleFileId: "google-document-id"
+            )
+
+            try context.service.moveMeeting(id: meeting.id, toProjectId: destination.id)
+
+            let movedMeeting = try context.database.dbQueue.read { db in
+                try MeetingRecord.fetchOne(db, key: meeting.id)
+            }
+            let vaultExport = try context.repository.fetchSummaryExport(
+                forMeetingId: meeting.id,
+                type: .vault
+            )
+            #expect(movedMeeting?.projectId == destination.id)
+            #expect(vaultExport?.vaultRelativePath == "Destination/Summary.md")
+            #expect(
+                try context.repository.fetchSummaryExport(forMeetingId: meeting.id, type: .googleDocs)?.googleDocumentID
+                    == "google-document-id"
+            )
+            #expect(!FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Source/Summary.md").path))
+            #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Destination/Summary.md").path))
+        }
+
+        @Test
+        func movesStoredSummaryToVaultRootWhenProjectIsCleared() throws {
+            let context = try makeContext()
+            defer { try? FileManager.default.removeItem(at: context.rootURL) }
+
+            let source = try context.service.createProject(leafName: "Source", parentProjectId: nil)
+            let meeting = try insertMeeting(projectId: source.id, context: context)
+            try insertSummary(
+                meetingId: meeting.id,
+                path: "Source/Summary.md",
+                context: context,
+                writeFile: true
+            )
+
+            try context.service.moveMeeting(id: meeting.id, toProjectId: nil)
+
+            let movedMeeting = try context.database.dbQueue.read { db in
+                try MeetingRecord.fetchOne(db, key: meeting.id)
+            }
+            #expect(movedMeeting?.projectId == nil)
+            #expect(try context.repository.fetchSummaryVaultRelativePath(forMeetingId: meeting.id) == "Summary.md")
+            #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Summary.md").path))
+        }
+
+        @Test
+        func clearsMissingSummaryExportAndStillMovesMeeting() throws {
+            let context = try makeContext()
+            defer { try? FileManager.default.removeItem(at: context.rootURL) }
+
+            let source = try context.service.createProject(leafName: "Source", parentProjectId: nil)
+            let destination = try context.service.createProject(leafName: "Destination", parentProjectId: nil)
+            let meeting = try insertMeeting(projectId: source.id, context: context)
+            try insertSummary(meetingId: meeting.id, path: "Source/Missing.md", context: context)
+
+            try context.service.moveMeeting(id: meeting.id, toProjectId: destination.id)
+
+            let movedMeeting = try context.database.dbQueue.read { db in
+                try MeetingRecord.fetchOne(db, key: meeting.id)
+            }
+            #expect(movedMeeting?.projectId == destination.id)
+            #expect(try context.repository.fetchSummaryExport(forMeetingId: meeting.id, type: .vault) == nil)
+        }
+
+        @Test
+        func doesNotMoveSummaryThroughProjectSymlinkOutsideVault() throws {
+            let context = try makeContext()
+            defer { try? FileManager.default.removeItem(at: context.rootURL) }
+
+            let source = try context.service.createProject(leafName: "Source", parentProjectId: nil)
+            let destination = try context.service.createProject(leafName: "Destination", parentProjectId: nil)
+            let meeting = try insertMeeting(projectId: source.id, context: context)
+            let sourceURL = context.vaultURL.appending(path: "Source", directoryHint: .isDirectory)
+            let outsideURL = context.rootURL.appending(path: "Outside", directoryHint: .isDirectory)
+            try FileManager.default.removeItem(at: sourceURL)
+            try FileManager.default.createDirectory(at: outsideURL, withIntermediateDirectories: false)
+            try Data("Outside".utf8).write(to: outsideURL.appending(path: "Summary.md"), options: .atomic)
+            try FileManager.default.createSymbolicLink(at: sourceURL, withDestinationURL: outsideURL)
+            try insertSummary(meetingId: meeting.id, path: "Source/Summary.md", context: context)
+
+            try context.service.moveMeeting(id: meeting.id, toProjectId: destination.id)
+
+            #expect(try context.repository.fetchSummaryVaultRelativePath(forMeetingId: meeting.id) == nil)
+            #expect(FileManager.default.fileExists(atPath: outsideURL.appending(path: "Summary.md").path))
+            #expect(!FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Destination/Summary.md").path))
+        }
+
+        @Test
+        func rejectsDestinationProjectSymlinkOutsideVault() throws {
+            let context = try makeContext()
+            defer { try? FileManager.default.removeItem(at: context.rootURL) }
+
+            let source = try context.service.createProject(leafName: "Source", parentProjectId: nil)
+            let destination = try context.service.createProject(leafName: "Destination", parentProjectId: nil)
+            let meeting = try insertMeeting(projectId: source.id, context: context)
+            try insertSummary(
+                meetingId: meeting.id,
+                path: "Source/Summary.md",
+                context: context,
+                writeFile: true
+            )
+            let destinationURL = context.vaultURL.appending(path: "Destination", directoryHint: .isDirectory)
+            let outsideURL = context.rootURL.appending(path: "Outside", directoryHint: .isDirectory)
+            try FileManager.default.removeItem(at: destinationURL)
+            try FileManager.default.createDirectory(at: outsideURL, withIntermediateDirectories: false)
+            try FileManager.default.createSymbolicLink(at: destinationURL, withDestinationURL: outsideURL)
+
+            #expect(throws: ProjectWorkspaceError.invalidMoveDestination) {
+                try context.service.moveMeeting(id: meeting.id, toProjectId: destination.id)
+            }
+
+            #expect(try context.repository.fetchSummaryVaultRelativePath(forMeetingId: meeting.id) == "Source/Summary.md")
+            #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Source/Summary.md").path))
+            #expect(!FileManager.default.fileExists(atPath: outsideURL.appending(path: "Summary.md").path))
+        }
+
+        @Test
+        func preservesSummaryAndExportWhenFileInspectionFails() throws {
+            struct InspectionFailure: Error {}
+
+            let context = try makeContext(summaryFileResolver: { _, _ in throw InspectionFailure() })
+            defer { try? FileManager.default.removeItem(at: context.rootURL) }
+
+            let source = try context.service.createProject(leafName: "Source", parentProjectId: nil)
+            let destination = try context.service.createProject(leafName: "Destination", parentProjectId: nil)
+            let meeting = try insertMeeting(projectId: source.id, context: context)
+            try insertSummary(
+                meetingId: meeting.id,
+                path: "Source/Summary.md",
+                context: context,
+                writeFile: true
+            )
+
+            #expect(throws: InspectionFailure.self) {
+                try context.service.moveMeeting(id: meeting.id, toProjectId: destination.id)
+            }
+
+            #expect(try context.repository.fetchSummaryVaultRelativePath(forMeetingId: meeting.id) == "Source/Summary.md")
+            #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Source/Summary.md").path))
+            #expect(!FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Destination/Summary.md").path))
+        }
+
+        @Test
+        func rejectsMovingOneMeetingWhenSummaryFileIsShared() throws {
+            let context = try makeContext()
+            defer { try? FileManager.default.removeItem(at: context.rootURL) }
+
+            let source = try context.service.createProject(leafName: "Source", parentProjectId: nil)
+            let destination = try context.service.createProject(leafName: "Destination", parentProjectId: nil)
+            let movingMeeting = try insertMeeting(projectId: source.id, context: context)
+            let remainingMeeting = try insertMeeting(projectId: source.id, context: context)
+            try insertSummary(
+                meetingId: movingMeeting.id,
+                path: "Source/Summary.md",
+                context: context,
+                writeFile: true
+            )
+            try insertSummary(meetingId: remainingMeeting.id, path: "Source/Summary.md", context: context)
+
+            #expect(throws: ProjectWorkspaceError.summaryFileShared("Summary.md")) {
+                try context.service.moveMeeting(id: movingMeeting.id, toProjectId: destination.id)
+            }
+
+            #expect(try context.repository.fetchSummaryVaultRelativePath(forMeetingId: movingMeeting.id) == "Source/Summary.md")
+            #expect(try context.repository.fetchSummaryVaultRelativePath(forMeetingId: remainingMeeting.id) == "Source/Summary.md")
+            #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Source/Summary.md").path))
+            #expect(!FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Destination/Summary.md").path))
+        }
+
+        @Test
+        func rejectsSummaryNameCollisionWithoutChangingMeeting() throws {
+            let context = try makeContext()
+            defer { try? FileManager.default.removeItem(at: context.rootURL) }
+
+            let source = try context.service.createProject(leafName: "Source", parentProjectId: nil)
+            let destination = try context.service.createProject(leafName: "Destination", parentProjectId: nil)
+            let meeting = try insertMeeting(projectId: source.id, context: context)
+            try insertSummary(
+                meetingId: meeting.id,
+                path: "Source/Summary.md",
+                context: context,
+                writeFile: true
+            )
+            try Data("Existing".utf8).write(
+                to: context.vaultURL.appending(path: "Destination/Summary.md"),
+                options: .atomic
+            )
+
+            #expect(throws: ProjectWorkspaceError.summaryFileAlreadyExists("Summary.md")) {
+                try context.service.moveMeeting(id: meeting.id, toProjectId: destination.id)
+            }
+
+            let unchangedMeeting = try context.database.dbQueue.read { db in
+                try MeetingRecord.fetchOne(db, key: meeting.id)
+            }
+            #expect(unchangedMeeting?.projectId == source.id)
+            #expect(try context.repository.fetchSummaryVaultRelativePath(forMeetingId: meeting.id) == "Source/Summary.md")
+            #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Source/Summary.md").path))
+        }
+
+        @Test
+        func rejectsDuplicateSummaryNamesInBatchBeforeMovingFiles() throws {
+            let context = try makeContext()
+            defer { try? FileManager.default.removeItem(at: context.rootURL) }
+
+            let firstSource = try context.service.createProject(leafName: "First", parentProjectId: nil)
+            let secondSource = try context.service.createProject(leafName: "Second", parentProjectId: nil)
+            let destination = try context.service.createProject(leafName: "Destination", parentProjectId: nil)
+            let firstMeeting = try insertMeeting(projectId: firstSource.id, context: context)
+            let secondMeeting = try insertMeeting(projectId: secondSource.id, context: context)
+            try insertSummary(
+                meetingId: firstMeeting.id,
+                path: "First/Summary.md",
+                context: context,
+                writeFile: true
+            )
+            try insertSummary(
+                meetingId: secondMeeting.id,
+                path: "Second/Summary.md",
+                context: context,
+                writeFile: true
+            )
+
+            #expect(throws: ProjectWorkspaceError.summaryFileAlreadyExists("Summary.md")) {
+                try context.service.moveMeetings(
+                    ids: [firstMeeting.id, secondMeeting.id],
+                    toProjectId: destination.id
+                )
+            }
+
+            #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "First/Summary.md").path))
+            #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Second/Summary.md").path))
+            #expect(!FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Destination/Summary.md").path))
+        }
+
+        @Test
+        func restoresSummaryWhenMeetingDatabaseUpdateFails() throws {
+            let context = try makeContext()
+            defer { try? FileManager.default.removeItem(at: context.rootURL) }
+
+            let source = try context.service.createProject(leafName: "Source", parentProjectId: nil)
+            let destination = try context.service.createProject(leafName: "Destination", parentProjectId: nil)
+            let meeting = try insertMeeting(projectId: source.id, context: context)
+            try insertSummary(
+                meetingId: meeting.id,
+                path: "Source/Summary.md",
+                context: context,
+                writeFile: true
+            )
+            try context.database.dbQueue.write { db in
+                try db.execute(sql: """
+                CREATE TRIGGER fail_meeting_move
+                BEFORE UPDATE OF projectId ON meetings
+                BEGIN
+                    SELECT RAISE(ABORT, 'forced meeting move failure');
+                END
+                """)
+            }
+
+            #expect(throws: (any Error).self) {
+                try context.service.moveMeeting(id: meeting.id, toProjectId: destination.id)
+            }
+
+            let unchangedMeeting = try context.database.dbQueue.read { db in
+                try MeetingRecord.fetchOne(db, key: meeting.id)
+            }
+            #expect(unchangedMeeting?.projectId == source.id)
+            #expect(try context.repository.fetchSummaryVaultRelativePath(forMeetingId: meeting.id) == "Source/Summary.md")
+            #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Source/Summary.md").path))
+            #expect(!FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Destination/Summary.md").path))
+        }
 
         @Test
         func deletesHierarchyAfterMovingMeetings() async throws {
@@ -171,7 +462,12 @@ import GRDB
             let child = try context.service.createProject(leafName: "Child", parentProjectId: source.id)
             let destination = try context.service.createProject(leafName: "Destination", parentProjectId: nil)
             let meeting = try insertMeeting(projectId: child.id, context: context)
-            try insertSummary(meetingId: meeting.id, path: "Source/Child/Summary.md", context: context)
+            try insertSummary(
+                meetingId: meeting.id,
+                path: "Source/Child/Summary.md",
+                context: context,
+                writeFile: true
+            )
             try insertSegment(meetingId: meeting.id, context: context)
             try context.repository.addTag(name: "important", toMeetingId: meeting.id, colorHex: "#FF0000")
             let audioURL = try await insertAudio(meetingId: meeting.id, context: context)
@@ -188,25 +484,35 @@ import GRDB
             )
             let summary = try #require(fetchedSummary)
             #expect(fetchedMeeting?.projectId == destination.id)
-            #expect(vaultExport == nil)
+            #expect(vaultExport?.vaultRelativePath == "Destination/Summary.md")
             #expect(try summary.loadDocument().sections.first?.blocks == [.paragraph("Body")])
             #expect(try context.repository.fetchSegments(forMeetingId: meeting.id).count == 1)
             #expect(try context.repository.fetchTagsForMeeting(id: meeting.id).map(\.name) == ["important"])
             #expect(FileManager.default.fileExists(atPath: audioURL.path))
+            #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Destination/Summary.md").path))
             #expect(try context.repository.fetchProject(id: source.id) == nil)
             #expect(try context.repository.fetchProject(id: child.id) == nil)
             #expect(FileManager.default.fileExists(atPath: context.trashURL.appending(path: "Source").path))
         }
 
         @Test
-        func movingMeetingsPreservesSummaryPathsOutsideDeletedHierarchy() async throws {
+        func movingMeetingsRelocatesSummariesOutsideDeletedHierarchy() async throws {
             let context = try makeContext()
             defer { try? FileManager.default.removeItem(at: context.rootURL) }
 
             let source = try context.service.createProject(leafName: "Source", parentProjectId: nil)
             let destination = try context.service.createProject(leafName: "Destination", parentProjectId: nil)
             let meeting = try insertMeeting(projectId: source.id, context: context)
-            try insertSummary(meetingId: meeting.id, path: "Archive/Summary.md", context: context)
+            try FileManager.default.createDirectory(
+                at: context.vaultURL.appending(path: "Archive", directoryHint: .isDirectory),
+                withIntermediateDirectories: false
+            )
+            try insertSummary(
+                meetingId: meeting.id,
+                path: "Archive/Summary.md",
+                context: context,
+                writeFile: true
+            )
 
             try await context.service.deleteProjectHierarchy(id: source.id, meetingDisposition: .move(to: destination.id))
 
@@ -214,7 +520,9 @@ import GRDB
                 forMeetingId: meeting.id,
                 type: .vault
             )
-            #expect(vaultExport?.vaultRelativePath == "Archive/Summary.md")
+            #expect(vaultExport?.vaultRelativePath == "Destination/Summary.md")
+            #expect(!FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Archive/Summary.md").path))
+            #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Destination/Summary.md").path))
         }
 
         @Test
@@ -267,10 +575,53 @@ import GRDB
             #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Project").path))
             #expect(!FileManager.default.fileExists(atPath: context.trashURL.appending(path: "Project").path))
         }
+
+        @Test
+        func restoresFolderAndSummaryWhenDeleteAfterMeetingMoveFails() async throws {
+            let context = try makeContext()
+            defer { try? FileManager.default.removeItem(at: context.rootURL) }
+
+            let source = try context.service.createProject(leafName: "Source", parentProjectId: nil)
+            let destination = try context.service.createProject(leafName: "Destination", parentProjectId: nil)
+            let meeting = try insertMeeting(projectId: source.id, context: context)
+            try insertSummary(
+                meetingId: meeting.id,
+                path: "Source/Summary.md",
+                context: context,
+                writeFile: true
+            )
+            try await context.database.dbQueue.write { db in
+                try db.execute(sql: """
+                CREATE TRIGGER fail_project_delete_after_move
+                BEFORE DELETE ON projects
+                BEGIN
+                    SELECT RAISE(ABORT, 'forced delete failure after move');
+                END
+                """)
+            }
+
+            await #expect(throws: (any Error).self) {
+                try await context.service.deleteProjectHierarchy(
+                    id: source.id,
+                    meetingDisposition: .move(to: destination.id)
+                )
+            }
+
+            let unchangedMeeting = try await context.database.dbQueue.read { db in
+                try MeetingRecord.fetchOne(db, key: meeting.id)
+            }
+            #expect(unchangedMeeting?.projectId == source.id)
+            #expect(try context.repository.fetchSummaryVaultRelativePath(forMeetingId: meeting.id) == "Source/Summary.md")
+            #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Source/Summary.md").path))
+            #expect(!FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Destination/Summary.md").path))
+            #expect(!FileManager.default.fileExists(atPath: context.trashURL.appending(path: "Source").path))
+        }
     }
 
     private extension ProjectWorkspaceServiceTests {
-        private func makeContext() throws -> ProjectWorkspaceTestContext {
+        private func makeContext(
+            summaryFileResolver: @escaping ProjectWorkspaceService.SummaryFileResolver = ProjectWorkspaceService.resolveSummaryFile
+        ) throws -> ProjectWorkspaceTestContext {
             let rootURL = FileManager.default.temporaryDirectory
                 .appending(path: UUID().uuidString, directoryHint: .isDirectory)
             let vaultURL = rootURL.appending(path: "Vault", directoryHint: .isDirectory)
@@ -296,7 +647,8 @@ import GRDB
                     let destinationURL = trashURL.appending(path: sourceURL.lastPathComponent, directoryHint: .isDirectory)
                     try FileManager.default.moveItem(at: sourceURL, to: destinationURL)
                     return destinationURL
-                }
+                },
+                summaryFileResolver: summaryFileResolver
             )
             return ProjectWorkspaceTestContext(
                 rootURL: rootURL,
@@ -328,7 +680,8 @@ import GRDB
         private func insertSummary(
             meetingId: UUID,
             path: String,
-            context: ProjectWorkspaceTestContext
+            context: ProjectWorkspaceTestContext,
+            writeFile: Bool = false
         ) throws {
             try context.repository.upsertSummary(
                 SummaryRecord(
@@ -345,6 +698,9 @@ import GRDB
                 forMeetingId: meetingId,
                 relativePath: path
             )
+            if writeFile {
+                try Data("Summary".utf8).write(to: context.vaultURL.appending(path: path), options: .atomic)
+            }
         }
 
         private func insertSegment(

--- a/Tests/DahliaTests/ProjectWorkspaceServiceTests.swift
+++ b/Tests/DahliaTests/ProjectWorkspaceServiceTests.swift
@@ -227,7 +227,7 @@ import GRDB
         }
 
         @Test
-        func clearsMissingSummaryExportAndStillMovesMeeting() throws {
+        func preservesMissingSummaryExportAndStillMovesMeeting() throws {
             let context = try makeContext()
             defer { try? FileManager.default.removeItem(at: context.rootURL) }
 
@@ -242,7 +242,7 @@ import GRDB
                 try MeetingRecord.fetchOne(db, key: meeting.id)
             }
             #expect(movedMeeting?.projectId == destination.id)
-            #expect(try context.repository.fetchSummaryExport(forMeetingId: meeting.id, type: .vault) == nil)
+            #expect(try context.repository.fetchSummaryVaultRelativePath(forMeetingId: meeting.id) == "Source/Missing.md")
         }
 
         @Test
@@ -263,7 +263,7 @@ import GRDB
 
             try context.service.moveMeeting(id: meeting.id, toProjectId: destination.id)
 
-            #expect(try context.repository.fetchSummaryVaultRelativePath(forMeetingId: meeting.id) == nil)
+            #expect(try context.repository.fetchSummaryVaultRelativePath(forMeetingId: meeting.id) == "Source/Summary.md")
             #expect(FileManager.default.fileExists(atPath: outsideURL.appending(path: "Summary.md").path))
             #expect(!FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Destination/Summary.md").path))
         }
@@ -338,16 +338,50 @@ import GRDB
                 context: context,
                 writeFile: true
             )
-            try insertSummary(meetingId: remainingMeeting.id, path: "Source/Summary.md", context: context)
+            try insertSummary(meetingId: remainingMeeting.id, path: "source/summary.md", context: context)
 
             #expect(throws: ProjectWorkspaceError.summaryFileShared("Summary.md")) {
                 try context.service.moveMeeting(id: movingMeeting.id, toProjectId: destination.id)
             }
 
             #expect(try context.repository.fetchSummaryVaultRelativePath(forMeetingId: movingMeeting.id) == "Source/Summary.md")
-            #expect(try context.repository.fetchSummaryVaultRelativePath(forMeetingId: remainingMeeting.id) == "Source/Summary.md")
+            #expect(try context.repository.fetchSummaryVaultRelativePath(forMeetingId: remainingMeeting.id) == "source/summary.md")
             #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Source/Summary.md").path))
             #expect(!FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Destination/Summary.md").path))
+        }
+
+        @Test
+        func movesSharedSummaryOnceWhenAllReferencingMeetingsMove() async throws {
+            let context = try makeContext()
+            defer { try? FileManager.default.removeItem(at: context.rootURL) }
+
+            let source = try context.service.createProject(leafName: "Source", parentProjectId: nil)
+            let destination = try context.service.createProject(leafName: "Destination", parentProjectId: nil)
+            let firstMeeting = try insertMeeting(projectId: source.id, context: context)
+            let secondMeeting = try insertMeeting(projectId: source.id, context: context)
+            try insertSummary(
+                meetingId: firstMeeting.id,
+                path: "Source/Summary.md",
+                context: context,
+                writeFile: true
+            )
+            try insertSummary(meetingId: secondMeeting.id, path: "Source/Summary.md", context: context)
+
+            try await context.service.deleteProjectHierarchy(
+                id: source.id,
+                meetingDisposition: .move(to: destination.id)
+            )
+
+            #expect(
+                try context.repository.fetchSummaryVaultRelativePath(forMeetingId: firstMeeting.id)
+                    == "Destination/Summary.md"
+            )
+            #expect(
+                try context.repository.fetchSummaryVaultRelativePath(forMeetingId: secondMeeting.id)
+                    == "Destination/Summary.md"
+            )
+            #expect(FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Destination/Summary.md").path))
+            #expect(!FileManager.default.fileExists(atPath: context.vaultURL.appending(path: "Source/Summary.md").path))
         }
 
         @Test


### PR DESCRIPTION
## Summary

- Move an exported Vault summary Markdown file when its meeting is assigned to another project or moved to the Vault root.
- Apply the same relocation behavior when deleting a project and moving its meetings elsewhere.
- Keep Vault export metadata and file operations consistent with collision checks and runtime rollback.

## Why

Changing a meeting's project previously updated only the database assignment. An already exported Vault summary remained in the old project directory, leaving the meeting and its summary out of sync.

## Safety and behavior

- Never overwrite an existing destination summary.
- Clear stale Vault export metadata when the referenced file is genuinely missing.
- Preserve metadata when file inspection fails for another reason.
- Reject paths that resolve outside the Vault through symbolic links.
- Roll back moved summaries when the database update fails.
- Preserve Google Docs export metadata.
- Defensively reject anomalous data where multiple meetings share one Vault summary URL.

## Validation

- `swift test`: 823 Swift Testing tests and 3 XCTest tests passed.
- `swift test --filter ProjectWorkspaceServiceTests`: 24 tests passed.
- `CI=true ./scripts/lint.sh`: SwiftFormat reported 0 files requiring formatting; SwiftLint completed with no errors and the repository's configured non-blocking warnings.
- `git diff --check`
