### PR TITLE
Separate summary toolbar actions

### DIFF
--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -470,11 +470,20 @@ struct ControlPanelView: View {
     private var detailToolbar: some ToolbarContent {
         ToolbarSpacer(.flexible, placement: .primaryAction)
 
-        ToolbarItemGroup(placement: .primaryAction) {
+        ToolbarItem(placement: .primaryAction) {
             ShareSummaryToolbarButton(viewModel: viewModel)
-            GenerateSummaryToolbarButton(viewModel: viewModel)
+        }
 
-            if showsToolbarRecordButton {
+        ToolbarSpacer(.fixed, placement: .primaryAction)
+
+        ToolbarItem(placement: .primaryAction) {
+            GenerateSummaryToolbarButton(viewModel: viewModel)
+        }
+
+        if showsToolbarRecordButton {
+            ToolbarSpacer(.fixed, placement: .primaryAction)
+
+            ToolbarItem(placement: .primaryAction) {
                 RecordToolbarButton(
                     viewModel: viewModel,
                     sidebarViewModel: sidebarViewModel,


### PR DESCRIPTION
## Summary

- render Share, Generate Summary, and Record as independent toolbar items
- add fixed toolbar spacing so Share and Generate Summary stay visually separate in every state
- preserve the existing button actions and enabled-state logic

## Why

Share and Generate Summary represent different actions, but placing them in one `ToolbarItemGroup` caused macOS to render them as a joined control in the normal state. During summary generation they appeared separate, creating an inconsistent toolbar layout.

## Validation

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build`
- `CI=true ./scripts/lint.sh` (SwiftFormat clean; existing SwiftLint warnings remain)