### PR TITLE
Parallelize summary generation by meeting

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>29</string>
+    <string>30</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.6.1</string>
+    <string>0.6.2</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/Models/SummaryGenerationJob.swift
+++ b/Sources/Dahlia/Models/SummaryGenerationJob.swift
@@ -19,10 +19,6 @@ final class SummaryGenerationJob: Identifiable {
         stepStatuses.contains(where: \.isFailed)
     }
 
-    var failureMessages: [String] {
-        stepStatuses.compactMap(\.failureMessage)
-    }
-
     var isFinished: Bool {
         stepStatuses.allSatisfy(\.isTerminal)
     }

--- a/Sources/Dahlia/Models/SummaryGenerationJob.swift
+++ b/Sources/Dahlia/Models/SummaryGenerationJob.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// A single meeting-scoped summary generation and its optional exports.
+@MainActor @Observable
+final class SummaryGenerationJob: Identifiable {
+    let id = UUID.v7()
+    let meetingId: UUID
+    let meetingName: String
+    let startedAt: Date
+    let progress = SummaryProgressState()
+
+    init(meetingId: UUID, meetingName: String, startedAt: Date = .now) {
+        self.meetingId = meetingId
+        self.meetingName = meetingName
+        self.startedAt = startedAt
+    }
+
+    var hasFailure: Bool {
+        stepStatuses.contains(where: \.isFailed)
+    }
+
+    var failureMessages: [String] {
+        stepStatuses.compactMap(\.failureMessage)
+    }
+
+    var isFinished: Bool {
+        stepStatuses.allSatisfy(\.isTerminal)
+    }
+
+    private var stepStatuses: [SummaryProgressState.StepStatus] {
+        [progress.summaryGeneration, progress.vaultExport, progress.googleDocsExport]
+    }
+}

--- a/Sources/Dahlia/Models/SummaryGenerationSettings.swift
+++ b/Sources/Dahlia/Models/SummaryGenerationSettings.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Immutable LLM settings captured when a summary job starts.
+struct SummaryGenerationSettings: Equatable, Sendable {
+    let modelID: String?
+    let reasoningEffort: String
+    let detailLevelInstruction: String
+    let languageDisplayName: String
+
+    @MainActor
+    static func current(_ settings: AppSettings = .shared) -> Self {
+        Self(
+            modelID: settings.codexModelID.nilIfBlank,
+            reasoningEffort: settings.codexReasoningEffort,
+            detailLevelInstruction: settings.summaryDetailLevel.instruction,
+            languageDisplayName: settings.llmSummaryLanguage.displayName
+        )
+    }
+}

--- a/Sources/Dahlia/Models/SummaryProgressState.swift
+++ b/Sources/Dahlia/Models/SummaryProgressState.swift
@@ -25,6 +25,22 @@ final class SummaryProgressState {
             }
         }
 
+        var isFailed: Bool {
+            if case .failed = self {
+                true
+            } else {
+                false
+            }
+        }
+
+        var failureMessage: String? {
+            if case let .failed(message) = self {
+                message
+            } else {
+                nil
+            }
+        }
+
         var accessibilityDescription: String {
             switch self {
             case .pending: L10n.waiting
@@ -36,41 +52,15 @@ final class SummaryProgressState {
         }
     }
 
-    var isVisible = false
     var vaultExport: StepStatus = .pending
     var googleDocsExport: StepStatus = .pending
     var summaryGeneration: StepStatus = .pending
-    private var presentationID: UUID?
 
-    /// 全ステップが完了またはスキップ済みか。
+    /// 全ステップが完了・失敗・スキップのいずれかに到達したか。
     var isAllDone: Bool {
         vaultExport.isTerminal
             && googleDocsExport.isTerminal
             && summaryGeneration.isTerminal
     }
 
-    func reset() {
-        vaultExport = .pending
-        googleDocsExport = .pending
-        summaryGeneration = .pending
-    }
-
-    @discardableResult
-    func show() -> UUID {
-        let presentationID = UUID()
-        reset()
-        self.presentationID = presentationID
-        isVisible = true
-        return presentationID
-    }
-
-    func dismiss() {
-        presentationID = nil
-        isVisible = false
-    }
-
-    func dismiss(ifCurrent presentationID: UUID) {
-        guard self.presentationID == presentationID else { return }
-        dismiss()
-    }
 }

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -485,6 +485,7 @@
 
 /* Summary */
 "Generating summary..." = "Generating summary...";
+"Running Tasks" = "Running Tasks";
 "No summary has been generated yet." = "No summary has been generated yet.";
 "Summary image unavailable" = "Summary image unavailable";
 "Summary generated" = "Summary generated";

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -814,6 +814,7 @@
 "No matching meetings" = "No matching meetings";
 "Meeting unavailable" = "Meeting unavailable";
 "Show meeting details" = "Show meeting details";
+"Could not generate the summary." = "Could not generate the summary.";
 
 /* MCP */
 "MCP" = "MCP";

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -642,6 +642,9 @@
 "Include the latest meetings from the same calendar series in the summary context." = "Include the latest meetings from the same calendar series in the summary context.";
 "Generate this summary?" = "Generate this summary?";
 "Review the context and export options before generating the summary." = "Review the context and export options before generating the summary.";
+"Regenerate Summaries" = "Regenerate Summaries";
+"Regenerate selected summaries?" = "Regenerate selected summaries?";
+"Each selected meeting is regenerated independently. Existing summaries are replaced only after generation succeeds." = "Each selected meeting is regenerated independently. Existing summaries are replaced only after generation succeeds.";
 "Export Summary to Vault" = "Export Summary to Vault";
 "Write the generated summary and related files to the current Vault." = "Write the generated summary and related files to the current Vault.";
 "Export Summary to Google Docs" = "Export Summary to Google Docs";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -814,6 +814,7 @@
 "No matching meetings" = "一致するミーティングはありません";
 "Meeting unavailable" = "利用できないミーティング";
 "Show meeting details" = "ミーティングの詳細を表示";
+"Could not generate the summary." = "要約を生成できませんでした。";
 
 /* MCP */
 "MCP" = "MCP";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -485,6 +485,7 @@
 
 /* Summary */
 "Generating summary..." = "要約を生成中...";
+"Running Tasks" = "実行中のタスク";
 "No summary has been generated yet." = "要約はまだ生成されていません。";
 "Summary image unavailable" = "要約の画像を表示できません";
 "Summary generated" = "要約が生成されました";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -642,6 +642,9 @@
 "Include the latest meetings from the same calendar series in the summary context." = "同じカレンダー予定系列の直近ミーティングを要約コンテキストに含めます。";
 "Generate this summary?" = "要約を生成しますか？";
 "Review the context and export options before generating the summary." = "要約を生成する前に、コンテキストと書き出し設定を確認してください。";
+"Regenerate Summaries" = "要約を再生成";
+"Regenerate selected summaries?" = "選択したミーティングの要約を再生成しますか？";
+"Each selected meeting is regenerated independently. Existing summaries are replaced only after generation succeeds." = "選択したミーティングごとに要約を再生成します。既存の要約は、再生成に成功した場合のみ置き換えられます。";
 "Export Summary to Vault" = "要約を Vault へ書き出す";
 "Write the generated summary and related files to the current Vault." = "生成した要約と関連ファイルを現在の Vault へ書き出します。";
 "Export Summary to Google Docs" = "要約を Google Docs へ書き出す";

--- a/Sources/Dahlia/Services/CodexAppServerService.swift
+++ b/Sources/Dahlia/Services/CodexAppServerService.swift
@@ -1221,6 +1221,17 @@ private extension CodexAppServerService {
             }
         }
 
+        func waitUntilActiveTurnCountForTesting(_ count: Int) async throws {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: .seconds(2))
+            while generations.values.count(where: { $0.key != nil }) < count {
+                guard clock.now < deadline else {
+                    throw CodexAppServerError.requestTimedOut("active turn test wait")
+                }
+                try await Task.sleep(for: .milliseconds(10))
+            }
+        }
+
         func waitUntilConfigurationReloadIsWaitingForTesting() async {
             if !generationDrainWaiters.isEmpty { return }
             await withCheckedContinuation { continuation in

--- a/Sources/Dahlia/Services/CodexAppServerService.swift
+++ b/Sources/Dahlia/Services/CodexAppServerService.swift
@@ -1223,7 +1223,7 @@ private extension CodexAppServerService {
 
         func waitUntilActiveTurnCountForTesting(_ count: Int) async throws {
             let clock = ContinuousClock()
-            let deadline = clock.now.advanced(by: .seconds(2))
+            let deadline = clock.now.advanced(by: .seconds(10))
             while generations.values.count(where: { $0.key != nil }) < count {
                 guard clock.now < deadline else {
                     throw CodexAppServerError.requestTimedOut("active turn test wait")

--- a/Sources/Dahlia/Services/SummaryService.swift
+++ b/Sources/Dahlia/Services/SummaryService.swift
@@ -16,12 +16,13 @@ enum SummaryService {
         noteText: String? = nil,
         screenshots: [MeetingScreenshotRecord] = [],
         recordingSessions: [RecordingSessionTimeline] = [],
-        repository: MeetingRepository? = nil
+        repository: MeetingRepository? = nil,
+        generationSettings: SummaryGenerationSettings? = nil
     ) async throws -> GeneratedSummary {
-        let settings = AppSettings.shared
+        let generationSettings = generationSettings ?? .current()
 
         let systemPrompt = summaryGenerationInstructions(
-            settings: settings,
+            generationSettings: generationSettings,
             includesPreviousMeetings: !promptContext.previousMeetings.isEmpty
         )
         let inputs = await makeCodexInputs(.init(
@@ -38,8 +39,8 @@ enum SummaryService {
         )
 
         let responseText = try await CodexAppServerService.shared.generate(.init(
-            model: settings.codexModelID.nilIfBlank,
-            reasoningEffort: settings.codexReasoningEffort,
+            model: generationSettings.modelID,
+            reasoningEffort: generationSettings.reasoningEffort,
             developerInstructions: systemPrompt,
             inputs: inputs,
             outputSchema: SummaryDocumentResponse.outputSchema,
@@ -285,6 +286,16 @@ enum SummaryService {
         settings: AppSettings,
         includesPreviousMeetings: Bool
     ) -> String {
+        summaryGenerationInstructions(
+            generationSettings: .current(settings),
+            includesPreviousMeetings: includesPreviousMeetings
+        )
+    }
+
+    static func summaryGenerationInstructions(
+        generationSettings: SummaryGenerationSettings,
+        includesPreviousMeetings: Bool
+    ) -> String {
         // カスタム instruction は一時的に無効化し、保存済みの選択にかかわらず既定値を使う。
         var sections = [
             AppSettings.defaultSummaryPrompt,
@@ -293,8 +304,8 @@ enum SummaryService {
         if includesPreviousMeetings {
             sections.append(codexPreviousMeetingsInstruction)
         }
-        sections.append("# Detail Level\n\(settings.summaryDetailLevel.instruction)")
-        sections.append("# Language\nWrite the summary in \(settings.llmSummaryLanguage.displayName).")
+        sections.append("# Detail Level\n\(generationSettings.detailLevelInstruction)")
+        sections.append("# Language\nWrite the summary in \(generationSettings.languageDisplayName).")
         return sections.joined(separator: "\n\n") + codexStructuredInstruction
     }
 

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1344,6 +1344,7 @@ enum L10n {
 
     // MARK: - Summary
 
+    static var runningTasks: String { String(localized: "Running Tasks", bundle: bundle) }
     static var generatingSummary: String { String(localized: "Generating summary...", bundle: bundle) }
     static var summaryGenerationFailed: String { String(localized: "Could not generate the summary.", bundle: bundle) }
     static var noSummaryYet: String { String(localized: "No summary has been generated yet.", bundle: bundle) }

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1345,6 +1345,7 @@ enum L10n {
     // MARK: - Summary
 
     static var generatingSummary: String { String(localized: "Generating summary...", bundle: bundle) }
+    static var summaryGenerationFailed: String { String(localized: "Could not generate the summary.", bundle: bundle) }
     static var noSummaryYet: String { String(localized: "No summary has been generated yet.", bundle: bundle) }
     static var summaryImageUnavailable: String { String(localized: "Summary image unavailable", bundle: bundle) }
     static var summaryGenerated: String { String(localized: "Summary generated", bundle: bundle) }

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -616,6 +616,15 @@ enum L10n {
         localized: "Review the context and export options before generating the summary.",
         bundle: bundle
     ) }
+    static var regenerateSummaries: String { String(localized: "Regenerate Summaries", bundle: bundle) }
+    static var regenerateSelectedSummariesConfirmationTitle: String { String(
+        localized: "Regenerate selected summaries?",
+        bundle: bundle
+    ) }
+    static var regenerateSelectedSummariesConfirmationDescription: String { String(
+        localized: "Each selected meeting is regenerated independently. Existing summaries are replaced only after generation succeeds.",
+        bundle: bundle
+    ) }
     static var exportBatchSummaryToVault: String { String(
         localized: "Export Summary to Vault",
         bundle: bundle

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -15,6 +15,19 @@ import UniformTypeIdentifiers
 
 private let captionViewModelLogger = Logger(subsystem: "com.dahlia", category: "CaptionViewModel")
 
+struct SummaryGenerationRunnerInput {
+    let promptContext: SummaryPromptContext
+    let transcriptText: String
+    let noteText: String?
+    let screenshots: [MeetingScreenshotRecord]
+    let recordingSessions: [RecordingSessionTimeline]
+    let repository: MeetingRepository
+    let generationSettings: SummaryGenerationSettings
+}
+
+typealias SummaryGenerationRunner = @MainActor (SummaryGenerationRunnerInput) async throws -> SummaryService.GeneratedSummary
+typealias SummaryJobSleeper = @Sendable (Duration) async throws -> Void
+
 private enum ScreenshotError: LocalizedError {
     case encodingFailed
     case displayUnavailable
@@ -144,11 +157,25 @@ final class CaptionViewModel: ObservableObject {
 
     // MARK: - Summary State
 
-    @Published var summaryGeneratingMeetingId: UUID?
-    var isSummaryGenerating: Bool { summaryGeneratingMeetingId != nil }
-    private var pendingBatchSummaryRequestsBySessionId: [UUID: (meetingId: UUID, options: SummaryGenerationOptions)] = [:]
-    @Published var summaryError: String?
-    @Published private(set) var googleDocsExportError: String?
+    @Published private(set) var summaryGenerationJobs: [SummaryGenerationJob] = []
+    @Published var summaryGeneratingMeetingIDs: Set<UUID> = []
+    private var pendingBatchSummaryRequestsBySessionId: [UUID: PendingBatchSummaryRequest] = [:]
+    private var completedBatchSummarySessionIDs: Set<UUID> = []
+    private var batchSummaryContextsBySessionId: [UUID: BatchSummaryContext] = [:]
+    @Published private var summaryErrorsByMeetingId: [UUID: String] = [:]
+    @Published private var googleDocsExportErrorsByMeetingId: [UUID: String] = [:]
+    var isSummaryGenerating: Bool {
+        currentMeetingId.map(isSummaryGenerating(meetingId:)) ?? false
+    }
+
+    var summaryError: String? {
+        currentMeetingId.flatMap { summaryErrorsByMeetingId[$0] }
+    }
+
+    var googleDocsExportError: String? {
+        currentMeetingId.flatMap { googleDocsExportErrorsByMeetingId[$0] }
+    }
+
     private var isExportingCurrentSummaryToGoogleDocs = false
     private var isGoogleDocsExportBusy = false
     private var googleDocsExportWaiters: [CheckedContinuation<Void, Never>] = []
@@ -162,8 +189,6 @@ final class CaptionViewModel: ObservableObject {
 
     /// Summary タブへの切り替えをリクエストするフラグ。
     @Published var requestShowSummaryTab = false
-    /// 要約生成の進捗トースト状態。
-    let summaryProgress = SummaryProgressState()
 
     // MARK: - Note State
 
@@ -237,7 +262,7 @@ final class CaptionViewModel: ObservableObject {
               canShareCurrentSummary else { return false }
 
         isExportingCurrentSummaryToGoogleDocs = true
-        googleDocsExportError = nil
+        googleDocsExportErrorsByMeetingId.removeValue(forKey: meetingId)
         defer { isExportingCurrentSummaryToGoogleDocs = false }
 
         let context = SummaryRenderContext(
@@ -265,7 +290,7 @@ final class CaptionViewModel: ObservableObject {
                 for: error,
                 defaultMessage: L10n.googleDocsExportFailed
             )
-            googleDocsExportError = message
+            googleDocsExportErrorsByMeetingId[meetingId] = message
             ErrorReportingService.capture(error, context: ["source": "googleDocsExport"])
             return false
         }
@@ -396,6 +421,7 @@ final class CaptionViewModel: ObservableObject {
     private var persistenceService: MeetingPersistenceService?
     private var failedPersistenceService: MeetingPersistenceService?
     private var failedTranscriptionEventPipeline: TranscriptionEventPipeline?
+    private var summaryPersistenceRecoveryTask: Task<String?, Never>?
     private var transcriptionEventPipeline: TranscriptionEventPipeline?
     private var liveTranscriptRelay: FinalizedLiveTranscriptRelay?
     private var isChatLiveModeEnabled = false
@@ -424,13 +450,31 @@ final class CaptionViewModel: ObservableObject {
     private var isSynchronizingSelectedLocale = false
     private let audioHardwareQueryService: AudioHardwareQueryService
     private let transcriptTranslationService = TranscriptTranslationService()
+    private let summaryGenerationRunner: SummaryGenerationRunner
+    private let summaryJobSleeper: SummaryJobSleeper
 
     private var activeDbQueueForSessionControls: DatabaseQueue? {
         recordingContext?.dbQueue ?? currentDbQueue
     }
 
-    init(audioHardwareQueryService: AudioHardwareQueryService = .shared) {
+    init(
+        audioHardwareQueryService: AudioHardwareQueryService = .shared,
+        summaryGenerationRunner: @escaping SummaryGenerationRunner = { input in
+            try await SummaryService.generateSummary(
+                promptContext: input.promptContext,
+                transcriptText: input.transcriptText,
+                noteText: input.noteText,
+                screenshots: input.screenshots,
+                recordingSessions: input.recordingSessions,
+                repository: input.repository,
+                generationSettings: input.generationSettings
+            )
+        },
+        summaryJobSleeper: @escaping SummaryJobSleeper = { try await Task.sleep(for: $0) }
+    ) {
         self.audioHardwareQueryService = audioHardwareQueryService
+        self.summaryGenerationRunner = summaryGenerationRunner
+        self.summaryJobSleeper = summaryJobSleeper
         bindStoreSegments()
         Task { [weak self] in
             await self?.refreshAvailableMicrophones()
@@ -520,7 +564,8 @@ final class CaptionViewModel: ObservableObject {
                 sessionId: sessionId,
                 meetingId: meetingId,
                 suggestedLocaleIdentifier: selectedLocale,
-                dbQueue: currentDbQueue
+                dbQueue: currentDbQueue,
+                vaultURL: currentVaultURL
             )
         case let .retranscriptionFailed(sessionId, _):
             guard let meetingId = currentMeetingId,
@@ -560,6 +605,12 @@ final class CaptionViewModel: ObservableObject {
         sessionIds: [UUID],
         meetingId: UUID
     ) {
+        if let currentDbQueue, let currentVaultURL {
+            batchSummaryContextsBySessionId[sessionId] = BatchSummaryContext(
+                dbQueue: currentDbQueue,
+                vaultURL: currentVaultURL
+            )
+        }
         let preferences = batchConfirmationPreferences(
             sessionId: sessionId,
             suggestedLocaleIdentifier: selectedLocale,
@@ -612,7 +663,8 @@ final class CaptionViewModel: ObservableObject {
             sessionId: sessionId,
             meetingId: meetingId,
             suggestedLocaleIdentifier: selectedLocale,
-            dbQueue: currentDbQueue
+            dbQueue: currentDbQueue,
+            vaultURL: currentVaultURL
         )
     }
 
@@ -625,7 +677,8 @@ final class CaptionViewModel: ObservableObject {
             sessionId: sessionId,
             meetingId: meetingId,
             suggestedLocaleIdentifier: selectedLocale,
-            dbQueue: dbQueue
+            dbQueue: dbQueue,
+            vaultURL: currentVaultURL
         )
     }
 
@@ -656,14 +709,13 @@ final class CaptionViewModel: ObservableObject {
             purpose: confirmation.purpose,
             initiallyGeneratesSummary: summaryGenerationOptions != nil
         )
-        if let summaryGenerationOptions {
-            pendingBatchSummaryRequestsBySessionId[confirmation.sessionId] = (
-                meetingId: confirmation.meetingId,
-                options: summaryGenerationOptions
-            )
-        } else {
-            pendingBatchSummaryRequestsBySessionId.removeValue(forKey: confirmation.sessionId)
-        }
+        let batchSummaryContext = batchSummaryContextsBySessionId[confirmation.sessionId]
+        updatePendingBatchSummaryRequest(
+            sessionID: confirmation.sessionId,
+            meetingID: confirmation.meetingId,
+            options: summaryGenerationOptions
+        )
+        batchSummaryContextsBySessionId.removeValue(forKey: confirmation.sessionId)
         pendingBatchTranscriptionConfirmation = nil
         if currentMeetingId == confirmation.meetingId {
             batchTranscriptionState = .queued(sessionId: confirmation.sessionId)
@@ -689,6 +741,9 @@ final class CaptionViewModel: ObservableObject {
                     )
                 }
             } catch {
+                if let batchSummaryContext {
+                    batchSummaryContextsBySessionId[confirmation.sessionId] = batchSummaryContext
+                }
                 if currentMeetingId == confirmation.meetingId {
                     switch confirmation.purpose {
                     case .initialOrRetry:
@@ -705,6 +760,26 @@ final class CaptionViewModel: ObservableObject {
         }
     }
 
+    private func updatePendingBatchSummaryRequest(
+        sessionID: UUID,
+        meetingID: UUID,
+        options: SummaryGenerationOptions?
+    ) {
+        if let options,
+           let context = batchSummaryContextsBySessionId[sessionID] {
+            pendingBatchSummaryRequestsBySessionId[sessionID] = PendingBatchSummaryRequest(
+                meetingId: meetingID,
+                options: options,
+                dbQueue: context.dbQueue,
+                vaultURL: context.vaultURL
+            )
+            completedBatchSummarySessionIDs.remove(sessionID)
+        } else {
+            pendingBatchSummaryRequestsBySessionId.removeValue(forKey: sessionID)
+            completedBatchSummarySessionIDs.remove(sessionID)
+        }
+    }
+
     func discardFailedBatchTranscription() {
         guard case let .failed(sessionId, _) = batchTranscriptionState,
               let meetingId = currentMeetingId,
@@ -714,6 +789,8 @@ final class CaptionViewModel: ObservableObject {
                 let repository = MeetingRepository(dbQueue: dbQueue)
                 guard try await repository.discardFailedBatchSessionSafely(id: sessionId) else { return }
                 pendingBatchSummaryRequestsBySessionId.removeValue(forKey: sessionId)
+                completedBatchSummarySessionIDs.remove(sessionId)
+                batchSummaryContextsBySessionId.removeValue(forKey: sessionId)
                 try refreshBatchTranscriptionState(meetingId: meetingId, dbQueue: dbQueue)
             } catch {
                 errorMessage = error.localizedDescription
@@ -760,12 +837,17 @@ final class CaptionViewModel: ObservableObject {
     }
 
     func handleBatchTranscriptionUpdate(_ update: BatchTranscriptionUpdate) async {
-        guard currentMeetingId == update.meetingId,
-              !(isBatchRecording && recordingMeetingId == update.meetingId) else { return }
-        batchTranscriptionState = update.state
-        guard case .completed = update.state,
-              canReloadMeetingAfterBatchCompletion(update.meetingId) else { return }
-        await reloadCurrentMeetingAfterBatchCompletion(meetingId: update.meetingId)
+        let isVisibleMeeting = currentMeetingId == update.meetingId
+        if isVisibleMeeting,
+           !(isBatchRecording && recordingMeetingId == update.meetingId) {
+            batchTranscriptionState = update.state
+        }
+        guard case let .completed(sessionID) = update.state else { return }
+        completedBatchSummarySessionIDs.insert(sessionID)
+        if isVisibleMeeting, canReloadMeetingAfterBatchCompletion(update.meetingId) {
+            await reloadCurrentMeetingAfterBatchCompletion(meetingId: update.meetingId)
+        }
+        generatePendingBatchSummaryIfReady(meetingId: update.meetingId)
     }
 
     private func canReloadMeetingAfterBatchCompletion(_ meetingId: UUID) -> Bool {
@@ -794,7 +876,6 @@ final class CaptionViewModel: ObservableObject {
                 initialPage: loaded.initialTranscriptPage
             )
             applyLoadedDetail(loaded)
-            generatePendingBatchSummaryIfReady(meetingId: meetingId)
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -1388,8 +1469,6 @@ final class CaptionViewModel: ObservableObject {
         currentSummaryGoogleFileId = nil
         lastSummaryURL = nil
         requestShowSummaryTab = false
-        summaryError = nil
-        googleDocsExportError = nil
     }
 
     /// 現在の文字起こしコンテキスト（ID・プロジェクト情報）をセットする。
@@ -2133,6 +2212,31 @@ final class CaptionViewModel: ObservableObject {
         return true
     }
 
+    /// Shares one persistence recovery attempt across concurrently starting summary jobs.
+    private func recoverFailedPersistenceForSummary() async -> String? {
+        if let summaryPersistenceRecoveryTask {
+            return await summaryPersistenceRecoveryTask.value
+        }
+        guard let failedPersistenceService else { return nil }
+        let failedTranscriptionEventPipeline = failedTranscriptionEventPipeline
+        let recoveryTask = Task { () -> String? in
+            let result = await failedPersistenceService.stop()
+            guard result.succeeded else {
+                return result.failureMessage ?? L10n.summaryGenerationFailed
+            }
+            await failedTranscriptionEventPipeline?.notifyPersistenceRecoveredAfterFinish()
+            return nil
+        }
+        summaryPersistenceRecoveryTask = recoveryTask
+        let failureMessage = await recoveryTask.value
+        summaryPersistenceRecoveryTask = nil
+        if failureMessage == nil {
+            self.failedPersistenceService = nil
+            self.failedTranscriptionEventPipeline = nil
+        }
+        return failureMessage
+    }
+
     private func finishStoppedBatchRecording(
         recordingSessionId: UUID,
         stopResult: RecordingSessionController.StopResult?,
@@ -2159,7 +2263,8 @@ final class CaptionViewModel: ObservableObject {
                 sessionId: recordingSessionId,
                 meetingId: meetingId,
                 suggestedLocaleIdentifier: selectedLocale,
-                dbQueue: dbQueue
+                dbQueue: dbQueue,
+                vaultURL: vaultURL
             )
         }
         await completeBatchRecording(
@@ -2173,8 +2278,15 @@ final class CaptionViewModel: ObservableObject {
         sessionId: UUID,
         meetingId: UUID,
         suggestedLocaleIdentifier: String,
-        dbQueue: DatabaseQueue?
+        dbQueue: DatabaseQueue?,
+        vaultURL: URL?
     ) {
+        if let dbQueue, let vaultURL {
+            batchSummaryContextsBySessionId[sessionId] = BatchSummaryContext(
+                dbQueue: dbQueue,
+                vaultURL: vaultURL
+            )
+        }
         let preferences = batchConfirmationPreferences(
             sessionId: sessionId,
             suggestedLocaleIdentifier: suggestedLocaleIdentifier,
@@ -2314,18 +2426,104 @@ final class CaptionViewModel: ObservableObject {
         currentProjectName ?? currentProjectURL?.lastPathComponent
     }
 
+    private struct SummaryGenerationRequest {
+        let meetingId: UUID
+        let meetingName: String
+        let dbQueue: DatabaseQueue
+        let projectURL: URL?
+        let projectName: String
+        let projectDescription: String?
+        let createdAt: Date
+        let vaultURL: URL
+        let noteText: String?
+        let recordingSessions: [RecordingSessionTimeline]
+        let options: SummaryGenerationOptions
+        let generationSettings: SummaryGenerationSettings
+        let retriesFailedPersistence: Bool
+    }
+
+    private struct BatchSummaryContext {
+        let dbQueue: DatabaseQueue
+        let vaultURL: URL
+    }
+
+    private struct PendingBatchSummaryRequest {
+        let meetingId: UUID
+        let options: SummaryGenerationOptions
+        let dbQueue: DatabaseQueue
+        let vaultURL: URL
+    }
+
+    private enum SummaryGenerationPreparationError: LocalizedError {
+        case meetingUnavailable
+        case emptyTranscript
+
+        var errorDescription: String? {
+            switch self {
+            case .meetingUnavailable: L10n.meetingUnavailable
+            case .emptyTranscript: L10n.transcriptEmpty
+            }
+        }
+    }
+
     // MARK: - Summary Generation
 
     /// 手動で要約を実行できるかどうか。
     var canGenerateSummary: Bool {
         guard !isListening,
               !isFinalizingRecording,
-              !isSummaryGenerating,
               !isDeletingScreenshots,
-              currentMeetingId != nil,
+              let currentMeetingId,
+              !isSummaryGenerating(meetingId: currentMeetingId),
               currentVaultURL != nil,
               batchTranscriptionState?.blocksSummaryGeneration != true else { return false }
         return currentMeetingHasTranscriptSegments
+    }
+
+    func isSummaryGenerating(meetingId: UUID) -> Bool {
+        summaryGeneratingMeetingIDs.contains(meetingId)
+    }
+
+    #if DEBUG
+        func registerPendingBatchSummaryForTesting(
+            sessionID: UUID,
+            meetingID: UUID,
+            options: SummaryGenerationOptions,
+            dbQueue: DatabaseQueue,
+            vaultURL: URL
+        ) {
+            pendingBatchSummaryRequestsBySessionId[sessionID] = PendingBatchSummaryRequest(
+                meetingId: meetingID,
+                options: options,
+                dbQueue: dbQueue,
+                vaultURL: vaultURL
+            )
+        }
+
+        func confirmPendingBatchSummaryForTesting(
+            sessionID: UUID,
+            meetingID: UUID,
+            options: SummaryGenerationOptions
+        ) {
+            updatePendingBatchSummaryRequest(
+                sessionID: sessionID,
+                meetingID: meetingID,
+                options: options
+            )
+            batchSummaryContextsBySessionId.removeValue(forKey: sessionID)
+        }
+    #endif
+
+    func dismissSummaryGenerationJob(_ jobID: UUID) {
+        guard let job = summaryGenerationJobs.first(where: { $0.id == jobID }),
+              job.hasFailure,
+              job.isFinished else { return }
+        summaryGenerationJobs.removeAll { $0.id == jobID }
+        let hasRemainingFailure = summaryGenerationJobs.contains { $0.meetingId == job.meetingId && $0.hasFailure }
+        if !hasRemainingFailure, !isSummaryGenerating(meetingId: job.meetingId) {
+            summaryErrorsByMeetingId.removeValue(forKey: job.meetingId)
+            googleDocsExportErrorsByMeetingId.removeValue(forKey: job.meetingId)
+        }
     }
 
     /// 確認画面で選択した設定を使って手動要約を実行する。
@@ -2338,232 +2536,295 @@ final class CaptionViewModel: ObservableObject {
               let meetingId = currentMeetingId,
               let vaultURL = currentVaultURL,
               let dbQueue = currentDbQueue else { return }
-        let projectURL = currentProjectURL
-        let createdAt = store.timeBase
-        let projectName = selectedProjectName ?? ""
-        let recordingSessions = store.recordingSessions
+        saveNoteImmediately()
+        let repo = MeetingRepository(dbQueue: dbQueue)
+        let meetingName = (try? repo.fetchMeeting(id: meetingId)?.name.nilIfBlank)
+            ?? L10n.newMeeting
+        let project = try? currentProjectId.flatMap(repo.fetchProject(id:))
+        let request = SummaryGenerationRequest(
+            meetingId: meetingId,
+            meetingName: meetingName,
+            dbQueue: dbQueue,
+            projectURL: currentProjectURL,
+            projectName: project?.name ?? selectedProjectName ?? "",
+            projectDescription: project?.description,
+            createdAt: store.timeBase,
+            vaultURL: vaultURL,
+            noteText: noteText.nilIfBlank,
+            recordingSessions: store.recordingSessions,
+            options: options,
+            generationSettings: .current(),
+            retriesFailedPersistence: true
+        )
         requestShowSummaryTab = true
-        Task {
-            guard await retryFailedPersistenceIfNeeded() else { return }
-            do {
-                let summaryInput = try await Task.detached(priority: .userInitiated) {
-                    try FullTranscriptLoader.summaryInput(
-                        meetingId: meetingId,
-                        dbQueue: dbQueue,
-                        recordingSessions: recordingSessions,
-                        timeBase: createdAt
-                    )
-                }.value
-                guard currentMeetingId == meetingId else { return }
-                await generateSummary(
-                    meetingId: meetingId,
-                    transcriptText: summaryInput.text,
-                    projectURL: projectURL,
-                    createdAt: createdAt,
-                    vaultURL: vaultURL,
-                    projectName: projectName,
-                    segments: summaryInput.segments,
-                    recordingSessions: recordingSessions,
-                    options: options
-                )
-            } catch {
-                summaryError = error.localizedDescription
-            }
-        }
+        startSummaryGeneration(request)
     }
 
     private func generatePendingBatchSummaryIfReady(meetingId: UUID) {
+        guard !isSummaryGenerating(meetingId: meetingId) else { return }
         let pendingRequests = pendingBatchSummaryRequestsBySessionId.compactMap { sessionId, request in
-            request.meetingId == meetingId
-                ? (sessionId: sessionId, options: request.options)
+            request.meetingId == meetingId && completedBatchSummarySessionIDs.contains(sessionId)
+                ? (sessionId: sessionId, request: request)
                 : nil
         }
-        guard currentMeetingId == meetingId,
-              canGenerateSummary,
-              !pendingRequests.isEmpty else { return }
-        for request in pendingRequests {
-            pendingBatchSummaryRequestsBySessionId.removeValue(forKey: request.sessionId)
+        guard let first = pendingRequests.first else { return }
+        let options = SummaryGenerationOptions.merging(pendingRequests.map(\.request.options))
+        do {
+            let request = try makePersistedSummaryRequest(
+                meetingId: meetingId,
+                dbQueue: first.request.dbQueue,
+                vaultURL: first.request.vaultURL,
+                options: options
+            )
+            for pending in pendingRequests {
+                pendingBatchSummaryRequestsBySessionId.removeValue(forKey: pending.sessionId)
+                completedBatchSummarySessionIDs.remove(pending.sessionId)
+            }
+            startSummaryGeneration(request)
+        } catch {
+            for pending in pendingRequests {
+                pendingBatchSummaryRequestsBySessionId.removeValue(forKey: pending.sessionId)
+                completedBatchSummarySessionIDs.remove(pending.sessionId)
+            }
+            recordSummaryPreparationFailure(
+                error.localizedDescription,
+                meetingId: meetingId,
+                dbQueue: first.request.dbQueue
+            )
         }
-        let options = SummaryGenerationOptions.merging(pendingRequests.map(\.options))
-        triggerSummary(options: options)
     }
 
-    // Summary generation coordinates persistence and two optional export destinations as one user operation.
-    // swiftlint:disable:next function_body_length function_parameter_count
-    func generateSummary(
+    private func makePersistedSummaryRequest(
         meetingId: UUID,
-        transcriptText: String,
-        projectURL: URL?,
-        createdAt: Date,
+        dbQueue: DatabaseQueue,
         vaultURL: URL,
-        projectName: String,
-        segments: [TranscriptSegment],
-        recordingSessions: [RecordingSessionTimeline],
         options: SummaryGenerationOptions
-    ) async {
-        guard !transcriptText.isEmpty,
-              !isDeletingScreenshots else { return }
+    ) throws -> SummaryGenerationRequest {
+        let snapshot = try dbQueue.read { db in
+            let meeting = try MeetingRecord.fetchOne(db, key: meetingId)
+            let project = try meeting?.projectId.flatMap { try ProjectRecord.fetchOne(db, key: $0) }
+            let note = try MeetingNoteRecord.fetchOne(db, key: meetingId)
+            let recordingSessions = try RecordingSessionRecord
+                .filter(Column("meetingId") == meetingId)
+                .order(Column("offsetSeconds").asc, Column("startedAt").asc)
+                .fetchAll(db)
+            return (meeting, project, note, recordingSessions)
+        }
+        guard let meeting = snapshot.0 else { throw SummaryGenerationPreparationError.meetingUnavailable }
+        let project = snapshot.1
+        return SummaryGenerationRequest(
+            meetingId: meetingId,
+            meetingName: meeting.name.nilIfBlank ?? L10n.newMeeting,
+            dbQueue: dbQueue,
+            projectURL: project.map { vaultURL.appending(path: $0.name, directoryHint: .isDirectory) },
+            projectName: project?.name ?? "",
+            projectDescription: project?.description,
+            createdAt: meeting.createdAt,
+            vaultURL: vaultURL,
+            noteText: snapshot.2?.text.nilIfBlank,
+            recordingSessions: snapshot.3.map(RecordingSessionTimeline.init),
+            options: options,
+            generationSettings: .current(),
+            retriesFailedPersistence: false
+        )
+    }
 
-        // 要約前にノートを即座に保存してから取得
-        saveNoteImmediately()
-        let currentNoteText = noteText
+    private func recordSummaryPreparationFailure(
+        _ message: String,
+        meetingId: UUID,
+        dbQueue: DatabaseQueue
+    ) {
+        let meetingName = (try? MeetingRepository(dbQueue: dbQueue).fetchMeeting(id: meetingId)?.name.nilIfBlank)
+            ?? L10n.newMeeting
+        let job = SummaryGenerationJob(meetingId: meetingId, meetingName: meetingName)
+        job.progress.summaryGeneration = .failed(message)
+        job.progress.vaultExport = .skipped
+        job.progress.googleDocsExport = .skipped
+        summaryGenerationJobs.append(job)
+        summaryErrorsByMeetingId[meetingId] = message
+    }
 
-        summaryGeneratingMeetingId = meetingId
-        summaryError = nil
-        googleDocsExportError = nil
-        lastSummaryURL = nil
-        var progressPresentationID: UUID?
+    private func startSummaryGeneration(_ request: SummaryGenerationRequest) {
+        guard !isSummaryGenerating(meetingId: request.meetingId) else { return }
+        let job = SummaryGenerationJob(meetingId: request.meetingId, meetingName: request.meetingName)
+        let exportOptions = request.options.exportOptions
+        job.progress.vaultExport = exportOptions.exportsToVault ? .pending : .skipped
+        job.progress.googleDocsExport = exportOptions.exportsToGoogleDocs ? .pending : .skipped
+        summaryGenerationJobs.append(job)
+        summaryErrorsByMeetingId.removeValue(forKey: request.meetingId)
+        googleDocsExportErrorsByMeetingId.removeValue(forKey: request.meetingId)
+        summaryGeneratingMeetingIDs.insert(request.meetingId)
+        if currentMeetingId == request.meetingId {
+            lastSummaryURL = nil
+        }
+
+        Task { [weak self] in
+            await self?.runSummaryGeneration(request, job: job)
+        }
+    }
+
+    private func runSummaryGeneration(_ request: SummaryGenerationRequest, job: SummaryGenerationJob) async {
+        defer { finishSummaryGeneration(request, job: job) }
+
+        if request.retriesFailedPersistence {
+            if let message = await recoverFailedPersistenceForSummary() {
+                failSummaryGeneration(message, request: request, job: job)
+                return
+            }
+        }
 
         do {
-            let dbQueue = currentDbQueue
-            let projectId = currentProjectId
-            let repo = dbQueue.map { MeetingRepository(dbQueue: $0) }
-            var screenshots: [MeetingScreenshotRecord] = []
-            var promptProjectName = projectName.nilIfBlank
-            var projectDescription: String?
-            var calendarEvent: CalendarEventRecord?
-            var previousMeetings: [SummaryPreviousMeetingMetadata] = []
-            if let repo {
-                screenshots = (try? repo.fetchScreenshots(forMeetingId: meetingId)) ?? []
-                calendarEvent = try repo.fetchCalendarEvent(forMeetingId: meetingId)
-                previousMeetings = try repo.fetchPreviousMeetingMetadata(
-                    forMeetingId: meetingId,
-                    limit: options.previousMeetingCount
+            let summaryInput = try await Task.detached(priority: .userInitiated) {
+                try FullTranscriptLoader.summaryInput(
+                    meetingId: request.meetingId,
+                    dbQueue: request.dbQueue,
+                    recordingSessions: request.recordingSessions,
+                    timeBase: request.createdAt
                 )
-                if let projectId,
-                   let project = try repo.fetchProject(id: projectId) {
-                    promptProjectName = project.name
-                    projectDescription = project.description
-                }
-            }
-
-            progressPresentationID = summaryProgress.show()
-            let exportOptions = options.exportOptions
-            summaryProgress.vaultExport = exportOptions.exportsToVault ? .pending : .skipped
-            summaryProgress.googleDocsExport = exportOptions.exportsToGoogleDocs ? .pending : .skipped
-
-            // LLM 要約
-            summaryProgress.summaryGeneration = .running
-
-            let generatedSummary = try await SummaryService.generateSummary(
-                promptContext: SummaryPromptContext(
-                    meetingId: meetingId,
-                    recordedAt: createdAt,
-                    calendarEvent: calendarEvent,
-                    projectName: promptProjectName,
-                    projectDescription: projectDescription,
-                    previousMeetings: previousMeetings
-                ),
-                transcriptText: transcriptText,
-                noteText: currentNoteText.isEmpty ? nil : currentNoteText,
-                screenshots: screenshots,
-                recordingSessions: recordingSessions,
-                repository: repo
-            )
-
-            // Regeneration invalidates the previous export locations. Keep the old
-            // Vault path only long enough to overwrite the existing file when selected.
-            let storedSummaryRelativePath = try repo?.fetchSummaryVaultRelativePath(forMeetingId: meetingId)
-
-            if let repo {
-                try repo.applyGeneratedSummary(
-                    toMeetingId: meetingId,
-                    document: generatedSummary.document,
-                    tags: generatedSummary.document.tags
-                )
-            }
-            summaryProgress.summaryGeneration = .completed
-            if currentMeetingId == meetingId {
-                currentSummaryDocument = generatedSummary.document
-                currentSummaryGoogleFileId = nil
-            }
-
-            if exportOptions.exportsToVault {
-                summaryProgress.vaultExport = .running
-                do {
-                    let fileURL = try await VaultSummaryExportService.exportSummaryBundle(
-                        projectURL: projectURL,
-                        vaultURL: vaultURL,
-                        storedSummaryRelativePath: storedSummaryRelativePath,
-                        meetingId: meetingId,
-                        createdAt: createdAt,
-                        projectName: projectName,
-                        segments: segments,
-                        recordingSessions: recordingSessions,
-                        screenshots: screenshots,
-                        summaryFileName: generatedSummary.fileName,
-                        summaryMarkdown: generatedSummary.markdown
-                    )
-                    if let relativePath = VaultSummaryFileLocator.relativePath(for: fileURL, vaultURL: vaultURL) {
-                        try repo?.updateSummaryVaultRelativePath(forMeetingId: meetingId, relativePath: relativePath)
-                    }
-                    summaryProgress.vaultExport = .completed
-                    if currentMeetingId == meetingId {
-                        lastSummaryURL = fileURL
-                    }
-                } catch {
-                    summaryProgress.vaultExport = .failed(error.localizedDescription)
-                    if currentMeetingId == meetingId {
-                        summaryError = error.localizedDescription
-                    }
-                    ErrorReportingService.capture(error, context: ["source": "vaultSummaryExport"])
-                }
-            }
-
-            if exportOptions.exportsToGoogleDocs {
-                summaryProgress.googleDocsExport = .running
-                do {
-                    let fileId = try await exportSummaryToGoogleDocs(
-                        document: generatedSummary.document,
-                        context: SummaryRenderContext(
-                            meetingId: meetingId,
-                            createdAt: createdAt,
-                            screenshots: screenshots
-                        ),
-                        fileName: generatedSummary.fileName
-                    )
-                    try persistGoogleDocsFileId(fileId, meetingId: meetingId, dbQueue: dbQueue)
-                    summaryProgress.googleDocsExport = .completed
-                } catch {
-                    let message = GoogleAuthErrorFormatter.message(
-                        for: error,
-                        defaultMessage: L10n.googleDocsExportFailed
-                    )
-                    summaryProgress.googleDocsExport = .failed(message)
-                    if currentMeetingId == meetingId {
-                        googleDocsExportError = message
-                    }
-                    ErrorReportingService.capture(error, context: ["source": "batchGoogleDocsExport"])
-                }
-            }
+            }.value
+            guard !summaryInput.text.isEmpty else { throw SummaryGenerationPreparationError.emptyTranscript }
+            try await generateSummary(request: request, summaryInput: summaryInput, job: job)
         } catch {
-            if currentMeetingId == meetingId {
-                summaryError = error.localizedDescription
-                requestShowSummaryTab = false
-            }
-            summaryProgress.summaryGeneration = .failed(error.localizedDescription)
-            summaryProgress.vaultExport = .skipped
-            summaryProgress.googleDocsExport = .skipped
+            failSummaryGeneration(error.localizedDescription, request: request, job: job)
             if Self.shouldCaptureSummaryGenerationError(error) {
                 ErrorReportingService.capture(error, context: ["source": "summaryGeneration"])
             }
         }
+    }
 
-        if summaryGeneratingMeetingId == meetingId {
-            summaryGeneratingMeetingId = nil
+    // Summary generation coordinates persistence and two optional export destinations as one user operation.
+    // swiftlint:disable:next function_body_length
+    private func generateSummary(
+        request: SummaryGenerationRequest,
+        summaryInput: FullTranscriptSummaryInput,
+        job: SummaryGenerationJob
+    ) async throws {
+        let meetingId = request.meetingId
+        let repo = MeetingRepository(dbQueue: request.dbQueue)
+
+        let screenshots = (try? repo.fetchScreenshots(forMeetingId: meetingId)) ?? []
+        let calendarEvent = try repo.fetchCalendarEvent(forMeetingId: meetingId)
+        let previousMeetings = try repo.fetchPreviousMeetingMetadata(
+            forMeetingId: meetingId,
+            limit: request.options.previousMeetingCount
+        )
+        let promptProjectName = request.projectName.nilIfBlank
+
+        job.progress.summaryGeneration = .running
+
+        let generatedSummary = try await summaryGenerationRunner(SummaryGenerationRunnerInput(
+            promptContext: SummaryPromptContext(
+                meetingId: meetingId,
+                recordedAt: request.createdAt,
+                calendarEvent: calendarEvent,
+                projectName: promptProjectName,
+                projectDescription: request.projectDescription,
+                previousMeetings: previousMeetings
+            ),
+            transcriptText: summaryInput.text,
+            noteText: request.noteText,
+            screenshots: screenshots,
+            recordingSessions: request.recordingSessions,
+            repository: repo,
+            generationSettings: request.generationSettings
+        ))
+
+        let storedSummaryRelativePath = try repo.fetchSummaryVaultRelativePath(forMeetingId: meetingId)
+
+        try repo.applyGeneratedSummary(
+            toMeetingId: meetingId,
+            document: generatedSummary.document,
+            tags: generatedSummary.document.tags
+        )
+        job.progress.summaryGeneration = .completed
+        if currentMeetingId == meetingId {
+            currentSummaryDocument = generatedSummary.document
+            currentSummaryGoogleFileId = nil
         }
 
-        // 全完了後に自動で非表示
-        if summaryProgress.isAllDone, let progressPresentationID {
-            try? await Task.sleep(for: .seconds(2))
-            withAnimation(.easeOut(duration: 0.3)) {
-                summaryProgress.dismiss(ifCurrent: progressPresentationID)
+        let exportOptions = request.options.exportOptions
+        if exportOptions.exportsToVault {
+            job.progress.vaultExport = .running
+            do {
+                let fileURL = try await VaultSummaryExportService.exportSummaryBundle(
+                    projectURL: request.projectURL,
+                    vaultURL: request.vaultURL,
+                    storedSummaryRelativePath: storedSummaryRelativePath,
+                    meetingId: meetingId,
+                    createdAt: request.createdAt,
+                    projectName: request.projectName,
+                    segments: summaryInput.segments,
+                    recordingSessions: request.recordingSessions,
+                    screenshots: screenshots,
+                    summaryFileName: generatedSummary.fileName,
+                    summaryMarkdown: generatedSummary.markdown
+                )
+                if let relativePath = VaultSummaryFileLocator.relativePath(for: fileURL, vaultURL: request.vaultURL) {
+                    try repo.updateSummaryVaultRelativePath(forMeetingId: meetingId, relativePath: relativePath)
+                }
+                job.progress.vaultExport = .completed
+                if currentMeetingId == meetingId { lastSummaryURL = fileURL }
+            } catch {
+                job.progress.vaultExport = .failed(error.localizedDescription)
+                summaryErrorsByMeetingId[meetingId] = error.localizedDescription
+                ErrorReportingService.capture(error, context: ["source": "vaultSummaryExport"])
             }
         }
 
-        if let currentMeetingId {
-            generatePendingBatchSummaryIfReady(meetingId: currentMeetingId)
+        if exportOptions.exportsToGoogleDocs {
+            job.progress.googleDocsExport = .running
+            do {
+                let fileId = try await exportSummaryToGoogleDocs(
+                    document: generatedSummary.document,
+                    context: SummaryRenderContext(
+                        meetingId: meetingId,
+                        createdAt: request.createdAt,
+                        screenshots: screenshots
+                    ),
+                    fileName: generatedSummary.fileName
+                )
+                try persistGoogleDocsFileId(fileId, meetingId: meetingId, dbQueue: request.dbQueue)
+                job.progress.googleDocsExport = .completed
+            } catch {
+                let message = GoogleAuthErrorFormatter.message(
+                    for: error,
+                    defaultMessage: L10n.googleDocsExportFailed
+                )
+                job.progress.googleDocsExport = .failed(message)
+                googleDocsExportErrorsByMeetingId[meetingId] = message
+                ErrorReportingService.capture(error, context: ["source": "batchGoogleDocsExport"])
+            }
         }
+    }
+
+    private func failSummaryGeneration(
+        _ message: String,
+        request: SummaryGenerationRequest,
+        job: SummaryGenerationJob
+    ) {
+        summaryErrorsByMeetingId[request.meetingId] = message
+        if currentMeetingId == request.meetingId { requestShowSummaryTab = false }
+        job.progress.summaryGeneration = .failed(message)
+        job.progress.vaultExport = .skipped
+        job.progress.googleDocsExport = .skipped
+    }
+
+    private func finishSummaryGeneration(
+        _ request: SummaryGenerationRequest,
+        job: SummaryGenerationJob
+    ) {
+        summaryGeneratingMeetingIDs.remove(request.meetingId)
+        if !job.hasFailure, job.progress.isAllDone {
+            Task { [weak self] in
+                guard let self else { return }
+                try? await self.summaryJobSleeper(.seconds(2))
+                withAnimation(.easeOut(duration: 0.3)) {
+                    self.summaryGenerationJobs.removeAll { $0.id == job.id }
+                }
+            }
+        }
+
+        generatePendingBatchSummaryIfReady(meetingId: request.meetingId)
     }
 
     private func persistGoogleDocsFileId(

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -201,7 +201,13 @@ final class CaptionViewModel: ObservableObject {
     // MARK: - Screenshot State
 
     @Published var screenshots: [MeetingScreenshotRecord] = []
-    @Published private(set) var isDeletingScreenshots = false
+    @Published private(set) var isDeletingScreenshots = false {
+        didSet {
+            guard oldValue, !isDeletingScreenshots else { return }
+            generatePendingBatchSummariesIfReady()
+        }
+    }
+
     /// キャプチャ対象として選択可能なウィンドウ一覧。
     @Published var availableWindows: [ScreenshotWindowOption] = []
     /// スクリーンショット取得対象。未設定の場合はキャプチャしない。
@@ -843,7 +849,9 @@ final class CaptionViewModel: ObservableObject {
             batchTranscriptionState = update.state
         }
         guard case let .completed(sessionID) = update.state else { return }
-        completedBatchSummarySessionIDs.insert(sessionID)
+        if pendingBatchSummaryRequestsBySessionId[sessionID] != nil {
+            completedBatchSummarySessionIDs.insert(sessionID)
+        }
         if isVisibleMeeting, canReloadMeetingAfterBatchCompletion(update.meetingId) {
             await reloadCurrentMeetingAfterBatchCompletion(meetingId: update.meetingId)
         }
@@ -2452,6 +2460,11 @@ final class CaptionViewModel: ObservableObject {
         let options: SummaryGenerationOptions
         let dbQueue: DatabaseQueue
         let vaultURL: URL
+
+        func hasSamePersistenceContext(as other: Self) -> Bool {
+            dbQueue === other.dbQueue
+                && vaultURL.standardizedFileURL == other.vaultURL.standardizedFileURL
+        }
     }
 
     private enum SummaryGenerationPreparationError: LocalizedError {
@@ -2518,6 +2531,14 @@ final class CaptionViewModel: ObservableObject {
                 options: options
             )
             batchSummaryContextsBySessionId.removeValue(forKey: sessionID)
+        }
+
+        var completedBatchSummarySessionCountForTesting: Int {
+            completedBatchSummarySessionIDs.count
+        }
+
+        func setScreenshotDeletionInProgressForTesting(_ isInProgress: Bool) {
+            isDeletingScreenshots = isInProgress
         }
     #endif
 
@@ -2599,13 +2620,19 @@ final class CaptionViewModel: ObservableObject {
     }
 
     private func generatePendingBatchSummaryIfReady(meetingId: UUID) {
-        guard !isSummaryGenerating(meetingId: meetingId) else { return }
-        let pendingRequests = pendingBatchSummaryRequestsBySessionId.compactMap { sessionId, request in
+        guard !isDeletingScreenshots,
+              !isSummaryGenerating(meetingId: meetingId) else { return }
+        let completedRequests = pendingBatchSummaryRequestsBySessionId.compactMap { sessionId, request in
             request.meetingId == meetingId && completedBatchSummarySessionIDs.contains(sessionId)
                 ? (sessionId: sessionId, request: request)
                 : nil
         }
-        guard let first = pendingRequests.first else { return }
+        .sorted { $0.sessionId.uuidString < $1.sessionId.uuidString }
+        guard let first = completedRequests.first else { return }
+        let pendingRequests = completedRequests.filter {
+            $0.request.hasSamePersistenceContext(as: first.request)
+        }
+        let sessionIDs = pendingRequests.map(\.sessionId)
         let options = SummaryGenerationOptions.merging(pendingRequests.map(\.request.options))
         do {
             let request = try makePersistedSummaryRequest(
@@ -2614,21 +2641,30 @@ final class CaptionViewModel: ObservableObject {
                 vaultURL: first.request.vaultURL,
                 options: options
             )
-            for pending in pendingRequests {
-                pendingBatchSummaryRequestsBySessionId.removeValue(forKey: pending.sessionId)
-                completedBatchSummarySessionIDs.remove(pending.sessionId)
-            }
+            removePendingBatchSummaryRequests(sessionIDs: sessionIDs)
             startSummaryGeneration(request)
         } catch {
-            for pending in pendingRequests {
-                pendingBatchSummaryRequestsBySessionId.removeValue(forKey: pending.sessionId)
-                completedBatchSummarySessionIDs.remove(pending.sessionId)
-            }
+            removePendingBatchSummaryRequests(sessionIDs: sessionIDs)
             recordSummaryPreparationFailure(
                 error.localizedDescription,
                 meetingId: meetingId,
                 dbQueue: first.request.dbQueue
             )
+            generatePendingBatchSummaryIfReady(meetingId: meetingId)
+        }
+    }
+
+    private func generatePendingBatchSummariesIfReady() {
+        let meetingIDs = Set(pendingBatchSummaryRequestsBySessionId.values.map(\.meetingId))
+        for meetingID in meetingIDs.sorted(by: { $0.uuidString < $1.uuidString }) {
+            generatePendingBatchSummaryIfReady(meetingId: meetingID)
+        }
+    }
+
+    private func removePendingBatchSummaryRequests(sessionIDs: [UUID]) {
+        for sessionID in sessionIDs {
+            pendingBatchSummaryRequestsBySessionId.removeValue(forKey: sessionID)
+            completedBatchSummarySessionIDs.remove(sessionID)
         }
     }
 

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -2468,16 +2468,23 @@ final class CaptionViewModel: ObservableObject {
 
     // MARK: - Summary Generation
 
+    private var canStartManualSummaryGeneration: Bool {
+        !isListening && !isFinalizingRecording && !isDeletingScreenshots
+    }
+
     /// 手動で要約を実行できるかどうか。
     var canGenerateSummary: Bool {
-        guard !isListening,
-              !isFinalizingRecording,
-              !isDeletingScreenshots,
+        guard canStartManualSummaryGeneration,
               let currentMeetingId,
               !isSummaryGenerating(meetingId: currentMeetingId),
               currentVaultURL != nil,
               batchTranscriptionState?.blocksSummaryGeneration != true else { return false }
         return currentMeetingHasTranscriptSegments
+    }
+
+    func canRegenerateSummaries(meetingIds: Set<UUID>) -> Bool {
+        canStartManualSummaryGeneration
+            && meetingIds.contains { !isSummaryGenerating(meetingId: $0) }
     }
 
     func isSummaryGenerating(meetingId: UUID) -> Bool {
@@ -2529,6 +2536,37 @@ final class CaptionViewModel: ObservableObject {
     /// 確認画面で選択した設定を使って手動要約を実行する。
     func triggerManualSummary(options: SummaryGenerationOptions = .manual) {
         triggerSummary(options: options)
+    }
+
+    /// DB に保存済みの複数ミーティングを、現在の画面選択を変更せず個別ジョブとして再生成する。
+    func triggerManualSummaries(
+        meetingIds: Set<UUID>,
+        dbQueue: DatabaseQueue?,
+        vaultURL: URL?,
+        options: SummaryGenerationOptions = .manual
+    ) {
+        guard canStartManualSummaryGeneration,
+              let dbQueue,
+              let vaultURL else { return }
+
+        for meetingId in meetingIds.sorted(by: { $0.uuidString < $1.uuidString })
+            where !isSummaryGenerating(meetingId: meetingId) {
+            do {
+                let request = try makePersistedSummaryRequest(
+                    meetingId: meetingId,
+                    dbQueue: dbQueue,
+                    vaultURL: vaultURL,
+                    options: options
+                )
+                startSummaryGeneration(request)
+            } catch {
+                recordSummaryPreparationFailure(
+                    error.localizedDescription,
+                    meetingId: meetingId,
+                    dbQueue: dbQueue
+                )
+            }
+        }
     }
 
     private func triggerSummary(options: SummaryGenerationOptions) {

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -76,6 +76,17 @@ struct ContentView: View {
                 .transition(.opacity.combined(with: .scale(scale: 0.98, anchor: .bottomTrailing)))
             }
         }
+        .overlay(alignment: .bottomTrailing) {
+            if !viewModel.summaryGenerationJobs.isEmpty {
+                SummaryProgressToastView(
+                    jobs: viewModel.summaryGenerationJobs,
+                    onDismiss: viewModel.dismissSummaryGenerationJob
+                )
+                .padding(16)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .animation(.easeInOut(duration: 0.3), value: viewModel.summaryGenerationJobs.map(\.id))
+            }
+        }
         .sheet(item: $viewModel.pendingBatchTranscriptionConfirmation) { confirmation in
             BatchTranscriptionConfirmationView(
                 locales: viewModel.batchTranscriptionLocaleOptions(

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -158,7 +158,10 @@ struct ContentView: View {
     @ViewBuilder
     private var detailView: some View {
         if sidebarViewModel.selectedMeetingIds.count > 1 {
-            MultipleMeetingSelectionView(sidebarViewModel: sidebarViewModel)
+            MultipleMeetingSelectionView(
+                viewModel: viewModel,
+                sidebarViewModel: sidebarViewModel
+            )
         } else if sidebarViewModel.selectedMeetingId != nil || viewModel.hasDraftMeeting || viewModel.currentMeetingId != nil {
             ControlPanelView(
                 viewModel: viewModel,
@@ -209,54 +212,5 @@ struct ContentView: View {
         } catch {
             viewModel.errorMessage = error.localizedDescription
         }
-    }
-}
-
-private struct MultipleMeetingSelectionView: View {
-    var sidebarViewModel: SidebarViewModel
-
-    var body: some View {
-        VStack(spacing: 18) {
-            Image(systemName: "checklist")
-                .font(.system(size: 42, weight: .regular))
-                .foregroundStyle(.secondary)
-
-            Text(L10n.selectedCount(sidebarViewModel.selectedMeetingIds.count))
-                .font(.title2.weight(.semibold))
-
-            HStack(spacing: 10) {
-                Menu {
-                    Button(L10n.noProject) {
-                        sidebarViewModel.moveMeetings(ids: sidebarViewModel.selectedMeetingIds, toProjectId: nil)
-                    }
-
-                    Divider()
-
-                    ForEach(sidebarViewModel.allProjectItems) { project in
-                        Button(project.projectName) {
-                            sidebarViewModel.moveMeetings(
-                                ids: sidebarViewModel.selectedMeetingIds,
-                                toProjectId: project.projectId
-                            )
-                        }
-                    }
-                } label: {
-                    Label(L10n.moveToProject, systemImage: "folder")
-                }
-
-                Button(role: .destructive) {
-                    sidebarViewModel.deleteMeetings(ids: sidebarViewModel.selectedMeetingIds)
-                } label: {
-                    Label(L10n.deleteCount(sidebarViewModel.selectedMeetingIds.count), systemImage: "trash")
-                }
-
-                Button(L10n.clear) {
-                    sidebarViewModel.clearMeetingSelection()
-                }
-            }
-            .buttonStyle(.bordered)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding()
     }
 }

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -443,14 +443,6 @@ struct ControlPanelView: View {
         } message: {
             Text(L10n.deleteSelectedScreenshotsConfirmation)
         }
-        .overlay(alignment: .bottomTrailing) {
-            if viewModel.summaryProgress.isVisible {
-                SummaryProgressToastView(state: viewModel.summaryProgress)
-                    .padding(16)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-                    .animation(.easeInOut(duration: 0.3), value: viewModel.summaryProgress.isVisible)
-            }
-        }
         .overlay {
             if let screenshot = expandedScreenshot {
                 ScreenshotOverlayView(screenshot: screenshot) {

--- a/Sources/Dahlia/Views/MultipleMeetingSelectionView.swift
+++ b/Sources/Dahlia/Views/MultipleMeetingSelectionView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+struct MultipleMeetingSelectionView: View {
+    @ObservedObject var viewModel: CaptionViewModel
+    var sidebarViewModel: SidebarViewModel
+    @State private var isSummaryConfirmationPresented = false
+
+    var body: some View {
+        VStack(spacing: 18) {
+            Image(systemName: "checklist")
+                .font(.system(size: 42, weight: .regular))
+                .foregroundStyle(.secondary)
+
+            Text(L10n.selectedCount(sidebarViewModel.selectedMeetingIds.count))
+                .font(.title2.weight(.semibold))
+
+            HStack(spacing: 10) {
+                Button(
+                    L10n.regenerateSummaries,
+                    systemImage: "sparkles",
+                    action: presentSummaryConfirmation
+                )
+                .buttonStyle(.borderedProminent)
+                .disabled(!viewModel.canRegenerateSummaries(meetingIds: sidebarViewModel.selectedMeetingIds))
+
+                Menu {
+                    Button(L10n.noProject) {
+                        sidebarViewModel.moveMeetings(ids: sidebarViewModel.selectedMeetingIds, toProjectId: nil)
+                    }
+
+                    Divider()
+
+                    ForEach(sidebarViewModel.allProjectItems) { project in
+                        Button(project.projectName) {
+                            sidebarViewModel.moveMeetings(
+                                ids: sidebarViewModel.selectedMeetingIds,
+                                toProjectId: project.projectId
+                            )
+                        }
+                    }
+                } label: {
+                    Label(L10n.moveToProject, systemImage: "folder")
+                }
+
+                Button(role: .destructive) {
+                    sidebarViewModel.deleteMeetings(ids: sidebarViewModel.selectedMeetingIds)
+                } label: {
+                    Label(L10n.deleteCount(sidebarViewModel.selectedMeetingIds.count), systemImage: "trash")
+                }
+
+                Button(L10n.clear) {
+                    sidebarViewModel.clearMeetingSelection()
+                }
+            }
+            .buttonStyle(.bordered)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+        .sheet(isPresented: $isSummaryConfirmationPresented) {
+            SummaryGenerationConfirmationView(
+                title: L10n.regenerateSelectedSummariesConfirmationTitle,
+                description: L10n.regenerateSelectedSummariesConfirmationDescription,
+                actionTitle: L10n.regenerateSummaries,
+                onGenerate: regenerateSummaries
+            )
+        }
+    }
+
+    private func presentSummaryConfirmation() {
+        isSummaryConfirmationPresented = true
+    }
+
+    private func regenerateSummaries(options: SummaryGenerationOptions) {
+        viewModel.triggerManualSummaries(
+            meetingIds: sidebarViewModel.selectedMeetingIds,
+            dbQueue: sidebarViewModel.dbQueue,
+            vaultURL: sidebarViewModel.currentVault?.url,
+            options: options
+        )
+    }
+}

--- a/Sources/Dahlia/Views/SummaryGenerationConfirmationView.swift
+++ b/Sources/Dahlia/Views/SummaryGenerationConfirmationView.swift
@@ -6,9 +6,20 @@ struct SummaryGenerationConfirmationView: View {
     @State private var exportsToVault = SummaryExportOptions.manual.exportsToVault
     @State private var exportsToGoogleDocs = SummaryExportOptions.manual.exportsToGoogleDocs
 
+    let title: String
+    let description: String
+    let actionTitle: String
     let onGenerate: (SummaryGenerationOptions) -> Void
 
-    init(onGenerate: @escaping (SummaryGenerationOptions) -> Void) {
+    init(
+        title: String = L10n.summaryGenerationConfirmationTitle,
+        description: String = L10n.summaryGenerationConfirmationDescription,
+        actionTitle: String = L10n.generateSummary,
+        onGenerate: @escaping (SummaryGenerationOptions) -> Void
+    ) {
+        self.title = title
+        self.description = description
+        self.actionTitle = actionTitle
         self.onGenerate = onGenerate
         _previousMeetingCount = State(initialValue: AppSettings.shared.summaryPreviousMeetingCount)
     }
@@ -16,9 +27,9 @@ struct SummaryGenerationConfirmationView: View {
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 6) {
-                Text(L10n.summaryGenerationConfirmationTitle)
+                Text(title)
                     .font(.headline)
-                Text(L10n.summaryGenerationConfirmationDescription)
+                Text(description)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -44,7 +55,7 @@ struct SummaryGenerationConfirmationView: View {
                 Spacer()
                 Button(L10n.cancel, role: .cancel, action: dismiss.callAsFunction)
                     .keyboardShortcut(.cancelAction)
-                Button(L10n.generateSummary, action: generateSummary)
+                Button(actionTitle, action: generateSummary)
                     .keyboardShortcut(.defaultAction)
             }
             .padding(20)

--- a/Sources/Dahlia/Views/SummaryProgressStepRow.swift
+++ b/Sources/Dahlia/Views/SummaryProgressStepRow.swift
@@ -5,32 +5,42 @@ struct SummaryProgressStepRow: View {
     let status: SummaryProgressState.StepStatus
 
     var body: some View {
-        HStack(spacing: 8) {
-            Group {
-                switch status {
-                case .pending:
-                    Image(systemName: "circle")
-                        .foregroundStyle(.tertiary)
-                case .running:
-                    ProgressView()
-                        .controlSize(.mini)
-                case .completed:
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
-                case .skipped:
-                    Image(systemName: "minus.circle")
-                        .foregroundStyle(.tertiary)
-                case .failed:
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(.red)
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 8) {
+                Group {
+                    switch status {
+                    case .pending:
+                        Image(systemName: "circle")
+                            .foregroundStyle(.tertiary)
+                    case .running:
+                        ProgressView()
+                            .controlSize(.mini)
+                    case .completed:
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                    case .skipped:
+                        Image(systemName: "minus.circle")
+                            .foregroundStyle(.tertiary)
+                    case .failed:
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.red)
+                    }
                 }
-            }
-            .frame(width: 14, height: 14)
-            .accessibilityHidden(true)
+                .frame(width: 14, height: 14)
+                .accessibilityHidden(true)
 
-            Text(label)
-                .font(.caption)
-                .foregroundStyle(textColor)
+                Text(label)
+                    .font(.caption)
+                    .foregroundStyle(textColor)
+            }
+
+            if let failureMessage = status.failureMessage {
+                Text(failureMessage)
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+                    .lineLimit(2)
+                    .padding(.leading, 22)
+            }
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(label)

--- a/Sources/Dahlia/Views/SummaryProgressToastView.swift
+++ b/Sources/Dahlia/Views/SummaryProgressToastView.swift
@@ -56,12 +56,6 @@ private struct SummaryGenerationJobProgressView: View {
             if !job.progress.googleDocsExport.isSkipped {
                 SummaryProgressStepRow(label: L10n.exportBatchSummaryToGoogleDocs, status: job.progress.googleDocsExport)
             }
-            ForEach(Array(Set(job.failureMessages)).sorted(), id: \.self) { message in
-                Text(message)
-                    .font(.caption2)
-                    .foregroundStyle(.red)
-                    .lineLimit(2)
-            }
         }
         .padding(10)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/Dahlia/Views/SummaryProgressToastView.swift
+++ b/Sources/Dahlia/Views/SummaryProgressToastView.swift
@@ -1,28 +1,70 @@
 import SwiftUI
 
-/// 要約生成時に右下に表示する進捗トースト。
+/// 要約生成時に右下に表示するミーティング別の進捗一覧。
 struct SummaryProgressToastView: View {
-    let state: SummaryProgressState
+    let jobs: [SummaryGenerationJob]
+    let onDismiss: (UUID) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 10) {
             Text(L10n.generatingSummary)
                 .font(.callout)
                 .bold()
                 .foregroundStyle(.primary)
 
-            SummaryProgressStepRow(label: L10n.generateSummary, status: state.summaryGeneration)
-            if !state.vaultExport.isSkipped {
-                SummaryProgressStepRow(label: L10n.exportBatchSummaryToVault, status: state.vaultExport)
+            ScrollView {
+                LazyVStack(spacing: 10) {
+                    ForEach(jobs) { job in
+                        SummaryGenerationJobProgressView(job: job, onDismiss: onDismiss)
+                    }
+                }
             }
-            if !state.googleDocsExport.isSkipped {
-                SummaryProgressStepRow(label: L10n.exportBatchSummaryToGoogleDocs, status: state.googleDocsExport)
-            }
+            .scrollIndicators(.automatic)
+            .frame(maxHeight: 360)
         }
         .padding(12)
-        .frame(minWidth: 220)
+        .frame(minWidth: 260, idealWidth: 300, maxWidth: 340)
         .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 10))
         .shadow(color: .black.opacity(0.12), radius: 12, y: 4)
         .shadow(color: .black.opacity(0.06), radius: 3, y: 1)
+    }
+}
+
+private struct SummaryGenerationJobProgressView: View {
+    let job: SummaryGenerationJob
+    let onDismiss: (UUID) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(job.meetingName)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                Spacer(minLength: 8)
+                if job.hasFailure, job.isFinished {
+                    Button(L10n.close, systemImage: "xmark", action: { onDismiss(job.id) })
+                        .labelStyle(.iconOnly)
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            SummaryProgressStepRow(label: L10n.generateSummary, status: job.progress.summaryGeneration)
+            if !job.progress.vaultExport.isSkipped {
+                SummaryProgressStepRow(label: L10n.exportBatchSummaryToVault, status: job.progress.vaultExport)
+            }
+            if !job.progress.googleDocsExport.isSkipped {
+                SummaryProgressStepRow(label: L10n.exportBatchSummaryToGoogleDocs, status: job.progress.googleDocsExport)
+            }
+            ForEach(Array(Set(job.failureMessages)).sorted(), id: \.self) { message in
+                Text(message)
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+                    .lineLimit(2)
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.primary.opacity(0.055), in: RoundedRectangle(cornerRadius: 8))
     }
 }

--- a/Sources/Dahlia/Views/SummaryProgressToastView.swift
+++ b/Sources/Dahlia/Views/SummaryProgressToastView.swift
@@ -7,7 +7,7 @@ struct SummaryProgressToastView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text(L10n.generatingSummary)
+            Text(L10n.runningTasks)
                 .font(.callout)
                 .bold()
                 .foregroundStyle(.primary)

--- a/Sources/Dahlia/Views/Toolbar/SessionControls.swift
+++ b/Sources/Dahlia/Views/Toolbar/SessionControls.swift
@@ -52,7 +52,7 @@ struct GenerateSummaryToolbarButton: View {
     @State private var isConfirmationPresented = false
 
     private var isGeneratingCurrentMeeting: Bool {
-        viewModel.summaryGeneratingMeetingId == viewModel.currentMeetingId
+        viewModel.isSummaryGenerating
     }
 
     var body: some View {

--- a/Tests/DahliaTests/CaptionViewModelSummaryGenerationTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelSummaryGenerationTests.swift
@@ -229,6 +229,116 @@ import GRDB
         }
 
         @Test
+        func pendingAutomaticRequestsKeepDifferentPersistenceContextsSeparate() async throws {
+            let original = try SummaryGenerationFixture()
+            let destination = try SummaryGenerationFixture()
+            defer {
+                original.removeFiles()
+                destination.removeFiles()
+            }
+            try destination.insertMeeting(
+                id: original.first.id,
+                name: "Moved",
+                transcript: "moved transcript"
+            )
+            let runner = BlockingSummaryRunner()
+            let viewModel = CaptionViewModel(summaryGenerationRunner: runner.run)
+            let options = SummaryGenerationOptions(
+                previousMeetingCount: 0,
+                exportOptions: SummaryExportOptions(exportsToVault: false, exportsToGoogleDocs: false)
+            )
+            let originalSessionID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000001"))
+            let destinationSessionID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000002"))
+
+            await original.select(original.first, in: viewModel, note: "manual")
+            viewModel.triggerManualSummary(options: options)
+            await runner.waitForCallCount(1)
+
+            viewModel.registerPendingBatchSummaryForTesting(
+                sessionID: originalSessionID,
+                meetingID: original.first.id,
+                options: options,
+                dbQueue: original.database.dbQueue,
+                vaultURL: original.vaultURL
+            )
+            viewModel.registerPendingBatchSummaryForTesting(
+                sessionID: destinationSessionID,
+                meetingID: original.first.id,
+                options: options,
+                dbQueue: destination.database.dbQueue,
+                vaultURL: destination.vaultURL
+            )
+            await viewModel.handleBatchTranscriptionUpdate(.init(
+                meetingId: original.first.id,
+                state: .completed(sessionId: originalSessionID)
+            ))
+            await viewModel.handleBatchTranscriptionUpdate(.init(
+                meetingId: original.first.id,
+                state: .completed(sessionId: destinationSessionID)
+            ))
+
+            runner.complete(meetingID: original.first.id, title: "Manual")
+            await runner.waitForCallCount(2)
+            runner.complete(meetingID: original.first.id, title: "Original context")
+            await runner.waitForCallCount(3)
+
+            #expect(try original.summary(for: original.first.id)?.loadDocument().title == "Original context")
+            #expect(try destination.summary(for: original.first.id) == nil)
+
+            runner.complete(meetingID: original.first.id, title: "Destination context")
+            #expect(await waitUntil { !viewModel.isSummaryGenerating(meetingId: original.first.id) })
+            #expect(try original.summary(for: original.first.id)?.loadDocument().title == "Original context")
+            #expect(try destination.summary(for: original.first.id)?.loadDocument().title == "Destination context")
+        }
+
+        @Test
+        func completedBatchWithoutSummaryRequestDoesNotRetainSessionID() async {
+            let viewModel = CaptionViewModel()
+
+            await viewModel.handleBatchTranscriptionUpdate(.init(
+                meetingId: .v7(),
+                state: .completed(sessionId: .v7())
+            ))
+
+            #expect(viewModel.completedBatchSummarySessionCountForTesting == 0)
+        }
+
+        @Test
+        func automaticSummaryWaitsUntilScreenshotDeletionFinishes() async throws {
+            let fixture = try SummaryGenerationFixture()
+            defer { fixture.removeFiles() }
+            let runner = BlockingSummaryRunner()
+            let viewModel = CaptionViewModel(summaryGenerationRunner: runner.run)
+            let sessionID = UUID.v7()
+            let options = SummaryGenerationOptions(
+                previousMeetingCount: 0,
+                exportOptions: SummaryExportOptions(exportsToVault: false, exportsToGoogleDocs: false)
+            )
+            viewModel.registerPendingBatchSummaryForTesting(
+                sessionID: sessionID,
+                meetingID: fixture.first.id,
+                options: options,
+                dbQueue: fixture.database.dbQueue,
+                vaultURL: fixture.vaultURL
+            )
+            viewModel.setScreenshotDeletionInProgressForTesting(true)
+
+            await viewModel.handleBatchTranscriptionUpdate(.init(
+                meetingId: fixture.first.id,
+                state: .completed(sessionId: sessionID)
+            ))
+
+            #expect(runner.calls.isEmpty)
+            #expect(viewModel.completedBatchSummarySessionCountForTesting == 1)
+
+            viewModel.setScreenshotDeletionInProgressForTesting(false)
+            await runner.waitForCallCount(1)
+            runner.complete(meetingID: fixture.first.id, title: "After deletion")
+            #expect(await waitUntil { !viewModel.isSummaryGenerating(meetingId: fixture.first.id) })
+            #expect(try fixture.summary(for: fixture.first.id)?.loadDocument().title == "After deletion")
+        }
+
+        @Test
         func backgroundPreparationFailureCreatesDismissibleJob() async throws {
             let fixture = try SummaryGenerationFixture()
             defer { fixture.removeFiles() }
@@ -478,6 +588,28 @@ import GRDB
             )
             try database.dbQueue.write { db in try session.insert(db) }
             return id
+        }
+
+        func insertMeeting(id: UUID, name: String, transcript: String) throws {
+            let createdAt = Date(timeIntervalSince1970: 1_776_384_120)
+            let meeting = MeetingRecord(
+                id: id,
+                vaultId: vault.id,
+                projectId: nil,
+                name: name,
+                createdAt: createdAt,
+                updatedAt: createdAt
+            )
+            let segment = TranscriptSegment(
+                startTime: createdAt,
+                text: transcript,
+                isConfirmed: true,
+                speakerLabel: "mic"
+            )
+            try database.dbQueue.write { db in
+                try meeting.insert(db)
+                try TranscriptSegmentRecord(from: segment, meetingId: id).insert(db)
+            }
         }
 
         func removeFiles() {

--- a/Tests/DahliaTests/CaptionViewModelSummaryGenerationTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelSummaryGenerationTests.swift
@@ -1,0 +1,420 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    @Suite(.serialized)
+    struct CaptionViewModelSummaryGenerationTests {
+        @Test
+        func differentMeetingsRunConcurrentlyAndOnlyUpdateTheirOwnSelection() async throws {
+            let fixture = try SummaryGenerationFixture()
+            defer { fixture.removeFiles() }
+            let runner = BlockingSummaryRunner()
+            let viewModel = CaptionViewModel(summaryGenerationRunner: runner.run)
+            let options = SummaryGenerationOptions(
+                previousMeetingCount: 0,
+                exportOptions: SummaryExportOptions(exportsToVault: false, exportsToGoogleDocs: false)
+            )
+
+            await fixture.select(fixture.first, in: viewModel, note: "first note")
+            viewModel.triggerManualSummary(options: options)
+            await runner.waitForCallCount(1)
+
+            await fixture.select(fixture.second, in: viewModel, note: "second note")
+            viewModel.triggerManualSummary(options: options)
+            await runner.waitForCallCount(2)
+
+            #expect(viewModel.summaryGeneratingMeetingIDs == [fixture.first.id, fixture.second.id])
+            #expect(runner.calls.map(\.meetingID) == [fixture.first.id, fixture.second.id])
+            #expect(runner.calls.map(\.noteText) == ["first note", "second note"])
+
+            runner.complete(meetingID: fixture.first.id, title: "First summary")
+            #expect(await waitUntil { !viewModel.isSummaryGenerating(meetingId: fixture.first.id) })
+            #expect(viewModel.isSummaryGenerating(meetingId: fixture.second.id))
+            #expect(viewModel.currentSummaryDocument == nil)
+
+            runner.complete(meetingID: fixture.second.id, title: "Second summary")
+            #expect(await waitUntil { !viewModel.isSummaryGenerating(meetingId: fixture.second.id) })
+            #expect(viewModel.currentSummaryDocument?.title == "Second summary")
+
+            let firstStored = try fixture.summary(for: fixture.first.id)
+            let secondStored = try fixture.summary(for: fixture.second.id)
+            #expect(try firstStored?.loadDocument().title == "First summary")
+            #expect(try secondStored?.loadDocument().title == "Second summary")
+        }
+
+        @Test
+        func settingsAreFrozenAndFailedJobSurvivesRetryUntilDismissed() async throws {
+            let fixture = try SummaryGenerationFixture()
+            defer { fixture.removeFiles() }
+            let runner = BlockingSummaryRunner()
+            let sleeper = ControlledSummaryJobSleeper()
+            let settings = AppSettings.shared
+            let originalModel = settings.codexModelID
+            let originalEffort = settings.codexReasoningEffort
+            settings.codexModelID = "frozen-model"
+            settings.codexReasoningEffort = "high"
+            defer {
+                settings.codexModelID = originalModel
+                settings.codexReasoningEffort = originalEffort
+            }
+            let viewModel = CaptionViewModel(
+                summaryGenerationRunner: runner.run,
+                summaryJobSleeper: sleeper.sleep
+            )
+            let options = SummaryGenerationOptions(
+                previousMeetingCount: 0,
+                exportOptions: SummaryExportOptions(exportsToVault: false, exportsToGoogleDocs: false)
+            )
+            await fixture.select(fixture.first, in: viewModel, note: "note")
+
+            viewModel.triggerManualSummary(options: options)
+            await runner.waitForCallCount(1)
+            settings.codexModelID = "changed-model"
+            settings.codexReasoningEffort = "low"
+            #expect(runner.calls[0].settings.modelID == "frozen-model")
+            #expect(runner.calls[0].settings.reasoningEffort == "high")
+
+            runner.fail(meetingID: fixture.first.id)
+            #expect(await waitUntil { !viewModel.isSummaryGenerating(meetingId: fixture.first.id) })
+            let failedJobID = try #require(viewModel.summaryGenerationJobs.first(where: \.hasFailure)?.id)
+
+            viewModel.triggerManualSummary(options: options)
+            await runner.waitForCallCount(2)
+            #expect(viewModel.summaryGenerationJobs.contains { $0.id == failedJobID })
+            #expect(viewModel.summaryGenerationJobs.count == 2)
+
+            runner.complete(meetingID: fixture.first.id, title: "Recovered")
+            #expect(await waitUntil { !viewModel.isSummaryGenerating(meetingId: fixture.first.id) })
+            await sleeper.waitUntilSleeping()
+            #expect(viewModel.summaryGenerationJobs.count == 2)
+            await sleeper.resume()
+            #expect(await waitUntil { viewModel.summaryGenerationJobs.count == 1 })
+            #expect(viewModel.summaryGenerationJobs[0].id == failedJobID)
+
+            viewModel.dismissSummaryGenerationJob(failedJobID)
+            #expect(viewModel.summaryGenerationJobs.isEmpty)
+        }
+
+        @Test
+        func automaticRequestsWaitForTheirSessionsAndCoalesceAfterTheActiveJob() async throws {
+            let fixture = try SummaryGenerationFixture()
+            defer { fixture.removeFiles() }
+            let runner = BlockingSummaryRunner()
+            let viewModel = CaptionViewModel(summaryGenerationRunner: runner.run)
+            let options = SummaryGenerationOptions(
+                previousMeetingCount: 0,
+                exportOptions: SummaryExportOptions(exportsToVault: false, exportsToGoogleDocs: false)
+            )
+            await fixture.select(fixture.first, in: viewModel, note: "manual")
+            viewModel.triggerManualSummary(options: options)
+            await runner.waitForCallCount(1)
+            await fixture.select(fixture.second, in: viewModel, note: "visible")
+
+            let firstSessionID = try fixture.insertRecordingSession(for: fixture.first, offset: 0)
+            let secondSessionID = UUID.v7()
+            viewModel.registerPendingBatchSummaryForTesting(
+                sessionID: firstSessionID,
+                meetingID: fixture.first.id,
+                options: options,
+                dbQueue: fixture.database.dbQueue,
+                vaultURL: fixture.vaultURL
+            )
+            viewModel.registerPendingBatchSummaryForTesting(
+                sessionID: secondSessionID,
+                meetingID: fixture.first.id,
+                options: options,
+                dbQueue: fixture.database.dbQueue,
+                vaultURL: fixture.vaultURL
+            )
+            await viewModel.handleBatchTranscriptionUpdate(.init(
+                meetingId: fixture.first.id,
+                state: .completed(sessionId: firstSessionID)
+            ))
+            #expect(runner.calls.count == 1)
+
+            runner.complete(meetingID: fixture.first.id, title: "Manual")
+            await runner.waitForCallCount(2)
+            #expect(runner.calls[1].recordingSessionIDs == [firstSessionID])
+
+            _ = try fixture.insertRecordingSession(
+                for: fixture.first,
+                id: secondSessionID,
+                offset: 60
+            )
+            await viewModel.handleBatchTranscriptionUpdate(.init(
+                meetingId: fixture.first.id,
+                state: .completed(sessionId: secondSessionID)
+            ))
+            #expect(runner.calls.count == 2)
+
+            runner.complete(meetingID: fixture.first.id, title: "First automatic")
+            await runner.waitForCallCount(3)
+            #expect(Set(runner.calls[2].recordingSessionIDs) == [firstSessionID, secondSessionID])
+            runner.complete(meetingID: fixture.first.id, title: "Second automatic")
+            #expect(await waitUntil { !viewModel.isSummaryGenerating(meetingId: fixture.first.id) })
+            #expect(runner.calls.count == 3)
+            #expect(viewModel.currentMeetingId == fixture.second.id)
+            #expect(viewModel.currentSummaryDocument == nil)
+        }
+
+        @Test
+        func backgroundPreparationFailureCreatesDismissibleJob() async throws {
+            let fixture = try SummaryGenerationFixture()
+            defer { fixture.removeFiles() }
+            let viewModel = CaptionViewModel()
+            let missingMeetingID = UUID.v7()
+            let sessionID = UUID.v7()
+            viewModel.registerPendingBatchSummaryForTesting(
+                sessionID: sessionID,
+                meetingID: missingMeetingID,
+                options: SummaryGenerationOptions(
+                    previousMeetingCount: 0,
+                    exportOptions: SummaryExportOptions(exportsToVault: false, exportsToGoogleDocs: false)
+                ),
+                dbQueue: fixture.database.dbQueue,
+                vaultURL: fixture.vaultURL
+            )
+
+            await viewModel.handleBatchTranscriptionUpdate(.init(
+                meetingId: missingMeetingID,
+                state: .completed(sessionId: sessionID)
+            ))
+
+            let failedJob = try #require(viewModel.summaryGenerationJobs.first)
+            #expect(failedJob.meetingId == missingMeetingID)
+            #expect(failedJob.hasFailure)
+            #expect(failedJob.isFinished)
+            viewModel.dismissSummaryGenerationJob(failedJob.id)
+            #expect(viewModel.summaryGenerationJobs.isEmpty)
+        }
+
+        @Test
+        func batchConfirmationKeepsOriginalDatabaseAndVaultAfterNavigation() async throws {
+            let original = try SummaryGenerationFixture()
+            let destination = try SummaryGenerationFixture()
+            defer {
+                original.removeFiles()
+                destination.removeFiles()
+            }
+            let runner = BlockingSummaryRunner()
+            let viewModel = CaptionViewModel(summaryGenerationRunner: runner.run)
+            let options = SummaryGenerationOptions(
+                previousMeetingCount: 0,
+                exportOptions: SummaryExportOptions(exportsToVault: false, exportsToGoogleDocs: false)
+            )
+            await original.select(original.first, in: viewModel, note: "original")
+            let sessionID = try original.insertRecordingSession(for: original.first, offset: 0)
+            viewModel.presentBatchTranscriptionConfirmation(
+                sessionId: sessionID,
+                meetingId: original.first.id,
+                dbQueue: original.database.dbQueue
+            )
+
+            await destination.select(destination.first, in: viewModel, note: "destination")
+            viewModel.confirmPendingBatchSummaryForTesting(
+                sessionID: sessionID,
+                meetingID: original.first.id,
+                options: options
+            )
+            await viewModel.handleBatchTranscriptionUpdate(.init(
+                meetingId: original.first.id,
+                state: .completed(sessionId: sessionID)
+            ))
+            await runner.waitForCallCount(1)
+
+            #expect(runner.calls[0].meetingID == original.first.id)
+            runner.complete(meetingID: original.first.id, title: "Original summary")
+            #expect(await waitUntil { !viewModel.isSummaryGenerating(meetingId: original.first.id) })
+            #expect(try original.summary(for: original.first.id) != nil)
+            #expect(try destination.summary(for: original.first.id) == nil)
+            #expect(viewModel.currentMeetingId == destination.first.id)
+            #expect(viewModel.currentSummaryDocument == nil)
+        }
+
+        private func waitUntil(
+            attempts: Int = 200,
+            condition: @escaping @MainActor () -> Bool
+        ) async -> Bool {
+            for _ in 0 ..< attempts {
+                if condition() { return true }
+                await Task.yield()
+            }
+            return condition()
+        }
+    }
+
+    @MainActor
+    private final class BlockingSummaryRunner {
+        struct Call {
+            let meetingID: UUID
+            let noteText: String?
+            let settings: SummaryGenerationSettings
+            let recordingSessionIDs: [UUID]
+        }
+
+        enum TestError: Error {
+            case failed
+        }
+
+        private(set) var calls: [Call] = []
+        private var continuations: [UUID: CheckedContinuation<Result<SummaryService.GeneratedSummary, Error>, Never>] = [:]
+        private var callWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+
+        func run(_ input: SummaryGenerationRunnerInput) async throws -> SummaryService.GeneratedSummary {
+            calls.append(Call(
+                meetingID: input.promptContext.meetingId,
+                noteText: input.noteText,
+                settings: input.generationSettings,
+                recordingSessionIDs: input.recordingSessions.map(\.id)
+            ))
+            resumeCallWaiters()
+            let result = await withCheckedContinuation { continuation in
+                continuations[input.promptContext.meetingId] = continuation
+            }
+            return try result.get()
+        }
+
+        func waitForCallCount(_ count: Int) async {
+            if calls.count >= count { return }
+            await withCheckedContinuation { continuation in
+                callWaiters.append((count, continuation))
+            }
+        }
+
+        func complete(meetingID: UUID, title: String) {
+            continuations.removeValue(forKey: meetingID)?.resume(returning: .success(.init(
+                document: SummaryDocument(title: title, sections: []),
+                fileName: "summary.md",
+                markdown: title
+            )))
+        }
+
+        func fail(meetingID: UUID) {
+            continuations.removeValue(forKey: meetingID)?.resume(returning: .failure(TestError.failed))
+        }
+
+        private func resumeCallWaiters() {
+            let ready = callWaiters.filter { calls.count >= $0.count }
+            callWaiters.removeAll { calls.count >= $0.count }
+            ready.forEach { $0.continuation.resume() }
+        }
+    }
+
+    private actor ControlledSummaryJobSleeper {
+        private var continuation: CheckedContinuation<Void, Never>?
+        private var waiter: CheckedContinuation<Void, Never>?
+
+        func sleep(for _: Duration) async throws {
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+                waiter?.resume()
+                waiter = nil
+            }
+        }
+
+        func waitUntilSleeping() async {
+            if continuation != nil { return }
+            await withCheckedContinuation { waiter = $0 }
+        }
+
+        func resume() {
+            continuation?.resume()
+            continuation = nil
+        }
+    }
+
+    @MainActor
+    private final class SummaryGenerationFixture {
+        let database: AppDatabaseManager
+        let vault: VaultRecord
+        let vaultURL: URL
+        let first: MeetingRecord
+        let second: MeetingRecord
+
+        init() throws {
+            database = try AppDatabaseManager(path: ":memory:")
+            vaultURL = FileManager.default.temporaryDirectory
+                .appending(path: "dahlia-summary-vm-\(UUID.v7())", directoryHint: .isDirectory)
+            try FileManager.default.createDirectory(at: vaultURL, withIntermediateDirectories: true)
+            let now = Date(timeIntervalSince1970: 1_776_384_000)
+            vault = VaultRecord(id: .v7(), path: vaultURL.path, name: "Test", createdAt: now, lastOpenedAt: now)
+            first = MeetingRecord(
+                id: .v7(), vaultId: vault.id, projectId: nil, name: "First", createdAt: now, updatedAt: now
+            )
+            second = MeetingRecord(
+                id: .v7(),
+                vaultId: vault.id,
+                projectId: nil,
+                name: "Second",
+                createdAt: now.addingTimeInterval(60),
+                updatedAt: now.addingTimeInterval(60)
+            )
+            let firstSegment = TranscriptSegment(
+                startTime: now, text: "first transcript", isConfirmed: true, speakerLabel: "mic"
+            )
+            let secondSegment = TranscriptSegment(
+                startTime: now.addingTimeInterval(60), text: "second transcript", isConfirmed: true, speakerLabel: "mic"
+            )
+            try database.dbQueue.write { db in
+                try vault.insert(db)
+                try first.insert(db)
+                try second.insert(db)
+                try TranscriptSegmentRecord(from: firstSegment, meetingId: first.id).insert(db)
+                try TranscriptSegmentRecord(from: secondSegment, meetingId: second.id).insert(db)
+            }
+        }
+
+        func select(_ meeting: MeetingRecord, in viewModel: CaptionViewModel, note: String) async {
+            viewModel.loadMeeting(
+                meeting.id,
+                dbQueue: database.dbQueue,
+                projectURL: nil,
+                projectId: nil,
+                vaultURL: vaultURL
+            )
+            for _ in 0 ..< 200 {
+                if viewModel.currentMeetingId == meeting.id,
+                   viewModel.currentMeetingHasTranscriptSegments { break }
+                await Task.yield()
+            }
+            viewModel.noteText = note
+        }
+
+        func summary(for meetingID: UUID) throws -> SummaryRecord? {
+            try database.dbQueue.read { db in
+                try SummaryRecord.fetchOne(db, key: meetingID)
+            }
+        }
+
+        func insertRecordingSession(
+            for meeting: MeetingRecord,
+            id: UUID = .v7(),
+            offset: TimeInterval
+        ) throws -> UUID {
+            let startedAt = meeting.createdAt.addingTimeInterval(offset)
+            let session = RecordingSessionRecord(
+                id: id,
+                meetingId: meeting.id,
+                startedAt: startedAt,
+                endedAt: startedAt.addingTimeInterval(30),
+                duration: 30,
+                offsetSeconds: offset,
+                createdAt: startedAt,
+                updatedAt: startedAt,
+                transcriptionMode: .batch,
+                retainAudioAfterBatch: false,
+                batchCompletedAt: startedAt.addingTimeInterval(30)
+            )
+            try database.dbQueue.write { db in try session.insert(db) }
+            return id
+        }
+
+        func removeFiles() {
+            try? FileManager.default.removeItem(at: vaultURL)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/CaptionViewModelSummaryGenerationTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelSummaryGenerationTests.swift
@@ -9,6 +9,73 @@ import GRDB
     @Suite(.serialized)
     struct CaptionViewModelSummaryGenerationTests {
         @Test
+        func selectedMeetingsRegenerateConcurrentlyWithoutChangingCurrentMeeting() async throws {
+            let fixture = try SummaryGenerationFixture()
+            defer { fixture.removeFiles() }
+            let runner = BlockingSummaryRunner()
+            let viewModel = CaptionViewModel(summaryGenerationRunner: runner.run)
+            let meetingIDs: Set<UUID> = [fixture.first.id, fixture.second.id]
+            let options = SummaryGenerationOptions(
+                previousMeetingCount: 0,
+                exportOptions: SummaryExportOptions(exportsToVault: false, exportsToGoogleDocs: false)
+            )
+
+            #expect(viewModel.canRegenerateSummaries(meetingIds: meetingIDs))
+            viewModel.triggerManualSummaries(
+                meetingIds: meetingIDs,
+                dbQueue: fixture.database.dbQueue,
+                vaultURL: fixture.vaultURL,
+                options: options
+            )
+            await runner.waitForCallCount(2)
+
+            #expect(Set(runner.calls.map(\.meetingID)) == meetingIDs)
+            #expect(viewModel.summaryGeneratingMeetingIDs == meetingIDs)
+            #expect(!viewModel.canRegenerateSummaries(meetingIds: meetingIDs))
+            #expect(viewModel.currentMeetingId == nil)
+
+            runner.complete(meetingID: fixture.first.id, title: "First regenerated")
+            runner.complete(meetingID: fixture.second.id, title: "Second regenerated")
+            #expect(await waitUntil { viewModel.summaryGeneratingMeetingIDs.isEmpty })
+            #expect(try fixture.summary(for: fixture.first.id) != nil)
+            #expect(try fixture.summary(for: fixture.second.id) != nil)
+            #expect(viewModel.currentMeetingId == nil)
+        }
+
+        @Test
+        func selectedMeetingRegenerationSkipsMeetingAlreadyGenerating() async throws {
+            let fixture = try SummaryGenerationFixture()
+            defer { fixture.removeFiles() }
+            let runner = BlockingSummaryRunner()
+            let viewModel = CaptionViewModel(summaryGenerationRunner: runner.run)
+            let meetingIDs: Set<UUID> = [fixture.first.id, fixture.second.id]
+            let options = SummaryGenerationOptions(
+                previousMeetingCount: 0,
+                exportOptions: SummaryExportOptions(exportsToVault: false, exportsToGoogleDocs: false)
+            )
+
+            await fixture.select(fixture.first, in: viewModel, note: "first")
+            viewModel.triggerManualSummary(options: options)
+            await runner.waitForCallCount(1)
+
+            #expect(viewModel.canRegenerateSummaries(meetingIds: meetingIDs))
+            viewModel.triggerManualSummaries(
+                meetingIds: meetingIDs,
+                dbQueue: fixture.database.dbQueue,
+                vaultURL: fixture.vaultURL,
+                options: options
+            )
+            await runner.waitForCallCount(2)
+
+            #expect(runner.calls.count(where: { $0.meetingID == fixture.first.id }) == 1)
+            #expect(runner.calls.count(where: { $0.meetingID == fixture.second.id }) == 1)
+
+            runner.complete(meetingID: fixture.first.id, title: "First")
+            runner.complete(meetingID: fixture.second.id, title: "Second")
+            #expect(await waitUntil { viewModel.summaryGeneratingMeetingIDs.isEmpty })
+        }
+
+        @Test
         func differentMeetingsRunConcurrentlyAndOnlyUpdateTheirOwnSelection() async throws {
             let fixture = try SummaryGenerationFixture()
             defer { fixture.removeFiles() }

--- a/Tests/DahliaTests/CaptionViewModelTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelTests.swift
@@ -209,12 +209,24 @@ import GRDB
         }
 
         @Test
-        func canGenerateSummaryIsDisabledWhileAnotherSummaryIsGenerating() {
+        func canGenerateSummaryRemainsEnabledWhileAnotherMeetingSummaryIsGenerating() {
             let viewModel = summaryReadyViewModel()
+            let currentMeetingID = viewModel.currentMeetingId
 
             #expect(viewModel.canGenerateSummary)
 
-            viewModel.summaryGeneratingMeetingId = UUID.v7()
+            viewModel.summaryGeneratingMeetingIDs = [UUID.v7()]
+
+            #expect(viewModel.canGenerateSummary)
+            #expect(currentMeetingID != nil)
+        }
+
+        @Test
+        func canGenerateSummaryIsDisabledForTheGeneratingMeeting() throws {
+            let viewModel = summaryReadyViewModel()
+            let currentMeetingID = try #require(viewModel.currentMeetingId)
+
+            viewModel.summaryGeneratingMeetingIDs = [currentMeetingID]
 
             #expect(!viewModel.canGenerateSummary)
         }
@@ -227,7 +239,7 @@ import GRDB
             viewModel.triggerManualSummary()
 
             #expect(!viewModel.requestShowSummaryTab)
-            #expect(viewModel.summaryGeneratingMeetingId == nil)
+            #expect(viewModel.summaryGeneratingMeetingIDs.isEmpty)
         }
 
         @Test

--- a/Tests/DahliaTests/CodexAppServerConcurrencyTests.swift
+++ b/Tests/DahliaTests/CodexAppServerConcurrencyTests.swift
@@ -1,0 +1,266 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct CodexAppServerConcurrencyTests {
+        @Test
+        func cancellingOneConcurrentGenerationDoesNotInterruptTheOther() async throws {
+            let transport = TestCodexAppServerTransport(mode: .generationBlocks)
+            let service = CodexAppServerService(transportFactory: { transport })
+            let first = Task { try await service.generate(request) }
+            let second = Task { try await service.generate(request) }
+
+            try await service.waitUntilActiveTurnCountForTesting(2)
+            first.cancel()
+            await transport.waitUntilSent("turn/interrupt")
+
+            let messages = await transport.messages()
+            let interrupted = try #require(messages.last {
+                $0.objectValue?["method"]?.stringValue == "turn/interrupt"
+            }?.objectValue?["params"]?.objectValue)
+            let interruptedThreadID = try #require(interrupted["threadId"]?.stringValue)
+            let interruptedTurnID = try #require(interrupted["turnId"]?.stringValue)
+            let remaining = try #require(startedTurns(in: messages).first {
+                $0.threadID != interruptedThreadID || $0.turnID != interruptedTurnID
+            })
+            assertDistinctGenerationContexts(in: messages)
+
+            await completeTurn(remaining, text: #"{"status":"remaining"}"#, transport: transport)
+
+            await #expect(throws: CancellationError.self) { _ = try await first.value }
+            #expect(try await second.value == #"{"status":"remaining"}"#)
+            let methods = messages.compactMap { $0.objectValue?["method"]?.stringValue }
+            #expect(methods.count(where: { $0 == "turn/start" }) == 2)
+            #expect(methods.count(where: { $0 == "turn/interrupt" }) == 1)
+            await service.shutdown()
+        }
+
+        @Test
+        func concurrentGenerationsCompleteOutOfOrderIndependently() async throws {
+            let transport = TestCodexAppServerTransport(mode: .generationBlocks)
+            let service = CodexAppServerService(transportFactory: { transport })
+            let first = Task { try await service.generate(request) }
+            let second = Task { try await service.generate(request) }
+
+            try await service.waitUntilActiveTurnCountForTesting(2)
+            let messages = await transport.messages()
+            let turns = startedTurns(in: messages)
+            #expect(turns.count == 2)
+            assertDistinctGenerationContexts(in: messages)
+
+            await completeTurn(turns[1], text: #"{"order":"second"}"#, transport: transport)
+            await completeTurn(turns[0], text: #"{"order":"first"}"#, transport: transport)
+
+            let firstValue = try await first.value
+            let secondValue = try await second.value
+            let results = [firstValue, secondValue]
+            #expect(Set(results) == [#"{"order":"first"}"#, #"{"order":"second"}"#])
+            await service.shutdown()
+        }
+
+        @Test
+        func failedConcurrentGenerationDoesNotInterruptTheOther() async throws {
+            let transport = TestCodexAppServerTransport(mode: .generationBlocks)
+            let service = CodexAppServerService(transportFactory: { transport })
+            let first = Task { try await service.generate(request) }
+            let second = Task { try await service.generate(request) }
+
+            try await service.waitUntilActiveTurnCountForTesting(2)
+            let turns = startedTurns(in: await transport.messages())
+            await failTurn(turns[0], transport: transport)
+            await completeTurn(turns[1], text: #"{"status":"survived"}"#, transport: transport)
+
+            let results = [await result(of: first), await result(of: second)]
+            #expect(results.count(where: {
+                guard case let .success(value) = $0 else { return false }
+                return value == #"{"status":"survived"}"#
+            }) == 1)
+            #expect(results.count(where: { result in
+                guard case let .failure(error) = result else { return false }
+                return error is CodexAppServerError
+            }) == 1)
+            await service.shutdown()
+        }
+
+        @Test
+        func timedOutConcurrentGenerationDoesNotInterruptTheOther() async throws {
+            let timeout = Duration.seconds(270)
+            let clock = SummaryTimeoutTestClock(summaryTimeout: timeout)
+            let transport = TestCodexAppServerTransport(mode: .generationBlocks)
+            let service = CodexAppServerService(
+                transportFactory: { transport },
+                clock: clock,
+                summaryTimeout: timeout
+            )
+            let first = Task { try await service.generate(request) }
+            let second = Task { try await service.generate(request) }
+
+            try await service.waitUntilActiveTurnCountForTesting(2)
+            await clock.waitForSummarySleeps(2)
+            await clock.fireNextSummaryTimeout()
+            await transport.waitUntilSent("turn/interrupt")
+
+            let messages = await transport.messages()
+            let interrupted = try #require(messages.last {
+                $0.objectValue?["method"]?.stringValue == "turn/interrupt"
+            }?.objectValue?["params"]?.objectValue)
+            let remaining = try #require(startedTurns(in: messages).first {
+                $0.threadID != interrupted["threadId"]?.stringValue
+                    || $0.turnID != interrupted["turnId"]?.stringValue
+            })
+            await completeTurn(remaining, text: #"{"status":"survived"}"#, transport: transport)
+
+            let results = [await result(of: first), await result(of: second)]
+            #expect(results.count(where: {
+                guard case let .success(value) = $0 else { return false }
+                return value == #"{"status":"survived"}"#
+            }) == 1)
+            #expect(results.count(where: { result in
+                guard case let .failure(error) = result,
+                      let appServerError = error as? CodexAppServerError,
+                      case let .requestTimedOut(operation) = appServerError else { return false }
+                return operation == "summary"
+            }) == 1)
+            await service.shutdown()
+        }
+
+        private var request: CodexAppServerRequest {
+            CodexAppServerRequest(
+                model: nil,
+                developerInstructions: "Summarize.",
+                inputs: [.text("Transcript")],
+                outputSchema: Data(#"{"type":"object"}"#.utf8)
+            )
+        }
+
+        private func startedTurns(in messages: [JSONValue]) -> [(threadID: String, turnID: String)] {
+            messages.enumerated().compactMap { offset, message in
+                guard message.objectValue?["method"]?.stringValue == "turn/start",
+                      let threadID = message.objectValue?["params"]?.objectValue?["threadId"]?.stringValue else { return nil }
+                let index = messages[...offset].count { $0.objectValue?["method"]?.stringValue == "turn/start" }
+                return (threadID, "turn-\(index)")
+            }
+        }
+
+        private func completeTurn(
+            _ turn: (threadID: String, turnID: String),
+            text: String,
+            transport: TestCodexAppServerTransport
+        ) async {
+            await transport.sendFromServer(.object([
+                "method": .string("item/completed"),
+                "params": .object([
+                    "threadId": .string(turn.threadID),
+                    "turnId": .string(turn.turnID),
+                    "item": .object([
+                        "id": .string("item-remaining"),
+                        "type": .string("agentMessage"),
+                        "text": .string(text),
+                    ]),
+                ]),
+            ]))
+            await transport.sendFromServer(.object([
+                "method": .string("turn/completed"),
+                "params": .object([
+                    "threadId": .string(turn.threadID),
+                    "turn": .object([
+                        "id": .string(turn.turnID),
+                        "status": .string("completed"),
+                        "items": .array([]),
+                    ]),
+                ]),
+            ]))
+        }
+
+        private func failTurn(
+            _ turn: (threadID: String, turnID: String),
+            transport: TestCodexAppServerTransport
+        ) async {
+            await transport.sendFromServer(.object([
+                "method": .string("turn/completed"),
+                "params": .object([
+                    "threadId": .string(turn.threadID),
+                    "turn": .object([
+                        "id": .string(turn.turnID),
+                        "status": .string("failed"),
+                        "error": .object(["message": .string("failed")]),
+                    ]),
+                ]),
+            ]))
+        }
+
+        private func result(of task: Task<String, any Error>) async -> Result<String, any Error> {
+            do {
+                return .success(try await task.value)
+            } catch {
+                return .failure(error)
+            }
+        }
+
+        private func assertDistinctGenerationContexts(in messages: [JSONValue]) {
+            let turns = startedTurns(in: messages)
+            #expect(Set(turns.map(\.threadID)).count == 2)
+            #expect(Set(turns.map(\.turnID)).count == 2)
+            let workingDirectories = messages.compactMap { message -> String? in
+                guard message.objectValue?["method"]?.stringValue == "thread/start" else { return nil }
+                return message.objectValue?["params"]?.objectValue?["cwd"]?.stringValue
+            }
+            #expect(Set(workingDirectories).count == 2)
+        }
+    }
+
+    private actor SummaryTimeoutTestClock: CodexAppServerClock {
+        private let summaryTimeout: Duration
+        private var summarySleepOrder: [UUID] = []
+        private var summarySleepContinuations: [UUID: CheckedContinuation<Void, any Error>] = [:]
+        private var sleepWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+
+        init(summaryTimeout: Duration) {
+            self.summaryTimeout = summaryTimeout
+        }
+
+        func sleep(for duration: Duration) async throws {
+            guard duration == summaryTimeout else {
+                try await Task.sleep(for: duration)
+                return
+            }
+            let id = UUID.v7()
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    summarySleepOrder.append(id)
+                    summarySleepContinuations[id] = continuation
+                    resumeSleepWaiters()
+                }
+            } onCancel: {
+                Task { await self.cancelSleep(id) }
+            }
+        }
+
+        func waitForSummarySleeps(_ count: Int) async {
+            if summarySleepContinuations.count >= count { return }
+            await withCheckedContinuation { continuation in
+                sleepWaiters.append((count, continuation))
+            }
+        }
+
+        func fireNextSummaryTimeout() {
+            guard let id = summarySleepOrder.first else { return }
+            summarySleepOrder.removeFirst()
+            summarySleepContinuations.removeValue(forKey: id)?.resume()
+        }
+
+        private func cancelSleep(_ id: UUID) {
+            summarySleepOrder.removeAll { $0 == id }
+            summarySleepContinuations.removeValue(forKey: id)?.resume(throwing: CancellationError())
+        }
+
+        private func resumeSleepWaiters() {
+            let ready = sleepWaiters.filter { summarySleepContinuations.count >= $0.count }
+            sleepWaiters.removeAll { summarySleepContinuations.count >= $0.count }
+            ready.forEach { $0.continuation.resume() }
+        }
+    }
+#endif

--- a/Tests/DahliaTests/SummaryProgressStateTests.swift
+++ b/Tests/DahliaTests/SummaryProgressStateTests.swift
@@ -19,28 +19,20 @@
         }
 
         @Test
-        func resetRestoresGoogleDocsExportToPending() {
-            let state = SummaryProgressState()
-            state.googleDocsExport = .failed("offline")
+        func generationJobsKeepMeetingProgressAndFailuresIndependent() {
+            let first = SummaryGenerationJob(meetingId: .v7(), meetingName: "Planning")
+            let second = SummaryGenerationJob(meetingId: .v7(), meetingName: "Review")
 
-            state.reset()
+            first.progress.summaryGeneration = .failed("offline")
+            first.progress.vaultExport = .skipped
+            first.progress.googleDocsExport = .skipped
+            second.progress.summaryGeneration = .running
 
-            #expect(!state.googleDocsExport.isTerminal)
-        }
-
-        @Test
-        func delayedDismissDoesNotHideNewerProgress() {
-            let state = SummaryProgressState()
-            let firstPresentationID = state.show()
-            let secondPresentationID = state.show()
-
-            state.dismiss(ifCurrent: firstPresentationID)
-
-            #expect(state.isVisible)
-
-            state.dismiss(ifCurrent: secondPresentationID)
-
-            #expect(!state.isVisible)
+            #expect(first.hasFailure)
+            #expect(first.isFinished)
+            #expect(first.failureMessages == ["offline"])
+            #expect(!second.hasFailure)
+            #expect(second.failureMessages.isEmpty)
         }
     }
 #endif

--- a/Tests/DahliaTests/SummaryProgressStateTests.swift
+++ b/Tests/DahliaTests/SummaryProgressStateTests.swift
@@ -24,15 +24,17 @@
             let second = SummaryGenerationJob(meetingId: .v7(), meetingName: "Review")
 
             first.progress.summaryGeneration = .failed("offline")
-            first.progress.vaultExport = .skipped
-            first.progress.googleDocsExport = .skipped
+            first.progress.vaultExport = .failed("offline")
+            first.progress.googleDocsExport = .failed("offline")
             second.progress.summaryGeneration = .running
 
             #expect(first.hasFailure)
             #expect(first.isFinished)
-            #expect(first.failureMessages == ["offline"])
+            #expect(first.progress.summaryGeneration.failureMessage == "offline")
+            #expect(first.progress.vaultExport.failureMessage == "offline")
+            #expect(first.progress.googleDocsExport.failureMessage == "offline")
             #expect(!second.hasFailure)
-            #expect(second.failureMessages.isEmpty)
+            #expect(second.progress.summaryGeneration.failureMessage == nil)
         }
     }
 #endif

--- a/Tests/DahliaTests/TestCodexAppServerTransport.swift
+++ b/Tests/DahliaTests/TestCodexAppServerTransport.swift
@@ -27,6 +27,8 @@ actor TestCodexAppServerTransport: CodexAppServerTransport {
     private var receiveContinuation: CheckedContinuation<Data?, Never>?
     private var methodWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
     private var modelListCount = 0
+    private var threadStartCount = 0
+    private var turnStartCount = 0
     private var heldRequestID: Int?
     private var closeContinuation: CheckedContinuation<Void, Never>?
     private var didStartClosing = false
@@ -50,10 +52,12 @@ actor TestCodexAppServerTransport: CodexAppServerTransport {
         resumeMethodWaiters(method)
 
         guard let requestID = object["id"]?.intValue else { return }
-        enqueueResponse(to: requestID, method: method)
+        enqueueResponse(to: requestID, method: method, request: object)
     }
 
-    private func enqueueResponse(to requestID: Int, method: String) {
+    private func enqueueResponse(to requestID: Int, method: String, request: [String: JSONValue]) {
+        if enqueueGenerationLifecycleResponse(to: requestID, method: method, request: request) { return }
+
         switch method {
         case "initialize":
             enqueueInitializeResponse(requestID: requestID)
@@ -94,17 +98,33 @@ actor TestCodexAppServerTransport: CodexAppServerTransport {
                 "origins": .object([:]),
                 "layers": .null,
             ])))
-        case "thread/start":
-            enqueue(response(id: requestID, result: .object([
-                "thread": .object(["id": .string("thread-1")]),
-            ])))
-        case "turn/start":
-            enqueueTurnStartResponse(requestID: requestID)
         case "turn/interrupt", "thread/unsubscribe":
             enqueue(response(id: requestID, result: .object([:])))
         default:
             enqueueTestResponse(to: requestID, method: method)
         }
+    }
+
+    private func enqueueGenerationLifecycleResponse(
+        to requestID: Int,
+        method: String,
+        request: [String: JSONValue]
+    ) -> Bool {
+        if method == "thread/start" {
+            threadStartCount += 1
+            enqueue(response(id: requestID, result: .object([
+                "thread": .object(["id": .string("thread-\(threadStartCount)")]),
+            ])))
+            return true
+        }
+        if method == "turn/start" {
+            enqueueTurnStartResponse(
+                requestID: requestID,
+                threadID: request["params"]?.objectValue?["threadId"]?.stringValue ?? "thread-1"
+            )
+            return true
+        }
+        return false
     }
 
     private func enqueueAccountReadResponse(requestID: Int) {
@@ -211,10 +231,12 @@ actor TestCodexAppServerTransport: CodexAppServerTransport {
         ])))
     }
 
-    private func enqueueTurnStartResponse(requestID: Int) {
+    private func enqueueTurnStartResponse(requestID: Int, threadID: String) {
+        turnStartCount += 1
+        let turnID = "turn-\(turnStartCount)"
         enqueue(response(id: requestID, result: .object([
             "turn": .object([
-                "id": .string("turn-1"),
+                "id": .string(turnID),
                 "status": .string("inProgress"),
             ]),
         ])))
@@ -226,9 +248,9 @@ actor TestCodexAppServerTransport: CodexAppServerTransport {
             enqueue(jsonValue: .object([
                 "method": .string("turn/completed"),
                 "params": .object([
-                    "threadId": .string("thread-1"),
+                    "threadId": .string(threadID),
                     "turn": .object([
-                        "id": .string("turn-1"),
+                        "id": .string(turnID),
                         "status": .string("failed"),
                         "error": .object(error),
                     ]),
@@ -240,8 +262,8 @@ actor TestCodexAppServerTransport: CodexAppServerTransport {
         enqueue(jsonValue: .object([
             "method": .string("item/completed"),
             "params": .object([
-                "threadId": .string("thread-1"),
-                "turnId": .string("turn-1"),
+                "threadId": .string(threadID),
+                "turnId": .string(turnID),
                 "item": .object([
                     "id": .string("item-1"),
                     "type": .string("agentMessage"),
@@ -252,9 +274,9 @@ actor TestCodexAppServerTransport: CodexAppServerTransport {
         enqueue(jsonValue: .object([
             "method": .string("turn/completed"),
             "params": .object([
-                "threadId": .string("thread-1"),
+                "threadId": .string(threadID),
                 "turn": .object([
-                    "id": .string("turn-1"),
+                    "id": .string(turnID),
                     "status": .string("completed"),
                     "items": .array([]),
                 ]),


### PR DESCRIPTION
## Summary

- run summary generation concurrently across different meetings while preventing same-meeting overlap
- snapshot meeting, database, Vault, and generation settings for each job and coalesce repeated automatic requests
- show a scrollable per-meeting progress list, automatically removing successes while retaining failures until dismissal
- isolate Codex app-server threads, turns, cancellation, timeout, and temporary directories for concurrent generations
- bump the app version from 0.6.1 (29) to 0.6.2 (30)
- regenerate summaries for multiple sidebar-selected meetings as independent concurrent jobs

## Why

The previous ViewModel tracked one global summary operation, so generating a summary for one meeting blocked every other meeting. Background batch completions also depended on the currently selected meeting. This refactor scopes orchestration, persistence, and progress state by meeting while retaining the existing shared connection/configuration caches and Google Docs output serialization.

## Validation

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build`
- `plutil -lint Resources/Info.plist`
- targeted tests: 97 tests in 7 suites passed
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test`: 843 Swift Testing tests in 141 suites and 3 XCTest tests passed
- `CI=true ./scripts/lint.sh`: SwiftFormat checked 436 files with no formatting changes; SwiftLint completed with existing non-blocking warnings
- deep review completed; detected major findings were addressed
