### PR TITLE
Add microphone diagnostics and live log tail

### DIFF
--- a/Sources/Dahlia/Audio/AudioCaptureManager+CaptureSetup.swift
+++ b/Sources/Dahlia/Audio/AudioCaptureManager+CaptureSetup.swift
@@ -2,6 +2,50 @@
 import CoreAudio
 
 extension AudioCaptureManager {
+    func prepareCaptureAttempt(
+        inputNode: AVAudioInputNode,
+        targetFormat: AVAudioFormat,
+        selectedDeviceID: AudioDeviceID?,
+        enablesVoiceProcessing: Bool,
+        diagnosticCaptureID: UUID
+    ) throws -> (hardware: AVAudioFormat, source: AVAudioFormat, converter: AVAudioConverter) {
+        try configureVoiceProcessingInput(
+            inputNode,
+            enabled: enablesVoiceProcessing,
+            diagnosticCaptureID: diagnosticCaptureID
+        )
+        try configureInputDeviceForCapture(
+            selectedDeviceID,
+            inputNode: inputNode,
+            diagnosticCaptureID: diagnosticCaptureID
+        )
+        let voiceProcessingFormat = try configureVoiceProcessingGraph(
+            enabled: enablesVoiceProcessing,
+            inputNode: inputNode
+        )
+        let formats = try Self.validatedCaptureFormats(
+            inputNode: inputNode,
+            voiceProcessingFormat: voiceProcessingFormat,
+            enablesVoiceProcessing: enablesVoiceProcessing
+        )
+        recordDiagnosticSnapshot(
+            captureID: diagnosticCaptureID,
+            stage: .voiceProcessingGraphConfigured,
+            inputNode: inputNode,
+            inputHardwareFormat: formats.hardware.diagnosticDescription,
+            inputClientFormat: formats.source.diagnosticDescription,
+            outputHardwareFormat: enablesVoiceProcessing
+                ? engine.outputNode.outputFormat(forBus: 0).diagnosticDescription
+                : nil,
+            targetFormat: targetFormat.diagnosticDescription
+        )
+        guard let converter = AudioConverter.makeConverter(from: formats.source, to: targetFormat) else {
+            throw AudioCaptureError.converterCreationFailed
+        }
+        converter.sampleRateConverterQuality = AVAudioQuality.medium.rawValue
+        return (formats.hardware, formats.source, converter)
+    }
+
     func installInputTap(
         on inputNode: AVAudioInputNode,
         bufferSize: AVAudioFrameCount,
@@ -55,20 +99,6 @@ extension AudioCaptureManager {
             inputNode: inputNode,
             detail: selectedDeviceID.map(String.init) ?? "system-default"
         )
-    }
-
-    func configureVoiceProcessingGraphForCapture(
-        enabled: Bool,
-        inputNode: AVAudioInputNode,
-        diagnosticCaptureID: UUID
-    ) throws -> AVAudioFormat? {
-        let format = try configureVoiceProcessingGraph(enabled: enabled, inputNode: inputNode)
-        recordDiagnosticSnapshot(
-            captureID: diagnosticCaptureID,
-            stage: .voiceProcessingGraphConfigured,
-            inputNode: inputNode
-        )
-        return format
     }
 
     static func validatedCaptureFormats(

--- a/Sources/Dahlia/Audio/AudioCaptureManager+Devices.swift
+++ b/Sources/Dahlia/Audio/AudioCaptureManager+Devices.swift
@@ -1,3 +1,5 @@
+import AudioToolbox
+@preconcurrency import AVFoundation
 import CoreAudio
 import Foundation
 
@@ -103,7 +105,7 @@ extension AudioCaptureManager {
         return isRunning != 0
     }
 
-    private static func deviceName(for deviceID: AudioDeviceID) -> String? {
+    static func deviceName(for deviceID: AudioDeviceID) -> String? {
         var address = globalAddress(kAudioObjectPropertyName)
         var propertySize = UInt32(MemoryLayout<CFString?>.size)
         var name: Unmanaged<CFString>?
@@ -122,5 +124,20 @@ extension AudioCaptureManager {
         }
 
         return name.takeRetainedValue() as String
+    }
+
+    static func currentDeviceID(for inputNode: AVAudioInputNode) -> AudioDeviceID? {
+        guard let audioUnit = inputNode.audioUnit else { return nil }
+        var deviceID = AudioDeviceID(0)
+        var propertySize = UInt32(MemoryLayout<AudioDeviceID>.size)
+        let status = AudioUnitGetProperty(
+            audioUnit,
+            kAudioOutputUnitProperty_CurrentDevice,
+            kAudioUnitScope_Global,
+            0,
+            &deviceID,
+            &propertySize
+        )
+        return status == noErr && deviceID != 0 ? deviceID : nil
     }
 }

--- a/Sources/Dahlia/Audio/AudioCaptureManager+Diagnostics.swift
+++ b/Sources/Dahlia/Audio/AudioCaptureManager+Diagnostics.swift
@@ -35,8 +35,13 @@ extension AudioCaptureManager {
         captureID: UUID,
         stage: MicrophoneCaptureDiagnosticStage,
         inputNode: AVAudioInputNode,
+        inputHardwareFormat: String? = nil,
+        inputClientFormat: String? = nil,
+        outputHardwareFormat: String? = nil,
+        targetFormat: String? = nil,
         detail: String? = nil
     ) {
+        let activeDeviceID = Self.currentDeviceID(for: inputNode)
         MicrophoneCaptureDiagnostics.shared.record(
             captureID: captureID,
             stage: stage,
@@ -44,7 +49,52 @@ extension AudioCaptureManager {
             voiceProcessingBypassed: inputNode.isVoiceProcessingBypassed,
             voiceProcessingInputMuted: inputNode.isVoiceProcessingInputMuted,
             voiceProcessingAGCEnabled: inputNode.isVoiceProcessingAGCEnabled,
+            defaultDeviceID: Self.defaultInputDeviceID(),
+            activeDeviceID: activeDeviceID,
+            activeDeviceName: activeDeviceID.flatMap(Self.deviceName),
+            engineRunning: engine.isRunning,
+            inputHardwareFormat: inputHardwareFormat ?? inputNode.inputFormat(forBus: 0).diagnosticDescription,
+            inputClientFormat: inputClientFormat ?? inputNode.outputFormat(forBus: 0).diagnosticDescription,
+            outputHardwareFormat: outputHardwareFormat,
+            targetFormat: targetFormat,
             detail: detail
+        )
+    }
+
+    func startHealthMonitoring(captureID: UUID) {
+        healthMonitoringTask?.cancel()
+        healthMonitoringTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(5))
+                } catch {
+                    return
+                }
+                guard let self,
+                      let snapshot = healthTracker.snapshot(captureID: captureID) else { return }
+                MicrophoneCaptureDiagnostics.shared.record(
+                    captureID: captureID,
+                    stage: .captureHealth,
+                    detail: snapshot.diagnosticDescription
+                )
+            }
+        }
+    }
+
+    func finishCaptureDiagnostics(
+        stage: MicrophoneCaptureDiagnosticStage,
+        detail: String
+    ) {
+        guard let captureID = activeDiagnosticCaptureID else { return }
+        healthMonitoringTask?.cancel()
+        healthMonitoringTask = nil
+        let summary = healthTracker.finish(captureID: captureID)?.diagnosticDescription
+        let combinedDetail = [detail, summary].compactMap(\.self).joined(separator: " ")
+        recordDiagnosticSnapshot(
+            captureID: captureID,
+            stage: stage,
+            inputNode: engine.inputNode,
+            detail: combinedDetail
         )
     }
 
@@ -61,6 +111,9 @@ extension AudioCaptureManager {
                 voiceProcessingBypassed: inputNode.isVoiceProcessingBypassed,
                 voiceProcessingInputMuted: inputNode.isVoiceProcessingInputMuted,
                 voiceProcessingAGCEnabled: inputNode.isVoiceProcessingAGCEnabled,
+                activeDeviceID: Self.currentDeviceID(for: inputNode),
+                engineRunning: true,
+                inputClientFormat: inputNode.outputFormat(forBus: 0).diagnosticDescription,
                 detail: "frames=\(frameLength)"
             )
         }

--- a/Sources/Dahlia/Audio/AudioCaptureManager+Recovery.swift
+++ b/Sources/Dahlia/Audio/AudioCaptureManager+Recovery.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+extension AudioCaptureManager {
+    @objc func engineConfigurationDidChange() {
+        lifecycleQueue.async { [weak self] in
+            guard let self else { return }
+            if let captureID = activeDiagnosticCaptureID {
+                recordDiagnosticSnapshot(
+                    captureID: captureID,
+                    stage: .configurationChanged,
+                    inputNode: engine.inputNode,
+                    detail: "notificationReceived=true"
+                )
+            }
+            lifecycleQueue.asyncAfter(deadline: .now() + .milliseconds(100)) { [weak self] in
+                self?.recoverFromConfigurationChangeIfNeeded()
+            }
+        }
+    }
+
+    private func recoverFromConfigurationChangeIfNeeded() {
+        let lifecycleDescription = String(describing: lifecycleState)
+        let engineIsRunning = engine.isRunning
+        let hasActiveRequest = activeRequest != nil
+        guard lifecycleState == .running,
+              !engineIsRunning,
+              let request = activeRequest else {
+            recordNonInterruptingConfigurationChange(
+                lifecycleDescription: lifecycleDescription,
+                hasActiveRequest: hasActiveRequest
+            )
+            return
+        }
+        lifecycleState = .restarting
+        activeRequest = nil
+        if let captureID = activeDiagnosticCaptureID {
+            recordDiagnosticSnapshot(
+                captureID: captureID,
+                stage: .restartStarted,
+                inputNode: engine.inputNode,
+                detail: "lifecycle=\(lifecycleDescription) engineRunning=\(engineIsRunning)"
+            )
+            finishCaptureDiagnostics(stage: .captureStopped, detail: "reason=configurationChange")
+        }
+        restartCaptureAfterConfigurationChange(request)
+    }
+
+    private func recordNonInterruptingConfigurationChange(
+        lifecycleDescription: String,
+        hasActiveRequest: Bool
+    ) {
+        guard let captureID = activeDiagnosticCaptureID else { return }
+        recordDiagnosticSnapshot(
+            captureID: captureID,
+            stage: .configurationChanged,
+            inputNode: engine.inputNode,
+            detail: "lifecycle=\(lifecycleDescription) activeRequest=\(hasActiveRequest) restartRequired=false"
+        )
+    }
+
+    private func restartCaptureAfterConfigurationChange(_ request: CaptureRequest) {
+        guard lifecycleState == .restarting else { return }
+        resetCaptureAttempt()
+        activeDiagnosticCaptureID = nil
+        do {
+            try startCaptureAfterConfigurationChange(request)
+        } catch {
+            captureRestartFailed(error)
+        }
+    }
+
+    private func startCaptureAfterConfigurationChange(_ request: CaptureRequest) throws {
+        _ = try startCapture(request)
+        activeRequest = request
+        lifecycleState = .running
+        guard let captureID = activeDiagnosticCaptureID else { return }
+        recordDiagnosticSnapshot(
+            captureID: captureID,
+            stage: .restartSucceeded,
+            inputNode: engine.inputNode
+        )
+    }
+
+    private func captureRestartFailed(_ error: any Error) {
+        if let captureID = activeDiagnosticCaptureID {
+            recordDiagnosticSnapshot(
+                captureID: captureID,
+                stage: .restartFailed,
+                inputNode: engine.inputNode,
+                detail: error.localizedDescription
+            )
+        }
+        resetCaptureAttempt()
+        activeDiagnosticCaptureID = nil
+        lifecycleState = .stopped
+        notifyUnexpectedStop(Self.audioCaptureError(from: error))
+    }
+}

--- a/Sources/Dahlia/Audio/AudioCaptureManager.swift
+++ b/Sources/Dahlia/Audio/AudioCaptureManager.swift
@@ -31,7 +31,7 @@ enum AudioCaptureError: Error, LocalizedError {
 final class AudioCaptureManager: NSObject, @unchecked Sendable {
     private static let logger = Logger(subsystem: "com.dahlia", category: "MicrophoneCapture")
 
-    private struct CaptureRequest {
+    struct CaptureRequest {
         let targetFormat: AVAudioFormat
         let selectedDeviceID: AudioDeviceID?
         let bufferSize: AVAudioFrameCount
@@ -39,7 +39,7 @@ final class AudioCaptureManager: NSObject, @unchecked Sendable {
         let context: MicrophoneCaptureContext
     }
 
-    private enum LifecycleState {
+    enum LifecycleState {
         case stopped
         case starting
         case running
@@ -67,11 +67,14 @@ final class AudioCaptureManager: NSObject, @unchecked Sendable {
     }
 
     private(set) var engine = AVAudioEngine()
-    private let lifecycleQueue = DispatchQueue(label: "com.dahlia.microphone-capture.lifecycle")
+    let lifecycleQueue = DispatchQueue(label: "com.dahlia.microphone-capture.lifecycle")
     private let conversionState = OSAllocatedUnfairLock(initialState: ConversionState())
     private let handlerState = OSAllocatedUnfairLock(initialState: HandlerState())
-    private var lifecycleState = LifecycleState.stopped
-    private var activeRequest: CaptureRequest?
+    let healthTracker = MicrophoneCaptureHealthTracker()
+    var lifecycleState = LifecycleState.stopped
+    var activeRequest: CaptureRequest?
+    var activeDiagnosticCaptureID: UUID?
+    var healthMonitoringTask: Task<Void, Never>?
     var hasInputTap = false
     private var hasVoiceProcessingOutputConnection = false
 
@@ -106,6 +109,7 @@ final class AudioCaptureManager: NSObject, @unchecked Sendable {
     }
 
     deinit {
+        healthMonitoringTask?.cancel()
         NotificationCenter.default.removeObserver(self)
     }
 }
@@ -153,6 +157,7 @@ extension AudioCaptureManager {
                 lifecycleState = .running
                 return startInfo
             } catch {
+                activeDiagnosticCaptureID = nil
                 resetCaptureAttempt()
                 lifecycleState = .stopped
                 throw error
@@ -160,14 +165,22 @@ extension AudioCaptureManager {
         }
     }
 
-    private func startCapture(_ request: CaptureRequest) throws -> AudioCaptureStartInfo {
+    func startCapture(_ request: CaptureRequest) throws -> AudioCaptureStartInfo {
         var lastError: (any Error)?
-        let selectedDeviceDescription = request.selectedDeviceID.map(String.init) ?? "system-default"
-        let diagnosticCaptureID = MicrophoneCaptureDiagnostics.shared.beginCapture(context: request.context)
-
-        Self.logger.info(
-            "Starting microphone capture; device=\(selectedDeviceDescription, privacy: .public), voiceProcessing=\(request.prefersVoiceProcessing)"
+        let defaultDeviceID = Self.defaultInputDeviceID()
+        let activeDeviceID = request.selectedDeviceID ?? defaultDeviceID
+        let diagnosticCaptureID = MicrophoneCaptureDiagnostics.shared.beginCapture(
+            context: request.context,
+            requestedVoiceProcessing: request.prefersVoiceProcessing,
+            selectedDeviceID: request.selectedDeviceID,
+            defaultDeviceID: defaultDeviceID,
+            activeDeviceID: activeDeviceID,
+            activeDeviceName: activeDeviceID.flatMap(Self.deviceName),
+            deviceRunningBeforeCapture: activeDeviceID.map(Self.isDeviceRunningSomewhere),
+            targetFormat: request.targetFormat.diagnosticDescription,
+            detail: "bufferSize=\(request.bufferSize)"
         )
+        activeDiagnosticCaptureID = diagnosticCaptureID
 
         for enablesVoiceProcessing in Self.voiceProcessingAttemptOrder(
             prefersVoiceProcessing: request.prefersVoiceProcessing
@@ -192,9 +205,6 @@ extension AudioCaptureManager {
                     inputNode: engine.inputNode,
                     detail: error.localizedDescription
                 )
-                Self.logger.error(
-                    "Microphone capture attempt failed; voiceProcessing=\(enablesVoiceProcessing), error=\(error.localizedDescription, privacy: .public)"
-                )
                 resetCaptureAttempt()
             }
         }
@@ -215,60 +225,38 @@ extension AudioCaptureManager {
             stage: .inputNodeReady,
             inputNode: inputNode
         )
-        try configureVoiceProcessingInput(
-            inputNode,
-            enabled: enablesVoiceProcessing,
+        let captureSetup = try prepareCaptureAttempt(
+            inputNode: inputNode,
+            targetFormat: targetFormat,
+            selectedDeviceID: selectedDeviceID,
+            enablesVoiceProcessing: enablesVoiceProcessing,
             diagnosticCaptureID: diagnosticCaptureID
         )
-
-        try configureInputDeviceForCapture(
-            selectedDeviceID,
-            inputNode: inputNode,
-            diagnosticCaptureID: diagnosticCaptureID
-        )
-        let voiceProcessingFormat = try configureVoiceProcessingGraphForCapture(
-            enabled: enablesVoiceProcessing,
-            inputNode: inputNode,
-            diagnosticCaptureID: diagnosticCaptureID
-        )
-        let captureFormats = try Self.validatedCaptureFormats(
-            inputNode: inputNode,
-            voiceProcessingFormat: voiceProcessingFormat,
-            enablesVoiceProcessing: enablesVoiceProcessing
-        )
-        let hardwareFormat = captureFormats.hardware
-        let sourceFormat = captureFormats.source
-
-        Self.logger.info("Microphone hardware format: \(hardwareFormat.diagnosticDescription, privacy: .public)")
-        Self.logger.info("Microphone source format: \(sourceFormat.diagnosticDescription, privacy: .public)")
-        Self.logger.info("Microphone target format: \(targetFormat.diagnosticDescription, privacy: .public)")
-
-        guard let audioConverter = AudioConverter.makeConverter(from: sourceFormat, to: targetFormat) else {
-            throw AudioCaptureError.converterCreationFailed
-        }
-        audioConverter.sampleRateConverterQuality = AVAudioQuality.medium.rawValue
 
         installInputTap(
             on: inputNode,
             bufferSize: bufferSize,
-            sourceFormat: sourceFormat,
+            sourceFormat: captureSetup.source,
             diagnosticCaptureID: diagnosticCaptureID
         )
-        try prepareAndStartEngine(inputNode: inputNode, diagnosticCaptureID: diagnosticCaptureID)
+        healthTracker.begin(captureID: diagnosticCaptureID)
+        do {
+            try prepareAndStartEngine(inputNode: inputNode, diagnosticCaptureID: diagnosticCaptureID)
+        } catch {
+            healthTracker.reset()
+            throw error
+        }
         conversionState.withLock { state in
-            state.converter = audioConverter
+            state.converter = captureSetup.converter
             state.targetFormat = targetFormat
             state.didLogFirstBuffer = false
             state.didLogConversionFailure = false
         }
-        Self.logger.info("Microphone engine started; voiceProcessing=\(enablesVoiceProcessing)")
-        Self.logger.info(
-            "Microphone modes; preferred=\(AVCaptureDevice.preferredMicrophoneMode.rawValue), active=\(AVCaptureDevice.activeMicrophoneMode.rawValue)"
-        )
+        startHealthMonitoring(captureID: diagnosticCaptureID)
 
         return AudioCaptureStartInfo(
-            hardwareFormatDescription: hardwareFormat.diagnosticDescription,
-            sourceFormatDescription: sourceFormat.diagnosticDescription,
+            hardwareFormatDescription: captureSetup.hardware.diagnosticDescription,
+            sourceFormatDescription: captureSetup.source.diagnosticDescription,
             targetFormatDescription: targetFormat.diagnosticDescription
         )
     }
@@ -316,53 +304,10 @@ extension AudioCaptureManager {
             guard lifecycleState != .stopped else { return }
             lifecycleState = .stopping
             activeRequest = nil
+            finishCaptureDiagnostics(stage: .captureStopped, detail: "reason=requested")
             resetCaptureAttempt()
+            activeDiagnosticCaptureID = nil
             lifecycleState = .stopped
-        }
-    }
-
-    @objc private func engineConfigurationDidChange() {
-        Self.logger.notice("Received microphone engine configuration change notification")
-        lifecycleQueue.asyncAfter(deadline: .now() + .milliseconds(100)) { [weak self] in
-            self?.recoverFromConfigurationChangeIfNeeded()
-        }
-    }
-
-    private func recoverFromConfigurationChangeIfNeeded() {
-        let lifecycleDescription = String(describing: lifecycleState)
-        let engineIsRunning = engine.isRunning
-        let hasActiveRequest = activeRequest != nil
-        Self.logger.notice(
-            "Evaluating microphone configuration change; lifecycle=\(lifecycleDescription, privacy: .public), engineRunning=\(engineIsRunning), activeRequest=\(hasActiveRequest)"
-        )
-        guard lifecycleState == .running,
-              !engineIsRunning,
-              let request = activeRequest else {
-            Self.logger.notice("Microphone configuration change did not interrupt active capture")
-            return
-        }
-        lifecycleState = .restarting
-        activeRequest = nil
-        Self.logger.notice("Microphone capture interruption detected; restarting capture")
-        restartCaptureAfterConfigurationChange(request)
-    }
-
-    private func restartCaptureAfterConfigurationChange(_ request: CaptureRequest) {
-        guard lifecycleState == .restarting else { return }
-        Self.logger.notice("Restarting microphone engine after a configuration change")
-        resetCaptureAttempt()
-        do {
-            _ = try startCapture(request)
-            activeRequest = request
-            lifecycleState = .running
-            Self.logger.notice("Microphone engine recovered after a configuration change")
-        } catch {
-            resetCaptureAttempt()
-            lifecycleState = .stopped
-            Self.logger.error(
-                "Microphone engine recovery failed: \(error.localizedDescription, privacy: .public)"
-            )
-            notifyUnexpectedStop(Self.audioCaptureError(from: error))
         }
     }
 
@@ -371,8 +316,18 @@ extension AudioCaptureManager {
         inputNode: AVAudioInputNode,
         diagnosticCaptureID: UUID
     ) {
+        let shouldSampleHealthLevel = healthTracker.recordBuffer(
+            captureID: diagnosticCaptureID,
+            frameLength: inputBuffer.frameLength
+        )
         let levelsHandler = onInputLevels
-        levelsHandler?(AudioLevelCalculator.normalizedLevels(in: inputBuffer))
+        if levelsHandler != nil || shouldSampleHealthLevel {
+            let levels = AudioLevelCalculator.normalizedLevels(in: inputBuffer)
+            levelsHandler?(levels)
+            if shouldSampleHealthLevel, let level = levels.max() {
+                healthTracker.recordLevel(level, captureID: diagnosticCaptureID)
+            }
+        }
 
         let shouldLogFirstBuffer = conversionState.withLock { state in
             guard state.targetFormat != nil, !state.didLogFirstBuffer else { return false }
@@ -384,10 +339,6 @@ extension AudioCaptureManager {
                 captureID: diagnosticCaptureID,
                 inputNode: inputNode,
                 frameLength: inputBuffer.frameLength
-            )
-            let formatDescription = inputBuffer.format.diagnosticDescription
-            Self.logger.info(
-                "Received first microphone buffer; frames=\(inputBuffer.frameLength), format=\(formatDescription, privacy: .public)"
             )
         }
 
@@ -402,9 +353,7 @@ extension AudioCaptureManager {
                 }
                 converter.sampleRateConverterQuality = AVAudioQuality.medium.rawValue
                 state.converter = converter
-                Self.logger.notice(
-                    "Recreated microphone converter for input format: \(inputBuffer.format.diagnosticDescription, privacy: .public)"
-                )
+                Self.logger.notice("captureID=\(diagnosticCaptureID.uuidString, privacy: .public) recreatedConverter=true")
             }
             guard let converter = state.converter,
                   let outputBuffer = AudioConverter.convert(inputBuffer, to: targetFormat, using: converter) else {
@@ -414,7 +363,9 @@ extension AudioCaptureManager {
         }
         if let failure = conversionResult.1 {
             let inputDescription = inputBuffer.format.diagnosticDescription
-            Self.logger.error("Failed to convert microphone buffer: \(inputDescription, privacy: .public)")
+            Self.logger.error(
+                "captureID=\(diagnosticCaptureID.uuidString, privacy: .public) conversionFailed=true inputFormat=\(inputDescription, privacy: .public)"
+            )
             lifecycleQueue.async { [weak self] in
                 self?.failActiveCapture(failure)
             }
@@ -445,7 +396,10 @@ extension AudioCaptureManager {
         }
     }
 
-    private func resetCaptureAttempt() {
+    func resetCaptureAttempt() {
+        healthMonitoringTask?.cancel()
+        healthMonitoringTask = nil
+        healthTracker.reset()
         conversionState.withLock { state in
             state = ConversionState()
         }
@@ -478,19 +432,21 @@ extension AudioCaptureManager {
         guard lifecycleState == .running || lifecycleState == .restarting else { return }
         lifecycleState = .stopping
         activeRequest = nil
+        finishCaptureDiagnostics(stage: .unexpectedStop, detail: "error=\(error.localizedDescription)")
         resetCaptureAttempt()
+        activeDiagnosticCaptureID = nil
         lifecycleState = .stopped
         notifyUnexpectedStop(error)
     }
 
-    private func notifyUnexpectedStop(_ error: AudioCaptureError?) {
+    func notifyUnexpectedStop(_ error: AudioCaptureError?) {
         guard let handler = onUnexpectedStop else { return }
         DispatchQueue.global(qos: .userInitiated).async {
             handler(error)
         }
     }
 
-    private static func audioCaptureError(from error: any Error) -> AudioCaptureError {
+    static func audioCaptureError(from error: any Error) -> AudioCaptureError {
         error as? AudioCaptureError ?? .microphoneDeviceUnavailable
     }
 }

--- a/Sources/Dahlia/Audio/MicrophoneCaptureDiagnosticSnapshot.swift
+++ b/Sources/Dahlia/Audio/MicrophoneCaptureDiagnosticSnapshot.swift
@@ -13,5 +13,16 @@ struct MicrophoneCaptureDiagnosticSnapshot: Identifiable, Equatable {
     let voiceProcessingBypassed: Bool?
     let voiceProcessingInputMuted: Bool?
     let voiceProcessingAGCEnabled: Bool?
+    let requestedVoiceProcessing: Bool?
+    let selectedDeviceID: AudioDeviceID?
+    let defaultDeviceID: AudioDeviceID?
+    let activeDeviceID: AudioDeviceID?
+    let activeDeviceName: String?
+    let deviceRunningBeforeCapture: Bool?
+    let engineRunning: Bool?
+    let inputHardwareFormat: String?
+    let inputClientFormat: String?
+    let outputHardwareFormat: String?
+    let targetFormat: String?
     let detail: String?
 }

--- a/Sources/Dahlia/Audio/MicrophoneCaptureDiagnosticStage.swift
+++ b/Sources/Dahlia/Audio/MicrophoneCaptureDiagnosticStage.swift
@@ -12,5 +12,12 @@ enum MicrophoneCaptureDiagnosticStage: String {
     case enginePrepared = "Audio Engine Prepared"
     case engineStarted = "Audio Engine Started"
     case firstAudioBufferReceived = "First Audio Buffer Received"
+    case captureHealth = "Capture Health"
+    case configurationChanged = "Audio Configuration Changed"
+    case restartStarted = "Capture Restart Started"
+    case restartSucceeded = "Capture Restart Succeeded"
+    case restartFailed = "Capture Restart Failed"
+    case captureStopped = "Capture Stopped"
+    case unexpectedStop = "Unexpected Capture Stop"
     case attemptFailed = "Capture Attempt Failed"
 }

--- a/Sources/Dahlia/Audio/MicrophoneCaptureDiagnostics.swift
+++ b/Sources/Dahlia/Audio/MicrophoneCaptureDiagnostics.swift
@@ -3,6 +3,9 @@ import Foundation
 import os
 
 final class MicrophoneCaptureDiagnostics: Sendable {
+    private static let logger = Logger(subsystem: "com.dahlia", category: "MicrophoneCapture")
+    private static let maximumSnapshotCount = 200
+
     typealias MicrophoneModeProvider = @Sendable () -> (
         preferred: AVCaptureDevice.MicrophoneMode,
         active: AVCaptureDevice.MicrophoneMode
@@ -26,20 +29,39 @@ final class MicrophoneCaptureDiagnostics: Sendable {
     }
 
     @discardableResult
-    func beginCapture(context: MicrophoneCaptureContext) -> UUID {
+    func beginCapture(
+        context: MicrophoneCaptureContext,
+        requestedVoiceProcessing: Bool? = nil,
+        selectedDeviceID: AudioDeviceID? = nil,
+        defaultDeviceID: AudioDeviceID? = nil,
+        activeDeviceID: AudioDeviceID? = nil,
+        activeDeviceName: String? = nil,
+        deviceRunningBeforeCapture: Bool? = nil,
+        targetFormat: String? = nil,
+        detail: String? = nil
+    ) -> UUID {
         let captureID = UUID.v7()
         let modes = modeProvider()
         let snapshot = makeSnapshot(
             captureID: captureID,
             context: context,
             stage: .captureRequested,
-            modes: modes
+            modes: modes,
+            requestedVoiceProcessing: requestedVoiceProcessing,
+            selectedDeviceID: selectedDeviceID,
+            defaultDeviceID: defaultDeviceID,
+            activeDeviceID: activeDeviceID,
+            activeDeviceName: activeDeviceName,
+            deviceRunningBeforeCapture: deviceRunningBeforeCapture,
+            targetFormat: targetFormat,
+            detail: detail
         )
         state.withLock { state in
             state.captureID = captureID
             state.context = context
             state.snapshots = [snapshot]
         }
+        Self.log(snapshot)
         return captureID
     }
 
@@ -50,12 +72,23 @@ final class MicrophoneCaptureDiagnostics: Sendable {
         voiceProcessingBypassed: Bool? = nil,
         voiceProcessingInputMuted: Bool? = nil,
         voiceProcessingAGCEnabled: Bool? = nil,
+        requestedVoiceProcessing: Bool? = nil,
+        selectedDeviceID: AudioDeviceID? = nil,
+        defaultDeviceID: AudioDeviceID? = nil,
+        activeDeviceID: AudioDeviceID? = nil,
+        activeDeviceName: String? = nil,
+        deviceRunningBeforeCapture: Bool? = nil,
+        engineRunning: Bool? = nil,
+        inputHardwareFormat: String? = nil,
+        inputClientFormat: String? = nil,
+        outputHardwareFormat: String? = nil,
+        targetFormat: String? = nil,
         detail: String? = nil
     ) {
         let modes = modeProvider()
-        state.withLock { state in
-            guard state.captureID == captureID else { return }
-            state.snapshots.append(makeSnapshot(
+        let snapshot = state.withLock { state -> MicrophoneCaptureDiagnosticSnapshot? in
+            guard state.captureID == captureID else { return nil }
+            let snapshot = makeSnapshot(
                 captureID: captureID,
                 context: state.context,
                 stage: stage,
@@ -64,8 +97,27 @@ final class MicrophoneCaptureDiagnostics: Sendable {
                 voiceProcessingBypassed: voiceProcessingBypassed,
                 voiceProcessingInputMuted: voiceProcessingInputMuted,
                 voiceProcessingAGCEnabled: voiceProcessingAGCEnabled,
+                requestedVoiceProcessing: requestedVoiceProcessing,
+                selectedDeviceID: selectedDeviceID,
+                defaultDeviceID: defaultDeviceID,
+                activeDeviceID: activeDeviceID,
+                activeDeviceName: activeDeviceName,
+                deviceRunningBeforeCapture: deviceRunningBeforeCapture,
+                engineRunning: engineRunning,
+                inputHardwareFormat: inputHardwareFormat,
+                inputClientFormat: inputClientFormat,
+                outputHardwareFormat: outputHardwareFormat,
+                targetFormat: targetFormat,
                 detail: detail
-            ))
+            )
+            state.snapshots.append(snapshot)
+            if state.snapshots.count > Self.maximumSnapshotCount {
+                state.snapshots.removeFirst(state.snapshots.count - Self.maximumSnapshotCount)
+            }
+            return snapshot
+        }
+        if let snapshot {
+            Self.log(snapshot)
         }
     }
 
@@ -85,6 +137,17 @@ final class MicrophoneCaptureDiagnostics: Sendable {
         voiceProcessingBypassed: Bool? = nil,
         voiceProcessingInputMuted: Bool? = nil,
         voiceProcessingAGCEnabled: Bool? = nil,
+        requestedVoiceProcessing: Bool? = nil,
+        selectedDeviceID: AudioDeviceID? = nil,
+        defaultDeviceID: AudioDeviceID? = nil,
+        activeDeviceID: AudioDeviceID? = nil,
+        activeDeviceName: String? = nil,
+        deviceRunningBeforeCapture: Bool? = nil,
+        engineRunning: Bool? = nil,
+        inputHardwareFormat: String? = nil,
+        inputClientFormat: String? = nil,
+        outputHardwareFormat: String? = nil,
+        targetFormat: String? = nil,
         detail: String? = nil
     ) -> MicrophoneCaptureDiagnosticSnapshot {
         MicrophoneCaptureDiagnosticSnapshot(
@@ -99,7 +162,85 @@ final class MicrophoneCaptureDiagnostics: Sendable {
             voiceProcessingBypassed: voiceProcessingBypassed,
             voiceProcessingInputMuted: voiceProcessingInputMuted,
             voiceProcessingAGCEnabled: voiceProcessingAGCEnabled,
+            requestedVoiceProcessing: requestedVoiceProcessing,
+            selectedDeviceID: selectedDeviceID,
+            defaultDeviceID: defaultDeviceID,
+            activeDeviceID: activeDeviceID,
+            activeDeviceName: activeDeviceName,
+            deviceRunningBeforeCapture: deviceRunningBeforeCapture,
+            engineRunning: engineRunning,
+            inputHardwareFormat: inputHardwareFormat,
+            inputClientFormat: inputClientFormat,
+            outputHardwareFormat: outputHardwareFormat,
+            targetFormat: targetFormat,
             detail: detail
         )
+    }
+
+    nonisolated static func renderedLine(_ snapshot: MicrophoneCaptureDiagnosticSnapshot) -> String {
+        var components = [
+            "captureID=\(snapshot.captureID.uuidString)",
+            "context=\(contextName(snapshot.context))",
+            "stage=\(String(reflecting: snapshot.stage.rawValue))",
+            "preferredMode=\(microphoneModeName(snapshot.preferredMicrophoneMode))",
+            "activeMode=\(microphoneModeName(snapshot.activeMicrophoneMode))",
+        ]
+        append("requestedVP", snapshot.requestedVoiceProcessing, to: &components)
+        append("vpEnabled", snapshot.voiceProcessingEnabled, to: &components)
+        append("vpBypassed", snapshot.voiceProcessingBypassed, to: &components)
+        append("vpMuted", snapshot.voiceProcessingInputMuted, to: &components)
+        append("vpAGC", snapshot.voiceProcessingAGCEnabled, to: &components)
+        append("selectedDevice", snapshot.selectedDeviceID, to: &components)
+        append("defaultDevice", snapshot.defaultDeviceID, to: &components)
+        append("activeDevice", snapshot.activeDeviceID, to: &components)
+        appendQuoted("activeDeviceName", snapshot.activeDeviceName, to: &components)
+        append("runningBeforeCapture", snapshot.deviceRunningBeforeCapture, to: &components)
+        append("engineRunning", snapshot.engineRunning, to: &components)
+        appendQuoted("inputHardwareFormat", snapshot.inputHardwareFormat, to: &components)
+        appendQuoted("inputClientFormat", snapshot.inputClientFormat, to: &components)
+        appendQuoted("outputHardwareFormat", snapshot.outputHardwareFormat, to: &components)
+        appendQuoted("targetFormat", snapshot.targetFormat, to: &components)
+        appendQuoted("detail", snapshot.detail, to: &components)
+        return components.joined(separator: " ")
+    }
+
+    private static func log(_ snapshot: MicrophoneCaptureDiagnosticSnapshot) {
+        let line = renderedLine(snapshot)
+        switch snapshot.stage {
+        case .attemptFailed, .restartFailed, .unexpectedStop:
+            logger.error("\(line, privacy: .public)")
+        default:
+            logger.notice("\(line, privacy: .public)")
+        }
+    }
+
+    private nonisolated static func append(
+        _ key: String,
+        _ value: (some CustomStringConvertible)?,
+        to components: inout [String]
+    ) {
+        guard let value else { return }
+        components.append("\(key)=\(value)")
+    }
+
+    private nonisolated static func appendQuoted(_ key: String, _ value: String?, to components: inout [String]) {
+        guard let value else { return }
+        components.append("\(key)=\(String(reflecting: value))")
+    }
+
+    private nonisolated static func contextName(_ context: MicrophoneCaptureContext) -> String {
+        switch context {
+        case .recording: "recording"
+        case .audioTest: "audioTest"
+        }
+    }
+
+    private nonisolated static func microphoneModeName(_ mode: AVCaptureDevice.MicrophoneMode) -> String {
+        switch mode {
+        case .standard: "standard"
+        case .wideSpectrum: "wideSpectrum"
+        case .voiceIsolation: "voiceIsolation"
+        @unknown default: "unknown(\(mode.rawValue))"
+        }
     }
 }

--- a/Sources/Dahlia/Audio/MicrophoneCaptureHealthSnapshot.swift
+++ b/Sources/Dahlia/Audio/MicrophoneCaptureHealthSnapshot.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+struct MicrophoneCaptureHealthSnapshot: Equatable, Sendable {
+    let captureID: UUID
+    let elapsed: Duration
+    let intervalBufferCount: Int
+    let totalBufferCount: Int
+    let totalFrameCount: Int64
+    let lastLevel: Double?
+    let lastBufferAge: Duration?
+
+    var diagnosticDescription: String {
+        var components = [
+            "elapsedSeconds=\(elapsed.seconds.formatted(.number.precision(.fractionLength(3))))",
+            "intervalBuffers=\(intervalBufferCount)",
+            "totalBuffers=\(totalBufferCount)",
+            "totalFrames=\(totalFrameCount)",
+        ]
+        if let lastLevel {
+            components.append("lastLevel=\(lastLevel.formatted(.number.precision(.fractionLength(4))))")
+        }
+        if let lastBufferAge {
+            components.append(
+                "lastBufferAgeSeconds=\(lastBufferAge.seconds.formatted(.number.precision(.fractionLength(3))))"
+            )
+        }
+        return components.joined(separator: " ")
+    }
+}
+
+private extension Duration {
+    var seconds: Double {
+        let components = self.components
+        return Double(components.seconds) + Double(components.attoseconds) / 1e18
+    }
+}

--- a/Sources/Dahlia/Audio/MicrophoneCaptureHealthTracker.swift
+++ b/Sources/Dahlia/Audio/MicrophoneCaptureHealthTracker.swift
@@ -1,0 +1,101 @@
+@preconcurrency import AVFoundation
+import Foundation
+import os
+
+final class MicrophoneCaptureHealthTracker: Sendable {
+    private static let levelSampleInterval = Duration.seconds(5)
+
+    private struct State {
+        var captureID: UUID?
+        var startedAt: ContinuousClock.Instant?
+        var lastBufferAt: ContinuousClock.Instant?
+        var nextLevelSampleAt: ContinuousClock.Instant?
+        var intervalBufferCount = 0
+        var totalBufferCount = 0
+        var totalFrameCount: Int64 = 0
+        var lastLevel: Double?
+
+        func snapshot(
+            captureID: UUID,
+            at now: ContinuousClock.Instant
+        ) -> MicrophoneCaptureHealthSnapshot? {
+            guard self.captureID == captureID,
+                  let startedAt else { return nil }
+            return MicrophoneCaptureHealthSnapshot(
+                captureID: captureID,
+                elapsed: startedAt.duration(to: now),
+                intervalBufferCount: intervalBufferCount,
+                totalBufferCount: totalBufferCount,
+                totalFrameCount: totalFrameCount,
+                lastLevel: lastLevel,
+                lastBufferAge: lastBufferAt?.duration(to: now)
+            )
+        }
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    func begin(captureID: UUID, at now: ContinuousClock.Instant = .now) {
+        state.withLock { state in
+            state = State(
+                captureID: captureID,
+                startedAt: now,
+                nextLevelSampleAt: now
+            )
+        }
+    }
+
+    func recordBuffer(
+        captureID: UUID,
+        frameLength: AVAudioFrameCount,
+        at now: ContinuousClock.Instant = .now
+    ) -> Bool {
+        state.withLock { state in
+            guard state.captureID == captureID else { return false }
+            state.intervalBufferCount += 1
+            state.totalBufferCount += 1
+            state.totalFrameCount += Int64(frameLength)
+            state.lastBufferAt = now
+            guard let nextLevelSampleAt = state.nextLevelSampleAt,
+                  now >= nextLevelSampleAt else { return false }
+            state.nextLevelSampleAt = now.advanced(by: Self.levelSampleInterval)
+            return true
+        }
+    }
+
+    func recordLevel(_ level: Double, captureID: UUID) {
+        state.withLock { state in
+            guard state.captureID == captureID else { return }
+            state.lastLevel = level
+        }
+    }
+
+    func snapshot(
+        captureID: UUID,
+        at now: ContinuousClock.Instant = .now,
+        resetsInterval: Bool = true
+    ) -> MicrophoneCaptureHealthSnapshot? {
+        state.withLock { state in
+            guard let snapshot = state.snapshot(captureID: captureID, at: now) else { return nil }
+            if resetsInterval {
+                state.intervalBufferCount = 0
+            }
+            return snapshot
+        }
+    }
+
+    func finish(
+        captureID: UUID,
+        at now: ContinuousClock.Instant = .now
+    ) -> MicrophoneCaptureHealthSnapshot? {
+        state.withLock { state in
+            guard let snapshot = state.snapshot(captureID: captureID, at: now) else { return nil }
+            state = State()
+            return snapshot
+        }
+    }
+
+    func reset() {
+        state.withLock { $0 = State() }
+    }
+}

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -672,9 +672,10 @@
 "View Dahlia logs from the current app session. Private values remain redacted." = "View Dahlia logs from the current app session. Private values remain redacted.";
 "Logs Unavailable" = "Logs Unavailable";
 "No Logs" = "No Logs";
-"Use Dahlia, then refresh to load new log entries." = "Use Dahlia, then refresh to load new log entries.";
+"New logs from this app session appear here automatically." = "New logs from this app session appear here automatically.";
 "Search logs…" = "Search logs…";
 "Refresh Logs" = "Refresh Logs";
+"Follow Latest Logs" = "Follow Latest Logs";
 "Copy Displayed Logs" = "Copy Displayed Logs";
 "System Microphone Mode" = "System Microphone Mode";
 "Selected Mode" = "Selected Mode";
@@ -702,6 +703,13 @@
 "Audio Engine Prepared" = "Audio Engine Prepared";
 "Audio Engine Started" = "Audio Engine Started";
 "First Audio Buffer Received" = "First Audio Buffer Received";
+"Capture Health" = "Capture Health";
+"Audio Configuration Changed" = "Audio Configuration Changed";
+"Capture Restart Started" = "Capture Restart Started";
+"Capture Restart Succeeded" = "Capture Restart Succeeded";
+"Capture Restart Failed" = "Capture Restart Failed";
+"Capture Stopped" = "Capture Stopped";
+"Unexpected Capture Stop" = "Unexpected Capture Stop";
 "Capture Attempt Failed" = "Capture Attempt Failed";
 "Start Test" = "Start Test";
 "Stop Test" = "Stop Test";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -672,9 +672,10 @@
 "View Dahlia logs from the current app session. Private values remain redacted." = "現在のアプリセッションに記録された Dahlia のログを表示します。非公開の値はマスクされたままです。";
 "Logs Unavailable" = "ログを取得できません";
 "No Logs" = "ログがありません";
-"Use Dahlia, then refresh to load new log entries." = "Dahlia を操作してから再読み込みすると、新しいログを確認できます。";
+"New logs from this app session appear here automatically." = "このアプリセッションの新しいログが自動的に表示されます。";
 "Search logs…" = "ログを検索…";
 "Refresh Logs" = "ログを再読み込み";
+"Follow Latest Logs" = "最新ログを追従";
 "Copy Displayed Logs" = "表示中のログをコピー";
 "System Microphone Mode" = "システムのマイクモード";
 "Selected Mode" = "選択中のモード";
@@ -702,6 +703,13 @@
 "Audio Engine Prepared" = "オーディオエンジン準備";
 "Audio Engine Started" = "オーディオエンジン開始";
 "First Audio Buffer Received" = "最初の音声バッファ受信";
+"Capture Health" = "マイク取得状態";
+"Audio Configuration Changed" = "オーディオ構成変更";
+"Capture Restart Started" = "マイク取得の再起動開始";
+"Capture Restart Succeeded" = "マイク取得の再起動成功";
+"Capture Restart Failed" = "マイク取得の再起動失敗";
+"Capture Stopped" = "マイク取得停止";
+"Unexpected Capture Stop" = "マイク取得の予期しない停止";
 "Capture Attempt Failed" = "取得試行失敗";
 "Start Test" = "テスト開始";
 "Stop Test" = "テスト停止";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1410,11 +1410,12 @@ enum L10n {
     static var applicationLogsUnavailable: String { String(localized: "Logs Unavailable", bundle: bundle) }
     static var noApplicationLogs: String { String(localized: "No Logs", bundle: bundle) }
     static var noApplicationLogsDescription: String { String(
-        localized: "Use Dahlia, then refresh to load new log entries.",
+        localized: "New logs from this app session appear here automatically.",
         bundle: bundle
     ) }
     static var searchApplicationLogs: String { String(localized: "Search logs…", bundle: bundle) }
     static var refreshApplicationLogs: String { String(localized: "Refresh Logs", bundle: bundle) }
+    static var followLatestApplicationLogs: String { String(localized: "Follow Latest Logs", bundle: bundle) }
     static var copyDisplayedLogs: String { String(localized: "Copy Displayed Logs", bundle: bundle) }
     static var systemMicrophoneMode: String { String(localized: "System Microphone Mode", bundle: bundle) }
     static var preferredMicrophoneMode: String { String(localized: "Selected Mode", bundle: bundle) }

--- a/Sources/Dahlia/ViewModels/ApplicationLogViewModel.swift
+++ b/Sources/Dahlia/ViewModels/ApplicationLogViewModel.swift
@@ -5,33 +5,62 @@ import OSLog
 @MainActor
 @Observable
 final class ApplicationLogViewModel {
-    private static let maximumEntryCount = 2000
-    private static let subsystem = "com.dahlia"
+    private nonisolated static let maximumEntryCount = 2000
+    private static let pollingInterval = Duration.seconds(1)
+    private nonisolated static let subsystem = "com.dahlia"
+
+    typealias LogLoader = @Sendable () async throws -> [String]
+    typealias Sleeper = @Sendable (Duration) async throws -> Void
 
     private(set) var logLines: [String]
     private(set) var errorMessage: String?
+    private(set) var revision = 0
 
-    init(logLines: [String] = []) {
-        self.logLines = logLines
+    private let loadLogs: LogLoader
+    private let sleep: Sleeper
+    private var isRefreshing = false
+
+    init(
+        logLines: [String] = [],
+        loadLogs: @escaping LogLoader = ApplicationLogViewModel.loadCurrentProcessLogs,
+        sleep: @escaping Sleeper = { try await Task.sleep(for: $0) }
+    ) {
+        self.logLines = Array(logLines.suffix(Self.maximumEntryCount))
+        self.loadLogs = loadLogs
+        self.sleep = sleep
     }
 
     var hasLogs: Bool {
         !logLines.isEmpty
     }
 
-    func refresh() {
+    func monitor() async {
+        while !Task.isCancelled {
+            await refresh()
+            do {
+                try await sleep(Self.pollingInterval)
+            } catch {
+                return
+            }
+        }
+    }
+
+    func refresh() async {
+        guard !isRefreshing else { return }
+        isRefreshing = true
+        defer { isRefreshing = false }
+
         do {
-            let store = try OSLogStore(scope: .currentProcessIdentifier)
-            let predicate = NSPredicate(format: "subsystem == %@", Self.subsystem)
-            let entries = try store.getEntries(with: .reverse, matching: predicate)
-            logLines = entries.lazy
-                .compactMap { $0 as? OSLogEntryLog }
-                .prefix(Self.maximumEntryCount)
-                .map(Self.renderedLine)
-                .reversed()
+            let loadedLines = try await loadLogs()
+            guard !Task.isCancelled else { return }
+            let boundedLines = Array(loadedLines.suffix(Self.maximumEntryCount))
+            if boundedLines != logLines {
+                logLines = boundedLines
+                revision &+= 1
+            }
             errorMessage = nil
         } catch {
-            logLines = []
+            guard !Task.isCancelled else { return }
             errorMessage = error.localizedDescription
         }
     }
@@ -48,6 +77,17 @@ final class ApplicationLogViewModel {
     nonisolated static func renderedLine(_ entry: OSLogEntryLog) -> String {
         let timestamp = entry.date.formatted(.iso8601)
         return "\(timestamp) [\(levelName(entry.level))] [\(entry.category)] \(entry.composedMessage)"
+    }
+
+    private nonisolated static func loadCurrentProcessLogs() async throws -> [String] {
+        let store = try OSLogStore(scope: .currentProcessIdentifier)
+        let predicate = NSPredicate(format: "subsystem == %@", Self.subsystem)
+        let entries = try store.getEntries(with: .reverse, matching: predicate)
+        return entries.lazy
+            .compactMap { $0 as? OSLogEntryLog }
+            .prefix(Self.maximumEntryCount)
+            .map(Self.renderedLine)
+            .reversed()
     }
 
     private nonisolated static func levelName(_ level: OSLogEntryLog.Level) -> String {

--- a/Sources/Dahlia/ViewModels/MicrophoneRecognitionTestModel.swift
+++ b/Sources/Dahlia/ViewModels/MicrophoneRecognitionTestModel.swift
@@ -133,6 +133,39 @@ final class MicrophoneRecognitionTestModel {
         if let agcEnabled = snapshot.voiceProcessingAGCEnabled {
             components.append("AGC=\(agcEnabled)")
         }
+        if let requestedVoiceProcessing = snapshot.requestedVoiceProcessing {
+            components.append("requestedVP=\(requestedVoiceProcessing)")
+        }
+        if let selectedDeviceID = snapshot.selectedDeviceID {
+            components.append("selectedDevice=\(selectedDeviceID)")
+        }
+        if let defaultDeviceID = snapshot.defaultDeviceID {
+            components.append("defaultDevice=\(defaultDeviceID)")
+        }
+        if let activeDeviceID = snapshot.activeDeviceID {
+            components.append("activeDevice=\(activeDeviceID)")
+        }
+        if let activeDeviceName = snapshot.activeDeviceName {
+            components.append(activeDeviceName)
+        }
+        if let deviceRunningBeforeCapture = snapshot.deviceRunningBeforeCapture {
+            components.append("runningBeforeCapture=\(deviceRunningBeforeCapture)")
+        }
+        if let engineRunning = snapshot.engineRunning {
+            components.append("engineRunning=\(engineRunning)")
+        }
+        if let inputHardwareFormat = snapshot.inputHardwareFormat {
+            components.append("hardware=\(inputHardwareFormat)")
+        }
+        if let inputClientFormat = snapshot.inputClientFormat {
+            components.append("client=\(inputClientFormat)")
+        }
+        if let outputHardwareFormat = snapshot.outputHardwareFormat {
+            components.append("output=\(outputHardwareFormat)")
+        }
+        if let targetFormat = snapshot.targetFormat {
+            components.append("target=\(targetFormat)")
+        }
         if let detail = snapshot.detail {
             components.append(detail)
         }

--- a/Sources/Dahlia/Views/Debug/ApplicationLogView.swift
+++ b/Sources/Dahlia/Views/Debug/ApplicationLogView.swift
@@ -3,14 +3,27 @@ import SwiftUI
 struct ApplicationLogView: View {
     @State private var model = ApplicationLogViewModel()
     @State private var searchText = ""
+    @State private var scrollPosition = ScrollPosition()
+    @State private var isFollowingLatest = true
 
     private var displayedText: String {
         model.text(matching: searchText)
     }
 
     var body: some View {
-        Group {
-            if let errorMessage = model.errorMessage {
+        VStack(spacing: 0) {
+            if let errorMessage = model.errorMessage, model.hasLogs {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal)
+                    .padding(.vertical, 8)
+                    .background(.bar)
+                Divider()
+            }
+
+            if let errorMessage = model.errorMessage, !model.hasLogs {
                 ContentUnavailableView(
                     L10n.applicationLogsUnavailable,
                     systemImage: "exclamationmark.triangle",
@@ -32,6 +45,15 @@ struct ApplicationLogView: View {
                         .frame(maxWidth: .infinity, alignment: .topLeading)
                         .padding()
                 }
+                .scrollPosition($scrollPosition)
+                .defaultScrollAnchor(.bottomLeading, for: .initialOffset)
+                .defaultScrollAnchor(.bottomLeading, for: .alignment)
+                .onScrollGeometryChange(for: Bool.self) { geometry in
+                    let visibleBottom = geometry.contentOffset.y + geometry.containerSize.height
+                    return visibleBottom >= geometry.contentSize.height - 24
+                } action: { _, isAtBottom in
+                    isFollowingLatest = isAtBottom
+                }
             }
         }
         .searchable(text: $searchText, prompt: L10n.searchApplicationLogs)
@@ -40,8 +62,15 @@ struct ApplicationLogView: View {
                 Button(
                     L10n.refreshApplicationLogs,
                     systemImage: "arrow.clockwise",
-                    action: model.refresh
+                    action: refreshLogs
                 )
+
+                Button(
+                    L10n.followLatestApplicationLogs,
+                    systemImage: "arrow.down.to.line",
+                    action: followLatest
+                )
+                .disabled(isFollowingLatest || displayedText.isEmpty)
 
                 Button(
                     L10n.copyDisplayedLogs,
@@ -52,7 +81,34 @@ struct ApplicationLogView: View {
             }
         }
         .task {
-            model.refresh()
+            await model.monitor()
+        }
+        .onChange(of: model.revision) {
+            guard isFollowingLatest else { return }
+            scrollToLatest()
+        }
+        .onChange(of: searchText) {
+            guard isFollowingLatest else { return }
+            scrollToLatest()
+        }
+    }
+
+    private func refreshLogs() {
+        Task {
+            await model.refresh()
+        }
+    }
+
+    private func followLatest() {
+        isFollowingLatest = true
+        scrollToLatest()
+    }
+
+    private func scrollToLatest() {
+        var transaction = Transaction(animation: nil)
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            scrollPosition.scrollTo(edge: .bottom)
         }
     }
 

--- a/Tests/DahliaTests/ApplicationLogLoaderStub.swift
+++ b/Tests/DahliaTests/ApplicationLogLoaderStub.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+actor ApplicationLogLoaderStub {
+    enum StubError: Error {
+        case unavailable
+    }
+
+    private var responses: [Result<[String], StubError>]
+    private(set) var callCount = 0
+
+    init(responses: [Result<[String], StubError>]) {
+        self.responses = responses
+    }
+
+    func load() throws -> [String] {
+        callCount += 1
+        guard !responses.isEmpty else { return [] }
+        return try responses.removeFirst().get()
+    }
+}

--- a/Tests/DahliaTests/ApplicationLogSleeperStub.swift
+++ b/Tests/DahliaTests/ApplicationLogSleeperStub.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+actor ApplicationLogSleeperStub {
+    private var remainingSuccessfulSleeps: Int
+
+    init(successfulSleepCount: Int) {
+        remainingSuccessfulSleeps = successfulSleepCount
+    }
+
+    func sleep(for _: Duration) throws {
+        guard remainingSuccessfulSleeps > 0 else {
+            throw CancellationError()
+        }
+        remainingSuccessfulSleeps -= 1
+    }
+}

--- a/Tests/DahliaTests/ApplicationLogViewModelTests.swift
+++ b/Tests/DahliaTests/ApplicationLogViewModelTests.swift
@@ -22,5 +22,77 @@
             #expect(model.text(matching: "recording") == "[NOTICE] Recording stopped")
             #expect(model.text(matching: "missing").isEmpty)
         }
+
+        @Test
+        func refreshUpdatesOnlyWhenSnapshotChanges() async {
+            let loader = ApplicationLogLoaderStub(responses: [
+                .success(["first"]),
+                .success(["first"]),
+                .success(["first", "second"]),
+            ])
+            let model = ApplicationLogViewModel(loadLogs: { try await loader.load() })
+
+            await model.refresh()
+            #expect(model.logLines == ["first"])
+            #expect(model.revision == 1)
+
+            await model.refresh()
+            #expect(model.revision == 1)
+
+            await model.refresh()
+            #expect(model.logLines == ["first", "second"])
+            #expect(model.revision == 2)
+        }
+
+        @Test
+        func refreshPreservesLogsAcrossTransientFailure() async {
+            let loader = ApplicationLogLoaderStub(responses: [
+                .success(["first"]),
+                .failure(.unavailable),
+                .success(["first", "recovered"]),
+            ])
+            let model = ApplicationLogViewModel(loadLogs: { try await loader.load() })
+
+            await model.refresh()
+            await model.refresh()
+            #expect(model.logLines == ["first"])
+            #expect(model.errorMessage != nil)
+
+            await model.refresh()
+            #expect(model.logLines == ["first", "recovered"])
+            #expect(model.errorMessage == nil)
+        }
+
+        @Test
+        func refreshKeepsNewestTwoThousandLines() async {
+            let lines = (0 ..< 2_100).map(String.init)
+            let loader = ApplicationLogLoaderStub(responses: [.success(lines)])
+            let model = ApplicationLogViewModel(loadLogs: { try await loader.load() })
+
+            await model.refresh()
+
+            #expect(model.logLines.count == 2_000)
+            #expect(model.logLines.first == "100")
+            #expect(model.logLines.last == "2099")
+        }
+
+        @Test
+        func monitorStopsWhenPollingSleepIsCancelled() async {
+            let loader = ApplicationLogLoaderStub(responses: [
+                .success(["first"]),
+                .success(["first", "second"]),
+                .success(["unexpected"]),
+            ])
+            let sleeper = ApplicationLogSleeperStub(successfulSleepCount: 1)
+            let model = ApplicationLogViewModel(
+                loadLogs: { try await loader.load() },
+                sleep: { try await sleeper.sleep(for: $0) }
+            )
+
+            await model.monitor()
+
+            #expect(model.logLines == ["first", "second"])
+            #expect(await loader.callCount == 2)
+        }
     }
 #endif

--- a/Tests/DahliaTests/MicrophoneCaptureDiagnosticsTests.swift
+++ b/Tests/DahliaTests/MicrophoneCaptureDiagnosticsTests.swift
@@ -48,5 +48,49 @@
             #expect(snapshot.context == .audioTest)
             #expect(snapshot.stage == .captureRequested)
         }
+
+        @Test
+        func rendersStructuredCaptureMetadata() throws {
+            let diagnostics = MicrophoneCaptureDiagnostics(modeProvider: {
+                (preferred: .voiceIsolation, active: .standard)
+            })
+            let captureID = diagnostics.beginCapture(
+                context: .recording,
+                requestedVoiceProcessing: true,
+                selectedDeviceID: 42,
+                defaultDeviceID: 7,
+                activeDeviceID: 42,
+                activeDeviceName: "USB Mic",
+                deviceRunningBeforeCapture: true,
+                targetFormat: "16000 Hz, 1 ch, Float32"
+            )
+            let snapshot = try #require(diagnostics.snapshots().first)
+
+            let line = MicrophoneCaptureDiagnostics.renderedLine(snapshot)
+
+            #expect(line.contains("captureID=\(captureID.uuidString)"))
+            #expect(line.contains("context=recording"))
+            #expect(line.contains("requestedVP=true"))
+            #expect(line.contains("selectedDevice=42"))
+            #expect(line.contains("runningBeforeCapture=true"))
+            #expect(line.contains("activeDeviceName=\"USB Mic\""))
+            #expect(line.contains("targetFormat=\"16000 Hz, 1 ch, Float32\""))
+        }
+
+        @Test
+        func boundsInMemorySnapshots() {
+            let diagnostics = MicrophoneCaptureDiagnostics(modeProvider: {
+                (preferred: .standard, active: .standard)
+            })
+            let captureID = diagnostics.beginCapture(context: .recording)
+
+            for index in 0 ..< 250 {
+                diagnostics.record(captureID: captureID, stage: .captureHealth, detail: "index=\(index)")
+            }
+
+            let snapshots = diagnostics.snapshots()
+            #expect(snapshots.count == 200)
+            #expect(snapshots.last?.detail == "index=249")
+        }
     }
 #endif

--- a/Tests/DahliaTests/MicrophoneCaptureHealthTrackerTests.swift
+++ b/Tests/DahliaTests/MicrophoneCaptureHealthTrackerTests.swift
@@ -1,0 +1,59 @@
+import AVFoundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct MicrophoneCaptureHealthTrackerTests {
+        @Test
+        func tracksBuffersLevelsAndIntervalSnapshots() throws {
+            let tracker = MicrophoneCaptureHealthTracker()
+            let captureID = UUID.v7()
+            let start = ContinuousClock.now
+            tracker.begin(captureID: captureID, at: start)
+
+            #expect(tracker.recordBuffer(captureID: captureID, frameLength: 480, at: start))
+            tracker.recordLevel(0.25, captureID: captureID)
+            #expect(!tracker.recordBuffer(
+                captureID: captureID,
+                frameLength: 480,
+                at: start.advanced(by: .seconds(1))
+            ))
+
+            let first = try #require(tracker.snapshot(
+                captureID: captureID,
+                at: start.advanced(by: .seconds(5))
+            ))
+            #expect(first.intervalBufferCount == 2)
+            #expect(first.totalBufferCount == 2)
+            #expect(first.totalFrameCount == 960)
+            #expect(first.lastLevel == 0.25)
+            #expect(first.lastBufferAge == .seconds(4))
+
+            let second = try #require(tracker.snapshot(
+                captureID: captureID,
+                at: start.advanced(by: .seconds(10))
+            ))
+            #expect(second.intervalBufferCount == 0)
+            #expect(second.totalBufferCount == 2)
+        }
+
+        @Test
+        func finishReturnsSummaryAndResetsTracker() throws {
+            let tracker = MicrophoneCaptureHealthTracker()
+            let captureID = UUID.v7()
+            let start = ContinuousClock.now
+            tracker.begin(captureID: captureID, at: start)
+            _ = tracker.recordBuffer(captureID: captureID, frameLength: 240, at: start)
+
+            let summary = try #require(tracker.finish(
+                captureID: captureID,
+                at: start.advanced(by: .seconds(2))
+            ))
+
+            #expect(summary.totalBufferCount == 1)
+            #expect(summary.totalFrameCount == 240)
+            #expect(tracker.snapshot(captureID: captureID) == nil)
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary

- application log window を1秒間隔のリアルタイム tail に変更
- `captureID` で相関可能な構造化マイク診断ログを追加
- 録音中のバッファ数・フレーム数・入力レベル・最終バッファ経過時間を5秒ごとに記録
- engine 構成変更、再起動、停止時の診断と決定的なテストを追加

## Why

Microsoft Teams のネイティブ版・Web版で、Dahlia 録音中にマイク入力が停止する事象があります。一方、Google Meet と Zoom では再現せず、現状のログだけでは Dahlia のバッファ停止、ゼロレベル化、Audio Engine 再構成、Voice Processing 状態変化、Teams 側だけの障害を分類できませんでした。

このPRでは録音挙動、Voice Processing、マイクモード、音声フォーマットを変更せず、原因確認に必要な観測性を追加します。音声データ、文字起こし、会議名はログへ含めません。

## User impact

アプリケーションログ画面は表示中に自動更新されます。末尾表示中のみ新着へ追従し、上へスクロールすると追従を停止します。「最新ログを追従」で再開できます。一時的な取得失敗時も既存ログを保持して自動再試行します。

## Validation

- `swift build`
- 対象テスト: 4 suites / 19 tests passed
- 全テスト: 142 suites / 854 tests passed
- `CI=true ./scripts/lint.sh`
- `git diff --check`

## Manual follow-up

- [ ] Teams ネイティブ版／Web版で開始順序を変えて再現
- [ ] Google Meet／Zoom と同じマイクで比較
- [ ] 問題発生時刻と `captureID` の診断行を照合