### PR TITLE
Allow project selection before summary generation

### DIFF
--- a/Sources/Dahlia/Models/BatchTranscriptionConfirmation.swift
+++ b/Sources/Dahlia/Models/BatchTranscriptionConfirmation.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+struct BatchTranscriptionProjectSelection {
+    let projects: [FlatProjectRow]
+    let selectedProjectId: UUID?
+    let errorMessage: String?
+}
+
 struct BatchTranscriptionConfirmation: Identifiable, Equatable {
     enum Purpose: Equatable {
         case initialOrRetry

--- a/Sources/Dahlia/Models/BatchTranscriptionConfirmation.swift
+++ b/Sources/Dahlia/Models/BatchTranscriptionConfirmation.swift
@@ -1,9 +1,15 @@
 import Foundation
 
-struct BatchTranscriptionProjectSelection {
+struct BatchTranscriptionProjectSelection: Equatable {
     let projects: [FlatProjectRow]
     let selectedProjectId: UUID?
     let errorMessage: String?
+
+    static let unavailable = BatchTranscriptionProjectSelection(
+        projects: [],
+        selectedProjectId: nil,
+        errorMessage: nil
+    )
 }
 
 struct BatchTranscriptionConfirmation: Identifiable, Equatable {
@@ -20,6 +26,7 @@ struct BatchTranscriptionConfirmation: Identifiable, Equatable {
     let automaticLanguageCandidateSnapshot: BatchLanguageDetectionCandidateSnapshot?
     let purpose: Purpose
     let initiallyGeneratesSummary: Bool
+    let projectSelection: BatchTranscriptionProjectSelection
 
     init(
         sessionId: UUID,
@@ -29,7 +36,8 @@ struct BatchTranscriptionConfirmation: Identifiable, Equatable {
         initialLanguageSelection: BatchTranscriptionLanguageSelection? = nil,
         automaticLanguageCandidateSnapshot: BatchLanguageDetectionCandidateSnapshot? = nil,
         purpose: Purpose = .initialOrRetry,
-        initiallyGeneratesSummary: Bool = false
+        initiallyGeneratesSummary: Bool = false,
+        projectSelection: BatchTranscriptionProjectSelection = .unavailable
     ) {
         if case let .retranscription(sessionIds) = purpose {
             precondition(!sessionIds.isEmpty && sessionIds.contains(sessionId))
@@ -43,6 +51,7 @@ struct BatchTranscriptionConfirmation: Identifiable, Equatable {
         self.automaticLanguageCandidateSnapshot = automaticLanguageCandidateSnapshot
         self.purpose = purpose
         self.initiallyGeneratesSummary = initiallyGeneratesSummary
+        self.projectSelection = projectSelection
     }
 
     var id: UUID { sessionId }

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -663,6 +663,7 @@
 "Generate Summary After Transcription" = "Generate Summary After Transcription";
 "Automatically generate a summary when batch transcription succeeds." = "Automatically generate a summary when batch transcription succeeds.";
 "Summary and Export" = "Summary and Export";
+"Project" = "Project";
 "Previous Meetings in Context" = "Previous Meetings in Context";
 "Include the latest meetings from the same calendar series in the summary context." = "Include the latest meetings from the same calendar series in the summary context.";
 "Generate this summary?" = "Generate this summary?";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -663,6 +663,7 @@
 "Generate Summary After Transcription" = "文字起こし後に要約を生成";
 "Automatically generate a summary when batch transcription succeeds." = "バッチ文字起こしが成功したら、自動的に要約を生成します。";
 "Summary and Export" = "要約と書き出し";
+"Project" = "プロジェクト";
 "Previous Meetings in Context" = "過去ミーティングのコンテキスト";
 "Include the latest meetings from the same calendar series in the summary context." = "同じカレンダー予定系列の直近ミーティングを要約コンテキストに含めます。";
 "Generate this summary?" = "要約を生成しますか？";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -603,6 +603,7 @@ enum L10n {
         bundle: bundle
     ) }
     static var summaryAndExport: String { String(localized: "Summary and Export", bundle: bundle) }
+    static var project: String { String(localized: "Project", bundle: bundle) }
     static var previousMeetingsInSummaryContext: String { String(
         localized: "Previous Meetings in Context",
         bundle: bundle

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -662,6 +662,74 @@ final class CaptionViewModel: ObservableObject {
         )
     }
 
+    func batchTranscriptionProjectSelection(
+        for confirmation: BatchTranscriptionConfirmation
+    ) -> BatchTranscriptionProjectSelection {
+        guard let context = batchSummaryContextsBySessionId[confirmation.sessionId] else {
+            return BatchTranscriptionProjectSelection(
+                projects: [],
+                selectedProjectId: nil,
+                errorMessage: L10n.meetingUnavailable
+            )
+        }
+
+        do {
+            let snapshot = try context.dbQueue.read { db -> (MeetingRecord, [ProjectRecord]) in
+                guard let meeting = try MeetingRecord.fetchOne(db, key: confirmation.meetingId) else {
+                    throw SummaryGenerationPreparationError.meetingUnavailable
+                }
+                let projects = try ProjectRecord
+                    .filter(Column("vaultId") == meeting.vaultId)
+                    .order(Column("name").asc)
+                    .fetchAll(db)
+                return (meeting, projects)
+            }
+            return BatchTranscriptionProjectSelection(
+                projects: FlatProjectRow.buildRows(fromRecords: snapshot.1),
+                selectedProjectId: snapshot.0.projectId,
+                errorMessage: nil
+            )
+        } catch {
+            return BatchTranscriptionProjectSelection(
+                projects: [],
+                selectedProjectId: nil,
+                errorMessage: error.localizedDescription
+            )
+        }
+    }
+
+    func assignPendingBatchTranscriptionProject(_ projectId: UUID?) -> String? {
+        guard let confirmation = pendingBatchTranscriptionConfirmation,
+              let context = batchSummaryContextsBySessionId[confirmation.sessionId] else {
+            return L10n.meetingUnavailable
+        }
+
+        do {
+            let repository = MeetingRepository(dbQueue: context.dbQueue)
+            guard let meeting = try repository.fetchMeeting(id: confirmation.meetingId),
+                  let vault = try repository.fetchAllVaults().first(where: { $0.id == meeting.vaultId }),
+                  vault.url.standardizedFileURL == context.vaultURL.standardizedFileURL else {
+                return L10n.meetingUnavailable
+            }
+            guard meeting.projectId != projectId else { return nil }
+
+            try ProjectWorkspaceService(repository: repository, vault: vault)
+                .moveMeeting(id: meeting.id, toProjectId: projectId)
+
+            if currentMeetingId == meeting.id, currentDbQueue === context.dbQueue {
+                let project = try projectId.flatMap(repository.fetchProject(id:))
+                setExplicitProjectContext(
+                    projectURL: project.map { context.vaultURL.appending(path: $0.name, directoryHint: .isDirectory) },
+                    projectId: projectId,
+                    projectName: project?.name
+                )
+            }
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
     func presentBatchTranscriptionConfirmation() {
         guard case let .awaitingConfirmation(sessionId) = batchTranscriptionState,
               let meetingId = currentMeetingId else { return }
@@ -2555,7 +2623,8 @@ final class CaptionViewModel: ObservableObject {
     }
 
     /// 確認画面で選択した設定を使って手動要約を実行する。
-    func triggerManualSummary(options: SummaryGenerationOptions = .manual) {
+    @discardableResult
+    func triggerManualSummary(options: SummaryGenerationOptions = .manual) -> Bool {
         triggerSummary(options: options)
     }
 
@@ -2590,11 +2659,11 @@ final class CaptionViewModel: ObservableObject {
         }
     }
 
-    private func triggerSummary(options: SummaryGenerationOptions) {
+    private func triggerSummary(options: SummaryGenerationOptions) -> Bool {
         guard canGenerateSummary,
               let meetingId = currentMeetingId,
               let vaultURL = currentVaultURL,
-              let dbQueue = currentDbQueue else { return }
+              let dbQueue = currentDbQueue else { return false }
         saveNoteImmediately()
         let repo = MeetingRepository(dbQueue: dbQueue)
         let meetingName = (try? repo.fetchMeeting(id: meetingId)?.name.nilIfBlank)
@@ -2616,7 +2685,7 @@ final class CaptionViewModel: ObservableObject {
             retriesFailedPersistence: true
         )
         requestShowSummaryTab = true
-        startSummaryGeneration(request)
+        return startSummaryGeneration(request)
     }
 
     private func generatePendingBatchSummaryIfReady(meetingId: UUID) {
@@ -2718,8 +2787,9 @@ final class CaptionViewModel: ObservableObject {
         summaryErrorsByMeetingId[meetingId] = message
     }
 
-    private func startSummaryGeneration(_ request: SummaryGenerationRequest) {
-        guard !isSummaryGenerating(meetingId: request.meetingId) else { return }
+    @discardableResult
+    private func startSummaryGeneration(_ request: SummaryGenerationRequest) -> Bool {
+        guard !isSummaryGenerating(meetingId: request.meetingId) else { return false }
         let job = SummaryGenerationJob(meetingId: request.meetingId, meetingName: request.meetingName)
         let exportOptions = request.options.exportOptions
         job.progress.vaultExport = exportOptions.exportsToVault ? .pending : .skipped
@@ -2735,6 +2805,7 @@ final class CaptionViewModel: ObservableObject {
         Task { [weak self] in
             await self?.runSummaryGeneration(request, job: job)
         }
+        return true
     }
 
     private func runSummaryGeneration(_ request: SummaryGenerationRequest, job: SummaryGenerationJob) async {

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -611,11 +611,13 @@ final class CaptionViewModel: ObservableObject {
         sessionIds: [UUID],
         meetingId: UUID
     ) {
+        var context: BatchSummaryContext?
         if let currentDbQueue, let currentVaultURL {
-            batchSummaryContextsBySessionId[sessionId] = BatchSummaryContext(
+            context = BatchSummaryContext(
                 dbQueue: currentDbQueue,
                 vaultURL: currentVaultURL
             )
+            batchSummaryContextsBySessionId[sessionId] = context
         }
         let preferences = batchConfirmationPreferences(
             sessionId: sessionId,
@@ -631,7 +633,8 @@ final class CaptionViewModel: ObservableObject {
             automaticLanguageCandidateSnapshot: preferences.automaticLanguageCandidateSnapshot,
             purpose: .retranscription(sessionIds: sessionIds),
             initiallyGeneratesSummary: hasCurrentMeetingSummary
-                || AppSettings.shared.generateSummaryAfterBatchTranscription
+                || AppSettings.shared.generateSummaryAfterBatchTranscription,
+            projectSelection: makeBatchTranscriptionProjectSelection(meetingId: meetingId, context: context)
         )
     }
 
@@ -662,20 +665,15 @@ final class CaptionViewModel: ObservableObject {
         )
     }
 
-    func batchTranscriptionProjectSelection(
-        for confirmation: BatchTranscriptionConfirmation
+    private func makeBatchTranscriptionProjectSelection(
+        meetingId: UUID,
+        context: BatchSummaryContext?
     ) -> BatchTranscriptionProjectSelection {
-        guard let context = batchSummaryContextsBySessionId[confirmation.sessionId] else {
-            return BatchTranscriptionProjectSelection(
-                projects: [],
-                selectedProjectId: nil,
-                errorMessage: L10n.meetingUnavailable
-            )
-        }
+        guard let context else { return .unavailable }
 
         do {
             let snapshot = try context.dbQueue.read { db -> (MeetingRecord, [ProjectRecord]) in
-                guard let meeting = try MeetingRecord.fetchOne(db, key: confirmation.meetingId) else {
+                guard let meeting = try MeetingRecord.fetchOne(db, key: meetingId) else {
                     throw SummaryGenerationPreparationError.meetingUnavailable
                 }
                 let projects = try ProjectRecord
@@ -699,10 +697,9 @@ final class CaptionViewModel: ObservableObject {
     }
 
     func assignPendingBatchTranscriptionProject(_ projectId: UUID?) -> String? {
-        guard let confirmation = pendingBatchTranscriptionConfirmation,
-              let context = batchSummaryContextsBySessionId[confirmation.sessionId] else {
-            return L10n.meetingUnavailable
-        }
+        guard let confirmation = pendingBatchTranscriptionConfirmation else { return L10n.meetingUnavailable }
+        if let errorMessage = confirmation.projectSelection.errorMessage { return errorMessage }
+        guard let context = batchSummaryContextsBySessionId[confirmation.sessionId] else { return nil }
 
         do {
             let repository = MeetingRepository(dbQueue: context.dbQueue)
@@ -724,6 +721,36 @@ final class CaptionViewModel: ObservableObject {
                     projectName: project?.name
                 )
             }
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
+    func assignCurrentMeetingProject(_ projectId: UUID?) -> String? {
+        guard let meetingId = currentMeetingId,
+              let dbQueue = currentDbQueue,
+              let vaultURL = currentVaultURL else {
+            return L10n.meetingUnavailable
+        }
+
+        do {
+            let repository = MeetingRepository(dbQueue: dbQueue)
+            guard let meeting = try repository.fetchMeeting(id: meetingId),
+                  let vault = try repository.fetchAllVaults().first(where: { $0.id == meeting.vaultId }),
+                  vault.url.standardizedFileURL == vaultURL.standardizedFileURL else {
+                return L10n.meetingUnavailable
+            }
+            guard meeting.projectId != projectId else { return nil }
+
+            try ProjectWorkspaceService(repository: repository, vault: vault)
+                .moveMeeting(id: meeting.id, toProjectId: projectId)
+            let project = try projectId.flatMap(repository.fetchProject(id:))
+            setExplicitProjectContext(
+                projectURL: project.map { vaultURL.appending(path: $0.name, directoryHint: .isDirectory) },
+                projectId: projectId,
+                projectName: project?.name
+            )
             return nil
         } catch {
             return error.localizedDescription
@@ -781,7 +808,11 @@ final class CaptionViewModel: ObservableObject {
             initialLanguageSelection: languageSelection,
             automaticLanguageCandidateSnapshot: automaticLanguageCandidates.snapshot,
             purpose: confirmation.purpose,
-            initiallyGeneratesSummary: summaryGenerationOptions != nil
+            initiallyGeneratesSummary: summaryGenerationOptions != nil,
+            projectSelection: makeBatchTranscriptionProjectSelection(
+                meetingId: confirmation.meetingId,
+                context: batchSummaryContextsBySessionId[confirmation.sessionId]
+            )
         )
         let batchSummaryContext = batchSummaryContextsBySessionId[confirmation.sessionId]
         updatePendingBatchSummaryRequest(
@@ -2357,11 +2388,13 @@ final class CaptionViewModel: ObservableObject {
         dbQueue: DatabaseQueue?,
         vaultURL: URL?
     ) {
+        var context: BatchSummaryContext?
         if let dbQueue, let vaultURL {
-            batchSummaryContextsBySessionId[sessionId] = BatchSummaryContext(
+            context = BatchSummaryContext(
                 dbQueue: dbQueue,
                 vaultURL: vaultURL
             )
+            batchSummaryContextsBySessionId[sessionId] = context
         }
         let preferences = batchConfirmationPreferences(
             sessionId: sessionId,
@@ -2375,7 +2408,8 @@ final class CaptionViewModel: ObservableObject {
             retainAudioAfterBatch: preferences.retainsAudio,
             initialLanguageSelection: preferences.languageSelection,
             automaticLanguageCandidateSnapshot: preferences.automaticLanguageCandidateSnapshot,
-            initiallyGeneratesSummary: AppSettings.shared.generateSummaryAfterBatchTranscription
+            initiallyGeneratesSummary: AppSettings.shared.generateSummaryAfterBatchTranscription,
+            projectSelection: makeBatchTranscriptionProjectSelection(meetingId: meetingId, context: context)
         )
         MainWindowOpener.shared.openMainWindow()
     }

--- a/Sources/Dahlia/Views/BatchTranscriptionConfirmationView.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionConfirmationView.swift
@@ -4,8 +4,9 @@ struct BatchTranscriptionConfirmationView: View {
     let locales: [Locale]
     let automaticLanguageLocales: [Locale]
     let displayLocale: Locale
+    let projects: [FlatProjectRow]
     let isRetranscription: Bool
-    let onStart: (BatchTranscriptionLanguageSelection, Bool, SummaryGenerationOptions?) -> Void
+    let onStart: (BatchTranscriptionLanguageSelection, Bool, SummaryGenerationOptions?, UUID?) -> String?
     let onPostpone: () -> Void
 
     @State private var languageSelection: BatchTranscriptionLanguageSelection
@@ -14,22 +15,28 @@ struct BatchTranscriptionConfirmationView: View {
     @State private var exportBatchSummaryToVault: Bool
     @State private var exportBatchSummaryToGoogleDocs: Bool
     @State private var previousMeetingCount: Int
+    @State private var selectedProjectId: UUID?
+    @State private var errorMessage: String?
 
     init(
         locales: [Locale],
         automaticLanguageLocales: [Locale],
         displayLocale: Locale,
+        projects: [FlatProjectRow],
+        initialProjectId: UUID?,
+        initialErrorMessage: String?,
         initialLanguageSelection: BatchTranscriptionLanguageSelection,
         initiallyRetainsAudioAfterBatch: Bool,
         initiallyGeneratesSummary: Bool,
         summaryGenerationOptions: SummaryGenerationOptions,
         isRetranscription: Bool,
-        onStart: @escaping (BatchTranscriptionLanguageSelection, Bool, SummaryGenerationOptions?) -> Void,
+        onStart: @escaping (BatchTranscriptionLanguageSelection, Bool, SummaryGenerationOptions?, UUID?) -> String?,
         onPostpone: @escaping () -> Void
     ) {
         self.locales = locales
         self.automaticLanguageLocales = automaticLanguageLocales
         self.displayLocale = displayLocale
+        self.projects = projects
         self.onStart = onStart
         self.onPostpone = onPostpone
         self.isRetranscription = isRetranscription
@@ -39,6 +46,8 @@ struct BatchTranscriptionConfirmationView: View {
         _exportBatchSummaryToVault = State(initialValue: summaryGenerationOptions.exportOptions.exportsToVault)
         _exportBatchSummaryToGoogleDocs = State(initialValue: summaryGenerationOptions.exportOptions.exportsToGoogleDocs)
         _previousMeetingCount = State(initialValue: summaryGenerationOptions.previousMeetingCount)
+        _selectedProjectId = State(initialValue: initialProjectId)
+        _errorMessage = State(initialValue: initialErrorMessage)
     }
 
     var body: some View {
@@ -66,8 +75,19 @@ struct BatchTranscriptionConfirmationView: View {
                 generateSummaryAfterBatchTranscription: $generateSummaryAfterBatchTranscription,
                 exportBatchSummaryToVault: $exportBatchSummaryToVault,
                 exportBatchSummaryToGoogleDocs: $exportBatchSummaryToGoogleDocs,
-                previousMeetingCount: $previousMeetingCount
+                previousMeetingCount: $previousMeetingCount,
+                projects: projects,
+                selectedProjectId: $selectedProjectId
             )
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 8)
+            }
 
             Divider()
 
@@ -103,7 +123,12 @@ struct BatchTranscriptionConfirmationView: View {
                 )
             )
             : nil
-        onStart(languageSelection, !deleteAudioAfterTranscription, summaryOptions)
+        errorMessage = onStart(
+            languageSelection,
+            !deleteAudioAfterTranscription,
+            summaryOptions,
+            selectedProjectId
+        )
     }
 
     private func persistSummaryPreferencesIfNeeded() {

--- a/Sources/Dahlia/Views/BatchTranscriptionOptionsForm.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionOptionsForm.swift
@@ -10,6 +10,8 @@ struct BatchTranscriptionOptionsForm: View {
     @Binding var exportBatchSummaryToVault: Bool
     @Binding var exportBatchSummaryToGoogleDocs: Bool
     @Binding var previousMeetingCount: Int
+    let projects: [FlatProjectRow]
+    @Binding var selectedProjectId: UUID?
 
     var body: some View {
         Form {
@@ -41,6 +43,8 @@ struct BatchTranscriptionOptionsForm: View {
             }
 
             Section(L10n.summaryAndExport) {
+                SummaryProjectPicker(projects: projects, selection: $selectedProjectId)
+
                 Toggle(isOn: $generateSummaryAfterBatchTranscription) {
                     Text(L10n.generateSummaryAfterBatchTranscription)
                     Text(L10n.generateSummaryAfterBatchTranscriptionDescription)

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -88,6 +88,7 @@ struct ContentView: View {
             }
         }
         .sheet(item: $viewModel.pendingBatchTranscriptionConfirmation) { confirmation in
+            let projectSelection = viewModel.batchTranscriptionProjectSelection(for: confirmation)
             BatchTranscriptionConfirmationView(
                 locales: viewModel.batchTranscriptionLocaleOptions(
                     preferredIdentifier: confirmation.suggestedLocaleIdentifier
@@ -96,12 +97,25 @@ struct ContentView: View {
                     snapshot: confirmation.automaticLanguageCandidateSnapshot
                 ).locales,
                 displayLocale: AppSettings.shared.appLanguage.locale,
+                projects: projectSelection.projects,
+                initialProjectId: projectSelection.selectedProjectId,
+                initialErrorMessage: projectSelection.errorMessage,
                 initialLanguageSelection: confirmation.initialLanguageSelection,
                 initiallyRetainsAudioAfterBatch: confirmation.retainAudioAfterBatch,
                 initiallyGeneratesSummary: confirmation.initiallyGeneratesSummary,
                 summaryGenerationOptions: AppSettings.shared.batchSummaryGenerationOptions,
                 isRetranscription: confirmation.isRetranscription,
-                onStart: viewModel.confirmBatchTranscription,
+                onStart: { languageSelection, retainAudio, summaryOptions, projectId in
+                    if let error = viewModel.assignPendingBatchTranscriptionProject(projectId) {
+                        return error
+                    }
+                    viewModel.confirmBatchTranscription(
+                        languageSelection: languageSelection,
+                        retainAudioAfterBatch: retainAudio,
+                        summaryGenerationOptions: summaryOptions
+                    )
+                    return nil
+                },
                 onPostpone: viewModel.postponeBatchTranscription
             )
             .interactiveDismissDisabled()

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -88,7 +88,6 @@ struct ContentView: View {
             }
         }
         .sheet(item: $viewModel.pendingBatchTranscriptionConfirmation) { confirmation in
-            let projectSelection = viewModel.batchTranscriptionProjectSelection(for: confirmation)
             BatchTranscriptionConfirmationView(
                 locales: viewModel.batchTranscriptionLocaleOptions(
                     preferredIdentifier: confirmation.suggestedLocaleIdentifier
@@ -97,9 +96,9 @@ struct ContentView: View {
                     snapshot: confirmation.automaticLanguageCandidateSnapshot
                 ).locales,
                 displayLocale: AppSettings.shared.appLanguage.locale,
-                projects: projectSelection.projects,
-                initialProjectId: projectSelection.selectedProjectId,
-                initialErrorMessage: projectSelection.errorMessage,
+                projects: confirmation.projectSelection.projects,
+                initialProjectId: confirmation.projectSelection.selectedProjectId,
+                initialErrorMessage: confirmation.projectSelection.errorMessage,
                 initialLanguageSelection: confirmation.initialLanguageSelection,
                 initiallyRetainsAudioAfterBatch: confirmation.retainAudioAfterBatch,
                 initiallyGeneratesSummary: confirmation.initiallyGeneratesSummary,

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -469,7 +469,10 @@ struct ControlPanelView: View {
         ToolbarSpacer(.fixed, placement: .primaryAction)
 
         ToolbarItem(placement: .primaryAction) {
-            GenerateSummaryToolbarButton(viewModel: viewModel)
+            GenerateSummaryToolbarButton(
+                viewModel: viewModel,
+                sidebarViewModel: sidebarViewModel
+            )
         }
 
         if showsToolbarRecordButton {

--- a/Sources/Dahlia/Views/SummaryGenerationConfirmationView.swift
+++ b/Sources/Dahlia/Views/SummaryGenerationConfirmationView.swift
@@ -5,11 +5,32 @@ struct SummaryGenerationConfirmationView: View {
     @State private var previousMeetingCount: Int
     @State private var exportsToVault = SummaryExportOptions.manual.exportsToVault
     @State private var exportsToGoogleDocs = SummaryExportOptions.manual.exportsToGoogleDocs
+    @State private var selectedProjectId: UUID?
+    @State private var errorMessage: String?
 
     let title: String
     let description: String
     let actionTitle: String
-    let onGenerate: (SummaryGenerationOptions) -> Void
+    let projects: [FlatProjectRow]?
+    let onGenerate: (SummaryGenerationOptions, UUID?) -> String?
+
+    init(
+        title: String = L10n.summaryGenerationConfirmationTitle,
+        description: String = L10n.summaryGenerationConfirmationDescription,
+        actionTitle: String = L10n.generateSummary,
+        projects: [FlatProjectRow]? = nil,
+        initialProjectId: UUID? = nil,
+        onGenerate: @escaping (SummaryGenerationOptions, UUID?) -> String?
+    ) {
+        self.title = title
+        self.description = description
+        self.actionTitle = actionTitle
+        self.projects = projects
+        self.onGenerate = onGenerate
+        _previousMeetingCount = State(initialValue: AppSettings.shared.summaryPreviousMeetingCount)
+        _selectedProjectId = State(initialValue: initialProjectId)
+        _errorMessage = State(initialValue: nil)
+    }
 
     init(
         title: String = L10n.summaryGenerationConfirmationTitle,
@@ -17,11 +38,10 @@ struct SummaryGenerationConfirmationView: View {
         actionTitle: String = L10n.generateSummary,
         onGenerate: @escaping (SummaryGenerationOptions) -> Void
     ) {
-        self.title = title
-        self.description = description
-        self.actionTitle = actionTitle
-        self.onGenerate = onGenerate
-        _previousMeetingCount = State(initialValue: AppSettings.shared.summaryPreviousMeetingCount)
+        self.init(title: title, description: description, actionTitle: actionTitle) { options, _ in
+            onGenerate(options)
+            return nil
+        }
     }
 
     var body: some View {
@@ -39,6 +59,10 @@ struct SummaryGenerationConfirmationView: View {
 
             Form {
                 Section(L10n.summaryAndExport) {
+                    if let projects {
+                        SummaryProjectPicker(projects: projects, selection: $selectedProjectId)
+                    }
+
                     SummaryGenerationOptionsControls(
                         previousMeetingCount: $previousMeetingCount,
                         exportsToVault: $exportsToVault,
@@ -48,6 +72,15 @@ struct SummaryGenerationConfirmationView: View {
                 }
             }
             .formStyle(.grouped)
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 8)
+            }
 
             Divider()
 
@@ -65,13 +98,15 @@ struct SummaryGenerationConfirmationView: View {
 
     private func generateSummary() {
         AppSettings.shared.summaryPreviousMeetingCount = previousMeetingCount
-        onGenerate(SummaryGenerationOptions(
+        errorMessage = onGenerate(SummaryGenerationOptions(
             previousMeetingCount: AppSettings.shared.summaryPreviousMeetingCount,
             exportOptions: SummaryExportOptions(
                 exportsToVault: exportsToVault,
                 exportsToGoogleDocs: exportsToGoogleDocs
             )
-        ))
-        dismiss()
+        ), selectedProjectId)
+        if errorMessage == nil {
+            dismiss()
+        }
     }
 }

--- a/Sources/Dahlia/Views/SummaryProjectPicker.swift
+++ b/Sources/Dahlia/Views/SummaryProjectPicker.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct SummaryProjectPicker: View {
+    let projects: [FlatProjectRow]
+    @Binding var selection: UUID?
+
+    var body: some View {
+        Picker(L10n.project, selection: $selection) {
+            Text(L10n.noProject)
+                .tag(nil as UUID?)
+
+            ForEach(projects) { project in
+                Text(project.name)
+                    .tag(project.id as UUID?)
+                    .disabled(project.missingOnDisk && project.id != selection)
+            }
+        }
+        .pickerStyle(.menu)
+    }
+}

--- a/Sources/Dahlia/Views/SummaryProjectPicker.swift
+++ b/Sources/Dahlia/Views/SummaryProjectPicker.swift
@@ -9,10 +9,9 @@ struct SummaryProjectPicker: View {
             Text(L10n.noProject)
                 .tag(nil as UUID?)
 
-            ForEach(projects) { project in
+            ForEach(projects.filter { !$0.missingOnDisk || $0.id == selection }) { project in
                 Text(project.name)
                     .tag(project.id as UUID?)
-                    .disabled(project.missingOnDisk && project.id != selection)
             }
         }
         .pickerStyle(.menu)

--- a/Sources/Dahlia/Views/Toolbar/SessionControls.swift
+++ b/Sources/Dahlia/Views/Toolbar/SessionControls.swift
@@ -49,6 +49,7 @@ struct RecordToolbarButton: View {
 
 struct GenerateSummaryToolbarButton: View {
     @ObservedObject var viewModel: CaptionViewModel
+    var sidebarViewModel: SidebarViewModel
     @State private var isConfirmationPresented = false
 
     private var isGeneratingCurrentMeeting: Bool {
@@ -73,7 +74,11 @@ struct GenerateSummaryToolbarButton: View {
         .disabled(isGeneratingCurrentMeeting || !viewModel.canGenerateSummary)
         .help(isGeneratingCurrentMeeting ? L10n.generatingSummary : L10n.generateSummary)
         .sheet(isPresented: $isConfirmationPresented) {
-            SummaryGenerationConfirmationView(onGenerate: generateSummary)
+            SummaryGenerationConfirmationView(
+                projects: sidebarViewModel.flatProjects,
+                initialProjectId: viewModel.currentProjectId,
+                onGenerate: generateSummary
+            )
         }
     }
 
@@ -81,8 +86,29 @@ struct GenerateSummaryToolbarButton: View {
         isConfirmationPresented = true
     }
 
-    private func generateSummary(options: SummaryGenerationOptions) {
-        viewModel.triggerManualSummary(options: options)
+    private func generateSummary(options: SummaryGenerationOptions, projectId: UUID?) -> String? {
+        if let error = assignCurrentMeeting(to: projectId) {
+            return error
+        }
+        return viewModel.triggerManualSummary(options: options) ? nil : L10n.summaryGenerationFailed
+    }
+
+    private func assignCurrentMeeting(to projectId: UUID?) -> String? {
+        guard projectId != viewModel.currentProjectId else { return nil }
+        guard let meetingId = viewModel.currentMeetingId,
+              sidebarViewModel.moveMeeting(id: meetingId, toProjectId: projectId) else {
+            return sidebarViewModel.lastError ?? L10n.projectOperationFailedDescription
+        }
+
+        let project = projectId.flatMap { id in
+            sidebarViewModel.flatProjects.first(where: { $0.id == id })
+        }
+        viewModel.setExplicitProjectContext(
+            projectURL: project.map { sidebarViewModel.projectURL(for: $0.name) },
+            projectId: projectId,
+            projectName: project?.name
+        )
+        return nil
     }
 }
 

--- a/Sources/Dahlia/Views/Toolbar/SessionControls.swift
+++ b/Sources/Dahlia/Views/Toolbar/SessionControls.swift
@@ -87,28 +87,11 @@ struct GenerateSummaryToolbarButton: View {
     }
 
     private func generateSummary(options: SummaryGenerationOptions, projectId: UUID?) -> String? {
-        if let error = assignCurrentMeeting(to: projectId) {
+        if let error = viewModel.assignCurrentMeetingProject(projectId) {
             return error
         }
-        return viewModel.triggerManualSummary(options: options) ? nil : L10n.summaryGenerationFailed
-    }
-
-    private func assignCurrentMeeting(to projectId: UUID?) -> String? {
-        guard projectId != viewModel.currentProjectId else { return nil }
-        guard let meetingId = viewModel.currentMeetingId,
-              sidebarViewModel.moveMeeting(id: meetingId, toProjectId: projectId) else {
-            return sidebarViewModel.lastError ?? L10n.projectOperationFailedDescription
-        }
-
-        let project = projectId.flatMap { id in
-            sidebarViewModel.flatProjects.first(where: { $0.id == id })
-        }
-        viewModel.setExplicitProjectContext(
-            projectURL: project.map { sidebarViewModel.projectURL(for: $0.name) },
-            projectId: projectId,
-            projectName: project?.name
-        )
-        return nil
+        guard !viewModel.triggerManualSummary(options: options) else { return nil }
+        return viewModel.isSummaryGenerating ? nil : L10n.summaryGenerationFailed
     }
 }
 

--- a/Tests/DahliaTests/CaptionViewModelSummaryGenerationTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelSummaryGenerationTests.swift
@@ -9,6 +9,81 @@ import GRDB
     @Suite(.serialized)
     struct CaptionViewModelSummaryGenerationTests {
         @Test
+        func manualSummaryUsesProjectSelectedBeforeGeneration() async throws {
+            let fixture = try SummaryGenerationFixture()
+            defer { fixture.removeFiles() }
+            let runner = BlockingSummaryRunner()
+            let viewModel = CaptionViewModel(summaryGenerationRunner: runner.run)
+            let project = try fixture.insertProject(name: "Selected", description: "Selected context")
+            try fixture.assign(fixture.first, to: project)
+            let options = SummaryGenerationOptions(
+                previousMeetingCount: 0,
+                exportOptions: SummaryExportOptions(exportsToVault: false, exportsToGoogleDocs: false)
+            )
+
+            await fixture.select(fixture.first, in: viewModel, note: "note")
+            viewModel.setExplicitProjectContext(
+                projectURL: fixture.vaultURL.appending(path: project.name, directoryHint: .isDirectory),
+                projectId: project.id,
+                projectName: project.name
+            )
+            viewModel.triggerManualSummary(options: options)
+            await runner.waitForCallCount(1)
+
+            #expect(runner.calls[0].projectName == project.name)
+            #expect(runner.calls[0].projectDescription == "Selected context")
+            runner.complete(meetingID: fixture.first.id, title: "Summary")
+            #expect(await waitUntil { !viewModel.isSummaryGenerating(meetingId: fixture.first.id) })
+        }
+
+        @Test
+        func manualSummaryReportsWhenGenerationBecomesUnavailable() async throws {
+            let fixture = try SummaryGenerationFixture()
+            defer { fixture.removeFiles() }
+            let runner = BlockingSummaryRunner()
+            let viewModel = CaptionViewModel(summaryGenerationRunner: runner.run)
+            await fixture.select(fixture.first, in: viewModel, note: "note")
+            viewModel.setScreenshotDeletionInProgressForTesting(true)
+
+            #expect(!viewModel.triggerManualSummary(options: .manual))
+            #expect(runner.calls.isEmpty)
+            #expect(viewModel.summaryGenerationJobs.isEmpty)
+        }
+
+        @Test
+        func automaticBatchSummaryReloadsProjectSelectedAtConfirmation() async throws {
+            let fixture = try SummaryGenerationFixture()
+            defer { fixture.removeFiles() }
+            let runner = BlockingSummaryRunner()
+            let viewModel = CaptionViewModel(summaryGenerationRunner: runner.run)
+            let project = try fixture.insertProject(name: "Batch", description: "Batch context")
+            try fixture.assign(fixture.first, to: project)
+            let sessionID = try fixture.insertRecordingSession(for: fixture.first, offset: 0)
+            let options = SummaryGenerationOptions(
+                previousMeetingCount: 0,
+                exportOptions: SummaryExportOptions(exportsToVault: false, exportsToGoogleDocs: false)
+            )
+
+            viewModel.registerPendingBatchSummaryForTesting(
+                sessionID: sessionID,
+                meetingID: fixture.first.id,
+                options: options,
+                dbQueue: fixture.database.dbQueue,
+                vaultURL: fixture.vaultURL
+            )
+            await viewModel.handleBatchTranscriptionUpdate(.init(
+                meetingId: fixture.first.id,
+                state: .completed(sessionId: sessionID)
+            ))
+            await runner.waitForCallCount(1)
+
+            #expect(runner.calls[0].projectName == project.name)
+            #expect(runner.calls[0].projectDescription == "Batch context")
+            runner.complete(meetingID: fixture.first.id, title: "Summary")
+            #expect(await waitUntil { !viewModel.isSummaryGenerating(meetingId: fixture.first.id) })
+        }
+
+        @Test
         func selectedMeetingsRegenerateConcurrentlyWithoutChangingCurrentMeeting() async throws {
             let fixture = try SummaryGenerationFixture()
             defer { fixture.removeFiles() }
@@ -379,6 +454,7 @@ import GRDB
             }
             let runner = BlockingSummaryRunner()
             let viewModel = CaptionViewModel(summaryGenerationRunner: runner.run)
+            let project = try original.insertProject(name: "Original Project", description: "Original context")
             let options = SummaryGenerationOptions(
                 previousMeetingCount: 0,
                 exportOptions: SummaryExportOptions(exportsToVault: false, exportsToGoogleDocs: false)
@@ -392,6 +468,19 @@ import GRDB
             )
 
             await destination.select(destination.first, in: viewModel, note: "destination")
+            let confirmation = try #require(viewModel.pendingBatchTranscriptionConfirmation)
+            let projectSelection = viewModel.batchTranscriptionProjectSelection(for: confirmation)
+            #expect(projectSelection.projects.map(\.id) == [project.id])
+            #expect(projectSelection.selectedProjectId == nil)
+            #expect(projectSelection.errorMessage == nil)
+
+            #expect(viewModel.assignPendingBatchTranscriptionProject(.v7()) != nil)
+            #expect(try original.projectId(for: original.first.id) == nil)
+            #expect(viewModel.assignPendingBatchTranscriptionProject(project.id) == nil)
+            #expect(try original.projectId(for: original.first.id) == project.id)
+            #expect(viewModel.currentMeetingId == destination.first.id)
+            #expect(viewModel.currentProjectId == nil)
+
             viewModel.confirmPendingBatchSummaryForTesting(
                 sessionID: sessionID,
                 meetingID: original.first.id,
@@ -404,6 +493,8 @@ import GRDB
             await runner.waitForCallCount(1)
 
             #expect(runner.calls[0].meetingID == original.first.id)
+            #expect(runner.calls[0].projectName == project.name)
+            #expect(runner.calls[0].projectDescription == project.description)
             runner.complete(meetingID: original.first.id, title: "Original summary")
             #expect(await waitUntil { !viewModel.isSummaryGenerating(meetingId: original.first.id) })
             #expect(try original.summary(for: original.first.id) != nil)
@@ -429,6 +520,8 @@ import GRDB
         struct Call {
             let meetingID: UUID
             let noteText: String?
+            let projectName: String?
+            let projectDescription: String?
             let settings: SummaryGenerationSettings
             let recordingSessionIDs: [UUID]
         }
@@ -445,6 +538,8 @@ import GRDB
             calls.append(Call(
                 meetingID: input.promptContext.meetingId,
                 noteText: input.noteText,
+                projectName: input.promptContext.projectName,
+                projectDescription: input.promptContext.projectDescription,
                 settings: input.generationSettings,
                 recordingSessionIDs: input.recordingSessions.map(\.id)
             ))
@@ -564,6 +659,34 @@ import GRDB
         func summary(for meetingID: UUID) throws -> SummaryRecord? {
             try database.dbQueue.read { db in
                 try SummaryRecord.fetchOne(db, key: meetingID)
+            }
+        }
+
+        func projectId(for meetingID: UUID) throws -> UUID? {
+            try database.dbQueue.read { db in
+                try MeetingRecord.fetchOne(db, key: meetingID)?.projectId
+            }
+        }
+
+        func insertProject(name: String, description: String) throws -> ProjectRecord {
+            let projectURL = vaultURL.appending(path: name, directoryHint: .isDirectory)
+            try FileManager.default.createDirectory(at: projectURL, withIntermediateDirectories: true)
+            let project = ProjectRecord(
+                id: .v7(),
+                vaultId: vault.id,
+                name: name,
+                createdAt: first.createdAt,
+                description: description
+            )
+            try database.dbQueue.write { db in try project.insert(db) }
+            return project
+        }
+
+        func assign(_ meeting: MeetingRecord, to project: ProjectRecord) throws {
+            _ = try database.dbQueue.write { db in
+                try MeetingRecord
+                    .filter(key: meeting.id)
+                    .updateAll(db, Column("projectId").set(to: project.id))
             }
         }
 

--- a/Tests/DahliaTests/CaptionViewModelSummaryGenerationTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelSummaryGenerationTests.swift
@@ -15,18 +15,13 @@ import GRDB
             let runner = BlockingSummaryRunner()
             let viewModel = CaptionViewModel(summaryGenerationRunner: runner.run)
             let project = try fixture.insertProject(name: "Selected", description: "Selected context")
-            try fixture.assign(fixture.first, to: project)
             let options = SummaryGenerationOptions(
                 previousMeetingCount: 0,
                 exportOptions: SummaryExportOptions(exportsToVault: false, exportsToGoogleDocs: false)
             )
 
             await fixture.select(fixture.first, in: viewModel, note: "note")
-            viewModel.setExplicitProjectContext(
-                projectURL: fixture.vaultURL.appending(path: project.name, directoryHint: .isDirectory),
-                projectId: project.id,
-                projectName: project.name
-            )
+            #expect(viewModel.assignCurrentMeetingProject(project.id) == nil)
             viewModel.triggerManualSummary(options: options)
             await runner.waitForCallCount(1)
 
@@ -34,6 +29,24 @@ import GRDB
             #expect(runner.calls[0].projectDescription == "Selected context")
             runner.complete(meetingID: fixture.first.id, title: "Summary")
             #expect(await waitUntil { !viewModel.isSummaryGenerating(meetingId: fixture.first.id) })
+        }
+
+        @Test
+        func batchConfirmationWithoutPersistenceContextDoesNotBlockTranscription() throws {
+            let fixture = try SummaryGenerationFixture()
+            defer { fixture.removeFiles() }
+            let viewModel = CaptionViewModel()
+            let sessionID = try fixture.insertRecordingSession(for: fixture.first, offset: 0)
+
+            viewModel.presentBatchTranscriptionConfirmation(
+                sessionId: sessionID,
+                meetingId: fixture.first.id,
+                dbQueue: fixture.database.dbQueue
+            )
+
+            let confirmation = try #require(viewModel.pendingBatchTranscriptionConfirmation)
+            #expect(confirmation.projectSelection == .unavailable)
+            #expect(viewModel.assignPendingBatchTranscriptionProject(nil) == nil)
         }
 
         @Test
@@ -469,7 +482,7 @@ import GRDB
 
             await destination.select(destination.first, in: viewModel, note: "destination")
             let confirmation = try #require(viewModel.pendingBatchTranscriptionConfirmation)
-            let projectSelection = viewModel.batchTranscriptionProjectSelection(for: confirmation)
+            let projectSelection = confirmation.projectSelection
             #expect(projectSelection.projects.map(\.id) == [project.id])
             #expect(projectSelection.selectedProjectId == nil)
             #expect(projectSelection.errorMessage == nil)


### PR DESCRIPTION
## Summary

- add a project picker to the manual summary confirmation sheet
- add the same picker to the batch transcription confirmation sheet, independent of automatic summary selection
- persist the selected project before summary generation so project context is included in the generated summary
- keep batch confirmation operations bound to their original database and Vault context
- keep confirmation sheets open and show inline errors when project assignment or summary startup fails

## Why

Summaries use the meeting's project information as context, but it was easy to start a summary without first assigning the meeting to the intended project. The confirmation step now provides that last opportunity to choose an existing project or no project.

## Review follow-ups

- reject unavailable project destinations
- distinguish missing meetings and persistence failures from an intentionally unassigned project
- avoid silently dismissing the manual summary sheet when generation cannot start
- cover project changes for manual and automatic batch summaries, including navigation to another Vault while batch confirmation is pending

## Validation

- `swift build`
- `swift test --filter CaptionViewModelSummaryGenerationTests` (13 tests passed)
- `CI=true ./scripts/lint.sh` (exit 0; existing non-blocking SwiftLint warnings remain)
- `git diff --check`
