### PR TITLE
Enable scheduled update checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ xcrun notarytool store-credentials "dahlia-notary" \
 
 `./scripts/notarize.sh` uses `NOTARY_PROFILE` (default: `dahlia-notary`) and produces a signed, notarized, and stapled `Dahlia.dmg` ready for distribution.
 
-Dahlia uses Sparkle 2 for in-app updates. Its Ed25519 private key is stored in the login Keychain under the `com.dahlia.app` account and must be backed up securely. On a new release machine, import the existing private key with Sparkle's `generate_keys` tool; never generate a replacement key or commit the exported private key. `create-github-release.sh` signs the DMG update and appcast with this key, then uploads both `Dahlia.dmg` and `appcast.xml` to the GitHub Release.
+Dahlia uses Sparkle 2 for in-app updates. Production builds check for updates every 24 hours and prompt the user when one is available; updates are not installed automatically by default. Its Ed25519 private key is stored in the login Keychain under the `com.dahlia.app` account and must be backed up securely. On a new release machine, import the existing private key with Sparkle's `generate_keys` tool; never generate a replacement key or commit the exported private key. `create-github-release.sh` signs the DMG update and appcast with this key, then uploads both `Dahlia.dmg` and `appcast.xml` to the GitHub Release.
 
 When replacing the release laptop, migrate the Sparkle key as follows. The exported file is an unencrypted private key with the same sensitivity as a password. Export it directly to encrypted offline storage, transfer it through a trusted channel, and never place it in the repository, cloud-synced folders, chat, or issue attachments.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -83,7 +83,7 @@ xcrun notarytool store-credentials "dahlia-notary" \
 
 `./scripts/notarize.sh` は `NOTARY_PROFILE` 環境変数（既定値: `dahlia-notary`）を使い、署名・notarization・staple 済みの `Dahlia.dmg` を作成します。
 
-Dahlia のアプリ内更新には Sparkle 2 を使用します。Ed25519 秘密鍵はログインキーチェーンの `com.dahlia.app` アカウントに保存されるため、安全な場所へバックアップしてください。別のリリースマシンでは Sparkle の `generate_keys` ツールで既存の秘密鍵をインポートし、代替鍵を新規生成したり、エクスポートした秘密鍵をコミットしたりしないでください。`create-github-release.sh` はこの鍵で DMG 更新と appcast に署名し、GitHub Release へ `Dahlia.dmg` と `appcast.xml` をアップロードします。
+Dahlia のアプリ内更新には Sparkle 2 を使用します。製品版は24時間ごとに更新を確認し、利用可能な場合はユーザーに案内します。更新は既定では自動インストールしません。Ed25519 秘密鍵はログインキーチェーンの `com.dahlia.app` アカウントに保存されるため、安全な場所へバックアップしてください。別のリリースマシンでは Sparkle の `generate_keys` ツールで既存の秘密鍵をインポートし、代替鍵を新規生成したり、エクスポートした秘密鍵をコミットしたりしないでください。`create-github-release.sh` はこの鍵で DMG 更新と appcast に署名し、GitHub Release へ `Dahlia.dmg` と `appcast.xml` をアップロードします。
 
 リリース用ラップトップを交換するときは、次の手順で Sparkle 鍵を移行します。エクスポートファイルはパスワードと同等に機密性の高い、暗号化されていない秘密鍵です。暗号化済みのオフラインストレージへ直接エクスポートし、信頼できる経路で移してください。リポジトリ、クラウド同期フォルダ、チャット、Issue の添付ファイルには置かないでください。
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>30</string>
+    <string>31</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.6.2</string>
+    <string>0.6.3</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>
@@ -36,6 +36,12 @@
     <false/>
     <key>SUFeedURL</key>
     <string>https://github.com/dahlia-org/dahlia/releases/latest/download/appcast.xml</string>
+    <key>SUEnableAutomaticChecks</key>
+    <true/>
+    <key>SUScheduledCheckInterval</key>
+    <integer>86400</integer>
+    <key>SUAutomaticallyUpdate</key>
+    <false/>
     <key>SUPublicEDKey</key>
     <string>HR6N/+ImpB4ahCwyYLfF+CKJf2YG267B7pu5Q8CSB2E=</string>
     <key>SURequireSignedFeed</key>

--- a/scripts/create-github-release.sh
+++ b/scripts/create-github-release.sh
@@ -19,6 +19,9 @@ DMG_SPARKLE_FEED_URL=""
 DMG_SPARKLE_PUBLIC_KEY=""
 DMG_SPARKLE_REQUIRES_SIGNED_FEED=""
 DMG_SPARKLE_VERIFIES_BEFORE_EXTRACTION=""
+DMG_SPARKLE_AUTOMATIC_CHECKS=""
+DMG_SPARKLE_CHECK_INTERVAL=""
+DMG_SPARKLE_AUTOMATIC_UPDATES=""
 
 cleanup() {
     if [ -n "$DMG_MOUNT_DIR" ]; then
@@ -86,6 +89,9 @@ validate_dmg_versions() {
     DMG_SPARKLE_PUBLIC_KEY="$(/usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" "$app_info_plist")"
     DMG_SPARKLE_REQUIRES_SIGNED_FEED="$(/usr/libexec/PlistBuddy -c "Print :SURequireSignedFeed" "$app_info_plist")"
     DMG_SPARKLE_VERIFIES_BEFORE_EXTRACTION="$(/usr/libexec/PlistBuddy -c "Print :SUVerifyUpdateBeforeExtraction" "$app_info_plist")"
+    DMG_SPARKLE_AUTOMATIC_CHECKS="$(/usr/libexec/PlistBuddy -c "Print :SUEnableAutomaticChecks" "$app_info_plist")"
+    DMG_SPARKLE_CHECK_INTERVAL="$(/usr/libexec/PlistBuddy -c "Print :SUScheduledCheckInterval" "$app_info_plist")"
+    DMG_SPARKLE_AUTOMATIC_UPDATES="$(/usr/libexec/PlistBuddy -c "Print :SUAutomaticallyUpdate" "$app_info_plist")"
 
     hdiutil detach "$DMG_MOUNT_DIR" >/dev/null
     rmdir "$DMG_MOUNT_DIR"
@@ -174,6 +180,18 @@ EOF
     fi
     if [ "$DMG_SPARKLE_REQUIRES_SIGNED_FEED" != "true" ] || [ "$DMG_SPARKLE_VERIFIES_BEFORE_EXTRACTION" != "true" ]; then
         echo "error: DMG must require a signed Sparkle feed and verify updates before extraction" >&2
+        exit 1
+    fi
+    if [ "$DMG_SPARKLE_AUTOMATIC_CHECKS" != "true" ]; then
+        echo "error: DMG must enable automatic Sparkle update checks" >&2
+        exit 1
+    fi
+    if [ "$DMG_SPARKLE_CHECK_INTERVAL" != "86400" ]; then
+        echo "error: DMG Sparkle update check interval is ${DMG_SPARKLE_CHECK_INTERVAL}, expected 86400" >&2
+        exit 1
+    fi
+    if [ "$DMG_SPARKLE_AUTOMATIC_UPDATES" != "false" ]; then
+        echo "error: DMG must not enable automatic Sparkle updates by default" >&2
         exit 1
     fi
 

--- a/scripts/test-release-scripts.sh
+++ b/scripts/test-release-scripts.sh
@@ -102,6 +102,9 @@ test_sparkle_configuration_validation() {
     DMG_SPARKLE_PUBLIC_KEY="test-public-key"
     DMG_SPARKLE_REQUIRES_SIGNED_FEED="true"
     DMG_SPARKLE_VERIFIES_BEFORE_EXTRACTION="true"
+    DMG_SPARKLE_AUTOMATIC_CHECKS="true"
+    DMG_SPARKLE_CHECK_INTERVAL="86400"
+    DMG_SPARKLE_AUTOMATIC_UPDATES="false"
     gh() {
         printf '%s\n' "dahlia-org/dahlia"
     }
@@ -112,6 +115,15 @@ test_sparkle_configuration_validation() {
     expect_failure validate_sparkle_release_configuration
     DMG_SPARKLE_FEED_URL="https://github.com/dahlia-org/dahlia/releases/latest/download/appcast.xml"
     DMG_SPARKLE_PUBLIC_KEY="wrong-key"
+    expect_failure validate_sparkle_release_configuration
+    DMG_SPARKLE_PUBLIC_KEY="test-public-key"
+    DMG_SPARKLE_AUTOMATIC_CHECKS="false"
+    expect_failure validate_sparkle_release_configuration
+    DMG_SPARKLE_AUTOMATIC_CHECKS="true"
+    DMG_SPARKLE_CHECK_INTERVAL="3600"
+    expect_failure validate_sparkle_release_configuration
+    DMG_SPARKLE_CHECK_INTERVAL="86400"
+    DMG_SPARKLE_AUTOMATIC_UPDATES="true"
     expect_failure validate_sparkle_release_configuration
 }
 


### PR DESCRIPTION
## Summary

- enable Sparkle automatic update checks for production builds
- check every 24 hours and prompt when an update is available without installing automatically by default
- bump the app version to 0.6.3 (31)
- document the update behavior in English and Japanese

## Why

Dahlia already supported manual update checks, but automatic checks depended on Sparkle's opt-in prompt. This makes the intended daily update-check behavior explicit so users are notified when a release is available.

## Validation

- `plutil -lint Resources/Info.plist`
- `./scripts/test-release-scripts.sh`
- `./scripts/build-app.sh`
- verified version, build number, and Sparkle settings in the generated `Dahlia.app`
