### PR TITLE
Fix WhisperKit license xattr cleanup

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -129,6 +129,7 @@ embed_whisperkit_licenses() {
     mkdir -p "$destination_dir"
     cp "${checkout_dir}/LICENSE" "${destination_dir}/LICENSE"
     cp "${checkout_dir}/NOTICES" "${destination_dir}/NOTICES"
+    chmod u+w "${destination_dir}/LICENSE" "${destination_dir}/NOTICES"
 }
 
 has_entitlements() {

--- a/scripts/test-release-scripts.sh
+++ b/scripts/test-release-scripts.sh
@@ -315,10 +315,15 @@ test_whisperkit_license_embedding_validation() {
     mkdir -p "$checkout_dir"
     printf '%s' 'license fixture' > "${checkout_dir}/LICENSE"
     printf '%s' 'notices fixture' > "${checkout_dir}/NOTICES"
+    chmod a-w "${checkout_dir}/LICENSE" "${checkout_dir}/NOTICES"
 
     embed_whisperkit_licenses "$fake_project" "$contents_dir"
     cmp "${checkout_dir}/LICENSE" "${contents_dir}/Resources/Licenses/WhisperKit/LICENSE"
     cmp "${checkout_dir}/NOTICES" "${contents_dir}/Resources/Licenses/WhisperKit/NOTICES"
+    [ -w "${contents_dir}/Resources/Licenses/WhisperKit/LICENSE" ] \
+        || fail "embedded WhisperKit license was not writable"
+    [ -w "${contents_dir}/Resources/Licenses/WhisperKit/NOTICES" ] \
+        || fail "embedded WhisperKit notices were not writable"
 
     rm "${checkout_dir}/NOTICES"
     expect_failure embed_whisperkit_licenses "$fake_project" "$contents_dir"


### PR DESCRIPTION
## Summary

- make copied WhisperKit license files owner-writable before bundle attribute cleanup
- add regression coverage using read-only SwiftPM checkout fixtures

## Root cause

WhisperKit's `LICENSE` and `NOTICES` files are read-only in the SwiftPM checkout. `cp` preserved that mode in the app bundle, so the later recursive `xattr -cr` could not update those files and printed permission errors.

## Impact

`./scripts/build-app.sh` and other callers of the shared embedding helper can clear bundle attributes without permission errors from the WhisperKit license files.

## Validation

- `bash scripts/test-release-scripts.sh`
- `bash -n scripts/common.sh scripts/test-release-scripts.sh`
- `git diff --check`
- verified the real checkout files copy from mode `0444` to `0644` and no longer produce an `xattr -cr` permission error

The full app build was attempted, but the local volume ran out of space while SwiftPM was extracting Sentry artifacts, before reaching app bundle assembly.
