### PR TITLE
Optimize Swift worktree includes

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,3 +1,5 @@
-.env
-.env.*
-**/.claude/settings.local.json
+# Local environment used by the build and release scripts.
+/.env.local
+
+# Personal Claude Code permissions and settings.
+/.claude/settings.local.json


### PR DESCRIPTION
## Summary

- narrow the copied environment pattern to the root-level `.env.local` file used by Dahlia's build and release scripts
- anchor the personal Claude Code settings path to the repository root
- document why each ignored file is copied into managed worktrees

## Why

The previous `.env` and `.env.*` patterns were broader than Dahlia needs. SwiftPM build products and caches such as `.build`, `.swiftpm`, and `DerivedData` should remain worktree-local because they are generated, path-sensitive, and potentially very large. `Package.resolved` is already tracked by Git, while signing and notarization credentials remain in Keychain.

This keeps new managed worktrees usable without copying unnecessary Swift build state or matching future environment files unintentionally.

## Impact

New Codex or Claude managed worktrees continue to receive the local environment and personal Claude settings required by the existing workflow, with more explicit root-scoped matching. Existing worktrees are unaffected.

## Validation

- `git diff --check`
- confirmed `.env.local` and `.claude/settings.local.json` exist in the primary checkout
- confirmed both files are ignored by Git and are regular files rather than symlinks
- repository secret-scan pre-commit and pre-push hooks passed

Swift build and test commands were not run because this change only updates worktree copy patterns and does not modify Swift source or build configuration.