### PR TITLE
Fix menu bar rendering hangs

### DIFF
--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -121,7 +121,11 @@ final class CaptionViewModel: ObservableObject {
     var chatLiveModeFailureHandler: (@MainActor () -> Void)?
 
     @Published var isListening = false
-    @Published var isFinalizingRecording = false
+    @Published var isFinalizingRecording = false {
+        didSet { updateCanBeginRecording() }
+    }
+
+    @Published private(set) var canBeginRecording = true
     @Published var analyzerReady = false
     @Published var isPreparingAnalyzer = false
     @Published private(set) var activeTranscriptionMode: TranscriptionMode?
@@ -130,10 +134,22 @@ final class CaptionViewModel: ObservableObject {
     @Published var pendingBatchTranscriptionConfirmation: BatchTranscriptionConfirmation?
     @Published var errorMessage: String?
     @Published var availableMicrophones: [MicrophoneDevice] = []
-    @Published private(set) var defaultInputDeviceID: AudioDeviceID?
-    @Published private var hasResolvedDefaultInputDevice = false
-    @Published var microphoneSelection: MicrophoneSelection = .systemDefault
-    @Published var isSystemAudioEnabled = true
+    @Published private(set) var defaultInputDeviceID: AudioDeviceID? {
+        didSet { updateCanBeginRecording() }
+    }
+
+    @Published private var hasResolvedDefaultInputDevice = false {
+        didSet { updateCanBeginRecording() }
+    }
+
+    @Published var microphoneSelection: MicrophoneSelection = .systemDefault {
+        didSet { updateCanBeginRecording() }
+    }
+
+    @Published var isSystemAudioEnabled = true {
+        didSet { updateCanBeginRecording() }
+    }
+
     @Published var selectedLocale: String = AppSettings.shared.transcriptionLocale {
         didSet {
             guard selectedLocale != oldValue else { return }
@@ -317,8 +333,18 @@ final class CaptionViewModel: ObservableObject {
     }
 
     var systemDefaultMicrophoneTitle: String {
-        guard let defaultDeviceID = defaultInputDeviceID,
-              let deviceName = availableMicrophones.first(where: { $0.id == defaultDeviceID })?.name else {
+        Self.systemDefaultMicrophoneTitle(
+            microphones: availableMicrophones,
+            defaultDeviceID: defaultInputDeviceID
+        )
+    }
+
+    static func systemDefaultMicrophoneTitle(
+        microphones: [MicrophoneDevice],
+        defaultDeviceID: AudioDeviceID?
+    ) -> String {
+        guard let defaultDeviceID,
+              let deviceName = microphones.first(where: { $0.id == defaultDeviceID })?.name else {
             return L10n.sameAsSystem
         }
         return L10n.sameAsSystem(deviceName)
@@ -373,12 +399,6 @@ final class CaptionViewModel: ObservableObject {
 
     /// 少なくとも 1 つの音声ソースが有効か。
     var hasEnabledAudioSource: Bool { isMicEnabled || isSystemAudioEnabled }
-
-    var canBeginRecording: Bool {
-        recordingLifecycle == .idle
-            && !isFinalizingRecording
-            && hasEnabledAudioSource
-    }
 
     private var enabledRecordingAudioSources: Set<RecordingAudioSource> {
         var sources: Set<RecordingAudioSource> = []
@@ -436,7 +456,10 @@ final class CaptionViewModel: ObservableObject {
     private var activeTranscriptionPlan: TranscriptionSessionPlan?
     private var activeRecordingSessionId: UUID?
     private var activeControllerSources: Set<RecordingAudioSource> = []
-    private var recordingLifecycle: RecordingLifecycle = .idle
+    private var recordingLifecycle: RecordingLifecycle = .idle {
+        didSet { updateCanBeginRecording() }
+    }
+
     private var recordingConfigurationTasks: [Int: Task<Void, Never>] = [:]
     private var nextRecordingConfigurationID = 0
     private var pendingRealtimeRecognitionFailure: (source: RecordingAudioSource?, message: String)?
@@ -458,6 +481,14 @@ final class CaptionViewModel: ObservableObject {
     private let transcriptTranslationService = TranscriptTranslationService()
     private let summaryGenerationRunner: SummaryGenerationRunner
     private let summaryJobSleeper: SummaryJobSleeper
+
+    private func updateCanBeginRecording() {
+        let updatedValue = recordingLifecycle == .idle
+            && !isFinalizingRecording
+            && hasEnabledAudioSource
+        guard canBeginRecording != updatedValue else { return }
+        canBeginRecording = updatedValue
+    }
 
     private var activeDbQueueForSessionControls: DatabaseQueue? {
         recordingContext?.dbQueue ?? currentDbQueue

--- a/Sources/Dahlia/ViewModels/MenuBarRecordingState.swift
+++ b/Sources/Dahlia/ViewModels/MenuBarRecordingState.swift
@@ -1,0 +1,125 @@
+import Combine
+import Foundation
+import Observation
+
+/// メニューバーを `CaptionViewModel` 全体の高頻度な更新から隔離する、限定的な UI projection。
+@MainActor
+@Observable
+final class MenuBarRecordingState {
+    @ObservationIgnored private let viewModel: CaptionViewModel
+    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+
+    private(set) var isListening: Bool
+    private(set) var microphoneSelection: MicrophoneSelection
+    private(set) var isSystemAudioEnabled: Bool
+    private(set) var selectedLocale: String
+    private(set) var availableMicrophones: [MicrophoneDevice]
+    private(set) var filteredLocales: [Locale]
+    private(set) var availableWindows: [ScreenshotWindowOption]
+    private(set) var screenshotCaptureSource: ScreenshotCaptureSource
+    private(set) var systemDefaultMicrophoneTitle: String
+    private(set) var canBeginRecording: Bool
+
+    init(viewModel: CaptionViewModel) {
+        self.viewModel = viewModel
+        isListening = viewModel.isListening
+        microphoneSelection = viewModel.microphoneSelection
+        isSystemAudioEnabled = viewModel.isSystemAudioEnabled
+        selectedLocale = viewModel.selectedLocale
+        availableMicrophones = viewModel.availableMicrophones
+        filteredLocales = viewModel.filteredLocales
+        availableWindows = viewModel.availableWindows
+        screenshotCaptureSource = viewModel.screenshotCaptureSource
+        systemDefaultMicrophoneTitle = viewModel.systemDefaultMicrophoneTitle
+        canBeginRecording = viewModel.canBeginRecording
+
+        observeMenuState()
+    }
+
+    func refreshAvailableMicrophones() async {
+        await viewModel.refreshAvailableMicrophones()
+    }
+
+    func refreshAvailableWindows() {
+        viewModel.refreshAvailableWindows()
+    }
+
+    func selectMicrophone(_ selection: MicrophoneSelection) {
+        let oldSelection = viewModel.microphoneSelection
+        guard selection != oldSelection else { return }
+        viewModel.microphoneSelection = selection
+        viewModel.handleMicrophoneSelectionChange(from: oldSelection, to: selection)
+    }
+
+    func setSystemAudioEnabled(_ isEnabled: Bool) {
+        let oldValue = viewModel.isSystemAudioEnabled
+        guard isEnabled != oldValue else { return }
+        viewModel.isSystemAudioEnabled = isEnabled
+        viewModel.handleSystemAudioSelectionChange(from: oldValue, to: isEnabled)
+    }
+
+    func selectLocale(_ identifier: String) {
+        guard identifier != viewModel.selectedLocale else { return }
+        viewModel.selectedLocale = identifier
+    }
+
+    func selectScreenshotSource(_ source: ScreenshotCaptureSource) {
+        guard source != viewModel.screenshotCaptureSource else { return }
+        viewModel.screenshotCaptureSource = source
+    }
+
+    private func observeMenuState() {
+        viewModel.$isListening
+            .removeDuplicates()
+            .sink { [weak self] in self?.isListening = $0 }
+            .store(in: &cancellables)
+
+        viewModel.$microphoneSelection
+            .removeDuplicates()
+            .sink { [weak self] in self?.microphoneSelection = $0 }
+            .store(in: &cancellables)
+
+        viewModel.$isSystemAudioEnabled
+            .removeDuplicates()
+            .sink { [weak self] in self?.isSystemAudioEnabled = $0 }
+            .store(in: &cancellables)
+
+        viewModel.$selectedLocale
+            .removeDuplicates()
+            .sink { [weak self] in self?.selectedLocale = $0 }
+            .store(in: &cancellables)
+
+        viewModel.$availableMicrophones
+            .removeDuplicates()
+            .combineLatest(viewModel.$defaultInputDeviceID.removeDuplicates())
+            .sink { [weak self] microphones, defaultDeviceID in
+                guard let self else { return }
+                availableMicrophones = microphones
+                systemDefaultMicrophoneTitle = CaptionViewModel.systemDefaultMicrophoneTitle(
+                    microphones: microphones,
+                    defaultDeviceID: defaultDeviceID
+                )
+            }
+            .store(in: &cancellables)
+
+        viewModel.$filteredLocales
+            .removeDuplicates()
+            .sink { [weak self] in self?.filteredLocales = $0 }
+            .store(in: &cancellables)
+
+        viewModel.$availableWindows
+            .removeDuplicates()
+            .sink { [weak self] in self?.availableWindows = $0 }
+            .store(in: &cancellables)
+
+        viewModel.$screenshotCaptureSource
+            .removeDuplicates()
+            .sink { [weak self] in self?.screenshotCaptureSource = $0 }
+            .store(in: &cancellables)
+
+        viewModel.$canBeginRecording
+            .removeDuplicates()
+            .sink { [weak self] in self?.canBeginRecording = $0 }
+            .store(in: &cancellables)
+    }
+}

--- a/Sources/Dahlia/Views/MenuBarMenuView.swift
+++ b/Sources/Dahlia/Views/MenuBarMenuView.swift
@@ -1,12 +1,22 @@
 import SwiftUI
 
 struct MenuBarMenuView: View {
-    @ObservedObject var viewModel: CaptionViewModel
     let recordingCoordinator: RecordingCoordinator
     let calendarViewModel: MenuBarCalendarViewModel
 
+    @State private var recordingState: MenuBarRecordingState
     @ObservedObject private var settings = AppSettings.shared
     @Environment(\.openSettings) private var openSettings
+
+    init(
+        viewModel: CaptionViewModel,
+        recordingCoordinator: RecordingCoordinator,
+        calendarViewModel: MenuBarCalendarViewModel
+    ) {
+        self.recordingCoordinator = recordingCoordinator
+        self.calendarViewModel = calendarViewModel
+        _recordingState = State(initialValue: MenuBarRecordingState(viewModel: viewModel))
+    }
 
     var body: some View {
         VStack {
@@ -14,7 +24,8 @@ struct MenuBarMenuView: View {
                 MenuBarCalendarSectionView(
                     agenda: calendarViewModel.agenda,
                     now: calendarViewModel.currentDate,
-                    canStartRecording: recordingCoordinator.canStartNewMeeting,
+                    canStartRecording: recordingState.canBeginRecording
+                        && recordingCoordinator.canStartNewMeeting,
                     onJoinAndRecordEvent: joinAndRecordEvent,
                     onJoinEvent: joinEvent,
                     onShowEventInCalendar: showEventInCalendar,
@@ -25,7 +36,7 @@ struct MenuBarMenuView: View {
             }
 
             MenuBarRecordingControls(
-                viewModel: viewModel,
+                state: recordingState,
                 recordingCoordinator: recordingCoordinator
             )
 

--- a/Sources/Dahlia/Views/MenuBarRecordingControls.swift
+++ b/Sources/Dahlia/Views/MenuBarRecordingControls.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct MenuBarRecordingControls: View {
-    @ObservedObject var viewModel: CaptionViewModel
+    let state: MenuBarRecordingState
     let recordingCoordinator: RecordingCoordinator
 
     @AppStorage("liveSubtitleOverlayEnabled") private var liveSubtitleOverlayEnabled = false
@@ -10,11 +10,15 @@ struct MenuBarRecordingControls: View {
         VStack {
             Button(action: toggleRecording) {
                 Label(
-                    viewModel.isListening ? L10n.menuBarStopRecording : L10n.menuBarStartRecording,
-                    systemImage: viewModel.isListening ? "stop.fill" : "record.circle"
+                    state.isListening ? L10n.menuBarStopRecording : L10n.menuBarStartRecording,
+                    systemImage: state.isListening ? "stop.fill" : "record.circle"
                 )
             }
-            .disabled(!viewModel.isListening && !recordingCoordinator.canStartNewMeeting && AppSettings.shared.currentVault != nil)
+            .disabled(
+                !state.isListening
+                    && (!state.canBeginRecording || !recordingCoordinator.canStartNewMeeting)
+                    && AppSettings.shared.currentVault != nil
+            )
 
             Toggle(isOn: $liveSubtitleOverlayEnabled) {
                 Label(L10n.menuBarShowLiveSubtitles, systemImage: "text.bubble")
@@ -22,103 +26,136 @@ struct MenuBarRecordingControls: View {
             recordingSettingsMenus
         }
         .onAppear {
-            viewModel.refreshAvailableWindows()
+            state.refreshAvailableWindows()
         }
         .task {
-            await viewModel.refreshAvailableMicrophones()
+            await state.refreshAvailableMicrophones()
         }
     }
 
     @ViewBuilder
     private var recordingSettingsMenus: some View {
         Menu {
-            Picker(selection: $viewModel.microphoneSelection) {
-                Text(L10n.none).tag(MicrophoneSelection.none)
-                Divider()
-                Text(viewModel.systemDefaultMicrophoneTitle).tag(MicrophoneSelection.systemDefault)
-
-                if !viewModel.availableMicrophones.isEmpty {
-                    Divider()
-                }
-
-                ForEach(viewModel.availableMicrophones) { microphone in
-                    Text(microphone.name).tag(MicrophoneSelection.device(microphone.id))
-                }
+            Button {
+                state.selectMicrophone(.none)
             } label: {
-                EmptyView()
+                selectionLabel(L10n.none, isSelected: state.microphoneSelection == .none)
             }
-            .pickerStyle(.inline)
-            .labelsHidden()
-            .onChange(of: viewModel.microphoneSelection) { oldValue, newValue in
-                viewModel.handleMicrophoneSelectionChange(from: oldValue, to: newValue)
+            Divider()
+            Button {
+                state.selectMicrophone(.systemDefault)
+            } label: {
+                selectionLabel(
+                    state.systemDefaultMicrophoneTitle,
+                    isSelected: state.microphoneSelection == .systemDefault
+                )
+            }
+
+            if !state.availableMicrophones.isEmpty {
+                Divider()
+            }
+
+            ForEach(state.availableMicrophones) { microphone in
+                Button {
+                    state.selectMicrophone(.device(microphone.id))
+                } label: {
+                    selectionLabel(
+                        microphone.name,
+                        isSelected: state.microphoneSelection == .device(microphone.id)
+                    )
+                }
             }
         } label: {
             Label(L10n.microphone, systemImage: "mic.fill")
         }
 
         Menu {
-            Picker(selection: $viewModel.isSystemAudioEnabled) {
-                Text(L10n.noComputerAudio).tag(false)
-                Text(L10n.recordComputerAudio).tag(true)
+            Button {
+                state.setSystemAudioEnabled(false)
             } label: {
-                EmptyView()
+                selectionLabel(L10n.noComputerAudio, isSelected: !state.isSystemAudioEnabled)
             }
-            .pickerStyle(.inline)
-            .labelsHidden()
-            .onChange(of: viewModel.isSystemAudioEnabled) { oldValue, newValue in
-                viewModel.handleSystemAudioSelectionChange(from: oldValue, to: newValue)
+            Button {
+                state.setSystemAudioEnabled(true)
+            } label: {
+                selectionLabel(L10n.recordComputerAudio, isSelected: state.isSystemAudioEnabled)
             }
         } label: {
             Label(L10n.systemAudio, systemImage: "speaker.wave.2.fill")
         }
 
         Menu {
-            Picker(selection: $viewModel.selectedLocale) {
-                if viewModel.filteredLocales.isEmpty {
-                    let id = viewModel.selectedLocale
-                    let name = Locale.current.localizedString(forIdentifier: id) ?? id
-                    Text(name).tag(id)
-                } else {
-                    ForEach(viewModel.filteredLocales, id: \.identifier) { locale in
-                        let id = locale.identifier
-                        let name = locale.localizedString(forIdentifier: id) ?? id
-                        Text(name).tag(id)
+            if state.filteredLocales.isEmpty {
+                let identifier = state.selectedLocale
+                let name = Locale.current.localizedString(forIdentifier: identifier) ?? identifier
+                Button {
+                    state.selectLocale(identifier)
+                } label: {
+                    selectionLabel(name, isSelected: true)
+                }
+            } else {
+                ForEach(state.filteredLocales, id: \.identifier) { locale in
+                    let identifier = locale.identifier
+                    let name = locale.localizedString(forIdentifier: identifier) ?? identifier
+                    Button {
+                        state.selectLocale(identifier)
+                    } label: {
+                        selectionLabel(name, isSelected: state.selectedLocale == identifier)
                     }
                 }
-            } label: {
-                EmptyView()
             }
-            .pickerStyle(.inline)
-            .labelsHidden()
         } label: {
             Label(L10n.language, systemImage: "globe")
         }
 
         Menu {
-            Picker(selection: $viewModel.screenshotCaptureSource) {
-                Text(L10n.notSelected).tag(ScreenshotCaptureSource.none)
-                Divider()
-                Text(L10n.entireDesktop).tag(ScreenshotCaptureSource.entireDesktop)
-
-                if !viewModel.availableWindows.isEmpty {
-                    Divider()
-                }
-
-                ForEach(viewModel.availableWindows) { window in
-                    Text(window.displayName).tag(ScreenshotCaptureSource.window(window.id))
-                }
+            Button {
+                state.selectScreenshotSource(.none)
             } label: {
-                EmptyView()
+                selectionLabel(L10n.notSelected, isSelected: state.screenshotCaptureSource == .none)
             }
-            .pickerStyle(.inline)
-            .labelsHidden()
+            Divider()
+            Button {
+                state.selectScreenshotSource(.entireDesktop)
+            } label: {
+                selectionLabel(
+                    L10n.entireDesktop,
+                    isSelected: state.screenshotCaptureSource == .entireDesktop
+                )
+            }
+
+            if !state.availableWindows.isEmpty {
+                Divider()
+            }
+
+            ForEach(state.availableWindows) { window in
+                Button {
+                    state.selectScreenshotSource(.window(window.id))
+                } label: {
+                    selectionLabel(
+                        window.displayName,
+                        isSelected: state.screenshotCaptureSource == .window(window.id)
+                    )
+                }
+            }
         } label: {
             Label(L10n.source, systemImage: "rectangle.on.rectangle")
         }
     }
 
+    private func selectionLabel(_ title: String, isSelected: Bool) -> some View {
+        Group {
+            if isSelected {
+                Label(title, systemImage: "checkmark")
+            } else {
+                Text(title)
+            }
+        }
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
     private func toggleRecording() {
-        if viewModel.isListening {
+        if state.isListening {
             recordingCoordinator.stopRecording()
         } else if AppSettings.shared.currentVault == nil {
             MainWindowOpener.shared.openMainWindow()

--- a/Tests/DahliaTests/MenuBarRecordingStateTests.swift
+++ b/Tests/DahliaTests/MenuBarRecordingStateTests.swift
@@ -1,0 +1,100 @@
+#if canImport(Testing)
+    import CoreAudio
+    import Foundation
+    import os
+    import Testing
+    @testable import Dahlia
+
+    @MainActor
+    struct MenuBarRecordingStateTests {
+        @Test
+        func forwardsMenuSelections() {
+            let viewModel = makeViewModel()
+            let state = MenuBarRecordingState(viewModel: viewModel)
+
+            state.selectMicrophone(.none)
+            state.setSystemAudioEnabled(false)
+            state.selectScreenshotSource(.entireDesktop)
+
+            #expect(state.microphoneSelection == .none)
+            #expect(viewModel.microphoneSelection == .none)
+            #expect(!state.isSystemAudioEnabled)
+            #expect(!viewModel.isSystemAudioEnabled)
+            #expect(state.screenshotCaptureSource == .entireDesktop)
+            #expect(viewModel.screenshotCaptureSource == .entireDesktop)
+        }
+
+        @Test
+        func reflectsRelevantChangesFromCaptionViewModel() async {
+            let microphone = MicrophoneDevice(id: 42, name: "Test Microphone")
+            let viewModel = CaptionViewModel(
+                availableInputDevicesProvider: { [microphone] },
+                defaultInputDeviceIDProvider: { nil }
+            )
+            let state = MenuBarRecordingState(viewModel: viewModel)
+            let window = ScreenshotWindowOption(
+                id: 7,
+                appName: "Test App",
+                title: "Test Window",
+                isOnScreen: true
+            )
+
+            await state.refreshAvailableMicrophones()
+            viewModel.filteredLocales = [Locale(identifier: "en-US")]
+            viewModel.availableWindows = [window]
+
+            #expect(state.availableMicrophones == [microphone])
+            #expect(state.filteredLocales.map(\.identifier) == ["en-US"])
+            #expect(state.availableWindows == [window])
+        }
+
+        @Test
+        func updatesSystemDefaultMicrophoneTitleFromPublishedValues() async {
+            let input = OSAllocatedUnfairLock(
+                initialState: MicrophoneInputSnapshot(
+                    devices: [MicrophoneDevice(id: 1, name: "First Microphone")],
+                    defaultDeviceID: 1
+                )
+            )
+            let viewModel = CaptionViewModel(
+                availableInputDevicesProvider: { input.withLock(\.devices) },
+                defaultInputDeviceIDProvider: { input.withLock(\.defaultDeviceID) }
+            )
+            let state = MenuBarRecordingState(viewModel: viewModel)
+            await state.refreshAvailableMicrophones()
+
+            input.withLock {
+                $0.devices = [MicrophoneDevice(id: 2, name: "Second Microphone")]
+                $0.defaultDeviceID = 2
+            }
+            await state.refreshAvailableMicrophones()
+
+            #expect(state.systemDefaultMicrophoneTitle == L10n.sameAsSystem("Second Microphone"))
+        }
+
+        @Test
+        func updatesRecordingAvailabilityFromRelevantAudioSelections() {
+            let viewModel = makeViewModel()
+            let state = MenuBarRecordingState(viewModel: viewModel)
+
+            state.selectMicrophone(.none)
+            state.setSystemAudioEnabled(false)
+            #expect(!state.canBeginRecording)
+
+            state.setSystemAudioEnabled(true)
+            #expect(state.canBeginRecording)
+        }
+
+        private func makeViewModel() -> CaptionViewModel {
+            CaptionViewModel(
+                availableInputDevicesProvider: { [] },
+                defaultInputDeviceIDProvider: { nil }
+            )
+        }
+    }
+
+    private struct MicrophoneInputSnapshot {
+        var devices: [MicrophoneDevice]
+        var defaultDeviceID: AudioDeviceID?
+    }
+#endif


### PR DESCRIPTION
## Summary

- isolate menu bar recording controls from unrelated `CaptionViewModel` updates
- replace inline SwiftUI pickers with lightweight menu buttons
- publish recording availability explicitly and preserve selected-item accessibility
- add deterministic regression coverage for menu state forwarding and default microphone titles

## Root cause

Recent Sentry hang samples showed the main thread spending extended periods in SwiftUI/AppKit layout and menu picker rendering. `MenuBarMenuView` observed the entire `CaptionViewModel`, so transcript, screenshot, and other unrelated published updates repeatedly rebuilt four inline picker trees.

## Impact

The menu bar now observes only the state required by its recording controls. Unrelated high-frequency updates no longer invalidate the whole menu, reducing main-thread layout work while preserving recording configuration behavior.

## Validation

- `swift test --filter MenuBarRecordingStateTests` — 4 tests passed
- `swift test --filter CaptionViewModelTests` — 22 tests passed
- `swift build`
- `CI=true ./scripts/lint.sh` — SwiftFormat clean; no new SwiftLint violations
- `git diff --check`
