### PR TITLE
Fix transcription persistence cancellation

### DIFF
--- a/Sources/Dahlia/Services/TranscriptionEventPipeline.swift
+++ b/Sources/Dahlia/Services/TranscriptionEventPipeline.swift
@@ -12,6 +12,7 @@ actor TranscriptionEventPipeline { // swiftlint:disable:this type_body_length
     typealias PersistenceSink = @Sendable ([TranscriptionEvent]) async throws -> Void
     typealias PersistenceFlushSink = @Sendable () async throws -> Void
     typealias PersistenceResetSink = @Sendable () async throws -> Void
+    typealias PersistenceBatchSleep = @Sendable () async throws -> Void
 
     static let maximumPendingUIEventCount = 300
     static let maximumUIFinishWait: Duration = .seconds(2)
@@ -47,6 +48,7 @@ actor TranscriptionEventPipeline { // swiftlint:disable:this type_body_length
         case event(TranscriptionEvent)
         case flush(CheckedContinuation<Result<Void, Error>, Never>)
         case reset(CheckedContinuation<Result<Void, Error>, Never>)
+        case scheduledFlush(UInt64)
     }
 
     private let uiSink: UISink
@@ -55,6 +57,7 @@ actor TranscriptionEventPipeline { // swiftlint:disable:this type_body_length
     private let persistenceSink: PersistenceSink
     private let persistenceFlushSink: PersistenceFlushSink
     private let persistenceResetSink: PersistenceResetSink
+    private let persistenceBatchSleep: PersistenceBatchSleep
     private let uiSignals: AsyncStream<Void>
     private let uiSignalContinuation: AsyncStream<Void>.Continuation
     private let persistenceItems: AsyncStream<PersistenceItem>
@@ -84,6 +87,7 @@ actor TranscriptionEventPipeline { // swiftlint:disable:this type_body_length
 
     private var pendingPersistenceEvents: [TranscriptionEvent] = []
     private var persistenceBatchTask: Task<Void, Never>?
+    private var persistenceBatchGeneration: UInt64 = 0
     private var firstPersistenceError: Error?
 
     init(
@@ -92,7 +96,10 @@ actor TranscriptionEventPipeline { // swiftlint:disable:this type_body_length
         uiReloadSink: @escaping UIReloadSink = {},
         persistenceSink: @escaping PersistenceSink,
         persistenceFlushSink: @escaping PersistenceFlushSink = {},
-        persistenceResetSink: @escaping PersistenceResetSink = {}
+        persistenceResetSink: @escaping PersistenceResetSink = {},
+        persistenceBatchSleep: @escaping PersistenceBatchSleep = {
+            try await Task.sleep(for: .milliseconds(50))
+        }
     ) {
         let uiPair = AsyncStream.makeStream(
             of: Void.self,
@@ -108,6 +115,7 @@ actor TranscriptionEventPipeline { // swiftlint:disable:this type_body_length
         self.persistenceSink = persistenceSink
         self.persistenceFlushSink = persistenceFlushSink
         self.persistenceResetSink = persistenceResetSink
+        self.persistenceBatchSleep = persistenceBatchSleep
         self.uiSignals = uiPair.stream
         self.uiSignalContinuation = uiPair.continuation
         self.persistenceItems = persistencePair.stream
@@ -461,6 +469,10 @@ actor TranscriptionEventPipeline { // swiftlint:disable:this type_body_length
                 recordPersistenceError(error)
                 continuation.resume(returning: .failure(error))
             }
+        case let .scheduledFlush(generation):
+            guard generation == persistenceBatchGeneration else { return }
+            persistenceBatchTask = nil
+            await flushPersistenceBatch()
         }
     }
 
@@ -617,9 +629,17 @@ actor TranscriptionEventPipeline { // swiftlint:disable:this type_body_length
 
     private func schedulePersistenceBatchIfNeeded() {
         guard persistenceBatchTask == nil else { return }
-        persistenceBatchTask = Task { [weak self] in
-            try? await Task.sleep(for: .milliseconds(50))
-            await self?.flushPersistenceBatch()
+        persistenceBatchGeneration &+= 1
+        let generation = persistenceBatchGeneration
+        let persistenceBatchSleep = persistenceBatchSleep
+        let persistenceContinuation = persistenceContinuation
+        persistenceBatchTask = Task {
+            do {
+                try await persistenceBatchSleep()
+            } catch {
+                guard !Task.isCancelled else { return }
+            }
+            persistenceContinuation.yield(.scheduledFlush(generation))
         }
     }
 
@@ -644,9 +664,10 @@ actor TranscriptionEventPipeline { // swiftlint:disable:this type_body_length
     }
 
     private func finishPersistenceBatches() async {
-        while let task = persistenceBatchTask {
+        if let task = persistenceBatchTask {
+            persistenceBatchGeneration &+= 1
+            persistenceBatchTask = nil
             task.cancel()
-            await task.value
         }
         if !pendingPersistenceEvents.isEmpty {
             await flushPersistenceBatch()

--- a/Tests/DahliaTests/TranscriptionEventPipelineTests.swift
+++ b/Tests/DahliaTests/TranscriptionEventPipelineTests.swift
@@ -257,14 +257,19 @@
         @Test
         func resetRunsAfterEarlierPersistenceEvents() async throws {
             let operations = StringProbe()
+            let batchSleep = PersistenceBatchSleepProbe()
             let sessionID = UUID.v7()
             let pipeline = TranscriptionEventPipeline(
                 uiSink: { _ in },
                 persistenceSink: { _ in
+                    try Task.checkCancellation()
                     await operations.append("persist")
                 },
                 persistenceResetSink: {
                     await operations.append("reset")
+                },
+                persistenceBatchSleep: {
+                    try await batchSleep.sleep()
                 }
             )
 
@@ -272,10 +277,61 @@
             await pipeline.enqueue(.finalized(
                 makeSegment(sessionId: sessionID, text: "final", isConfirmed: true)
             ))
+            await batchSleep.waitUntilStarted()
             try await pipeline.resetPersistence()
             try await pipeline.finish()
 
             #expect(await operations.snapshot() == ["persist", "reset"])
+        }
+
+        @Test
+        func finishDoesNotCancelPendingPersistenceBatch() async throws {
+            let persistedEvents = TranscriptionEventProbe()
+            let batchSleep = PersistenceBatchSleepProbe()
+            let event = TranscriptionEvent.finalized(
+                makeSegment(sessionId: .v7(), text: "final", isConfirmed: true)
+            )
+            let pipeline = TranscriptionEventPipeline(
+                uiSink: { _ in },
+                persistenceSink: { events in
+                    try Task.checkCancellation()
+                    await persistedEvents.append(contentsOf: events)
+                },
+                persistenceBatchSleep: {
+                    try await batchSleep.sleep()
+                }
+            )
+
+            await pipeline.start()
+            await pipeline.enqueue(event)
+            await batchSleep.waitUntilStarted()
+            try await pipeline.finish()
+
+            #expect(await persistedEvents.snapshot() == [event])
+        }
+
+        @Test
+        func batchSleepFailureDoesNotDisablePersistence() async throws {
+            let persistedEvents = TranscriptionEventProbe()
+            let event = TranscriptionEvent.finalized(
+                makeSegment(sessionId: .v7(), text: "final", isConfirmed: true)
+            )
+            let pipeline = TranscriptionEventPipeline(
+                uiSink: { _ in },
+                persistenceSink: { events in
+                    await persistedEvents.append(contentsOf: events)
+                },
+                persistenceBatchSleep: {
+                    throw PersistenceBatchSleepError.failed
+                }
+            )
+
+            await pipeline.start()
+            await pipeline.enqueue(event)
+            await persistedEvents.waitForCount(1)
+            try await pipeline.finish()
+
+            #expect(await persistedEvents.snapshot() == [event])
         }
 
         @Test
@@ -466,6 +522,30 @@
             waiters.removeAll()
             continuations.forEach { $0.resume() }
         }
+    }
+
+    private actor PersistenceBatchSleepProbe {
+        private var isStarted = false
+        private var startWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func sleep() async throws {
+            isStarted = true
+            let waiters = startWaiters
+            startWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+            try await Task.sleep(for: .seconds(60))
+        }
+
+        func waitUntilStarted() async {
+            guard !isStarted else { return }
+            await withCheckedContinuation { continuation in
+                startWaiters.append(continuation)
+            }
+        }
+    }
+
+    private enum PersistenceBatchSleepError: Error {
+        case failed
     }
 
     private actor TranscriptionEventProbe {


### PR DESCRIPTION
## Summary

- separate the persistence debounce timer from the task that writes transcript events
- invalidate stale scheduled flushes when finishing or resetting the persistence pipeline
- keep final persistence work on the uncancelled persistence worker
- add deterministic regression coverage for finish, reset, and debounce-sleeper failures

## Root cause

Stopping transcription cancelled the debounce task and then continued into `TranscriptPersistenceWriter.flushPending()` from that same cancelled task. `Task.checkCancellation()` consequently threw `CancellationError`, which was reported to Sentry as `stopTranscriptionPersistence` even though stopping the recording was intentional.

Sentry issue: https://dahlia-app.sentry.io/issues/7428694532/

## Impact

Recording shutdown and persistence reset no longer propagate debounce cancellation into transcript storage. Pending transcript events are flushed once, in order, without adding a debounce delay to stop/reset operations.

## Validation

- `swift test --filter TranscriptionEventPipelineTests` — 12 tests passed
- `swift build`
- `CI=true ./scripts/lint.sh` — SwiftFormat clean; SwiftLint completed with existing repository warnings
- `git diff --check`