### PR TITLE
Prevent summary popovers from appearing above floating chat

### DIFF
--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -191,7 +191,8 @@ struct ContentView: View {
             ControlPanelView(
                 viewModel: viewModel,
                 sidebarViewModel: sidebarViewModel,
-                recordingCoordinator: recordingCoordinator
+                recordingCoordinator: recordingCoordinator,
+                allowsTranscriptReferencePopovers: !chatCoordinator.isFloatingVisible
             )
         } else {
             CalendarScheduleView(

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -296,6 +296,7 @@ struct ControlPanelView: View {
     @ObservedObject var viewModel: CaptionViewModel
     var sidebarViewModel: SidebarViewModel
     let recordingCoordinator: RecordingCoordinator
+    let allowsTranscriptReferencePopovers: Bool
     @ObservedObject private var appSettings = AppSettings.shared
     @State private var selectedTab: DetailTab = .notes
     @State private var expandedScreenshot: MeetingScreenshotRecord?
@@ -502,7 +503,8 @@ struct ControlPanelView: View {
                             guard let record = viewModel.screenshots.first(where: { $0.id == screenshotId }) else { return nil }
                             return record.imageData
                         },
-                        transcriptTextProvider: summaryTranscriptText
+                        transcriptTextProvider: summaryTranscriptText,
+                        allowsTranscriptReferencePopovers: allowsTranscriptReferencePopovers
                     )
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }

--- a/Sources/Dahlia/Views/SummaryDocumentView.swift
+++ b/Sources/Dahlia/Views/SummaryDocumentView.swift
@@ -4,15 +4,18 @@ struct SummaryDocumentView: View {
     let document: SummaryDocument
     let imageDataProvider: (UUID) -> Data?
     let transcriptTextProvider: (TranscriptReference) -> String?
+    let allowsTranscriptReferencePopovers: Bool
 
     init(
         document: SummaryDocument,
         imageDataProvider: @escaping (UUID) -> Data?,
-        transcriptTextProvider: @escaping (TranscriptReference) -> String? = { _ in nil }
+        transcriptTextProvider: @escaping (TranscriptReference) -> String? = { _ in nil },
+        allowsTranscriptReferencePopovers: Bool = true
     ) {
         self.document = document
         self.imageDataProvider = imageDataProvider
         self.transcriptTextProvider = transcriptTextProvider
+        self.allowsTranscriptReferencePopovers = allowsTranscriptReferencePopovers
     }
 
     var body: some View {
@@ -226,7 +229,8 @@ struct SummaryDocumentView: View {
         if let ref {
             TranscriptReferenceChip(
                 reference: ref,
-                transcriptText: transcriptTextProvider(ref)
+                transcriptText: transcriptTextProvider(ref),
+                allowsPopover: allowsTranscriptReferencePopovers
             )
         }
     }
@@ -280,6 +284,7 @@ private struct SummaryScreenshotImageView: View {
 private struct TranscriptReferenceChip: View {
     let reference: TranscriptReference
     let transcriptText: String?
+    let allowsPopover: Bool
 
     @State private var isTranscriptPopoverPresented = false
 
@@ -291,7 +296,13 @@ private struct TranscriptReferenceChip: View {
             .padding(.vertical, 2)
             .background(Color.primary.opacity(0.06), in: Capsule())
             .onHover { isHovering in
-                isTranscriptPopoverPresented = isHovering && transcriptText?.nilIfBlank != nil
+                isTranscriptPopoverPresented = allowsPopover
+                    && isHovering
+                    && transcriptText?.nilIfBlank != nil
+            }
+            .onChange(of: allowsPopover) {
+                guard !allowsPopover else { return }
+                isTranscriptPopoverPresented = false
             }
             .popover(isPresented: $isTranscriptPopoverPresented, arrowEdge: .bottom) {
                 if let transcriptText = transcriptText?.nilIfBlank {


### PR DESCRIPTION
## Summary

- suppress transcript-reference popovers while the floating AI chat is visible
- immediately dismiss an already-visible transcript popover when the chat opens
- restore normal hover previews after the floating chat is hidden

## Why

Transcript-reference previews are SwiftUI popovers with presentation state owned by each timestamp chip. The floating AI chat is rendered as an overlay in the same window, so opening it did not invalidate an already-presented popover. The popover could therefore remain above the chat even though its source content was underneath it.

This change passes the floating-chat visibility state through the meeting detail and summary views. Timestamp chips now gate new presentations and dismiss existing presentations when popovers become disallowed. Window levels are unchanged.

## Validation

- `swift build`
- `swift test`: 897 Swift Testing tests in 145 suites passed; 3 XCTest tests passed
- `swift test --filter CodexChatCoordinatorTests`: 9 tests in 1 suite passed
- `CI=true ./scripts/lint.sh`: SwiftFormat reported 0 files requiring formatting; SwiftLint completed with pre-existing unrelated violations
- `git diff --check`

## User impact

Opening, moving, or resizing the floating AI chat no longer allows summary transcript previews to appear through the chat surface. Transcript previews continue to work normally after the chat is hidden.