### PR TITLE
Suppress expected provider authentication reports

### DIFF
--- a/Sources/Dahlia/Services/CodexAppServerError.swift
+++ b/Sources/Dahlia/Services/CodexAppServerError.swift
@@ -11,6 +11,7 @@ enum CodexAppServerError: LocalizedError, Equatable {
     case invalidProtocolResponse
     case outputBufferOverflow
     case rpcError(code: Int?, message: String)
+    case providerAuthenticationFailed(String?)
     case turnFailed(String?)
     case turnInterrupted
     case emptyResponse
@@ -28,6 +29,8 @@ enum CodexAppServerError: LocalizedError, Equatable {
         case .invalidProtocolResponse: L10n.codexInvalidResponse
         case .outputBufferOverflow: L10n.codexOutputBufferOverflow
         case let .rpcError(_, message): L10n.codexRequestFailed(message)
+        case let .providerAuthenticationFailed(detail):
+            detail.map(L10n.codexRequestFailed) ?? L10n.codexTurnFailed
         case let .turnFailed(detail): detail.map(L10n.codexRequestFailed) ?? L10n.codexTurnFailed
         case .turnInterrupted: L10n.codexTurnInterrupted
         case .emptyResponse: L10n.llmErrorEmptyResponse

--- a/Sources/Dahlia/Services/CodexAppServerService+Authentication.swift
+++ b/Sources/Dahlia/Services/CodexAppServerService+Authentication.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension CodexAppServerService {
     nonisolated static func isAuthenticationRPCError(
         data: JSONValue?,
@@ -20,8 +22,20 @@ extension CodexAppServerService {
 
     nonisolated static func isAuthenticationTurnError(_ error: [String: JSONValue]?) -> Bool {
         guard let error else { return false }
-        let info = error["codexErrorInfo"] ?? error["codex_error_info"]
-        return info?.stringValue?.lowercased() == "unauthorized"
-            || info?.objectValue?["type"]?.stringValue?.lowercased() == "unauthorized"
+        let authenticationInfo = error["codexErrorInfo"] ?? error["codex_error_info"]
+        return authenticationInfo?.stringValue?.lowercased() == "unauthorized"
+            || authenticationInfo?.objectValue?["type"]?.stringValue?.lowercased() == "unauthorized"
+    }
+
+    nonisolated static func isExpectedProviderAuthenticationTurnError(_ error: [String: JSONValue]?) -> Bool {
+        guard let error,
+              let rawMessage = error["message"]?.stringValue
+        else { return false }
+
+        // Databricks can return this expected credential diagnostic without
+        // codexErrorInfo, so preserve it for the user without reporting it.
+        let message = rawMessage.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard message.hasPrefix("unexpected status 401 unauthorized:") else { return false }
+        return message.contains("credential was not sent or was of an unsupported type for this api.")
     }
 }

--- a/Sources/Dahlia/Services/CodexAppServerService.swift
+++ b/Sources/Dahlia/Services/CodexAppServerService.swift
@@ -947,6 +947,8 @@ private extension CodexAppServerService {
             let detail = turnError?["message"]?.stringValue
             if Self.isAuthenticationTurnError(turnError) {
                 waiter.continuation.resume(throwing: CodexAppServerError.notLoggedIn)
+            } else if Self.isExpectedProviderAuthenticationTurnError(turnError) {
+                waiter.continuation.resume(throwing: CodexAppServerError.providerAuthenticationFailed(detail))
             } else {
                 waiter.continuation.resume(throwing: CodexAppServerError.turnFailed(detail))
             }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -3088,7 +3088,7 @@ final class CaptionViewModel: ObservableObject {
         if let configurationError = error as? CodexConfigurationError, case .accountNotReady = configurationError { return false }
         guard let error = error as? CodexAppServerError else { return true }
         return switch error {
-        case .helperNotBundled, .notLoggedIn, .requestTimedOut, .turnInterrupted:
+        case .helperNotBundled, .notLoggedIn, .providerAuthenticationFailed, .requestTimedOut, .turnInterrupted:
             false
         default:
             true

--- a/Tests/DahliaTests/CodexAppServerServiceTests.swift
+++ b/Tests/DahliaTests/CodexAppServerServiceTests.swift
@@ -624,6 +624,51 @@ import Foundation
         }
 
         @Test
+        func expectedProviderAuthenticationFailurePreservesDetailWithoutReporting() async {
+            let transport = TestCodexAppServerTransport(mode: .generationFailsExpectedProviderAuthentication)
+            let service = CodexAppServerService(transportFactory: { transport })
+            let detail = """
+            unexpected status 401 Unauthorized: {"error_code":401,"message":"Credential was not sent or was of an unsupported type for this API."}
+            """
+            let expectedError = CodexAppServerError.providerAuthenticationFailed(detail)
+            let paddedTurnError: [String: JSONValue] = ["message": .string("\n \(detail)\n")]
+
+            #expect(CodexAppServerService.isExpectedProviderAuthenticationTurnError(paddedTurnError))
+            await #expect(throws: expectedError) {
+                _ = try await service.generate(.init(
+                    model: nil,
+                    developerInstructions: "Summarize.",
+                    inputs: [.text("Transcript")],
+                    outputSchema: Data(#"{"type":"object"}"#.utf8)
+                ))
+            }
+            #expect(expectedError.localizedDescription == L10n.codexRequestFailed(detail))
+            #expect(!CaptionViewModel.shouldCaptureSummaryGenerationError(expectedError))
+            await service.shutdown()
+        }
+
+        @Test
+        func unrelatedHTTPUnauthorizedTurnFailureRemainsReportable() async {
+            let transport = TestCodexAppServerTransport(mode: .generationFailsOtherHTTPUnauthorized)
+            let service = CodexAppServerService(transportFactory: { transport })
+            let detail = """
+            unexpected status 401 Unauthorized: {"error":"An upstream tool rejected its credentials."}
+            """
+            let expectedError = CodexAppServerError.turnFailed(detail)
+
+            await #expect(throws: expectedError) {
+                _ = try await service.generate(.init(
+                    model: nil,
+                    developerInstructions: "Summarize.",
+                    inputs: [.text("Transcript")],
+                    outputSchema: Data(#"{"type":"object"}"#.utf8)
+                ))
+            }
+            #expect(CaptionViewModel.shouldCaptureSummaryGenerationError(expectedError))
+            await service.shutdown()
+        }
+
+        @Test
         func unrelatedUnauthorizedTextRemainsTurnFailure() async {
             let transport = TestCodexAppServerTransport(mode: .generationFailsMessageOnlyUnauthorized)
             let service = CodexAppServerService(transportFactory: { transport })

--- a/Tests/DahliaTests/TestCodexAppServerTransport.swift
+++ b/Tests/DahliaTests/TestCodexAppServerTransport.swift
@@ -12,6 +12,8 @@ actor TestCodexAppServerTransport: CodexAppServerTransport {
         case generationCompletes
         case generationBlocks
         case generationFailsUnauthorized
+        case generationFailsExpectedProviderAuthentication
+        case generationFailsOtherHTTPUnauthorized
         case generationFailsMessageOnlyUnauthorized
         case signedOut
         case loginCompletes
@@ -240,11 +242,7 @@ actor TestCodexAppServerTransport: CodexAppServerTransport {
                 "status": .string("inProgress"),
             ]),
         ])))
-        if mode == .generationFailsUnauthorized || mode == .generationFailsMessageOnlyUnauthorized {
-            var error: [String: JSONValue] = ["message": .string("unauthorized while generating")]
-            if mode == .generationFailsUnauthorized {
-                error["codexErrorInfo"] = .string("unauthorized")
-            }
+        if let error = generationFailureError() {
             enqueue(jsonValue: .object([
                 "method": .string("turn/completed"),
                 "params": .object([
@@ -282,6 +280,35 @@ actor TestCodexAppServerTransport: CodexAppServerTransport {
                 ]),
             ]),
         ]))
+    }
+
+    private func generationFailureError() -> [String: JSONValue]? {
+        switch mode {
+        case .generationFailsUnauthorized:
+            [
+                "message": .string("unauthorized while generating"),
+                "codexErrorInfo": .string("unauthorized"),
+            ]
+        case .generationFailsExpectedProviderAuthentication:
+            [
+                "message": .string(
+                    "unexpected status 401 Unauthorized: "
+                        + #"{"error_code":401,"message":"Credential was not sent or was of an unsupported type for this API."}"#
+                ),
+            ]
+        case .generationFailsOtherHTTPUnauthorized:
+            [
+                "message": .string(
+                    """
+                    unexpected status 401 Unauthorized: {"error":"An upstream tool rejected its credentials."}
+                    """
+                ),
+            ]
+        case .generationFailsMessageOnlyUnauthorized:
+            ["message": .string("unauthorized while generating")]
+        default:
+            nil
+        }
     }
 
     private func enqueueTestResponse(to requestID: Int, method: String) {


### PR DESCRIPTION
## Summary

- classify the known Databricks AI Gateway credential diagnostic as an expected provider authentication failure
- preserve the original error detail shown to users while excluding this expected failure from Sentry reporting
- keep unrelated HTTP 401 and generic unauthorized failures reportable
- cover whitespace normalization and nearby false-positive boundaries with regression tests

## Root cause

Databricks can return its credential failure only as free-form `turn/completed` error text without structured `codexErrorInfo`. Dahlia therefore treated it as a generic `turnFailed` and captured it in Sentry. A broad 401 mapping would also suppress unrelated failures and incorrectly show the ChatGPT sign-in message, so the classifier is limited to the known Databricks diagnostic and uses a dedicated error that retains the original detail.

Sentry issue: https://dahlia-app.sentry.io/issues/7616780396/

## Validation

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter CodexAppServerServiceTests` — 44 tests passed, 2 integration tests skipped
- `env CI=true DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/lint.sh` — SwiftFormat clean; SwiftLint completed with existing non-blocking warnings
- `git diff --check`