### PR TITLE
Add batch transcription progress

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>32</string>
+    <string>33</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.6.4</string>
+    <string>0.6.5</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/Models/BatchTranscriptionProgress.swift
+++ b/Sources/Dahlia/Models/BatchTranscriptionProgress.swift
@@ -1,0 +1,4 @@
+struct BatchTranscriptionProgress: Equatable, Sendable {
+    let completedFileCount: Int
+    let totalFileCount: Int
+}

--- a/Sources/Dahlia/Models/BatchTranscriptionState.swift
+++ b/Sources/Dahlia/Models/BatchTranscriptionState.swift
@@ -5,7 +5,7 @@ enum BatchTranscriptionState: Equatable {
     case recording(sessionId: UUID)
     case awaitingConfirmation(sessionId: UUID)
     case queued(sessionId: UUID)
-    case running(sessionId: UUID)
+    case running(sessionId: UUID, progress: BatchTranscriptionProgress? = nil)
     case completed(sessionId: UUID)
     case failed(sessionId: UUID, message: String)
     case retranscriptionFailed(sessionId: UUID, message: String)
@@ -15,7 +15,7 @@ enum BatchTranscriptionState: Equatable {
         case let .recording(sessionId),
              let .awaitingConfirmation(sessionId),
              let .queued(sessionId),
-             let .running(sessionId),
+             let .running(sessionId, _),
              let .completed(sessionId),
              let .failed(sessionId, _),
              let .retranscriptionFailed(sessionId, _):
@@ -30,6 +30,20 @@ enum BatchTranscriptionState: Equatable {
         case .completed:
             false
         }
+    }
+
+    func preferringMoreAdvancedRunningProgress(over restoredState: Self) -> Self {
+        guard sessionId == restoredState.sessionId,
+              case let .running(_, currentProgress?) = self,
+              case let .running(_, restoredProgress) = restoredState else {
+            return restoredState
+        }
+        guard let restoredProgress else { return self }
+        guard currentProgress.totalFileCount == restoredProgress.totalFileCount,
+              currentProgress.completedFileCount >= restoredProgress.completedFileCount else {
+            return restoredState
+        }
+        return self
     }
 
     static func derive(from session: RecordingSessionRecord, isRunning: Bool = false) -> Self? {

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -663,6 +663,7 @@
 "Review and Start" = "Review and Start";
 "Waiting to transcribe the recording…" = "Waiting to transcribe the recording…";
 "Creating a high-accuracy transcript…" = "Creating a high-accuracy transcript…";
+"Files completed: %lld of %lld" = "Files completed: %1$lld of %2$lld";
 "High-accuracy transcription completed." = "High-accuracy transcription completed.";
 "Batch transcription failed: %@" = "Batch transcription failed: %@";
 "Retry Batch Transcription" = "Retry Batch Transcription";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -663,6 +663,7 @@
 "Review and Start" = "確認して開始";
 "Waiting to transcribe the recording…" = "録音の文字起こしを待機しています…";
 "Creating a high-accuracy transcript…" = "高精度な文字起こしを作成しています…";
+"Files completed: %lld of %lld" = "完了ファイル: %1$lld / %2$lld";
 "High-accuracy transcription completed." = "高精度な文字起こしが完了しました。";
 "Batch transcription failed: %@" = "バッチ文字起こしに失敗しました: %@";
 "Retry Batch Transcription" = "バッチ文字起こしを再試行";

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -75,6 +75,7 @@ actor BatchTranscriptionCoordinator {
     private var runningSessionId: UUID?
     private var runningProgress: BatchTranscriptionProgress?
     private var processorTask: Task<Void, Never>?
+    private var pendingProgressUpdate: BatchTranscriptionUpdate?
     private var progressNotificationTask: Task<Void, Never>?
 
     init(
@@ -620,16 +621,23 @@ extension BatchTranscriptionCoordinator {
             meetingId: meetingId,
             state: .running(sessionId: sessionId, progress: progress)
         )
-        let precedingTask = progressNotificationTask
-        progressNotificationTask = Task { [onStateChange] in
-            await precedingTask?.value
+        pendingProgressUpdate = update
+        guard progressNotificationTask == nil else { return }
+        progressNotificationTask = Task { [weak self] in
+            await self?.deliverPendingProgressUpdates()
+        }
+    }
+
+    private func deliverPendingProgressUpdates() async {
+        while let update = pendingProgressUpdate {
+            pendingProgressUpdate = nil
             await onStateChange(update)
         }
+        progressNotificationTask = nil
     }
 
     private func finishProgressNotifications() async {
         await progressNotificationTask?.value
-        progressNotificationTask = nil
     }
 
     private func notifyProgress(

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -612,16 +612,12 @@ extension BatchTranscriptionCoordinator {
         completedFileCount: Int,
         totalFileCount: Int
     ) {
-        let progress = BatchTranscriptionProgress(
+        pendingProgressUpdate = recordProgress(
+            meetingId: meetingId,
+            sessionId: sessionId,
             completedFileCount: completedFileCount,
             totalFileCount: totalFileCount
         )
-        runningProgress = progress
-        let update = BatchTranscriptionUpdate(
-            meetingId: meetingId,
-            state: .running(sessionId: sessionId, progress: progress)
-        )
-        pendingProgressUpdate = update
         guard progressNotificationTask == nil else { return }
         progressNotificationTask = Task { [weak self] in
             await self?.deliverPendingProgressUpdates()
@@ -646,17 +642,29 @@ extension BatchTranscriptionCoordinator {
         completedFileCount: Int,
         totalFileCount: Int
     ) async {
+        let update = recordProgress(
+            meetingId: meetingId,
+            sessionId: sessionId,
+            completedFileCount: completedFileCount,
+            totalFileCount: totalFileCount
+        )
+        await onStateChange(update)
+    }
+
+    private func recordProgress(
+        meetingId: UUID,
+        sessionId: UUID,
+        completedFileCount: Int,
+        totalFileCount: Int
+    ) -> BatchTranscriptionUpdate {
         let progress = BatchTranscriptionProgress(
             completedFileCount: completedFileCount,
             totalFileCount: totalFileCount
         )
         runningProgress = progress
-        await notify(
+        return BatchTranscriptionUpdate(
             meetingId: meetingId,
-            state: .running(
-                sessionId: sessionId,
-                progress: progress
-            )
+            state: .running(sessionId: sessionId, progress: progress)
         )
     }
 

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -52,11 +52,13 @@ actor BatchTranscriptionCoordinator {
 
     private struct TranscriptionWorkItem: Sendable {
         let index: Int
+        let fileIndex: Int
         let request: BatchSpeechTranscriptionRequest
     }
 
     private struct TranscriptionWorkResult: Sendable {
         let index: Int
+        let fileIndex: Int
         var segments: [TranscriptSegment]
         let localeIdentifier: String
     }
@@ -71,6 +73,7 @@ actor BatchTranscriptionCoordinator {
     let onStateChange: StateHandler
     private var pendingSessionIds: [UUID] = []
     private var runningSessionId: UUID?
+    private var runningProgress: BatchTranscriptionProgress?
     private var processorTask: Task<Void, Never>?
 
     init(
@@ -135,8 +138,9 @@ actor BatchTranscriptionCoordinator {
         }
     }
 
-    func isRunning(sessionId: UUID) -> Bool {
-        runningSessionId == sessionId
+    func runningState(sessionId: UUID) -> BatchTranscriptionState? {
+        guard runningSessionId == sessionId else { return nil }
+        return .running(sessionId: sessionId, progress: runningProgress)
     }
 
     func recordRecordingFailure(sessionId: UUID, message: String) async {
@@ -152,6 +156,7 @@ actor BatchTranscriptionCoordinator {
             while !pendingSessionIds.isEmpty {
                 let sessionId = pendingSessionIds.removeFirst()
                 runningSessionId = sessionId
+                runningProgress = nil
                 do {
                     try await markAttemptStarted(sessionId: sessionId)
                     let meetingId = try meetingId(for: sessionId)
@@ -164,6 +169,7 @@ actor BatchTranscriptionCoordinator {
                     await recordFailure(sessionId: sessionId, error: error)
                 }
                 runningSessionId = nil
+                runningProgress = nil
             }
             await languageDetector.unload()
             await speechRecognizer.unload()
@@ -288,8 +294,9 @@ actor BatchTranscriptionCoordinator {
         let automaticLanguageCandidateLocales = automaticLanguageCandidates.map {
             BatchLanguageDetectionCandidateResolver.candidates(snapshot: $0, supportedLocales: supportedLocales).locales
         }
+        let totalFileCount = verifiedSegments.count
         var workItems: [TranscriptionWorkItem] = []
-        for verified in verifiedSegments {
+        for (fileIndex, verified) in verifiedSegments.enumerated() {
             let ranges = try BatchTranscriptionAudioRangePlanner.ranges(
                 for: verified,
                 mode: job.session.batchLanguageDetectionMode
@@ -298,6 +305,7 @@ actor BatchTranscriptionCoordinator {
                 workItems.append(
                     TranscriptionWorkItem(
                         index: workItems.count,
+                        fileIndex: fileIndex,
                         request: BatchSpeechTranscriptionRequest(
                             audioURL: verified.url,
                             startFrame: range.startFrame,
@@ -316,13 +324,22 @@ actor BatchTranscriptionCoordinator {
                 )
             }
         }
+        await notifyProgress(
+            meetingId: job.meeting.id,
+            sessionId: job.session.id,
+            completedFileCount: 0,
+            totalFileCount: totalFileCount
+        )
         let recognitionState = Self.signposter.beginInterval("Recognize CAF files")
         let fallbackCollector = BatchLanguageFallbackCollector()
         var workResults: [TranscriptionWorkResult]
         do {
             workResults = try await transcribeConcurrently(
                 workItems: workItems,
-                fallbackCollector: fallbackCollector
+                fallbackCollector: fallbackCollector,
+                meetingId: job.meeting.id,
+                sessionId: job.session.id,
+                totalFileCount: totalFileCount
             )
             .sorted { $0.index < $1.index }
             Self.signposter.endInterval("Recognize CAF files", recognitionState)
@@ -397,39 +414,6 @@ actor BatchTranscriptionCoordinator {
         return workResults
     }
 
-    private func transcribeConcurrently(
-        workItems: [TranscriptionWorkItem],
-        fallbackCollector: BatchLanguageFallbackCollector
-    ) async throws -> [TranscriptionWorkResult] {
-        try await withThrowingTaskGroup(of: TranscriptionWorkResult.self) { group in
-            let initialCount = min(BatchTranscriptionConcurrency.appleSpeechMaximum, workItems.count)
-            for workItem in workItems.prefix(initialCount) {
-                group.addTask { [self] in
-                    try await transcribe(workItem: workItem, fallbackCollector: fallbackCollector)
-                }
-            }
-
-            var nextIndex = initialCount
-            var results: [TranscriptionWorkResult] = []
-            do {
-                while let result = try await group.next() {
-                    results.append(result)
-                    if nextIndex < workItems.count {
-                        let workItem = workItems[nextIndex]
-                        nextIndex += 1
-                        group.addTask { [self] in
-                            try await transcribe(workItem: workItem, fallbackCollector: fallbackCollector)
-                        }
-                    }
-                }
-                return results
-            } catch {
-                group.cancelAll()
-                throw error
-            }
-        }
-    }
-
     private func transcribe(
         workItem: TranscriptionWorkItem,
         fallbackCollector: BatchLanguageFallbackCollector
@@ -444,6 +428,7 @@ actor BatchTranscriptionCoordinator {
         )
         return TranscriptionWorkResult(
             index: workItem.index,
+            fileIndex: workItem.fileIndex,
             segments: result.segments,
             localeIdentifier: result.localeIdentifier
         )
@@ -557,6 +542,86 @@ actor BatchTranscriptionCoordinator {
 }
 
 extension BatchTranscriptionCoordinator {
+    private func transcribeConcurrently(
+        workItems: [TranscriptionWorkItem],
+        fallbackCollector: BatchLanguageFallbackCollector,
+        meetingId: UUID,
+        sessionId: UUID,
+        totalFileCount: Int
+    ) async throws -> [TranscriptionWorkResult] {
+        try await withThrowingTaskGroup(of: TranscriptionWorkResult.self) { group in
+            let initialCount = min(BatchTranscriptionConcurrency.appleSpeechMaximum, workItems.count)
+            for workItem in workItems.prefix(initialCount) {
+                group.addTask { [self] in
+                    try await transcribe(workItem: workItem, fallbackCollector: fallbackCollector)
+                }
+            }
+
+            var nextIndex = initialCount
+            var results: [TranscriptionWorkResult] = []
+            var remainingWorkItemCountByFile = Dictionary(
+                grouping: workItems,
+                by: \.fileIndex
+            ).mapValues(\.count)
+            var completedFileCount = 0
+            do {
+                while let result = try await group.next() {
+                    results.append(result)
+                    let didCompleteFile: Bool
+                    if remainingWorkItemCountByFile[result.fileIndex] == 1 {
+                        remainingWorkItemCountByFile[result.fileIndex] = nil
+                        completedFileCount += 1
+                        didCompleteFile = true
+                    } else if let remainingCount = remainingWorkItemCountByFile[result.fileIndex] {
+                        remainingWorkItemCountByFile[result.fileIndex] = remainingCount - 1
+                        didCompleteFile = false
+                    } else {
+                        didCompleteFile = false
+                    }
+                    if nextIndex < workItems.count {
+                        let workItem = workItems[nextIndex]
+                        nextIndex += 1
+                        group.addTask { [self] in
+                            try await transcribe(workItem: workItem, fallbackCollector: fallbackCollector)
+                        }
+                    }
+                    if didCompleteFile {
+                        await notifyProgress(
+                            meetingId: meetingId,
+                            sessionId: sessionId,
+                            completedFileCount: completedFileCount,
+                            totalFileCount: totalFileCount
+                        )
+                    }
+                }
+                return results
+            } catch {
+                group.cancelAll()
+                throw error
+            }
+        }
+    }
+
+    private func notifyProgress(
+        meetingId: UUID,
+        sessionId: UUID,
+        completedFileCount: Int,
+        totalFileCount: Int
+    ) async {
+        let progress = BatchTranscriptionProgress(
+            completedFileCount: completedFileCount,
+            totalFileCount: totalFileCount
+        )
+        runningProgress = progress
+        await notify(
+            meetingId: meetingId,
+            state: .running(
+                sessionId: sessionId,
+                progress: progress
+            )
+        )
+    }
+
     /// Resumes the delete-after-transcription policy if the app stopped after committing a result.
     private func recoverCompletedAudioPurges() async {
         guard let recordingAudioStore else { return }

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -75,6 +75,7 @@ actor BatchTranscriptionCoordinator {
     private var runningSessionId: UUID?
     private var runningProgress: BatchTranscriptionProgress?
     private var processorTask: Task<Void, Never>?
+    private var progressNotificationTask: Task<Void, Never>?
 
     init(
         dbQueue: DatabaseQueue,
@@ -586,7 +587,7 @@ extension BatchTranscriptionCoordinator {
                         }
                     }
                     if didCompleteFile {
-                        await notifyProgress(
+                        enqueueProgressNotification(
                             meetingId: meetingId,
                             sessionId: sessionId,
                             completedFileCount: completedFileCount,
@@ -594,12 +595,41 @@ extension BatchTranscriptionCoordinator {
                         )
                     }
                 }
+                await finishProgressNotifications()
                 return results
             } catch {
                 group.cancelAll()
+                await finishProgressNotifications()
                 throw error
             }
         }
+    }
+
+    private func enqueueProgressNotification(
+        meetingId: UUID,
+        sessionId: UUID,
+        completedFileCount: Int,
+        totalFileCount: Int
+    ) {
+        let progress = BatchTranscriptionProgress(
+            completedFileCount: completedFileCount,
+            totalFileCount: totalFileCount
+        )
+        runningProgress = progress
+        let update = BatchTranscriptionUpdate(
+            meetingId: meetingId,
+            state: .running(sessionId: sessionId, progress: progress)
+        )
+        let precedingTask = progressNotificationTask
+        progressNotificationTask = Task { [onStateChange] in
+            await precedingTask?.value
+            await onStateChange(update)
+        }
+    }
+
+    private func finishProgressNotifications() async {
+        await progressNotificationTask?.value
+        progressNotificationTask = nil
     }
 
     private func notifyProgress(

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -524,6 +524,10 @@ enum L10n {
     static var reviewBatchTranscription: String { String(localized: "Review and Start", bundle: bundle) }
     static var batchTranscriptionQueued: String { String(localized: "Waiting to transcribe the recording…", bundle: bundle) }
     static var batchTranscriptionRunning: String { String(localized: "Creating a high-accuracy transcript…", bundle: bundle) }
+    static func batchTranscriptionFileProgress(completed: Int, total: Int) -> String {
+        String(localized: "Files completed: \(completed) of \(total)", bundle: bundle)
+    }
+
     static var batchTranscriptionCompleted: String { String(localized: "High-accuracy transcription completed.", bundle: bundle) }
     static func batchTranscriptionFailed(_ reason: String) -> String {
         String(localized: "Batch transcription failed: \(reason)", bundle: bundle)

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -1564,10 +1564,10 @@ final class CaptionViewModel: ObservableObject {
         guard let coordinator = batchTranscriptionCoordinator,
               let visibleState = batchTranscriptionState else { return }
         Task {
-            if await coordinator.isRunning(sessionId: visibleState.sessionId),
-               batchTranscriptionState?.sessionId == visibleState.sessionId {
-                batchTranscriptionState = .running(sessionId: visibleState.sessionId)
-            }
+            guard let restoredState = await coordinator.runningState(sessionId: visibleState.sessionId),
+                  batchTranscriptionState?.sessionId == visibleState.sessionId else { return }
+            batchTranscriptionState = batchTranscriptionState?
+                .preferringMoreAdvancedRunningProgress(over: restoredState) ?? restoredState
         }
     }
 

--- a/Sources/Dahlia/Views/BatchTranscriptionStatusView.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionStatusView.swift
@@ -24,10 +24,31 @@ struct BatchTranscriptionStatusView: View {
                 ProgressView()
                     .controlSize(.small)
                 Text(L10n.batchTranscriptionQueued)
-            case .running:
-                ProgressView()
-                    .controlSize(.small)
-                Text(L10n.batchTranscriptionRunning)
+            case let .running(_, progress):
+                if let progress, progress.totalFileCount > 0 {
+                    ProgressView(
+                        value: Double(progress.completedFileCount),
+                        total: Double(progress.totalFileCount)
+                    ) {
+                        Text(L10n.batchTranscriptionRunning)
+                    } currentValueLabel: {
+                        Text(L10n.batchTranscriptionFileProgress(
+                            completed: progress.completedFileCount,
+                            total: progress.totalFileCount
+                        ))
+                    }
+                    .progressViewStyle(.linear)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .accessibilityLabel(L10n.batchTranscriptionRunning)
+                    .accessibilityValue(L10n.batchTranscriptionFileProgress(
+                        completed: progress.completedFileCount,
+                        total: progress.totalFileCount
+                    ))
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(L10n.batchTranscriptionRunning)
+                }
             case .completed:
                 Label(L10n.batchTranscriptionCompleted, systemImage: "checkmark.circle.fill")
                     .foregroundStyle(.green)

--- a/Tests/DahliaTests/BatchTranscriptionProgressTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionProgressTests.swift
@@ -1,0 +1,351 @@
+@preconcurrency import AVFoundation
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    @Suite(.serialized)
+    struct BatchTranscriptionProgressTests {
+        @Test
+        func reportsProgressFromCompletedCAFFileCount() async throws {
+            let fixture = try makeFixture(name: "BatchFileProgress", duration: 0.0125)
+            defer { fixture.removeFiles() }
+            try await createSegmentedAutomaticRecording(fixture: fixture)
+            let stateProbe = BatchProgressStateProbe()
+            let coordinator = makeCoordinator(
+                fixture: fixture,
+                detector: ProgressLanguageDetector(detections: ["ja", "en"]),
+                recognizer: ProgressSpeechRecognizer(),
+                stateProbe: stateProbe
+            )
+
+            await coordinator.enqueue(sessionId: fixture.session.id)
+            try await waitUntil { await stateProbe.didComplete }
+
+            #expect(await stateProbe.reportedProgress() == expectedProgress(totalFileCount: 2))
+        }
+
+        @Test
+        func reportsEachManualMultiRangeCAFAsOneCompletedFile() async throws {
+            let fixture = try makeFixture(name: "BatchManualMultiRangeProgress", duration: 0.015)
+            defer { fixture.removeFiles() }
+            try await createManualMultiRangeRecording(fixture: fixture)
+            let stateProbe = BatchProgressStateProbe()
+            let coordinator = makeCoordinator(
+                fixture: fixture,
+                detector: ProgressLanguageDetector(detections: []),
+                recognizer: ProgressSpeechRecognizer(),
+                stateProbe: stateProbe
+            )
+
+            await coordinator.enqueue(sessionId: fixture.session.id)
+            try await waitUntil { await stateProbe.didComplete }
+
+            #expect(await stateProbe.reportedProgress() == expectedProgress(totalFileCount: 2))
+        }
+
+        @Test
+        func slowProgressCallbackDoesNotDelayNextRecognition() async throws {
+            let fixture = try makeFixture(name: "BatchProgressCallbackConcurrency", duration: 0.025)
+            defer { fixture.removeFiles() }
+            try await createSeparateAutomaticRecordingFiles(fixture: fixture, fileCount: 5)
+            let stateProbe = SuspendingBatchProgressStateProbe()
+            defer { Task { await stateProbe.releaseProgressCallback() } }
+            let recognizer = ProgressSpeechRecognizer()
+            let coordinator = BatchTranscriptionCoordinator(
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL,
+                languageDetector: ProgressLanguageDetector(
+                    detections: Array(repeating: "ja", count: 5)
+                ),
+                speechRecognizer: recognizer,
+                supportedLocalesProvider: {
+                    [Locale(identifier: "ja_JP")]
+                },
+                onStateChange: { update in
+                    await stateProbe.record(update.state)
+                }
+            )
+
+            await coordinator.enqueue(sessionId: fixture.session.id)
+            try await waitUntil { await stateProbe.isHoldingProgressCallback }
+            try await waitUntil { await recognizer.callCount == 5 }
+            #expect(await coordinator.runningState(sessionId: fixture.session.id) == .running(
+                sessionId: fixture.session.id,
+                progress: BatchTranscriptionProgress(completedFileCount: 1, totalFileCount: 5)
+            ))
+
+            await stateProbe.releaseProgressCallback()
+            try await waitUntil { await stateProbe.didComplete }
+        }
+
+        private func makeFixture(name: String, duration: TimeInterval) throws -> BatchAudioTestFixture {
+            try BatchAudioTestFixture(
+                name: name,
+                endedAt: Date(timeIntervalSince1970: 1_776_384_001),
+                duration: duration,
+                retainAudioAfterBatch: true
+            )
+        }
+
+        private func makeCoordinator(
+            fixture: BatchAudioTestFixture,
+            detector: any BatchLanguageDetecting,
+            recognizer: any BatchSpeechRecognizing,
+            stateProbe: BatchProgressStateProbe
+        ) -> BatchTranscriptionCoordinator {
+            BatchTranscriptionCoordinator(
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL,
+                languageDetector: detector,
+                speechRecognizer: recognizer,
+                supportedLocalesProvider: {
+                    [Locale(identifier: "ja_JP"), Locale(identifier: "en_US")]
+                },
+                onStateChange: { update in
+                    await stateProbe.record(update.state)
+                }
+            )
+        }
+
+        private func createSegmentedAutomaticRecording(fixture: BatchAudioTestFixture) async throws {
+            let recorder = try makeRecorder(fixture: fixture, targetSegmentDuration: .milliseconds(5))
+            let writer = try await recorder.beginRange(
+                source: .microphone,
+                locale: Locale(identifier: "ja_JP"),
+                at: fixture.now
+            )
+            try writer.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 80))
+            try writer.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 120))
+            try await recorder.finish()
+            try await configureAutomaticLanguageDetection(fixture: fixture)
+        }
+
+        private func createSeparateAutomaticRecordingFiles(
+            fixture: BatchAudioTestFixture,
+            fileCount: Int
+        ) async throws {
+            let recorder = try makeRecorder(fixture: fixture, targetSegmentDuration: .seconds(60))
+            for fileIndex in 0 ..< fileCount {
+                let writer = try await recorder.beginRange(
+                    source: .microphone,
+                    locale: Locale(identifier: "ja_JP"),
+                    at: fixture.now.addingTimeInterval(Double(fileIndex) * 0.005)
+                )
+                try writer.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 80))
+                if fileIndex < fileCount - 1 {
+                    try await recorder.endRangeForReconfiguration(source: .microphone)
+                }
+            }
+            try await recorder.finish()
+            try await configureAutomaticLanguageDetection(
+                fixture: fixture,
+                candidates: BatchLanguageDetectionCandidateSnapshot(
+                    scope: .selected,
+                    languageIdentifiers: ["ja"],
+                    localeIdentifiers: ["ja_JP"]
+                )
+            )
+            let recordedFileCount = try await fixture.database.dbQueue.read { db in
+                try RecordingAudioSegmentRecord.fetchCount(db)
+            }
+            #expect(recordedFileCount == fileCount)
+        }
+
+        private func createManualMultiRangeRecording(fixture: BatchAudioTestFixture) async throws {
+            let recorder = try makeRecorder(fixture: fixture, targetSegmentDuration: .seconds(60))
+            let firstWriter = try await recorder.beginRange(
+                source: .microphone,
+                locale: Locale(identifier: "ja_JP"),
+                at: fixture.now
+            )
+            try firstWriter.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 80))
+            try await recorder.rotateRange(
+                source: .microphone,
+                locale: Locale(identifier: "en_US")
+            )
+            try firstWriter.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 80))
+            try await recorder.endRangeForReconfiguration(source: .microphone)
+            let secondWriter = try await recorder.beginRange(
+                source: .microphone,
+                locale: Locale(identifier: "ja_JP"),
+                at: fixture.now.addingTimeInterval(0.01)
+            )
+            try secondWriter.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 80))
+            try await recorder.finish()
+
+            let rangeCounts = try await fixture.database.dbQueue.read { db in
+                try RecordingAudioSegmentRecord
+                    .order(Column("segmentIndex").asc)
+                    .fetchAll(db)
+                    .map { segment in
+                        try RecordingAudioSegmentRangeRecord
+                            .filter(Column("audioSegmentId") == segment.id)
+                            .fetchCount(db)
+                    }
+            }
+            #expect(rangeCounts == [2, 1])
+        }
+
+        private func configureAutomaticLanguageDetection(
+            fixture: BatchAudioTestFixture,
+            candidates: BatchLanguageDetectionCandidateSnapshot = .init(
+                scope: .selected,
+                languageIdentifiers: ["en", "ja"],
+                localeIdentifiers: ["en_US", "ja_JP"]
+            )
+        ) async throws {
+            try await fixture.database.dbQueue.write { db in
+                guard var session = try RecordingSessionRecord.fetchOne(db, key: fixture.session.id) else {
+                    throw CocoaError(.fileNoSuchFile)
+                }
+                session.batchLanguageDetectionMode = .automatic
+                session.batchSelectedLocaleIdentifier = nil
+                session.batchAutomaticLanguageCandidatesJSON = try candidates.encoded()
+                try session.update(db)
+            }
+        }
+
+        private func makeRecorder(
+            fixture: BatchAudioTestFixture,
+            targetSegmentDuration: Duration
+        ) throws -> BatchAudioRecordingSession {
+            try BatchAudioRecordingSession(
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL,
+                meetingId: fixture.meeting.id,
+                recordingSessionId: fixture.session.id,
+                recordingStartTime: fixture.now,
+                sampleRate: 16000,
+                configuration: RecordingAudioStore.Configuration(
+                    targetSegmentDuration: targetSegmentDuration,
+                    maximumFinalizingSegmentCountPerSource: 2,
+                    maximumActiveSegmentDuration: .seconds(600),
+                    maximumActiveSegmentByteCount: 64 * 1024 * 1024,
+                    minimumAvailableCapacity: 0,
+                    capacityCheckInterval: .seconds(5)
+                )
+            )
+        }
+
+        private func makeBuffer(
+            format: AVAudioFormat,
+            frameCount: AVAudioFrameCount
+        ) throws -> AVAudioPCMBuffer {
+            let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount))
+            buffer.frameLength = frameCount
+            return buffer
+        }
+
+        private func expectedProgress(totalFileCount: Int) -> [BatchTranscriptionProgress] {
+            (0 ... totalFileCount).map {
+                BatchTranscriptionProgress(completedFileCount: $0, totalFileCount: totalFileCount)
+            }
+        }
+
+        private func waitUntil(
+            timeout: Duration = .seconds(5),
+            condition: @escaping @Sendable () async -> Bool
+        ) async throws {
+            let deadline = ContinuousClock.now.advanced(by: timeout)
+            while await !condition() {
+                guard ContinuousClock.now < deadline else {
+                    throw BatchTranscriptionProgressTestError.timedOut
+                }
+                try await Task.sleep(for: .milliseconds(10))
+            }
+        }
+    }
+
+    private enum BatchTranscriptionProgressTestError: Error {
+        case timedOut
+    }
+
+    private actor BatchProgressStateProbe {
+        private var states: [BatchTranscriptionState] = []
+
+        var didComplete: Bool {
+            states.contains {
+                if case .completed = $0 {
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+
+        func record(_ state: BatchTranscriptionState) {
+            states.append(state)
+        }
+
+        func reportedProgress() -> [BatchTranscriptionProgress] {
+            states.compactMap { state in
+                guard case let .running(_, progress?) = state else { return nil }
+                return progress
+            }
+        }
+    }
+
+    private actor SuspendingBatchProgressStateProbe {
+        private var progressContinuation: CheckedContinuation<Void, Never>?
+        private(set) var isHoldingProgressCallback = false
+        private(set) var didComplete = false
+        private var hasHeldProgressCallback = false
+
+        func record(_ state: BatchTranscriptionState) async {
+            if case .completed = state {
+                didComplete = true
+            }
+            guard case let .running(_, progress?) = state,
+                  progress.completedFileCount == 1,
+                  !hasHeldProgressCallback else { return }
+            hasHeldProgressCallback = true
+            isHoldingProgressCallback = true
+            await withCheckedContinuation { continuation in
+                progressContinuation = continuation
+            }
+            isHoldingProgressCallback = false
+        }
+
+        func releaseProgressCallback() {
+            progressContinuation?.resume()
+            progressContinuation = nil
+        }
+    }
+
+    private actor ProgressLanguageDetector: BatchLanguageDetecting {
+        private var detections: [String]
+
+        init(detections: [String]) {
+            self.detections = detections
+        }
+
+        func detectLanguage(
+            audioURL _: URL,
+            allowedLanguageIdentifiers _: Set<String>?
+        ) throws -> BatchLanguageDetectionOutcome {
+            guard !detections.isEmpty else { throw BatchLanguageDetectorError.inferenceFailed }
+            return .confidentDetection(detections.removeFirst())
+        }
+
+        func unload() async {}
+    }
+
+    private actor ProgressSpeechRecognizer: BatchSpeechRecognizing {
+        private(set) var callCount = 0
+
+        func recognize(audioURL _: URL, locale _: Locale) -> [BatchSpeechRecognition] {
+            callCount += 1
+            return [
+                BatchSpeechRecognition(
+                    startSeconds: 0.001,
+                    endSeconds: 0.002,
+                    text: "recognized-\(callCount)"
+                ),
+            ]
+        }
+    }
+#endif

--- a/Tests/DahliaTests/BatchTranscriptionProgressTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionProgressTests.swift
@@ -51,7 +51,8 @@ import GRDB
         func slowProgressCallbackDoesNotDelayNextRecognition() async throws {
             let fixture = try makeFixture(name: "BatchProgressCallbackConcurrency", duration: 0.025)
             defer { fixture.removeFiles() }
-            try await createSeparateAutomaticRecordingFiles(fixture: fixture, fileCount: 5)
+            let fileCount = BatchTranscriptionConcurrency.appleSpeechMaximum * 2
+            try await createSeparateAutomaticRecordingFiles(fixture: fixture, fileCount: fileCount)
             let stateProbe = SuspendingBatchProgressStateProbe()
             defer { Task { await stateProbe.releaseProgressCallback() } }
             let recognizer = ProgressSpeechRecognizer()
@@ -59,7 +60,7 @@ import GRDB
                 dbQueue: fixture.database.dbQueue,
                 managedRootURL: fixture.managedRootURL,
                 languageDetector: ProgressLanguageDetector(
-                    detections: Array(repeating: "ja", count: 5)
+                    detections: Array(repeating: "ja", count: fileCount)
                 ),
                 speechRecognizer: recognizer,
                 supportedLocalesProvider: {
@@ -72,11 +73,15 @@ import GRDB
 
             await coordinator.enqueue(sessionId: fixture.session.id)
             try await waitUntil { await stateProbe.isHoldingProgressCallback }
-            try await waitUntil { await recognizer.callCount == 5 }
-            #expect(await coordinator.runningState(sessionId: fixture.session.id) == .running(
+            try await waitUntil { await recognizer.callCount == fileCount }
+            let finalRunningState = BatchTranscriptionState.running(
                 sessionId: fixture.session.id,
-                progress: BatchTranscriptionProgress(completedFileCount: 1, totalFileCount: 5)
-            ))
+                progress: BatchTranscriptionProgress(completedFileCount: fileCount, totalFileCount: fileCount)
+            )
+            try await waitUntil {
+                await coordinator.runningState(sessionId: fixture.session.id) == finalRunningState
+            }
+            #expect(await coordinator.runningState(sessionId: fixture.session.id) == finalRunningState)
 
             await stateProbe.releaseProgressCallback()
             try await waitUntil { await stateProbe.didComplete }

--- a/Tests/DahliaTests/BatchTranscriptionProgressTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionProgressTests.swift
@@ -25,7 +25,7 @@ import GRDB
             await coordinator.enqueue(sessionId: fixture.session.id)
             try await waitUntil { await stateProbe.didComplete }
 
-            #expect(await stateProbe.reportedProgress() == expectedProgress(totalFileCount: 2))
+            expectCompleteProgress(await stateProbe.reportedProgress(), totalFileCount: 2)
         }
 
         @Test
@@ -44,7 +44,7 @@ import GRDB
             await coordinator.enqueue(sessionId: fixture.session.id)
             try await waitUntil { await stateProbe.didComplete }
 
-            #expect(await stateProbe.reportedProgress() == expectedProgress(totalFileCount: 2))
+            expectCompleteProgress(await stateProbe.reportedProgress(), totalFileCount: 2)
         }
 
         @Test
@@ -85,6 +85,7 @@ import GRDB
 
             await stateProbe.releaseProgressCallback()
             try await waitUntil { await stateProbe.didComplete }
+            expectCompleteProgress(await stateProbe.reportedProgress(), totalFileCount: fileCount)
         }
 
         private func makeFixture(name: String, duration: TimeInterval) throws -> BatchAudioTestFixture {
@@ -245,10 +246,20 @@ import GRDB
             return buffer
         }
 
-        private func expectedProgress(totalFileCount: Int) -> [BatchTranscriptionProgress] {
-            (0 ... totalFileCount).map {
-                BatchTranscriptionProgress(completedFileCount: $0, totalFileCount: totalFileCount)
-            }
+        private func expectCompleteProgress(
+            _ progressUpdates: [BatchTranscriptionProgress],
+            totalFileCount: Int
+        ) {
+            #expect(progressUpdates.first == BatchTranscriptionProgress(
+                completedFileCount: 0,
+                totalFileCount: totalFileCount
+            ))
+            #expect(progressUpdates.last == BatchTranscriptionProgress(
+                completedFileCount: totalFileCount,
+                totalFileCount: totalFileCount
+            ))
+            #expect(progressUpdates.allSatisfy { $0.totalFileCount == totalFileCount })
+            #expect(progressUpdates.map(\.completedFileCount) == progressUpdates.map(\.completedFileCount).sorted())
         }
 
         private func waitUntil(
@@ -299,13 +310,15 @@ import GRDB
         private(set) var isHoldingProgressCallback = false
         private(set) var didComplete = false
         private var hasHeldProgressCallback = false
+        private var progressUpdates: [BatchTranscriptionProgress] = []
 
         func record(_ state: BatchTranscriptionState) async {
             if case .completed = state {
                 didComplete = true
             }
-            guard case let .running(_, progress?) = state,
-                  progress.completedFileCount == 1,
+            guard case let .running(_, progress?) = state else { return }
+            progressUpdates.append(progress)
+            guard progress.completedFileCount > 0,
                   !hasHeldProgressCallback else { return }
             hasHeldProgressCallback = true
             isHoldingProgressCallback = true
@@ -318,6 +331,10 @@ import GRDB
         func releaseProgressCallback() {
             progressContinuation?.resume()
             progressContinuation = nil
+        }
+
+        func reportedProgress() -> [BatchTranscriptionProgress] {
+            progressUpdates
         }
     }
 

--- a/Tests/DahliaTests/BatchTranscriptionProgressTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionProgressTests.swift
@@ -259,7 +259,8 @@ import GRDB
                 totalFileCount: totalFileCount
             ))
             #expect(progressUpdates.allSatisfy { $0.totalFileCount == totalFileCount })
-            #expect(progressUpdates.map(\.completedFileCount) == progressUpdates.map(\.completedFileCount).sorted())
+            let completedFileCounts = progressUpdates.map(\.completedFileCount)
+            #expect(completedFileCounts == completedFileCounts.sorted())
         }
 
         private func waitUntil(

--- a/Tests/DahliaTests/BatchTranscriptionStateTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionStateTests.swift
@@ -26,6 +26,11 @@ import Foundation
             #expect(BatchTranscriptionState.derive(from: session) == .awaitingConfirmation(sessionId: session.id))
             #expect(BatchTranscriptionState.derive(from: session, isRunning: true) == .running(sessionId: session.id))
 
+            let progress = BatchTranscriptionProgress(completedFileCount: 2, totalFileCount: 5)
+            let running = BatchTranscriptionState.running(sessionId: session.id, progress: progress)
+            #expect(running.sessionId == session.id)
+            #expect(running == .running(sessionId: session.id, progress: progress))
+
             session.batchLastAttemptAt = now.addingTimeInterval(11)
             #expect(BatchTranscriptionState.derive(from: session) == .queued(sessionId: session.id))
 
@@ -65,6 +70,25 @@ import Foundation
             )
 
             #expect(BatchTranscriptionState.derive(from: session) == nil)
+        }
+
+        @Test
+        func restoredRunningStateDoesNotRegressNewerVisibleProgress() {
+            let sessionId = UUID.v7()
+            let indeterminate = BatchTranscriptionState.running(sessionId: sessionId)
+            let firstFile = BatchTranscriptionState.running(
+                sessionId: sessionId,
+                progress: BatchTranscriptionProgress(completedFileCount: 1, totalFileCount: 5)
+            )
+            let secondFile = BatchTranscriptionState.running(
+                sessionId: sessionId,
+                progress: BatchTranscriptionProgress(completedFileCount: 2, totalFileCount: 5)
+            )
+
+            #expect(indeterminate.preferringMoreAdvancedRunningProgress(over: firstFile) == firstFile)
+            #expect(firstFile.preferringMoreAdvancedRunningProgress(over: secondFile) == secondFile)
+            #expect(secondFile.preferringMoreAdvancedRunningProgress(over: firstFile) == secondFile)
+            #expect(secondFile.preferringMoreAdvancedRunningProgress(over: indeterminate) == secondFile)
         }
 
         @Test


### PR DESCRIPTION
## What changed

- Show determinate batch transcription progress based on completed CAF files and the total file count.
- Preserve the newest visible progress when caption details reload during an active batch.
- Keep recognition concurrency slots occupied while progress updates are delivered.
- Add localized English and Japanese progress labels and accessibility metadata.
- Add regression coverage for per-file progress, multi-range files, reload races, and slow progress callbacks.

## Why

Batch transcription previously exposed only an indeterminate running state, so users could not tell how much work remained. Progress could also regress during a detail reload, and awaiting the UI callback before scheduling the next recognition task could temporarily reduce throughput.

## Impact

Users now see a linear progress gauge and completed/total file count while batch transcription is running. Existing spinner behavior remains as a fallback until the total file count is available.

## Validation

- `swift build`
- 10 focused tests across `BatchTranscriptionProgressTests`, `BatchTranscriptionStateTests`, and `CaptionViewModelBatchUpdateTests`
- `git diff --check`
- SwiftFormat lint: passed
- `CI=true ./scripts/lint.sh`: completed; existing unrelated SwiftLint violations remain in the repository
