### PR TITLE
Clarify OAuth branding on homepage

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -42,6 +42,7 @@
     <link rel="apple-touch-icon" href="assets/app-icon.png" />
     <link rel="manifest" href="site.webmanifest" />
     <link rel="stylesheet" href="styles.css" />
+    <noscript><style>.reveal { opacity: 1; transform: none; }</style></noscript>
     <title>Dahlia — Stay present. Ask later.</title>
   </head>
   <body>
@@ -69,6 +70,7 @@
           <a href="#features">Product</a>
           <a href="#ai">AI &amp; MCP</a>
           <a href="#workflow">How it works</a>
+          <a href="#google-data">Google data</a>
           <a href="privacy/">Privacy</a>
           <a class="language-link" href="ja/" lang="ja" aria-label="このページを日本語で表示">JA</a>
           <a
@@ -90,12 +92,12 @@
           <div class="hero-copy">
             <div class="eyebrow reveal">Your private meeting memory for macOS</div>
             <h1 class="reveal reveal-delay-1">
-              Stay present.<br />
-              <span>Ask later.</span>
+              <span class="heading-line">Dahlia</span>
+              <span class="hero-tagline">Stay present. Ask later.</span>
             </h1>
             <p class="hero-lead reveal reveal-delay-2">
-              Dahlia captures the conversation, turns it into clear meeting memory,<br class="desktop-break" />
-              and lets you ask questions in the app—or from Claude Code and Codex.
+              Dahlia is a macOS app that records microphone and system audio, transcribes meetings on your Mac,
+              and helps you review, summarize, and ask questions about what was discussed.
             </p>
             <div class="hero-actions reveal reveal-delay-3">
               <a
@@ -265,6 +267,51 @@
               Dahlia keeps the conversation as structured, local meeting memory—not another document to forget.
               Summarize it, ask it questions, or bring it into the AI tools where your work already happens.
             </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="google-data-section" id="google-data">
+        <div class="section-shell">
+          <div class="google-data-heading reveal">
+            <p class="section-index">OPTIONAL GOOGLE INTEGRATIONS</p>
+            <h2>How Dahlia uses<br />Google data.</h2>
+            <p>
+              Google integrations are optional. Dahlia accesses Google data only after you choose to connect your
+              account and only to provide the features below.
+            </p>
+          </div>
+
+          <div class="google-data-cards">
+            <article class="google-data-card reveal">
+              <span class="google-data-icon" aria-hidden="true">▦</span>
+              <div>
+                <h3>Google Calendar</h3>
+                <p>
+                  Dahlia uses read-only access to your Google account and calendars you select to show upcoming events
+                  and meeting links and to start a recording from an event. Dahlia does not create, edit, or delete
+                  calendar events.
+                </p>
+              </div>
+            </article>
+
+            <article class="google-data-card reveal">
+              <span class="google-data-icon" aria-hidden="true">□</span>
+              <div>
+                <h3>Google Drive</h3>
+                <p>
+                  Dahlia uses Google Drive access to create and update the Meeting Notes folder and Google Docs you
+                  choose to export from Dahlia. Dahlia cannot access unrelated Drive files.
+                </p>
+              </div>
+            </article>
+          </div>
+
+          <div class="google-data-footer reveal">
+            <a class="google-data-link" href="https://dahlia-ai.org/privacy/">
+              Read the Privacy Policy <span aria-hidden="true">→</span>
+            </a>
+            <p>Learn how Dahlia accesses, stores, shares, and deletes Google user data.</p>
           </div>
         </div>
       </section>

--- a/website/ja/index.html
+++ b/website/ja/index.html
@@ -42,6 +42,7 @@
     <link rel="apple-touch-icon" href="../assets/app-icon.png" />
     <link rel="manifest" href="site.webmanifest" />
     <link rel="stylesheet" href="../styles.css" />
+    <noscript><style>.reveal { opacity: 1; transform: none; }</style></noscript>
     <title>Dahlia — 会話に集中。あとはAIに聞けばいい。</title>
   </head>
   <body>
@@ -69,6 +70,7 @@
           <a href="#features">プロダクト</a>
           <a href="#ai">AI &amp; MCP</a>
           <a href="#workflow">使い方</a>
+          <a href="#google-data">Googleデータ</a>
           <a href="privacy/">プライバシー</a>
           <a class="language-link" href="../" lang="en" aria-label="View this page in English">EN</a>
           <a
@@ -90,13 +92,15 @@
           <div class="hero-copy">
             <div class="eyebrow reveal">会議の記憶を、あなたのMacに</div>
             <h1 class="reveal reveal-delay-1">
-              <span class="heading-line">会話に集中。</span>
-              <span class="heading-line">あとは、<span class="hero-accent">AI</span>に</span>
-              <span class="heading-line">聞けばいい。</span>
+              <span class="heading-line">Dahlia</span>
+              <span class="hero-tagline">
+                <span class="heading-line">会話に集中。</span>
+                <span class="heading-line">あとはAIに聞けばいい。</span>
+              </span>
             </h1>
             <p class="hero-lead reveal reveal-delay-2">
-              <span class="copy-line">会議を記録し、あとから使える知識に。</span>
-              <span class="copy-line">必要なことは、DahliaやいつものAIに聞けます。</span>
+              <span class="copy-line">Dahliaは、マイクとシステム音声を録音し、Mac上で会議を文字起こしして、</span>
+              <span class="copy-line">内容の確認・要約・質問に使えるmacOSアプリです。</span>
             </p>
             <div class="hero-actions reveal reveal-delay-3">
               <a
@@ -268,6 +272,52 @@
               <span class="copy-line"><span class="mobile-copy-line">Macに蓄積され、いつでも検索し、質問できる</span><span class="mobile-copy-line">会議の記憶です。</span></span>
               <span class="copy-line"><span class="mobile-copy-line">決定の背景も、次のアクションも、</span><span class="mobile-copy-line">必要なときにすぐ取り出せます。</span></span>
             </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="google-data-section" id="google-data">
+        <div class="section-shell">
+          <div class="google-data-heading reveal">
+            <p class="section-index">任意のGOOGLE連携</p>
+            <h2>Dahliaによる<br />Googleデータの利用</h2>
+            <p>
+              Google連携は任意です。Dahliaは、ユーザーがGoogleアカウントを接続した場合にのみ、
+              以下の機能に必要なデータへアクセスします。
+            </p>
+          </div>
+
+          <div class="google-data-cards">
+            <article class="google-data-card reveal">
+              <span class="google-data-icon" aria-hidden="true">▦</span>
+              <div>
+                <h3>Google Calendar</h3>
+                <p>
+                  Dahliaは、Googleアカウントとユーザーが選択したカレンダーへの読み取り専用アクセスを使用して、
+                  今後の予定と会議リンクを表示し、予定から録音を開始できるようにします。
+                  カレンダーの予定を作成、変更、削除することはありません。
+                </p>
+              </div>
+            </article>
+
+            <article class="google-data-card reveal">
+              <span class="google-data-icon" aria-hidden="true">□</span>
+              <div>
+                <h3>Google Drive</h3>
+                <p>
+                  Dahliaは、Google Driveへのアクセスを使用して、Meeting Notesフォルダと、
+                  ユーザーがDahliaから書き出すGoogle Docsを作成・更新します。
+                  Dahliaは無関係なDriveファイルにアクセスできません。
+                </p>
+              </div>
+            </article>
+          </div>
+
+          <div class="google-data-footer reveal">
+            <a class="google-data-link" href="https://dahlia-ai.org/privacy/">
+              プライバシーポリシーを読む <span aria-hidden="true">→</span>
+            </a>
+            <p>DahliaによるGoogleユーザーデータへのアクセス、保存、共有、削除について説明しています。</p>
           </div>
         </div>
       </section>

--- a/website/styles.css
+++ b/website/styles.css
@@ -298,21 +298,32 @@ html[lang="ja"] :where(.section-heading h2, .ai-heading h2, .workflow-heading h2
   font-weight: 780;
 }
 
-.hero h1 .hero-accent {
-  display: inline-block;
-  margin-inline: 0.06em;
-  color: transparent;
-  background: linear-gradient(135deg, var(--violet) 15%, var(--magenta) 85%);
-  -webkit-background-clip: text;
-  background-clip: text;
-}
-
 .hero h1 > .heading-line,
 .statement > .heading-line {
   white-space: nowrap;
 }
 
+.hero-tagline {
+  display: block;
+  margin-top: 0.08em;
+  color: transparent;
+  background: linear-gradient(135deg, var(--violet) 15%, var(--magenta) 85%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  font-size: 0.56em;
+  line-height: 1.15;
+  letter-spacing: -0.04em;
+  white-space: nowrap;
+}
+
+html[lang="ja"] .hero-tagline {
+  font-size: 0.62em;
+  line-height: 1.22;
+  white-space: normal;
+}
+
 .hero-lead {
+  max-width: 650px;
   margin: 0;
   color: var(--muted);
   font-size: 16px;
@@ -1111,19 +1122,109 @@ html[lang="ja"] :where(.section-heading h2, .ai-heading h2, .workflow-heading h2
   line-height: 2;
 }
 
+.google-data-section {
+  padding: 130px 0 135px;
+  background:
+    radial-gradient(circle at 88% 16%, rgba(200, 64, 213, 0.12), transparent 28%),
+    #efebf5;
+}
+
+.google-data-cards {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 64px;
+}
+
+.google-data-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 22px;
+  padding: 38px;
+  border: 1px solid rgba(64, 43, 78, 0.1);
+  border-radius: 30px;
+  background: rgba(255, 254, 250, 0.88);
+  box-shadow: 0 16px 48px rgba(52, 33, 67, 0.06);
+}
+
+.google-data-icon {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  border-radius: 14px;
+  color: white;
+  background: linear-gradient(135deg, var(--violet), var(--magenta));
+  box-shadow: 0 10px 24px rgba(112, 65, 230, 0.2);
+  font-size: 17px;
+}
+
+.google-data-card h3 {
+  margin: 2px 0 12px;
+  font-size: 24px;
+  line-height: 1.2;
+  letter-spacing: -0.035em;
+}
+
+.google-data-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.85;
+}
+
+.google-data-footer {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin-top: 30px;
+}
+
+.google-data-footer p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.google-data-link {
+  flex: none;
+  min-height: 48px;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 20px;
+  border-radius: 999px;
+  color: white;
+  background: var(--ink);
+  font-size: 13px;
+  font-weight: 720;
+  transition: transform 180ms ease, background 180ms ease, box-shadow 180ms ease;
+}
+
+.google-data-link:hover {
+  transform: translateY(-2px);
+  background: var(--violet-deep);
+  box-shadow: 0 12px 28px rgba(78, 35, 166, 0.22);
+}
+
 .features-section {
   padding: 140px 0 150px;
 }
 
-.section-heading {
+:where(.section-heading, .google-data-heading) {
   display: grid;
   grid-template-columns: 0.36fr 0.82fr 0.55fr;
   gap: 30px;
   align-items: end;
+}
+
+.section-heading {
   margin-bottom: 70px;
 }
 
 .section-heading h2,
+.google-data-heading h2,
 .ai-heading h2,
 .workflow-heading h2,
 .privacy-copy h2 {
@@ -1133,7 +1234,7 @@ html[lang="ja"] :where(.section-heading h2, .ai-heading h2, .workflow-heading h2
   letter-spacing: -0.055em;
 }
 
-.section-heading > p:last-child {
+:where(.section-heading, .google-data-heading) > p:last-child {
   margin: 0 0 5px;
   color: var(--muted);
   font-size: 14px;
@@ -2553,8 +2654,8 @@ html[lang="ja"] :where(.section-heading h2, .ai-heading h2, .workflow-heading h2
   .note-one { right: -10px; }
   .note-two { left: -20px; }
   .proof-strip { flex-wrap: wrap; }
-  .section-heading { grid-template-columns: .32fr 1fr; }
-  .section-heading > p:last-child { grid-column: 2; }
+  :where(.section-heading, .google-data-heading) { grid-template-columns: .32fr 1fr; }
+  :where(.section-heading, .google-data-heading) > p:last-child { grid-column: 2; }
   .ai-heading { grid-template-columns: .32fr 1fr; }
   .privacy-layout { gap: 60px; }
 }
@@ -2571,7 +2672,9 @@ html[lang="ja"] :where(.section-heading h2, .ai-heading h2, .workflow-heading h2
     display: flex;
     flex-direction: column;
     justify-content: center;
-    gap: 30px;
+    gap: 22px;
+    padding: 80px 24px 40px;
+    overflow-y: auto;
     color: white;
     background: rgba(20, 15, 24, 0.97);
     visibility: hidden;
@@ -2579,7 +2682,7 @@ html[lang="ja"] :where(.section-heading h2, .ai-heading h2, .workflow-heading h2
     transition: opacity 180ms ease, visibility 180ms ease;
   }
   .site-nav.open { visibility: visible; opacity: 1; }
-  .site-nav > a:not(.nav-cta) { color: white; font-size: 25px; }
+  .site-nav > a:not(.nav-cta) { color: white; font-size: 22px; }
   .site-nav .nav-cta { border-color: rgba(255,255,255,.5); }
   .nav-toggle[aria-expanded="true"] span { background: white; }
   .legal-page .legal-nav {
@@ -2606,16 +2709,17 @@ html[lang="ja"] :where(.section-heading h2, .ai-heading h2, .workflow-heading h2
   .hero h1 { font-size: clamp(49px, 13vw, 70px); }
   html[lang="ja"] .hero h1 { font-size: clamp(49px, 13vw, 70px); }
   .hero-lead { font-size: 14px; }
-  .desktop-break { display: none; }
   .product-stage { width: 100%; margin-top: 10px; padding-bottom: 30px; }
   .mac-window { transform: none; }
   .floating-note { display: none; }
   .stage-orbit-one { width: 100%; height: auto; aspect-ratio: 1; left: 0; top: 0; }
   .stage-orbit-two { display: none; }
   .proof-strip strong { flex-basis: 100%; border: 0; padding: 7px 0 0; margin: 0; text-align: center; }
-  .statement-section, .features-section, .ai-section, .workflow-section, .privacy-section { padding: 95px 0; }
-  .statement-grid, .ai-heading, .workflow-heading, .privacy-layout { grid-template-columns: 1fr; gap: 35px; }
+  .statement-section, .google-data-section, .features-section, .ai-section, .workflow-section, .privacy-section { padding: 95px 0; }
+  .statement-grid, .google-data-heading, .ai-heading, .workflow-heading, .privacy-layout { grid-template-columns: 1fr; gap: 35px; }
   .statement { margin-top: 0; }
+  .google-data-heading > p:last-child { grid-column: 1; }
+  .google-data-cards { grid-template-columns: 1fr; margin-top: 48px; }
   .section-heading { grid-template-columns: 1fr; gap: 22px; margin-bottom: 48px; }
   .section-heading > p:last-child { grid-column: 1; }
   .feature-card-wide { grid-template-columns: 1fr; gap: 40px; }
@@ -2627,6 +2731,7 @@ html[lang="ja"] :where(.section-heading h2, .ai-heading h2, .workflow-heading h2
   .step-visual { grid-column: 2; }
   .step-copy { grid-column: 2; }
   .privacy-layout { gap: 50px; }
+  .google-data-footer { align-items: flex-start; flex-direction: column; gap: 16px; }
   .footer-inner { grid-template-columns: 1fr auto; padding: 30px 0; }
   .footer-inner > p { display: none; }
   .footer-links { justify-self: end; }
@@ -2635,6 +2740,8 @@ html[lang="ja"] :where(.section-heading h2, .ai-heading h2, .workflow-heading h2
 
 @media (max-width: 600px) {
   .mobile-copy-line { display: block; }
+  .hero-tagline { font-size: 0.47em; }
+  html[lang="ja"] .hero-tagline { font-size: 0.58em; }
   .hero-actions { align-items: flex-start; flex-direction: column; gap: 18px; }
   .hero-meta { max-width: 320px; }
   .product-stage { width: 128%; margin-left: -14%; padding-top: 45px; }
@@ -2692,6 +2799,8 @@ html[lang="ja"] :where(.section-heading h2, .ai-heading h2, .workflow-heading h2
   .step-transcribe i { left: auto; right: 42px; bottom: 53px; }
   .step-copy h3 { font-size: 29px; }
   .privacy-card { grid-template-columns: 1fr; }
+  .google-data-card { grid-template-columns: 1fr; padding: 30px; border-radius: 27px; }
+  .google-data-link { width: 100%; justify-content: center; }
   .final-cta { padding: 105px 0; }
   .cta-inner h2 { font-size: 48px; }
   .footer-inner { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary

- display the OAuth consent-screen name, `Dahlia`, prominently on the English and Japanese homepages
- explain that Dahlia records and transcribes meetings on macOS
- add a dedicated section describing the optional Google Calendar and Google Drive integrations
- link prominently to the privacy policy and keep the new content readable without JavaScript

## Why

Google OAuth branding verification reported that the homepage did not clearly explain the app's purpose and that its displayed name did not match the OAuth consent screen.

## Impact

Reviewers and users can now verify the app identity, purpose, Google data usage, and privacy policy from one continuous homepage flow. OAuth scopes and application behavior are unchanged.

## Validation

- `git diff --check`
- English desktop and Japanese mobile visual checks with Playwright
- verified zero browser console errors
- verified the required branding and Google data explanations remain visible without JavaScript
