### PR TITLE
ライブ字幕オーバーレイに待機中プレースホルダーを表示

### DIFF
--- a/Sources/Dahlia/Models/LiveSubtitleOverlayPayload.swift
+++ b/Sources/Dahlia/Models/LiveSubtitleOverlayPayload.swift
@@ -8,6 +8,12 @@ struct LiveSubtitleOverlayPayload: Equatable {
 
     let entries: [Entry]
 
+    /// 字幕は有効で録音中だが、表示対象のセグメントがまだ無いときに示すプレースホルダー。
+    /// これによりオーバーレイを隠さず「字幕待機中」であることをユーザーへ伝える。
+    static func waiting(placeholderText: String) -> Self {
+        Self(entries: [Entry(primaryText: placeholderText, secondaryText: nil)])
+    }
+
     static func latest(
         from segments: [TranscriptSegment],
         sourceMode: LiveSubtitleSourceMode = .includeMicrophone,

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -288,6 +288,8 @@
 "Overlay Segment Count" = "Overlay Segment Count";
 "Choose how many recent transcript segments the live subtitle overlay shows." = "Choose how many recent transcript segments the live subtitle overlay shows.";
 "Live subtitles stopped because the audio format could not be converted." = "Live subtitles stopped because the audio format could not be converted.";
+"Waiting for audio to caption…" = "Waiting for audio to caption…";
+"Waiting for system audio… Microphone speech is not shown in this source mode." = "Waiting for system audio… Microphone speech is not shown in this source mode.";
 
 /* Detail Tabs */
 "Summary" = "Summary";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -288,6 +288,8 @@
 "Overlay Segment Count" = "表示セグメント数";
 "Choose how many recent transcript segments the live subtitle overlay shows." = "ライブ字幕オーバーレイに表示する最近の文字起こしセグメント数を選びます。";
 "Live subtitles stopped because the audio format could not be converted." = "音声形式を変換できなかったため、ライブ字幕を停止しました。";
+"Waiting for audio to caption…" = "字幕にする音声を待機しています…";
+"Waiting for system audio… Microphone speech is not shown in this source mode." = "システムオーディオを待機しています… このソース設定ではマイク音声は表示されません。";
 
 /* Detail Tabs */
 "Summary" = "要約";

--- a/Sources/Dahlia/Services/LiveSubtitleOverlayCoordinator.swift
+++ b/Sources/Dahlia/Services/LiveSubtitleOverlayCoordinator.swift
@@ -50,15 +50,27 @@ final class LiveSubtitleOverlayCoordinator {
             return
         }
 
+        let sourceMode = AppSettings.shared.liveSubtitleSourceMode
         let payload = LiveSubtitleOverlayPayload.latest(
             from: viewModel.liveCaptionStore.segments,
-            sourceMode: AppSettings.shared.liveSubtitleSourceMode,
+            sourceMode: sourceMode,
             transcriptionLocaleIdentifier: AppSettings.shared.transcriptionLocale,
             translationEnabled: AppSettings.shared.transcriptTranslationEnabled,
             targetLanguageIdentifier: AppSettings.shared.transcriptTranslationTargetLanguage,
             maxEntries: max(1, AppSettings.shared.liveSubtitleOverlaySegmentCount)
         )
 
-        liveSubtitleOverlayService.update(payload: payload)
+        // 字幕は有効で録音中のため、表示対象がまだ無くてもオーバーレイは隠さず待機表示にする。
+        // これにより「字幕 ON なのにパネルすら出ない」状態を防ぐ。
+        liveSubtitleOverlayService.update(payload: payload ?? .waiting(placeholderText: waitingText(for: sourceMode)))
+    }
+
+    private func waitingText(for sourceMode: LiveSubtitleSourceMode) -> String {
+        switch sourceMode {
+        case .systemAudioOnly:
+            L10n.liveSubtitleWaitingForSystemAudio
+        case .includeMicrophone:
+            L10n.liveSubtitleWaitingForAudio
+        }
     }
 }

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -502,6 +502,14 @@ enum L10n {
         localized: "Live subtitles stopped because the audio format could not be converted.",
         bundle: bundle
     ) }
+    static var liveSubtitleWaitingForAudio: String { String(
+        localized: "Waiting for audio to caption…",
+        bundle: bundle
+    ) }
+    static var liveSubtitleWaitingForSystemAudio: String { String(
+        localized: "Waiting for system audio… Microphone speech is not shown in this source mode.",
+        bundle: bundle
+    ) }
 
     // MARK: - Detail Tabs
 

--- a/Tests/DahliaTests/LiveSubtitleOverlayCoordinatorTests.swift
+++ b/Tests/DahliaTests/LiveSubtitleOverlayCoordinatorTests.swift
@@ -50,6 +50,49 @@ import Foundation
         }
 
         @Test
+        func showsWaitingPlaceholderWhenSourceModeExcludesAvailableCaptions() throws {
+            let previousEnabled = AppSettings.shared.liveSubtitleOverlayEnabled
+            let previousSourceMode = AppSettings.shared.liveSubtitleSourceMode
+            AppSettings.shared.liveSubtitleOverlayEnabled = true
+            AppSettings.shared.liveSubtitleSourceMode = .systemAudioOnly
+            defer {
+                AppSettings.shared.liveSubtitleOverlayEnabled = previousEnabled
+                AppSettings.shared.liveSubtitleSourceMode = previousSourceMode
+            }
+
+            let viewModel = CaptionViewModel(
+                availableInputDevicesProvider: { [] },
+                defaultInputDeviceIDProvider: { nil }
+            )
+            let sessionID = UUID.v7()
+            viewModel.isListening = true
+            viewModel.liveCaptionStore.start(sessionId: sessionID)
+            // systemAudioOnly はマイク音声を除外するため、latest(...) は nil を返す。
+            viewModel.liveCaptionStore.apply(event: .finalized(
+                TranscriptSegment(
+                    sessionId: sessionID,
+                    startTime: .now,
+                    text: "Microphone speech",
+                    isConfirmed: true,
+                    speakerLabel: "mic"
+                )
+            ))
+            let presenter = FakeLiveSubtitlePresenter()
+
+            let coordinator = LiveSubtitleOverlayCoordinator(
+                viewModel: viewModel,
+                liveSubtitleOverlayService: presenter
+            )
+
+            // オーバーレイは隠されず、待機プレースホルダーが表示される。
+            let payload = try #require(presenter.lastPayload)
+            #expect(payload.entries.count == 1)
+            #expect(payload.entries.first?.secondaryText == nil)
+            #expect(presenter.hideCount == 0)
+            withExtendedLifetime(coordinator) {}
+        }
+
+        @Test
         func continuouslyChangingPreviewPublishesLatestAtBoundedCadence() async throws {
             let previousSetting = AppSettings.shared.liveSubtitleOverlayEnabled
             AppSettings.shared.liveSubtitleOverlayEnabled = true

--- a/Tests/DahliaTests/LiveSubtitleOverlayPayloadTests.swift
+++ b/Tests/DahliaTests/LiveSubtitleOverlayPayloadTests.swift
@@ -275,6 +275,15 @@ struct LiveSubtitleOverlayPayloadTests {
 
         #expect(payload == nil)
     }
+
+    @Test
+    func waitingBuildsSinglePlaceholderEntryWithoutTranslation() {
+        let payload = LiveSubtitleOverlayPayload.waiting(placeholderText: "Waiting…")
+
+        #expect(payload.entries == [
+            LiveSubtitleOverlayPayload.Entry(primaryText: "Waiting…", secondaryText: nil),
+        ])
+    }
 }
 #elseif canImport(XCTest)
 import XCTest
@@ -538,6 +547,14 @@ final class LiveSubtitleOverlayPayloadTests: XCTestCase {
         )
 
         XCTAssertNil(payload)
+    }
+
+    func testWaitingBuildsSinglePlaceholderEntryWithoutTranslation() {
+        let payload = LiveSubtitleOverlayPayload.waiting(placeholderText: "Waiting…")
+
+        XCTAssertEqual(payload.entries, [
+            LiveSubtitleOverlayPayload.Entry(primaryText: "Waiting…", secondaryText: nil),
+        ])
     }
 }
 #endif


### PR DESCRIPTION
## 背景

「ライブ字幕を有効にしても表示されない（バッチ・ライブ両方で発生）」という報告を調査した。

データ経路（認識 → `TranscriptionEventPipeline` → `LiveCaptionEventRelay` → `LiveCaptionStore` → `LiveSubtitleOverlayCoordinator` → `LiveSubtitleOverlayService`）と表示経路はすべて正しく結線されていた。実行時 UserDefaults を確認したところ、原因は設定値 **`liveSubtitleSourceMode = systemAudioOnly`（システム音声のみ）** だった。

`LiveSubtitleSourceMode.systemAudioOnly` は `speakerLabel == "system"` のセグメントしか字幕に通さないため、マイク（`"mic"`）発話は全除外される。システム音声が無い間は `LiveSubtitleOverlayPayload.latest(...)` が常に `nil` を返し、`update(nil)` → `hide()` でオーバーレイパネルが一切表示されなかった。realtime のメイン画面本文が出るのは別経路（`TranscriptStore`）のため、症状（本文は出る／オーバーレイだけ出ない／有効化タイミング非依存）と一致する。

これは実装バグではなく UX 上の落とし穴で、既存テスト `testLatestReturnsNilWhenNoSystemAudioExistsInSystemOnlyMode` も「systemAudioOnly + マイクのみ → nil」を仕様として明示していた。

## 変更内容

字幕が有効かつ録音中だが表示対象のセグメントがまだ無い場合、オーバーレイを隠すのではなく **待機中プレースホルダーのパネルを表示** する。

- `LiveSubtitleOverlayPayload.waiting(placeholderText:)` ファクトリを追加
- `LiveSubtitleOverlayCoordinator.sync()` で `latest(...)` が nil のとき hide せず待機表示（ソースモードに応じた文言）
- 待機文言を `L10n` と ja/en の `Localizable.strings` に追加（`systemAudioOnly` 時は「このソース設定ではマイク音声は表示されません」と明示）

実際にシステム音声セグメントが届けば自動的に通常字幕へ切り替わる。`liveSubtitleSourceMode` の既定値やユーザー設定は変更しない。

## テスト

- `swift build` 成功
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter LiveSubtitleOverlay` → **Test run with 15 tests in 2 suites passed**（新規回帰テスト含む）
  - `LiveSubtitleOverlayPayloadTests.waitingBuildsSinglePlaceholderEntryWithoutTranslation`
  - `LiveSubtitleOverlayCoordinatorTests.showsWaitingPlaceholderWhenSourceModeExcludesAvailableCaptions`（systemAudioOnly + mic のみでも hide されず待機表示されることを検証）
- `CI=true ./scripts/lint.sh` → 変更ファイルに新規警告なし

This pull request and its description were written by Isaac.
