### PR TITLE
Improve screenshot zoom interactions

### DIFF
--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -510,6 +510,8 @@
 "Could not add the vault." = "Could not add the vault.";
 "Could not remove the vault." = "Could not remove the vault.";
 "Open" = "Open";
+"Enlarge screenshot" = "Enlarge screenshot";
+"Enlarge screenshot: %@" = "Enlarge screenshot: %@";
 "Loading supported languages..." = "Loading supported languages...";
 "Search languages..." = "Search languages...";
 "No matching languages" = "No matching languages";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -510,6 +510,8 @@
 "Could not add the vault." = "保管庫を追加できませんでした。";
 "Could not remove the vault." = "保管庫の登録を解除できませんでした。";
 "Open" = "開く";
+"Enlarge screenshot" = "スクリーンショットを拡大表示";
+"Enlarge screenshot: %@" = "スクリーンショット「%@」を拡大表示";
 "Loading supported languages..." = "対応言語を読み込み中...";
 "Search languages..." = "言語を検索...";
 "No matching languages" = "該当する言語がありません";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -54,6 +54,14 @@ enum L10n {
         bundle: bundle
     ) }
     static var screenshotUsedInSummary: String { String(localized: "Used in summary", bundle: bundle) }
+
+    static func enlargeScreenshot(caption: String?) -> String {
+        guard let caption else {
+            return String(localized: "Enlarge screenshot", bundle: bundle)
+        }
+        return String(localized: "Enlarge screenshot: \(caption)", bundle: bundle)
+    }
+
     static var search: String { String(localized: "Search", bundle: bundle) }
     static var actions: String { String(localized: "Actions", bundle: bundle) }
     static var status: String { String(localized: "Status", bundle: bundle) }

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -401,12 +401,9 @@ struct ControlPanelView: View {
                 ScreenshotOverlayView(
                     screenshot: presentation.screenshot,
                     previewImage: presentation.previewImage,
-                    requestedAt: presentation.requestedAt
-                ) {
-                    withAnimation(.easeOut(duration: 0.15)) {
-                        expandedScreenshot = nil
-                    }
-                }
+                    requestedAt: presentation.requestedAt,
+                    onDismiss: dismissExpandedScreenshot
+                )
                 .transition(.opacity)
             }
         }
@@ -455,10 +452,8 @@ struct ControlPanelView: View {
                 VStack(alignment: .leading, spacing: 20) {
                     SummaryDocumentView(
                         document: document,
-                        imageDataProvider: { screenshotId in
-                            guard let record = viewModel.screenshots.first(where: { $0.id == screenshotId }) else { return nil }
-                            return record.imageData
-                        },
+                        imageDataProvider: { screenshotRecord(withID: $0)?.imageData },
+                        onOpenImage: openSummaryScreenshot,
                         transcriptTextProvider: summaryTranscriptText,
                         allowsTranscriptReferencePopovers: allowsTranscriptReferencePopovers
                     )
@@ -571,6 +566,22 @@ struct ControlPanelView: View {
         )
         withAnimation(.easeOut(duration: 0.15)) {
             expandedScreenshot = presentation
+        }
+    }
+
+    private func openSummaryScreenshot(_ screenshotID: UUID, previewImage: CGImage) {
+        guard let screenshot = screenshotRecord(withID: screenshotID) else { return }
+        openScreenshot(screenshot, previewImage: previewImage)
+    }
+
+    private func screenshotRecord(withID id: UUID) -> MeetingScreenshotRecord? {
+        viewModel.screenshots.first { $0.id == id }
+    }
+
+    private func dismissExpandedScreenshot() {
+        guard expandedScreenshot != nil else { return }
+        withAnimation(.easeOut(duration: 0.15)) {
+            expandedScreenshot = nil
         }
     }
 

--- a/Sources/Dahlia/Views/ScreenshotOverlayInputMonitor.swift
+++ b/Sources/Dahlia/Views/ScreenshotOverlayInputMonitor.swift
@@ -1,0 +1,77 @@
+import AppKit
+import SwiftUI
+
+struct ScreenshotOverlayInputMonitor: NSViewRepresentable {
+    let onDismiss: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onDismiss: onDismiss)
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        context.coordinator.startMonitoring(view: view)
+        return view
+    }
+
+    func updateNSView(_: NSView, context: Context) {
+        context.coordinator.onDismiss = onDismiss
+    }
+
+    static func dismantleNSView(_: NSView, coordinator: Coordinator) {
+        coordinator.stopMonitoring()
+    }
+
+    @MainActor
+    final class Coordinator {
+        private static let escapeKeyCode: UInt16 = 53
+
+        var onDismiss: () -> Void
+
+        private var eventMonitor: Any?
+
+        init(onDismiss: @escaping () -> Void) {
+            self.onDismiss = onDismiss
+        }
+
+        func startMonitoring(view: NSView) {
+            eventMonitor = NSEvent.addLocalMonitorForEvents(
+                matching: [.keyDown, .leftMouseDown, .rightMouseDown, .otherMouseDown]
+            ) { [weak self, weak view] event in
+                guard let self, let view else { return event }
+                return handle(event, in: view)
+            }
+        }
+
+        func handle(_ event: NSEvent, in view: NSView) -> NSEvent? {
+            guard event.window === view.window else { return event }
+
+            switch event.type {
+            case .keyDown:
+                guard event.keyCode == Self.escapeKeyCode else { return event }
+                onDismiss()
+                return nil
+            case .leftMouseDown, .rightMouseDown, .otherMouseDown:
+                break
+            default:
+                return event
+            }
+
+            let location = view.convert(event.locationInWindow, from: nil)
+            guard !view.bounds.contains(location) else { return event }
+
+            let dismiss = onDismiss
+            // Let the clicked control finish handling the event before removing the overlay.
+            Task { @MainActor in
+                dismiss()
+            }
+            return event
+        }
+
+        func stopMonitoring() {
+            guard let eventMonitor else { return }
+            NSEvent.removeMonitor(eventMonitor)
+            self.eventMonitor = nil
+        }
+    }
+}

--- a/Sources/Dahlia/Views/ScreenshotOverlayView.swift
+++ b/Sources/Dahlia/Views/ScreenshotOverlayView.swift
@@ -44,6 +44,7 @@ struct ScreenshotOverlayView: View {
         ZStack(alignment: .topTrailing) {
             Color.black.opacity(0.7)
                 .ignoresSafeArea()
+                .allowsHitTesting(false)
 
             GeometryReader { proxy in
                 Group {

--- a/Sources/Dahlia/Views/ScreenshotOverlayView.swift
+++ b/Sources/Dahlia/Views/ScreenshotOverlayView.swift
@@ -1,7 +1,27 @@
 import SwiftUI
 
+enum ScreenshotOverlayLayout {
+    static func fittedSize(imageSize: CGSize, availableSize: CGSize) -> CGSize {
+        guard imageSize.width > 0,
+              imageSize.height > 0,
+              availableSize.width > 0,
+              availableSize.height > 0 else { return .zero }
+
+        let scale = min(
+            availableSize.width / imageSize.width,
+            availableSize.height / imageSize.height
+        )
+        return CGSize(
+            width: imageSize.width * scale,
+            height: imageSize.height * scale
+        )
+    }
+}
+
 /// スクリーンショット拡大表示。手元の thumbnail を即時表示し、詳細画像へ段階更新する。
 struct ScreenshotOverlayView: View {
+    private static let imagePadding: CGFloat = 24
+
     /// Retina の全画面キャプチャを元解像度でレイヤー化すると、RenderBox の
     /// surface allocation が枯渇し得る。画面表示には十分なサイズへ制限する。
     private static let maximumDisplayPixelSize = 2400
@@ -22,25 +42,25 @@ struct ScreenshotOverlayView: View {
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
-            Button(action: onDismiss) {
-                Color.black.opacity(0.7)
-                    .ignoresSafeArea()
-            }
-            .buttonStyle(.plain)
-            .pointerStyle(.link)
-            .accessibilityLabel(L10n.close)
+            Color.black.opacity(0.7)
+                .ignoresSafeArea()
 
-            if let displayedImage {
-                Image(decorative: displayedImage, scale: 1)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .clipShape(.rect(cornerRadius: 8))
-                    .padding(24)
-            } else if case .failed = imageLoader.state {
-                Text(L10n.summaryImageUnavailable)
-                    .foregroundStyle(.secondary)
-            } else {
-                ProgressView()
+            GeometryReader { proxy in
+                Group {
+                    if let displayedImage {
+                        expandedImage(displayedImage, availableSize: proxy.size)
+                    } else if case .failed = imageLoader.state {
+                        monitoredContent {
+                            Text(L10n.summaryImageUnavailable)
+                                .foregroundStyle(.secondary)
+                        }
+                    } else {
+                        monitoredContent {
+                            ProgressView()
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
             }
 
             Button(L10n.close, systemImage: "xmark.circle.fill", action: onDismiss)
@@ -68,5 +88,31 @@ struct ScreenshotOverlayView: View {
             )
         }
         .onDisappear(perform: imageLoader.unload)
+    }
+
+    private func expandedImage(_ image: CGImage, availableSize: CGSize) -> some View {
+        let contentSize = CGSize(
+            width: max(0, availableSize.width - Self.imagePadding * 2),
+            height: max(0, availableSize.height - Self.imagePadding * 2)
+        )
+        let imageSize = ScreenshotOverlayLayout.fittedSize(
+            imageSize: CGSize(width: image.width, height: image.height),
+            availableSize: contentSize
+        )
+
+        return Image(decorative: image, scale: 1)
+            .resizable()
+            .frame(width: imageSize.width, height: imageSize.height)
+            .clipShape(.rect(cornerRadius: 8))
+            .background {
+                ScreenshotOverlayInputMonitor(onDismiss: onDismiss)
+            }
+    }
+
+    private func monitoredContent(@ViewBuilder content: () -> some View) -> some View {
+        content()
+            .background {
+                ScreenshotOverlayInputMonitor(onDismiss: onDismiss)
+            }
     }
 }

--- a/Sources/Dahlia/Views/SummaryDocumentView.swift
+++ b/Sources/Dahlia/Views/SummaryDocumentView.swift
@@ -3,17 +3,20 @@ import SwiftUI
 struct SummaryDocumentView: View {
     let document: SummaryDocument
     let imageDataProvider: (UUID) -> Data?
+    let onOpenImage: (UUID, CGImage) -> Void
     let transcriptTextProvider: (TranscriptReference) -> String?
     let allowsTranscriptReferencePopovers: Bool
 
     init(
         document: SummaryDocument,
         imageDataProvider: @escaping (UUID) -> Data?,
+        onOpenImage: @escaping (UUID, CGImage) -> Void,
         transcriptTextProvider: @escaping (TranscriptReference) -> String? = { _ in nil },
         allowsTranscriptReferencePopovers: Bool = true
     ) {
         self.document = document
         self.imageDataProvider = imageDataProvider
+        self.onOpenImage = onOpenImage
         self.transcriptTextProvider = transcriptTextProvider
         self.allowsTranscriptReferencePopovers = allowsTranscriptReferencePopovers
     }
@@ -152,7 +155,12 @@ struct SummaryDocumentView: View {
     private func imageView(screenshotId: UUID, caption: SummaryText) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             if let data = imageDataProvider(screenshotId) {
-                SummaryScreenshotImageView(screenshotID: screenshotId, data: data)
+                SummaryScreenshotImageView(
+                    screenshotID: screenshotId,
+                    data: data,
+                    accessibilityLabel: L10n.enlargeScreenshot(caption: caption.text.nilIfBlank),
+                    onOpen: onOpenImage
+                )
             } else {
                 Text(L10n.summaryImageUnavailable)
                     .font(.callout)
@@ -249,17 +257,27 @@ struct SummaryDocumentView: View {
 
 }
 
-private struct SummaryScreenshotImageView: View {
+struct SummaryScreenshotImageView: View {
     let screenshotID: UUID
     let data: Data
+    let accessibilityLabel: String
+    let onOpen: (UUID, CGImage) -> Void
     @StateObject private var imageLoader = ScreenshotImageLoadModel()
 
     var body: some View {
         Group {
             if case let .loaded(image) = imageLoader.state {
-                Image(decorative: image, scale: 1)
-                    .resizable()
-                    .scaledToFit()
+                Button {
+                    activate(image)
+                } label: {
+                    Image(decorative: image, scale: 1)
+                        .resizable()
+                        .scaledToFit()
+                }
+                .buttonStyle(.plain)
+                .pointerStyle(.link)
+                .accessibilityLabel(accessibilityLabel)
+                .help(accessibilityLabel)
             } else if case .failed = imageLoader.state {
                 Text(L10n.summaryImageUnavailable)
                     .font(.callout)
@@ -278,6 +296,10 @@ private struct SummaryScreenshotImageView: View {
                 maxPixelSize: 1200
             )
         }
+    }
+
+    func activate(_ image: CGImage) {
+        onOpen(screenshotID, image)
     }
 }
 

--- a/Tests/DahliaTests/ScreenshotOverlayViewTests.swift
+++ b/Tests/DahliaTests/ScreenshotOverlayViewTests.swift
@@ -1,0 +1,229 @@
+#if canImport(Testing)
+import AppKit
+import Testing
+@testable import Dahlia
+
+@MainActor
+struct ScreenshotOverlayViewTests {
+    @Test
+    func fittedSizePreservesLandscapeAndPortraitAspectRatios() {
+        #expect(ScreenshotOverlayLayout.fittedSize(
+            imageSize: CGSize(width: 1_600, height: 900),
+            availableSize: CGSize(width: 800, height: 600)
+        ) == CGSize(width: 800, height: 450))
+        #expect(ScreenshotOverlayLayout.fittedSize(
+            imageSize: CGSize(width: 900, height: 1_600),
+            availableSize: CGSize(width: 800, height: 600)
+        ) == CGSize(width: 337.5, height: 600))
+    }
+
+    @Test
+    func fittedSizeRejectsEmptyDimensions() {
+        #expect(ScreenshotOverlayLayout.fittedSize(
+            imageSize: .zero,
+            availableSize: CGSize(width: 800, height: 600)
+        ) == .zero)
+        #expect(ScreenshotOverlayLayout.fittedSize(
+            imageSize: CGSize(width: 1_600, height: 900),
+            availableSize: .zero
+        ) == .zero)
+    }
+
+    @Test
+    func imageClickIsForwardedWithoutDismissal() throws {
+        let fixture = try makeMouseFixture(
+            eventType: .leftMouseDown,
+            eventLocation: CGPoint(x: 50, y: 50)
+        )
+        var dismissCount = 0
+        let coordinator = ScreenshotOverlayInputMonitor.Coordinator {
+            dismissCount += 1
+        }
+
+        let handledEvent = coordinator.handle(fixture.event, in: fixture.view)
+
+        #expect(handledEvent === fixture.event)
+        #expect(dismissCount == 0)
+    }
+
+    @Test
+    func outsideMouseClicksAreForwardedAndDismiss() async throws {
+        for eventType in [NSEvent.EventType.leftMouseDown, .rightMouseDown, .otherMouseDown] {
+            let fixture = try makeMouseFixture(
+                eventType: eventType,
+                eventLocation: CGPoint(x: 150, y: 150)
+            )
+            var dismissCount = 0
+            let coordinator = ScreenshotOverlayInputMonitor.Coordinator {
+                dismissCount += 1
+            }
+
+            let handledEvent = coordinator.handle(fixture.event, in: fixture.view)
+
+            #expect(handledEvent === fixture.event)
+            #expect(dismissCount == 0)
+            await waitUntil { dismissCount == 1 }
+            #expect(dismissCount == 1)
+        }
+    }
+
+    @Test
+    func mouseUpOutsideImageIsForwardedWithoutDismissal() throws {
+        let fixture = try makeMouseFixture(
+            eventType: .leftMouseUp,
+            eventLocation: CGPoint(x: 150, y: 150)
+        )
+        var dismissCount = 0
+        let coordinator = ScreenshotOverlayInputMonitor.Coordinator {
+            dismissCount += 1
+        }
+
+        let handledEvent = coordinator.handle(fixture.event, in: fixture.view)
+
+        #expect(handledEvent === fixture.event)
+        #expect(dismissCount == 0)
+    }
+
+    @Test
+    func installedMonitorReceivesOutsideMouseDown() async throws {
+        let fixture = try makeMouseFixture(
+            eventType: .leftMouseDown,
+            eventLocation: CGPoint(x: 150, y: 150)
+        )
+        var dismissCount = 0
+        let coordinator = ScreenshotOverlayInputMonitor.Coordinator {
+            dismissCount += 1
+        }
+        coordinator.startMonitoring(view: fixture.view)
+        defer { coordinator.stopMonitoring() }
+
+        NSApp.sendEvent(fixture.event)
+
+        await waitUntil { dismissCount == 1 }
+        #expect(dismissCount == 1)
+    }
+
+    @Test
+    func escapeInOverlayWindowIsConsumedAndDismisses() throws {
+        let fixture = try makeKeyFixture(keyCode: 53)
+        var dismissCount = 0
+        let coordinator = ScreenshotOverlayInputMonitor.Coordinator {
+            dismissCount += 1
+        }
+
+        let handledEvent = coordinator.handle(fixture.event, in: fixture.view)
+
+        #expect(handledEvent == nil)
+        #expect(dismissCount == 1)
+    }
+
+    @Test
+    func otherKeysAreForwardedWithoutDismissal() throws {
+        let fixture = try makeKeyFixture(keyCode: 36)
+        var dismissCount = 0
+        let coordinator = ScreenshotOverlayInputMonitor.Coordinator {
+            dismissCount += 1
+        }
+
+        let handledEvent = coordinator.handle(fixture.event, in: fixture.view)
+
+        #expect(handledEvent === fixture.event)
+        #expect(dismissCount == 0)
+    }
+
+    @Test
+    func eventInAnotherWindowIsForwardedWithoutDismissal() throws {
+        let fixture = try makeMouseFixture(
+            eventType: .leftMouseDown,
+            eventLocation: CGPoint(x: 150, y: 150)
+        )
+        let otherWindow = NSWindow(
+            contentRect: CGRect(x: 0, y: 0, width: 200, height: 200),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        let event = try #require(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: CGPoint(x: 150, y: 150),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: otherWindow.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 0
+        ))
+        var dismissCount = 0
+        let coordinator = ScreenshotOverlayInputMonitor.Coordinator {
+            dismissCount += 1
+        }
+
+        let handledEvent = coordinator.handle(event, in: fixture.view)
+
+        #expect(handledEvent === event)
+        #expect(dismissCount == 0)
+    }
+
+    private func makeMouseFixture(
+        eventType: NSEvent.EventType,
+        eventLocation: CGPoint
+    ) throws -> (event: NSEvent, view: NSView) {
+        let window = makeWindow()
+        let view = makeView(in: window)
+        let event = try #require(NSEvent.mouseEvent(
+            with: eventType,
+            location: eventLocation,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 0
+        ))
+        return (event, view)
+    }
+
+    private func makeKeyFixture(keyCode: UInt16) throws -> (event: NSEvent, view: NSView) {
+        let window = makeWindow()
+        let view = makeView(in: window)
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: keyCode
+        ))
+        return (event, view)
+    }
+
+    private func makeWindow() -> NSWindow {
+        NSWindow(
+            contentRect: CGRect(x: 0, y: 0, width: 200, height: 200),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+    }
+
+    private func makeView(in window: NSWindow) -> NSView {
+        let view = NSView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        window.contentView?.addSubview(view)
+        return view
+    }
+
+    private func waitUntil(_ predicate: @MainActor () -> Bool) async {
+        for _ in 0 ..< 1_000 {
+            if predicate() { return }
+            await Task.yield()
+        }
+        Issue.record("Timed out waiting for MainActor state")
+    }
+}
+#endif

--- a/Tests/DahliaTests/SummaryDocumentViewTests.swift
+++ b/Tests/DahliaTests/SummaryDocumentViewTests.swift
@@ -1,0 +1,47 @@
+#if canImport(Testing)
+import CoreGraphics
+import Foundation
+import Testing
+@testable import Dahlia
+
+@MainActor
+struct SummaryDocumentViewTests {
+    @Test
+    func screenshotActivationForwardsIdentifierAndPreviewOnce() throws {
+        let screenshotID = UUID.v7()
+        let image = try #require(makeImage())
+        var openedScreenshotID: UUID?
+        var openedImage: CGImage?
+        var openCount = 0
+        let view = SummaryScreenshotImageView(
+            screenshotID: screenshotID,
+            data: Data(),
+            accessibilityLabel: "Enlarge screenshot"
+        ) { id, previewImage in
+            openedScreenshotID = id
+            openedImage = previewImage
+            openCount += 1
+        }
+
+        view.activate(image)
+
+        #expect(openedScreenshotID == screenshotID)
+        #expect(openedImage === image)
+        #expect(openCount == 1)
+    }
+
+    private func makeImage() -> CGImage? {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let context = CGContext(
+            data: nil,
+            width: 2,
+            height: 2,
+            bitsPerComponent: 8,
+            bytesPerRow: 8,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )
+        return context?.makeImage()
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- dismiss the enlarged screenshot with Escape or by clicking outside the image
- preserve sidebar and other control interactions while dismissing the overlay
- allow screenshots embedded in the summary page to open in the shared enlarged view
- add localized accessibility labels for screenshot enlargement
- cover overlay input handling, image sizing, and summary image activation with tests

## Why

The enlarged screenshot could previously be closed only with the top-right close button, and screenshots shown in generated summaries were not interactive. This makes dismissal consistent with standard modal interactions and lets users inspect summary screenshots at full size.

## Validation

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter 'ScreenshotOverlayViewTests|SummaryDocumentViewTests'` — 10 tests passed across 2 suites
- `CI=true ./scripts/lint.sh` — passed
- `git diff --check` — passed