### PR TITLE
Separate live subtitle settings and add microphone option

### DIFF
--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -175,7 +175,7 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     @AppStorage("transcriptTranslationTargetLanguage") var transcriptTranslationTargetLanguage = TranscriptTranslationLanguage.defaultIdentifier
     @AppStorage("liveSubtitleOverlayEnabled") var liveSubtitleOverlayEnabled = false
     @AppStorage("liveSubtitleOverlaySegmentCount") var liveSubtitleOverlaySegmentCount = 2
-    @AppStorage("liveSubtitleSourceMode") var liveSubtitleSourceModeRawValue = LiveSubtitleSourceMode.includeMicrophone.rawValue
+    @AppStorage("liveSubtitleSourceMode") var liveSubtitleSourceModeRawValue = LiveSubtitleSourceMode.defaultMode.rawValue
     @AppStorage("automaticScreenshotEnabled") var automaticScreenshotEnabled = true
     @AppStorage(AppSettings.automaticScreenshotIntervalSecondsUserDefaultsKey) private var storedAutomaticScreenshotIntervalSeconds =
         AppSettings.defaultAutomaticScreenshotIntervalSeconds
@@ -258,8 +258,13 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     }
 
     var liveSubtitleSourceMode: LiveSubtitleSourceMode {
-        get { LiveSubtitleSourceMode(rawValue: liveSubtitleSourceModeRawValue) ?? .includeMicrophone }
+        get { LiveSubtitleSourceMode(storedRawValue: liveSubtitleSourceModeRawValue) }
         set { liveSubtitleSourceModeRawValue = newValue.rawValue }
+    }
+
+    var includesMicrophoneInLiveSubtitles: Bool {
+        get { liveSubtitleSourceMode.includesMicrophone }
+        set { liveSubtitleSourceMode = LiveSubtitleSourceMode(includesMicrophone: newValue) }
     }
 
     var isTranscriptTranslationEffectivelyEnabled: Bool {

--- a/Sources/Dahlia/Models/LiveSubtitleOverlayPayload.swift
+++ b/Sources/Dahlia/Models/LiveSubtitleOverlayPayload.swift
@@ -10,7 +10,7 @@ struct LiveSubtitleOverlayPayload: Equatable {
 
     static func latest(
         from segments: [TranscriptSegment],
-        sourceMode: LiveSubtitleSourceMode = .includeMicrophone,
+        sourceMode: LiveSubtitleSourceMode = .defaultMode,
         transcriptionLocaleIdentifier: String,
         translationEnabled: Bool,
         targetLanguageIdentifier: String,

--- a/Sources/Dahlia/Models/LiveSubtitleSourceMode.swift
+++ b/Sources/Dahlia/Models/LiveSubtitleSourceMode.swift
@@ -1,18 +1,19 @@
-import Foundation
-
-enum LiveSubtitleSourceMode: String, CaseIterable, Identifiable {
+enum LiveSubtitleSourceMode: String {
     case systemAudioOnly
     case includeMicrophone
 
-    var id: String { rawValue }
+    static let defaultMode: Self = .systemAudioOnly
 
-    var displayName: String {
-        switch self {
-        case .systemAudioOnly:
-            L10n.systemAudioOnly
-        case .includeMicrophone:
-            L10n.includeMicrophone
-        }
+    init(storedRawValue: String) {
+        self = Self(rawValue: storedRawValue) ?? .defaultMode
+    }
+
+    init(includesMicrophone: Bool) {
+        self = includesMicrophone ? .includeMicrophone : .systemAudioOnly
+    }
+
+    var includesMicrophone: Bool {
+        self == .includeMicrophone
     }
 
     func includesSpeakerLabel(_ speakerLabel: String?) -> Bool {

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -282,9 +282,8 @@
 "Show live subtitles when recording starts." = "Show live subtitles when recording starts.";
 "Live subtitles are available with both real-time and batch transcription." = "Live subtitles are available with both real-time and batch transcription.";
 "In batch mode, subtitles are temporary and the final transcript is created after recording stops." = "In batch mode, subtitles are temporary and the final transcript is created after recording stops.";
-"System Audio Only" = "System Audio Only";
 "Include Microphone" = "Include Microphone";
-"Choose whether live subtitles only show system audio or also include microphone input." = "Choose whether live subtitles only show system audio or also include microphone input.";
+"Include microphone input in live subtitles. This does not change recorded audio or the final transcript." = "Include microphone input in live subtitles. This does not change recorded audio or the final transcript.";
 "Overlay Segment Count" = "Overlay Segment Count";
 "Choose how many recent transcript segments the live subtitle overlay shows." = "Choose how many recent transcript segments the live subtitle overlay shows.";
 "Live subtitles stopped because the audio format could not be converted." = "Live subtitles stopped because the audio format could not be converted.";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -282,9 +282,8 @@
 "Show live subtitles when recording starts." = "録音開始時にライブ字幕を表示します。";
 "Live subtitles are available with both real-time and batch transcription." = "ライブ字幕はリアルタイム文字起こしとバッチ文字起こしの両方で利用できます。";
 "In batch mode, subtitles are temporary and the final transcript is created after recording stops." = "バッチ方式では字幕は一時的な表示で、最終的な文字起こしは録音停止後に作成されます。";
-"System Audio Only" = "システムオーディオのみ";
 "Include Microphone" = "マイク入力を含める";
-"Choose whether live subtitles only show system audio or also include microphone input." = "ライブ字幕をシステムオーディオのみにするか、マイク入力も含めるかを選びます。";
+"Include microphone input in live subtitles. This does not change recorded audio or the final transcript." = "ライブ字幕にマイク入力を含めます。録音音声や最終的な文字起こしには影響しません。";
 "Overlay Segment Count" = "表示セグメント数";
 "Choose how many recent transcript segments the live subtitle overlay shows." = "ライブ字幕オーバーレイに表示する最近の文字起こしセグメント数を選びます。";
 "Live subtitles stopped because the audio format could not be converted." = "音声形式を変換できなかったため、ライブ字幕を停止しました。";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -487,10 +487,9 @@ enum L10n {
         bundle: bundle
     ) }
 
-    static var systemAudioOnly: String { String(localized: "System Audio Only", bundle: bundle) }
     static var includeMicrophone: String { String(localized: "Include Microphone", bundle: bundle) }
-    static var liveSubtitleSourceDescription: String { String(
-        localized: "Choose whether live subtitles only show system audio or also include microphone input.",
+    static var liveSubtitleMicrophoneDescription: String { String(
+        localized: "Include microphone input in live subtitles. This does not change recorded audio or the final transcript.",
         bundle: bundle
     ) }
     static var liveSubtitleOverlaySegmentCount: String { String(localized: "Overlay Segment Count", bundle: bundle) }

--- a/Sources/Dahlia/Views/Settings/LiveSubtitleSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/LiveSubtitleSettingsView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct LiveSubtitleSettingsView: View {
+    @ObservedObject private var settings = AppSettings.shared
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle(isOn: $settings.liveSubtitleOverlayEnabled) {
+                    Text(L10n.liveSubtitles)
+                    Text(L10n.liveSubtitleOverlayToggleDescription)
+                }
+                .toggleStyle(.switch)
+            } footer: {
+                Text(L10n.liveSubtitleOverlayDescription)
+            }
+
+            Section {
+                Toggle(isOn: $settings.includesMicrophoneInLiveSubtitles) {
+                    Text(L10n.includeMicrophone)
+                    Text(L10n.liveSubtitleMicrophoneDescription)
+                }
+                .toggleStyle(.switch)
+                .disabled(!settings.liveSubtitleOverlayEnabled)
+
+                Picker(selection: $settings.liveSubtitleOverlaySegmentCount) {
+                    ForEach(1 ..< 6, id: \.self) { count in
+                        Text("\(count)").tag(count)
+                    }
+                } label: {
+                    Text(L10n.liveSubtitleOverlaySegmentCount)
+                    Text(L10n.liveSubtitleOverlaySegmentCountDescription)
+                }
+                .pickerStyle(.menu)
+                .disabled(!settings.liveSubtitleOverlayEnabled)
+            } header: {
+                Text(L10n.liveSubtitleOverlay)
+            } footer: {
+                if !settings.liveSubtitleOverlayEnabled {
+                    Text(L10n.enableLiveSubtitlesToConfigure)
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+}

--- a/Sources/Dahlia/Views/Settings/SettingsCategory.swift
+++ b/Sources/Dahlia/Views/Settings/SettingsCategory.swift
@@ -6,6 +6,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
     case permissions
     case backups
     case transcription
+    case liveSubtitles
     case screenshots
     case calendar
     case cloudStorage
@@ -24,6 +25,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .permissions: L10n.permissions
         case .backups: L10n.backups
         case .transcription: L10n.transcription
+        case .liveSubtitles: L10n.liveSubtitles
         case .screenshots: L10n.screenshots
         case .calendar: L10n.calendar
         case .cloudStorage: L10n.export
@@ -42,6 +44,7 @@ enum SettingsCategory: String, CaseIterable, Identifiable {
         case .permissions: "hand.raised"
         case .backups: "externaldrive.badge.timemachine"
         case .transcription: "waveform"
+        case .liveSubtitles: "captions.bubble"
         case .screenshots: "photo.on.rectangle.angled"
         case .calendar: "calendar"
         case .cloudStorage: "square.and.arrow.up"

--- a/Sources/Dahlia/Views/Settings/SettingsDetailView.swift
+++ b/Sources/Dahlia/Views/Settings/SettingsDetailView.swift
@@ -21,6 +21,8 @@ struct SettingsDetailView: View {
                 )
             case .transcription:
                 TranscriptionSettingsView()
+            case .liveSubtitles:
+                LiveSubtitleSettingsView()
             case .screenshots:
                 ScreenshotSettingsView()
             case .calendar:

--- a/Sources/Dahlia/Views/Settings/SettingsGroup.swift
+++ b/Sources/Dahlia/Views/Settings/SettingsGroup.swift
@@ -23,7 +23,7 @@ enum SettingsGroup: CaseIterable, Identifiable {
     var categories: [SettingsCategory] {
         switch self {
         case .app: [.general, .permissions, .backups]
-        case .recording: [.transcription, .screenshots]
+        case .recording: [.transcription, .liveSubtitles, .screenshots]
         case .integrations: [.calendar, .cloudStorage]
         case .ai: [.modelProvider, .aiSummary, .mcp]
         case .advanced: [.developer, .audioDiagnostics]

--- a/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
@@ -98,43 +98,6 @@ struct TranscriptionSettingsView: View {
             }
 
             Section {
-                Toggle(isOn: $settings.liveSubtitleOverlayEnabled) {
-                    Text(L10n.liveSubtitles)
-                    Text(L10n.liveSubtitleOverlayToggleDescription)
-                }
-                .toggleStyle(.switch)
-
-                Picker(selection: $settings.liveSubtitleSourceModeRawValue) {
-                    ForEach(LiveSubtitleSourceMode.allCases) { mode in
-                        Text(mode.displayName).tag(mode.rawValue)
-                    }
-                } label: {
-                    Text(L10n.source)
-                    Text(L10n.liveSubtitleSourceDescription)
-                }
-                .disabled(!settings.liveSubtitleOverlayEnabled)
-
-                Picker(selection: $settings.liveSubtitleOverlaySegmentCount) {
-                    ForEach(1 ..< 6, id: \.self) { count in
-                        Text("\(count)").tag(count)
-                    }
-                } label: {
-                    Text(L10n.liveSubtitleOverlaySegmentCount)
-                    Text(L10n.liveSubtitleOverlaySegmentCountDescription)
-                }
-                .disabled(!settings.liveSubtitleOverlayEnabled)
-            } header: {
-                Text(L10n.liveSubtitleOverlay)
-            } footer: {
-                VStack(alignment: .leading) {
-                    Text(L10n.liveSubtitleOverlayDescription)
-                    if !settings.liveSubtitleOverlayEnabled {
-                        Text(L10n.enableLiveSubtitlesToConfigure)
-                    }
-                }
-            }
-
-            Section {
                 Picker(L10n.languageRange, selection: languageScopeBinding) {
                     ForEach(TranscriptionLanguageScope.allCases) { scope in
                         Text(scope.displayName).tag(scope)

--- a/Tests/DahliaTests/LiveSubtitleOverlayCoordinatorTests.swift
+++ b/Tests/DahliaTests/LiveSubtitleOverlayCoordinatorTests.swift
@@ -9,9 +9,9 @@ import Foundation
     struct LiveSubtitleOverlayCoordinatorTests {
         @Test
         func overlayReadsEphemeralCaptionStoreInsteadOfAuthoritativeTranscript() throws {
-            let previousSetting = AppSettings.shared.liveSubtitleOverlayEnabled
+            let settingsSnapshot = UserDefaultsValueSnapshot(key: "liveSubtitleOverlayEnabled")
             AppSettings.shared.liveSubtitleOverlayEnabled = true
-            defer { AppSettings.shared.liveSubtitleOverlayEnabled = previousSetting }
+            defer { settingsSnapshot.restore() }
 
             let viewModel = CaptionViewModel(
                 availableInputDevicesProvider: { [] },
@@ -51,9 +51,9 @@ import Foundation
 
         @Test
         func continuouslyChangingPreviewPublishesLatestAtBoundedCadence() async throws {
-            let previousSetting = AppSettings.shared.liveSubtitleOverlayEnabled
+            let settingsSnapshot = UserDefaultsValueSnapshot(key: "liveSubtitleOverlayEnabled")
             AppSettings.shared.liveSubtitleOverlayEnabled = true
-            defer { AppSettings.shared.liveSubtitleOverlayEnabled = previousSetting }
+            defer { settingsSnapshot.restore() }
 
             let viewModel = CaptionViewModel(
                 availableInputDevicesProvider: { [] },
@@ -87,6 +87,99 @@ import Foundation
             #expect(payload.entries.map(\.primaryText) == ["Preview 19"])
             #expect(presenter.updateCount - initialUpdateCount <= 2)
             withExtendedLifetime(coordinator) {}
+        }
+
+        @Test
+        func microphoneSettingUpdatesVisibleCaptionsWhileRecording() async {
+            let settingsSnapshots = [
+                UserDefaultsValueSnapshot(key: "liveSubtitleOverlayEnabled"),
+                UserDefaultsValueSnapshot(key: "liveSubtitleOverlaySegmentCount"),
+                UserDefaultsValueSnapshot(key: "liveSubtitleSourceMode"),
+            ]
+            defer {
+                for snapshot in settingsSnapshots {
+                    snapshot.restore()
+                }
+            }
+
+            let settings = AppSettings.shared
+            settings.liveSubtitleOverlayEnabled = true
+            settings.liveSubtitleOverlaySegmentCount = 2
+            settings.liveSubtitleSourceMode = .includeMicrophone
+
+            let viewModel = CaptionViewModel(
+                availableInputDevicesProvider: { [] },
+                defaultInputDeviceIDProvider: { nil }
+            )
+            let sessionID = UUID.v7()
+            viewModel.isListening = true
+            viewModel.liveCaptionStore.start(sessionId: sessionID)
+            viewModel.liveCaptionStore.apply(event: .finalized(
+                TranscriptSegment(
+                    sessionId: sessionID,
+                    startTime: .now,
+                    text: "Microphone",
+                    isConfirmed: true,
+                    speakerLabel: "mic"
+                )
+            ))
+            viewModel.liveCaptionStore.apply(event: .finalized(
+                TranscriptSegment(
+                    sessionId: sessionID,
+                    startTime: .now,
+                    text: "System",
+                    isConfirmed: true,
+                    speakerLabel: "system"
+                )
+            ))
+            let presenter = FakeLiveSubtitlePresenter()
+            let coordinator = LiveSubtitleOverlayCoordinator(
+                viewModel: viewModel,
+                liveSubtitleOverlayService: presenter
+            )
+
+            #expect(presenter.lastPayload?.entries.map(\.primaryText) == ["Microphone", "System"])
+
+            settings.includesMicrophoneInLiveSubtitles = false
+            let hidMicrophone = await waitUntil {
+                presenter.lastPayload?.entries.map(\.primaryText) == ["System"]
+            }
+            #expect(hidMicrophone)
+
+            settings.includesMicrophoneInLiveSubtitles = true
+            let restoredMicrophone = await waitUntil {
+                presenter.lastPayload?.entries.map(\.primaryText) == ["Microphone", "System"]
+            }
+            #expect(restoredMicrophone)
+            withExtendedLifetime(coordinator) {}
+        }
+
+        private func waitUntil(_ predicate: @MainActor () -> Bool) async -> Bool {
+            for _ in 0 ..< 100 {
+                if predicate() {
+                    return true
+                }
+                await Task.yield()
+            }
+            return predicate()
+        }
+    }
+
+    private struct UserDefaultsValueSnapshot {
+        let key: String
+        let value: Any?
+
+        init(key: String) {
+            self.key = key
+            value = UserDefaults.standard.object(forKey: key)
+        }
+
+        func restore() {
+            if let value {
+                UserDefaults.standard.set(value, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
         }
     }
 #endif

--- a/Tests/DahliaTests/LiveSubtitleOverlayPayloadTests.swift
+++ b/Tests/DahliaTests/LiveSubtitleOverlayPayloadTests.swift
@@ -6,9 +6,36 @@ import Testing
 
 struct LiveSubtitleOverlayPayloadTests {
     @Test
+    func latestDefaultsToSystemAudioOnly() {
+        let payload = LiveSubtitleOverlayPayload.latest(
+            from: [
+                TranscriptSegment(
+                    startTime: Date(timeIntervalSince1970: 1_776_384_000),
+                    text: "Microphone",
+                    isConfirmed: true,
+                    speakerLabel: "mic"
+                ),
+                TranscriptSegment(
+                    startTime: Date(timeIntervalSince1970: 1_776_384_001),
+                    text: "System",
+                    isConfirmed: true,
+                    speakerLabel: "system"
+                ),
+            ],
+            transcriptionLocaleIdentifier: "en_US",
+            translationEnabled: false,
+            targetLanguageIdentifier: "ja",
+            maxEntries: 2
+        )
+
+        #expect(payload?.entries.map(\.primaryText) == ["System"])
+    }
+
+    @Test
     func latestReturnsNilForEmptySegments() {
         let payload = LiveSubtitleOverlayPayload.latest(
             from: [],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: true,
             targetLanguageIdentifier: "ja",
@@ -29,6 +56,7 @@ struct LiveSubtitleOverlayPayloadTests {
                     speakerLabel: "mic"
                 ),
             ],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: true,
             targetLanguageIdentifier: "ja",
@@ -52,6 +80,7 @@ struct LiveSubtitleOverlayPayloadTests {
                     speakerLabel: "mic"
                 ),
             ],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: true,
             targetLanguageIdentifier: "ja",
@@ -75,6 +104,7 @@ struct LiveSubtitleOverlayPayloadTests {
                     speakerLabel: "mic"
                 ),
             ],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: true,
             targetLanguageIdentifier: "en",
@@ -103,6 +133,7 @@ struct LiveSubtitleOverlayPayloadTests {
                     isConfirmed: true
                 ),
             ],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: true,
             targetLanguageIdentifier: "ja",
@@ -140,6 +171,7 @@ struct LiveSubtitleOverlayPayloadTests {
                     speakerLabel: "system"
                 ),
             ],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: true,
             targetLanguageIdentifier: "ja",
@@ -170,6 +202,7 @@ struct LiveSubtitleOverlayPayloadTests {
                     speakerLabel: "system"
                 ),
             ],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: true,
             targetLanguageIdentifier: "ja",
@@ -194,6 +227,7 @@ struct LiveSubtitleOverlayPayloadTests {
                     speakerLabel: "system"
                 ),
             ],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: true,
             targetLanguageIdentifier: "ja",
@@ -213,6 +247,7 @@ struct LiveSubtitleOverlayPayloadTests {
                 TranscriptSegment(startTime: Date(timeIntervalSince1970: 1_776_384_001), text: "Two", isConfirmed: true),
                 TranscriptSegment(startTime: Date(timeIntervalSince1970: 1_776_384_002), text: "Three", isConfirmed: true),
             ],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: false,
             targetLanguageIdentifier: "ja",
@@ -283,6 +318,7 @@ final class LiveSubtitleOverlayPayloadTests: XCTestCase {
     func testLatestReturnsNilForEmptySegments() {
         let payload = LiveSubtitleOverlayPayload.latest(
             from: [],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: true,
             targetLanguageIdentifier: "ja",
@@ -302,6 +338,7 @@ final class LiveSubtitleOverlayPayloadTests: XCTestCase {
                     speakerLabel: "mic"
                 ),
             ],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: true,
             targetLanguageIdentifier: "ja",
@@ -324,6 +361,7 @@ final class LiveSubtitleOverlayPayloadTests: XCTestCase {
                     speakerLabel: "mic"
                 ),
             ],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: true,
             targetLanguageIdentifier: "ja",
@@ -346,6 +384,7 @@ final class LiveSubtitleOverlayPayloadTests: XCTestCase {
                     speakerLabel: "mic"
                 ),
             ],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: true,
             targetLanguageIdentifier: "en",
@@ -373,6 +412,7 @@ final class LiveSubtitleOverlayPayloadTests: XCTestCase {
                     isConfirmed: true
                 ),
             ],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: true,
             targetLanguageIdentifier: "ja",
@@ -409,6 +449,7 @@ final class LiveSubtitleOverlayPayloadTests: XCTestCase {
                     speakerLabel: "system"
                 ),
             ],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: true,
             targetLanguageIdentifier: "ja",
@@ -438,6 +479,7 @@ final class LiveSubtitleOverlayPayloadTests: XCTestCase {
                     speakerLabel: "system"
                 ),
             ],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: true,
             targetLanguageIdentifier: "ja",
@@ -461,6 +503,7 @@ final class LiveSubtitleOverlayPayloadTests: XCTestCase {
                     speakerLabel: "system"
                 ),
             ],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: true,
             targetLanguageIdentifier: "ja",
@@ -479,6 +522,7 @@ final class LiveSubtitleOverlayPayloadTests: XCTestCase {
                 TranscriptSegment(startTime: Date(timeIntervalSince1970: 1_776_384_001), text: "Two", isConfirmed: true),
                 TranscriptSegment(startTime: Date(timeIntervalSince1970: 1_776_384_002), text: "Three", isConfirmed: true),
             ],
+            sourceMode: .includeMicrophone,
             transcriptionLocaleIdentifier: "en_US",
             translationEnabled: false,
             targetLanguageIdentifier: "ja",

--- a/Tests/DahliaTests/LiveSubtitleSourceModeTests.swift
+++ b/Tests/DahliaTests/LiveSubtitleSourceModeTests.swift
@@ -1,0 +1,29 @@
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct LiveSubtitleSourceModeTests {
+        @Test
+        func defaultsToSystemAudioOnly() {
+            #expect(LiveSubtitleSourceMode.defaultMode == .systemAudioOnly)
+            #expect(!LiveSubtitleSourceMode.defaultMode.includesSpeakerLabel("mic"))
+            #expect(LiveSubtitleSourceMode.defaultMode.includesSpeakerLabel("system"))
+        }
+
+        @Test
+        func resolvesStoredRawValuesWithoutChangingTheirFormat() {
+            #expect(LiveSubtitleSourceMode(storedRawValue: "includeMicrophone") == .includeMicrophone)
+            #expect(LiveSubtitleSourceMode(storedRawValue: "systemAudioOnly") == .systemAudioOnly)
+            #expect(LiveSubtitleSourceMode(storedRawValue: "unsupported") == .defaultMode)
+        }
+
+        @Test
+        func mapsMicrophoneToggleToSourceMode() {
+            #expect(LiveSubtitleSourceMode(includesMicrophone: true) == .includeMicrophone)
+            #expect(LiveSubtitleSourceMode(includesMicrophone: false) == .systemAudioOnly)
+            #expect(LiveSubtitleSourceMode.includeMicrophone.includesMicrophone)
+            #expect(!LiveSubtitleSourceMode.systemAudioOnly.includesMicrophone)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/SettingsCategoryTests.swift
+++ b/Tests/DahliaTests/SettingsCategoryTests.swift
@@ -11,6 +11,7 @@
                 .permissions,
                 .backups,
                 .transcription,
+                .liveSubtitles,
                 .screenshots,
                 .calendar,
                 .cloudStorage,
@@ -46,6 +47,9 @@
             #expect(SettingsCategory.permissions.systemImage == "hand.raised")
             #expect(SettingsCategory.backups.systemImage == "externaldrive.badge.timemachine")
             #expect(SettingsCategory.modelProvider.label == L10n.aiConnection)
+            #expect(SettingsCategory.liveSubtitles.rawValue == "liveSubtitles")
+            #expect(SettingsCategory.liveSubtitles.label == L10n.liveSubtitles)
+            #expect(SettingsCategory.liveSubtitles.systemImage == "captions.bubble")
             #expect(SettingsCategory.cloudStorage.rawValue == "cloudStorage")
             #expect(SettingsCategory.cloudStorage.label == L10n.export)
             #expect(SettingsCategory.mcp.rawValue == "mcp")
@@ -59,6 +63,7 @@
         func advancedSettingsRemainAtTheEnd() {
             #expect(SettingsGroup.allCases.last == .advanced)
             #expect(SettingsGroup.app.categories == [.general, .permissions, .backups])
+            #expect(SettingsGroup.recording.categories == [.transcription, .liveSubtitles, .screenshots])
             #expect(SettingsGroup.advanced.categories == [.developer, .audioDiagnostics])
         }
 

--- a/docs/architecture/audio-transcription-data-flow.md
+++ b/docs/architecture/audio-transcription-data-flow.md
@@ -191,6 +191,10 @@ sequenceDiagram
 `TranscriptionEventPipeline.enqueue` は、確定イベントについて suspension より前に persistence lane への ingress を確定する。
 その後に UI と optional observer を処理するため、MainActor または字幕 consumer の停止が SQLite への進行を直接待たせない。
 
+ライブ字幕の音源設定は `LiveCaptionStore` からオーバーレイ payload を作る際の表示フィルタである。既定では
+システムオーディオだけを表示し、ユーザーが「マイク入力を含める」を有効にした場合はマイク由来の字幕も表示する。
+この設定は録音する音声、逐次認識器への入力、SQLite の正本文字起こしには影響しない。
+
 preview は保存しない。finalized segment と確定 translation は `TranscriptPersistenceWriter` が順序を保ち、
 SQLite failure 時は actor 内に保持して backoff 付きで再試行する。process が終了すれば memory backlog は失われ得るため、
 durable の境界は ingress ではなく SQLite commit である。


### PR DESCRIPTION
## Summary

- move live subtitle controls into a dedicated settings category
- add an option to include microphone-derived captions for offline meetings and events
- default live subtitle output to system audio only while preserving existing stored raw values
- document the display-only filtering behavior and add regression coverage

## Impact

Users can configure live subtitles independently from transcription settings and choose whether microphone input appears in the overlay. This option affects only subtitle display; it does not change recorded audio or the final transcript.

## Validation

- `swift test` — 940 Swift Testing tests and 3 XCTest tests passed
- `swift test --filter LiveSubtitle` — 19 tests in 4 suites passed
- `swift test --filter SettingsCategoryTests` — 7 tests passed
- `CI=true ./scripts/lint.sh` — passed; SwiftFormat reported 0 files requiring changes