### PR TITLE
Document release versioning policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,18 @@ ADRs preserve decision history; and `AGENTS.md` contains actionable instructions
 - The app has exactly four SwiftPM runtime dependencies: GRDB.swift, sentry-cocoa, Sparkle, and WhisperKit. The separate `BuildTools` package pins SwiftFormat. The app also verifies and bundles a pinned official arm64 release of the OpenAI Codex CLI as a runtime helper. Get confirmation before adding or updating dependencies.
 - Never destroy a released user's database. Do not modify registered migrations; add a new migration according to `Sources/Dahlia/Database/AGENTS.md`.
 
+## Release Versioning
+
+- Apply this policy prospectively when preparing a release. Do not revise or validate historical version numbers, missing releases, or build numbers against it.
+- Keep `CFBundleShortVersionString` in `x.y.z` format. Determine the next version from the complete set of changes since the latest release, not from each individual change.
+- Increment `z` for a release containing only backward-compatible fixes, improvements, or additions. This includes bug fixes, internal refactoring, documentation, backward-compatible features, and additive database migrations that do not change the meaning of existing data, such as new tables or indexes and nullable or defaulted columns.
+- Increment `y` and reset `z` to `0` when a release changes compatibility, a primary workflow, or an existing behavioral or data contract. This includes semantic changes to recording or transcription, changes to existing settings, MCP or backup contracts, table rebuilds, renames or removals, type, nullability, constraint, or relationship changes, and migrations that reinterpret, transform, or meaningfully backfill existing data.
+- When a release contains changes from multiple categories, use the highest required increment.
+- Never infer an `x.0.0` release. Increment `x` and reset `y` and `z` to `0` only when the user explicitly requests a major version; ask before release if a major increment appears necessary.
+- Update versions during release preparation, not as part of ordinary feature or fix changes.
+- Treat `CFBundleVersion` as an integer build number independent of the marketing version. Increase it from the latest published build for every newly published distribution artifact, including a replacement with the same marketing version. Local builds and unpublished attempts do not require an increment.
+- During release preparation, update `CFBundleShortVersionString` and `CFBundleVersion` together in `Resources/Info.plist`.
+
 ## Authorization
 
 - For requests to answer, explain, review, diagnose, or plan, inspect the relevant files and logs and report the result. Do not edit unless the request also asks for a change.


### PR DESCRIPTION
## Summary

- add a prospective release-versioning policy to the root `AGENTS.md`
- define patch and minor increments using compatibility and user/data-contract impact
- require explicit user direction for major versions
- document when marketing and build versions are updated

## Why

Release preparation did not have a repository-level rule for choosing the next marketing version or build number. This gives agents a consistent decision framework without retroactively applying it to historical releases.

## Impact

Future releases will choose versions from the complete set of changes since the latest release. Ordinary feature and fix work will no longer need to update version fields individually.

## Validation

- `git diff --check`
- verified `CLAUDE.md` remains a symlink to `AGENTS.md`
- commit and pre-push secret scans passed

Swift build and tests were not run because this is a documentation-only change.