### PR TITLE
Import AGENTS.md from Claude instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ This file applies to the entire repository. Before editing a path covered by a m
 | `Tests/DahliaTests/` | Test implementation and verification: `Tests/DahliaTests/AGENTS.md` |
 | `scripts/` | SwiftPM build, signing, notarization, and lint scripts |
 
-`CLAUDE.md` is a compatibility symlink to the `AGENTS.md` in the same directory. Do not maintain duplicate content.
+`CLAUDE.md` imports the `AGENTS.md` in the same directory with `@AGENTS.md`. Do not maintain duplicate content.
 
 ## Documentation Router
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/Sources/Dahlia/CLAUDE.md
+++ b/Sources/Dahlia/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/Sources/Dahlia/Database/CLAUDE.md
+++ b/Sources/Dahlia/Database/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/Tests/DahliaTests/CLAUDE.md
+++ b/Tests/DahliaTests/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
## Summary

- replace each `CLAUDE.md` compatibility symlink with a regular file that imports `@AGENTS.md`
- update the repository guidance to describe the import-based setup

## Why

`AGENTS.md` remains the canonical instruction file while Claude Code consumes it through its native `@` import syntax. This avoids relying on symlink support and keeps the files extensible for future Claude-specific guidance.

## Impact

Claude Code receives the same scoped repository instructions. There are no runtime application or user-data changes.

## Validation

- `git diff --check`
- verified all four `CLAUDE.md` files are regular files containing `@AGENTS.md`
- tests not run because this is a documentation/configuration-only change
