### PR TITLE
Add code review guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Use progressive disclosure: read the scoped `AGENTS.md` first, then open only th
 | Audio capture, recording, live subtitles, or realtime/batch transcript data flow | [`Audio and Transcription Data Flow`](docs/architecture/audio-transcription-data-flow.md) |
 | Recording, transcription, concurrency, persistence, or failure handling | [`ARCHITECTURE.md`](ARCHITECTURE.md#reliability-scope), then the relevant section |
 | UI interaction, rendering workload, or responsiveness | [`Sources/Dahlia/AGENTS.md`](Sources/Dahlia/AGENTS.md), then [`UI and Interaction Responsiveness`](ARCHITECTURE.md#ui-and-interaction-responsiveness) when workload behavior is affected |
+| Code review | [`Code Review Guide`](docs/code-review.md), then the architecture references routed by the closest applicable `AGENTS.md` |
 | Fixing an identified architecture deviation | [`Conformance Status`](ARCHITECTURE.md#conformance-status), then the matching item in [`Remediation Plan`](ARCHITECTURE.md#remediation-plan) |
 | Historical rationale or a change to an architectural decision | [`docs/adr/README.md`](docs/adr/README.md), then only the relevant ADR |
 
@@ -43,6 +44,12 @@ ADRs preserve decision history; and `AGENTS.md` contains actionable instructions
 - Use Swift Package Manager only. Do not generate an Xcode project.
 - The app has exactly four SwiftPM runtime dependencies: GRDB.swift, sentry-cocoa, Sparkle, and WhisperKit. The separate `BuildTools` package pins SwiftFormat. The app also verifies and bundles a pinned official arm64 release of the OpenAI Codex CLI as a runtime helper. Get confirmation before adding or updating dependencies.
 - Never destroy a released user's database. Do not modify registered migrations; add a new migration according to `Sources/Dahlia/Database/AGENTS.md`.
+
+## Code Review Rules
+
+- Before reporting findings, read [`docs/code-review.md`](docs/code-review.md) and the architecture sections routed by the closest applicable `AGENTS.md`.
+- Report only actionable defects introduced or exposed by the change. Each finding must identify a reachable trigger, the concrete impact, and the violated Dahlia contract or missing validation. Do not report style, formatting, or other deterministic checks enforced by CI.
+- Prioritize recording and transcription integrity, released-user data, correctness, security, and sustained responsiveness. Do not trade durable or recording-critical data for UI performance; bound, coalesce, cancel, or rebuild only projection work whose source of truth is preserved.
 
 ## Release Versioning
 
@@ -84,5 +91,5 @@ CI=true ./scripts/lint.sh              # Check SwiftFormat and SwiftLint without
 - Swift changes pass `swift build`, behavior changes pass targeted tests, and broader changes run `swift test` when warranted. Swift source changes also pass `CI=true ./scripts/lint.sh`.
 - Confirm from the test summary—not only exit code 0—that the intended tests actually ran.
 - Changes to public behavior, settings, or schemas include the corresponding tests, localization, and documentation.
-- Review the final diff for unintended changes and regressions.
+- Review the final diff against the applicable Code Review Rules for unintended changes and regressions.
 - If a check cannot run, report the exact command, reason, and next verification step. Do not describe an unverified check as passing.

--- a/Sources/Dahlia/AGENTS.md
+++ b/Sources/Dahlia/AGENTS.md
@@ -40,6 +40,20 @@ This file applies under `Sources/Dahlia/`. Changes under `Database/` must also f
 Before adding a responsibility that does not fit the documented ownership boundaries, inspect similar components and avoid creating a duplicate coordinator,
 store, repository, or global worker.
 
+## Code Review Rules
+
+### Runtime Isolation and Durability
+
+- Flag any changed path that lets MainActor, UI rendering, observers, previews, or caches gate audio acceptance, immutable segment writing, finalized transcript or translation persistence, or the documented stop drain. The safe path keeps recording-critical and durable work in owned lanes that progress independently of UI stalls and surface overload or failure explicitly.
+
+### MainActor and UI Workload
+
+- Flag database, disk, network, synchronous OS queries, or input-sized decode and parsing on MainActor, along with high-frequency changes that create unbounded tasks, reparsing, layout materialization, or state publication. The safe path moves input-sized non-UI work to an owned worker and exposes a bounded, cancelable, replaceable projection that rejects stale results by identity or generation.
+
+### Update-Rate Controls
+
+- Do not prescribe debouncing by default. Use debounce only when a quiet period has semantic meaning, throttle or coalescing when a continuous stream must make periodic progress, and latest-wins when only replaceable current state matters. None may drop audio frames or delay or drop the durable ingress of finalized data. Apply them only to rebuildable projection work whose source of truth is preserved, and require explicit bounds and relevant coverage for bursts, cancellation, stale completions, and MainActor stalls when these paths change.
+
 ## Implementation Conventions
 
 - Use time-sortable `UUID.v7()` values for new table-row and domain-entity IDs.

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -29,21 +29,44 @@ GPT-5.6 には、手順を細かく固定するより、成果、重要な制約
 - `Sources/Dahlia/AGENTS.md`: アプリ固有の所有関係、並行処理、UI とローカライズ
 - `Sources/Dahlia/Database/AGENTS.md`: データ保全とマイグレーション
 - `Tests/DahliaTests/AGENTS.md`: テストの隔離、実装規約、実行結果の判定
+- `docs/code-review.md`: 複数のレビュー手段で共有する finding の採用基準、チェックリスト、保守手順
 
 同じルールが複数階層に必要に見える場合は、上位に成果または制約を置き、下位にはその階層でだけ必要な実装条件を置く。`CLAUDE.md` は `AGENTS.md` へのシンボリックリンクなので直接編集しない。
+
+## レビュー指示の配置
+
+レビュー規則は、Codex managed review、ローカルの `codex review`、Claude の `/code-review`、実装後のセルフレビューで同じ正本を使う。
+
+- リポジトリ全体または subtree 固有の重大な制約: 最も近い `AGENTS.md` の `## Code Review Rules`
+- finding の採用基準、出力に必要な根拠、レビュー専用チェックリスト: `docs/code-review.md`
+- 現在の ownership、workload、failure mode、UI responsiveness の契約: `ARCHITECTURE.md`
+- 判断の経緯または既存決定の変更: 関連する ADR
+- format、lint、型検査など決定的に判定できる規則: test、lint、CI
+- 一つの PR だけで必要な観点: PR コメントまたはそのレビュー依頼
+
+Skill やプラグインには、レビューの起動、外部 reviewer の利用、finding の triage などのワークフローだけを置く。
+Dahlia 固有の制約を Skill ごとに複製しない。`CLAUDE.md` のシンボリックリンクと `AGENTS.md` からの参照により、
+Codex と Claude の両方を同じ規則へ誘導する。
+
+`## Code Review Rules` には、レビューで繰り返し説明する重大な規則を各 scope につき少数だけ置く。規則は
+「指摘する挙動」「発生する影響」「安全な経路または例外」を含め、関数名や一時的な実装詳細ではなく持続する契約として書く。
+詳細な背景や全チェック項目は `docs/code-review.md` または正本のアーキテクチャ文書へ分離する。
 
 ## 更新と評価
 
 1. 実際の失敗例または新しい要件を特定する。
 2. 矛盾、重複、古い例を先に削除する。
-3. 一度に 1 グループだけ変更し、その失敗を直す最小の指示を追加する。
-4. 小さなコード修正、UI のローカライズ、DB マイグレーション、テストのみの変更など、代表的な依頼で確認する。
-5. 成果の達成、不要な確認回数、検証漏れ、指示の総量を変更前後で比較する。
+3. 決定的に検出できる問題は、レビュー指示ではなく test、lint、CI へ移す。
+4. 一度に 1 グループだけ変更し、その失敗を直す最小の指示を追加する。
+5. 問題を含む差分と安全な差分の両方で、見逃しと false positive を確認する。
+6. 小さなコード修正、UI のローカライズ、DB マイグレーション、テストのみの変更など、代表的な依頼で確認する。
+7. 成果の達成、不要な確認回数、検証漏れ、false positive、指示の総量を変更前後で比較する。
 
 短くなったこと自体を成功とせず、必要な制約、根拠、検証結果を保ったまま代表的な作業の成功率が落ちないことを基準にする。
 
 ## 参照
 
-- [Using GPT-5.6 — Prompting best practices](https://developers.openai.com/api/docs/guides/latest-model#prompting-best-practices)
+- [Using GPT-5.6 — Prompting best practices](https://developers.openai.com/api/docs/guides/model-guidance?model=gpt-5.6#prompting-best-practices)
 - [Prompting guidance for GPT-5.6 Sol](https://developers.openai.com/api/docs/guides/prompt-guidance-gpt-5p6)
+- [Codex code review in GitHub](https://learn.chatgpt.com/docs/third-party/github)
 - [Custom instructions with AGENTS.md](https://learn.chatgpt.com/docs/agent-configuration/agents-md)

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -1,0 +1,103 @@
+# Dahlia コードレビューガイド
+
+この文書は、Codex managed review、ローカルの `codex review`、Claude の `/code-review`、実装後のセルフレビューで共有する。
+重大なレビュー規則は最も近い `AGENTS.md` の `## Code Review Rules`、技術的な正本は `ARCHITECTURE.md` と関連 ADR に置き、
+ここでは finding の採用基準とレビュー時の確認方法を定める。
+
+## レビューの準備
+
+1. 変更されたファイルと実行経路を確認し、適用されるすべての `AGENTS.md` を読む。
+2. diff だけで判断せず、呼び出し元、状態の owner、失敗経路、関連テストを必要な範囲で確認する。
+3. `AGENTS.md` の Documentation Router から、変更に関係するアーキテクチャ節だけを読む。
+4. レビュー依頼は read-only として扱い、修正も明示的に依頼された場合だけ編集する。
+
+## Finding の採用基準
+
+変更によって導入または顕在化する、到達可能で具体的な欠陥だけを finding とする。各 finding には次を含める。
+
+- 問題のある最小の file／line 範囲
+- 発生させる入力、状態、順序、負荷などの trigger
+- ユーザー、録音、文字起こし、永続データ、セキュリティ、応答性への具体的な impact
+- 違反する Dahlia の契約、または欠陥を防げていない検証上の根拠
+- 契約を保つ修正方向。広い redesign が必要なら、勝手に設計を確定せず必要な判断を明記する
+
+重大度は到達可能性と影響に基づけ、レビュー画面に表示させるために水増ししない。Codex の GitHub review が重大な finding
+だけを投稿する場合でも、根拠の弱い懸念を重大な欠陥として扱わない。
+
+次は原則として finding にしない。
+
+- 実行可能な失敗経路を示せない一般論または推測上の性能懸念
+- 挙動や保守上の欠陥を隠していない style、format、命名上の好み
+- lint、format、型検査など CI が決定的に判定する問題
+- 変更範囲と無関係な既存問題
+- テストがないという事実だけの指摘。現実的な回帰が検証されていない場合は、その回帰と影響を finding として説明する
+
+finding がない場合はその旨を明記し、実行できなかった検証や手動確認などの residual risk を分けて報告する。
+
+## Dahlia 固有のチェック
+
+### 契約と変更範囲
+
+- 依頼された挙動以外の recording、transcription、settings、schema、MCP、backup 契約を変えていないか。
+- 新しい coordinator、store、repository、worker が既存 owner と責務を重複していないか。
+- target state と異なる実装を、現在の実装例だけを根拠に正当化していないか。
+
+### Recording、Persistence、停止処理
+
+- capture callback と recording-critical lane が短時間、有界、non-suspending で MainActor を待たないか。
+- UI、observer、preview、cache、外部 I/O が audio acceptance または finalized persistence を gate していないか。
+- queue／stream に容量、overflow の意味、終了、cancellation、drain の所有者があるか。
+- failure、overflow、partial stop を成功やデータ欠落として隠していないか。
+- 正常停止が新規受付を閉じた後、文書化された順序で in-flight work を drain するか。
+
+### Concurrency とハング耐性
+
+- actor、lock、task、callback の lifecycle と mutable state の owner が明確か。
+- lock 内で I/O、外部 callback、unbounded allocation、`await` を実行していないか。
+- `Task.detached`、`@unchecked Sendable`、`@preconcurrency import` が ownership や data race を隠していないか。
+- MainActor の一時停止中にも recording-critical work と durable ingress が進行できるか。
+- interactive work と speculative work を同じ直列経路に置いて priority inversion を起こしていないか。
+
+### UI、描画、更新頻度
+
+- MainActor は表示状態の反映と短い計算に限定され、DB、disk、network、同期 OS query、入力サイズ依存の decode／parse を待たないか。
+- 高頻度イベントごとに全文 parse、全件 materialization、重い layout、無制限な task 作成や state publication をしていないか。
+- UI projection は window、件数、byte cost、更新頻度、同時実行数などデータ特性に合う上限を持つか。
+- 画面、選択対象、入力世代が変わったときに不要な処理を cancel し、identity または generation で stale completion を捨てるか。
+- raw content や durable source of truth を切り詰めることと、再生成可能な projection を制限することを混同していないか。
+
+更新頻度制御はイベントの意味から選ぶ。
+
+- `debounce`: 入力が止まった後に処理する意味があり、連続入力中に結果が出なくてもよい場合
+- `throttle`: 連続入力中も一定間隔で進捗または表示を更新する必要がある場合
+- `coalescing`: 複数イベントをまとめても意味と順序を保てる場合
+- `latest-wins`: 古い中間結果を破棄でき、現在の状態だけが必要な rebuildable work
+
+これらを audio frame を落としたり、確定文字起こし、確定翻訳、保存操作の durable ingress を遅延または欠落させたりする
+根拠にしない。正本が保たれる rebuildable UI projection にだけ適用し、変更時は burst、cancellation、stale completion、
+MainActor stall、UI catch-up のうち影響する境界を検証する。
+
+### Database とユーザーデータ
+
+- 登録済み migration の name、order、body を変更していないか。
+- released user の行、関係、識別子、意味を削除、再解釈、孤立させないか。
+- 新しい migration が直前 schema の既存行を保持し、空 DB への全 migration 適用にも成功するか。
+- UI または recording-critical path が同期 DB transaction を待たないか。
+
+### 検証の証拠
+
+- bug fix には修正前に失敗し修正後に通る regression test、または同等の再現可能な証拠があるか。
+- concurrency／UI test が固定 sleep ではなく観測可能な state、event、timeout を使うか。
+- 実行結果は exit code だけでなく、意図した test 数と suite が実際に走ったことまで確認されているか。
+- 実行できなかった build、test、lint、manual check が成功扱いされず、理由と次の確認方法が報告されているか。
+
+## 規則の保守
+
+新しい規則は、confirmed false negative、繰り返されるレビュー説明、または新しい重大な契約が生じたときに追加する。
+
+1. 問題を含む代表差分と、安全な実装の代表差分を用意する。
+2. 既存規則で検出できない理由を確認し、重複や矛盾を先に除く。
+3. 「指摘する挙動」「影響」「安全な経路または例外」を含む最小の規則を、最も近い `AGENTS.md` に追加する。
+4. 詳細説明または複数領域にまたがるチェックだけをこの文書へ追加する。
+5. 同じ差分で見逃しと false positive を再評価し、ノイズを生む規則は狭めるか削除する。
+6. 決定的に検出できる問題は test、lint、CI へ移し、レビュー規則から外す。

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -32,7 +32,9 @@
 - 変更範囲と無関係な既存問題
 - テストがないという事実だけの指摘。現実的な回帰が検証されていない場合は、その回帰と影響を finding として説明する
 
-finding がない場合はその旨を明記し、実行できなかった検証や手動確認などの residual risk を分けて報告する。
+finding がない場合は review surface の native contract で表す。fixed findings payload を要求する managed review では空の
+findings list を返し、prose や追加 field を要求しない。文章を許すローカルまたは Claude review では finding がない旨を明記し、
+実行できなかった検証や手動確認などの residual risk を分けて報告する。
 
 ## Dahlia 固有のチェック
 


### PR DESCRIPTION
## Summary

- add repository-wide and application-scoped Code Review Rules
- add a shared review guide for Codex, Claude, and local review workflows
- document how review guidance is maintained and separated from architecture and CI
- distinguish debounce, throttle, coalescing, and latest-wins semantics for UI workload review

## Why

Dahlia already documents its runtime resilience and UI responsiveness contracts, but review tools did not have an explicit, shared set of high-signal rules for applying those contracts. This change gives managed and local review workflows a common source of truth while keeping detailed architecture in the existing architecture documentation.

## Impact

This is documentation and agent-guidance only. It does not change application behavior, public APIs, dependencies, or persisted data.

## Validation

- `git diff --cached --check`
- verified all relative Markdown targets
- verified scoped `CLAUDE.md` symlinks still resolve to their corresponding `AGENTS.md`
- reviewed a representative concurrency/UI commit locally to calibrate durable-ingress and rebuildable-projection wording

Automated `codex review --commit 56690ab` was not run because the execution environment blocked repository content from being sent to the external review service.
