### PR TITLE
Preserve meeting detail tab selection

### DIFF
--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -376,8 +376,8 @@ struct ControlPanelView: View {
                 selectedScreenshotIds.removeAll()
             }
         }
-        .onChange(of: displayedMeetingIdentity) { _, newIdentity in
-            if newIdentity != nil {
+        .onChange(of: displayedMeetingIdentity) { oldIdentity, newIdentity in
+            if oldIdentity == nil, newIdentity != nil {
                 selectedTab = initialTabSelection
             }
             viewModel.requestShowSummaryTab = false


### PR DESCRIPTION
## Summary

- preserve the selected Notes, Screenshots, Transcript, or Summary tab when switching directly between meetings
- keep the existing initial tab selection for the first meeting shown
- retain explicit navigation to the Summary tab and the existing per-meeting transient-state cleanup

## Root cause

The meeting identity observer reapplied `initialTabSelection` for every non-nil meeting identity change, so switching from meeting A to meeting B replaced the user's current tab selection.

## User impact

Users can review the same type of content across multiple meetings without repeatedly reselecting the tab.

## Validation

- `swift build`
- `CI=true ./scripts/lint.sh` (SwiftFormat clean; SwiftLint completed with existing repository-wide violations unrelated to this change)
- `git diff --check`
- deep review found no actionable correctness, security, performance, or maintainability issues

Manual UI verification was not run because the repository does not include a SwiftUI view-inspection test harness for this private local state.