### PR TITLE
Show Thinking indicator while chat response is pending

### DIFF
--- a/Sources/Dahlia/Models/CodexChatConversationItem.swift
+++ b/Sources/Dahlia/Models/CodexChatConversationItem.swift
@@ -3,6 +3,7 @@ import Foundation
 enum CodexChatConversationItem: Identifiable, Equatable {
     case contextDivider(id: String, context: CodexChatContext?)
     case message(CodexChatMessage)
+    case thinking
 
     var id: String {
         switch self {
@@ -10,10 +11,15 @@ enum CodexChatConversationItem: Identifiable, Equatable {
             "context-\(id)"
         case let .message(message):
             "message-\(message.id)"
+        case .thinking:
+            "thinking"
         }
     }
 
-    static func build(from messages: [CodexChatMessage]) -> [Self] {
+    static func build(
+        from messages: [CodexChatMessage],
+        showsStandaloneThinking: Bool = false
+    ) -> [Self] {
         var items: [Self] = []
         var previousUserContext: CodexChatContext?
         var hasPreviousUserMessage = false
@@ -31,6 +37,9 @@ enum CodexChatConversationItem: Identifiable, Equatable {
                 hasPreviousUserMessage = true
             }
             items.append(.message(message))
+        }
+        if showsStandaloneThinking {
+            items.append(.thinking)
         }
         return items
     }

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -25,6 +25,7 @@ final class CodexChatSessionModel: Identifiable {
     var errorMessage: String?
     var noticeMessage: String?
     private(set) var activeTurnID: String?
+    private var activeResponseID: String?
     var lastSubmittedText: String?
     var attachedImages: [CodexChatImageAttachment] = []
     private(set) var pendingImagePreparationCount = 0
@@ -38,6 +39,10 @@ final class CodexChatSessionModel: Identifiable {
     var liveModeEnabled: Bool {
         get { isLiveModeEnabled }
         set { setLiveModeEnabled(newValue) }
+    }
+
+    var showsStandaloneThinking: Bool {
+        isGenerating && activeResponseID == nil
     }
 
     @ObservationIgnored private let service: any CodexChatServicing
@@ -58,7 +63,6 @@ final class CodexChatSessionModel: Identifiable {
     @ObservationIgnored private var activeSteeringManualSubmission: CodexChatManualSubmission?
     @ObservationIgnored private var activeTurnSupportsImages: Bool?
     @ObservationIgnored var activeSubmissionID: UUID?
-    @ObservationIgnored private var activeResponseID: String?
     @ObservationIgnored var turnTask: Task<Void, Never>?
     @ObservationIgnored private var steerTask: Task<Void, Never>?
     @ObservationIgnored private var failedSubmission: CodexChatFailedSubmission?

--- a/Sources/Dahlia/Views/CodexChat/CodexChatConversationView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatConversationView.swift
@@ -2,11 +2,15 @@ import SwiftUI
 
 struct CodexChatConversationView: View {
     let messages: [CodexChatMessage]
+    let showsStandaloneThinking: Bool
     let meetingNamesByID: [UUID: String]
     let meetingReferencesByID: [UUID: CodexChatMeetingReference]
 
     var body: some View {
-        let items = CodexChatConversationItem.build(from: messages)
+        let items = CodexChatConversationItem.build(
+            from: messages,
+            showsStandaloneThinking: showsStandaloneThinking
+        )
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 22) {
                 ForEach(items) { item in
@@ -19,6 +23,8 @@ struct CodexChatConversationView: View {
                             meetingNamesByID: meetingNamesByID,
                             meetingReferencesByID: meetingReferencesByID
                         )
+                    case .thinking:
+                        CodexChatThinkingIndicator()
                     }
                 }
             }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatView.swift
@@ -41,7 +41,7 @@ struct CodexChatView: View {
                     onOpenThread: openHistoryThread,
                     onLoadMore: loadMoreHistory
                 )
-            } else if session.messages.isEmpty {
+            } else if session.messages.isEmpty, !session.showsStandaloneThinking {
                 CodexChatEmptyStateView(
                     recentThreads: Array(coordinator.history.prefix(3)),
                     meetingNamesByID: session.meetingNamesByID,
@@ -51,6 +51,7 @@ struct CodexChatView: View {
             } else {
                 CodexChatConversationView(
                     messages: session.messages,
+                    showsStandaloneThinking: session.showsStandaloneThinking,
                     meetingNamesByID: session.meetingNamesByID,
                     meetingReferencesByID: session.meetingReferencesByID
                 )

--- a/Tests/DahliaTests/CodexChatConversationItemTests.swift
+++ b/Tests/DahliaTests/CodexChatConversationItemTests.swift
@@ -6,6 +6,64 @@ import Foundation
 
     struct CodexChatConversationItemTests {
         @Test
+        func addsThinkingWhileWaitingForStreamingResponse() {
+            let emptyConversation = CodexChatConversationItem.build(
+                from: [],
+                showsStandaloneThinking: true
+            )
+            let previousMessage = CodexChatMessage(
+                id: "previous",
+                role: .assistant,
+                text: "Previous answer"
+            )
+            let existingConversation = CodexChatConversationItem.build(
+                from: [previousMessage],
+                showsStandaloneThinking: true
+            )
+
+            #expect(emptyConversation == [.thinking])
+            #expect(existingConversation == [.message(previousMessage), .thinking])
+        }
+
+        @Test
+        func steeredConversationDoesNotDuplicateActiveResponseThinking() {
+            let response = CodexChatMessage(
+                id: "response",
+                role: .assistant,
+                text: "",
+                isStreaming: true
+            )
+            let followUp = CodexChatMessage(
+                id: "follow-up",
+                role: .user,
+                text: "Additional context"
+            )
+
+            let items = CodexChatConversationItem.build(
+                from: [response, followUp],
+                showsStandaloneThinking: false
+            )
+
+            #expect(items == [.message(response), .message(followUp)])
+        }
+
+        @Test
+        func completedResponseDoesNotRegainThinkingDuringReconciliation() {
+            let message = CodexChatMessage(
+                id: "answer",
+                role: .assistant,
+                text: "Answer"
+            )
+
+            let items = CodexChatConversationItem.build(
+                from: [message],
+                showsStandaloneThinking: false
+            )
+
+            #expect(items == [.message(message)])
+        }
+
+        @Test
         func insertsDividersOnlyAtContextTransitions() throws {
             let meetingA = try CodexChatContext.meeting(
                 id: #require(UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")),

--- a/Tests/DahliaTests/CodexChatSessionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatSessionModelTests.swift
@@ -700,6 +700,7 @@ import Foundation
         }
 
         let mode: Mode
+        private let delaysLoad: Bool
         private var steerErrors: [CodexAppServerError]
         private(set) var sentTextBlocks: [[String]] = []
         private(set) var steeredTextBlocks: [[String]] = []
@@ -708,6 +709,7 @@ import Foundation
         private(set) var unsubscribedThreadIDs: [String] = []
         private var blockedContinuation: AsyncThrowingStream<CodexChatTurnEvent, any Error>.Continuation?
         private var delayedSendContinuation: CheckedContinuation<Void, Never>?
+        private var delayedLoadContinuation: CheckedContinuation<Void, Never>?
 
         var unsubscribeCount: Int {
             unsubscribedThreadIDs.count
@@ -717,9 +719,18 @@ import Foundation
             delayedSendContinuation != nil
         }
 
-        init(mode: Mode, steerErrors: [CodexAppServerError] = []) {
+        var isLoadWaiting: Bool {
+            delayedLoadContinuation != nil
+        }
+
+        init(
+            mode: Mode,
+            steerErrors: [CodexAppServerError] = [],
+            delaysLoad: Bool = false
+        ) {
             self.mode = mode
             self.steerErrors = steerErrors
+            self.delaysLoad = delaysLoad
         }
 
         func models(forceRefresh _: Bool) async throws -> [CodexModel] {
@@ -731,6 +742,11 @@ import Foundation
         }
 
         func loadThread(id: String) async throws -> CodexChatThread {
+            if delaysLoad {
+                await withCheckedContinuation { continuation in
+                    delayedLoadContinuation = continuation
+                }
+            }
             let assistantMessages: [CodexChatMessage] = switch mode {
             case .complete, .block, .burstThenBlock, .bufferedBurstThenInterrupt,
                  .finishesWithoutTerminal, .interruptedThenBlock, .failThenComplete, .alwaysFail,
@@ -866,6 +882,11 @@ import Foundation
         func resumeDelayedSend() {
             delayedSendContinuation?.resume()
             delayedSendContinuation = nil
+        }
+
+        func resumeDelayedLoad() {
+            delayedLoadContinuation?.resume()
+            delayedLoadContinuation = nil
         }
 
         func unsubscribe(threadID: String) async {

--- a/Tests/DahliaTests/CodexChatThinkingPresentationTests.swift
+++ b/Tests/DahliaTests/CodexChatThinkingPresentationTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct CodexChatThinkingPresentationTests {
+        @Test
+        func standaloneThinkingHandsOffToActiveResponse() async {
+            let service = TestCodexChatService(mode: .block)
+            let settings = AppSettings()
+            settings.currentVault = Self.testVault()
+            let contextProvider = TestCodexChatContextProvider(shouldBlock: true)
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings,
+                contextProvider: contextProvider
+            )
+            session.draft = "Question"
+
+            session.sendDraft()
+            await waitUntil { contextProvider.requestCount == 1 }
+            #expect(session.showsStandaloneThinking)
+
+            contextProvider.resume()
+            await waitUntil { session.activeTurnID != nil }
+            #expect(!session.showsStandaloneThinking)
+
+            session.stop()
+            await waitUntil { !session.isGenerating }
+            #expect(!session.showsStandaloneThinking)
+        }
+
+        @Test
+        func completedResponseDoesNotShowThinkingDuringReconciliation() async {
+            let service = TestCodexChatService(mode: .complete, delaysLoad: true)
+            let settings = AppSettings()
+            settings.currentVault = Self.testVault()
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings
+            )
+            session.draft = "Question"
+
+            session.sendDraft()
+            await waitUntilAsync { await service.isLoadWaiting }
+
+            #expect(session.isGenerating)
+            #expect(session.messages.last?.text == "Final answer")
+            #expect(session.messages.last?.isStreaming == false)
+            #expect(!session.showsStandaloneThinking)
+
+            await service.resumeDelayedLoad()
+            await waitUntil { !session.isGenerating }
+        }
+
+        private static func testVault() -> VaultRecord {
+            VaultRecord(
+                id: .v7(),
+                path: "/tmp/chat-thinking-presentation-tests",
+                name: "Chat Thinking Presentation Tests",
+                createdAt: .now,
+                lastOpenedAt: .now
+            )
+        }
+
+        private func waitUntil(_ predicate: @MainActor () -> Bool) async {
+            for _ in 0 ..< 1000 {
+                if predicate() { return }
+                await Task.yield()
+            }
+            Issue.record("Timed out waiting for chat state")
+        }
+
+        private func waitUntilAsync(
+            _ predicate: @escaping @Sendable () async -> Bool
+        ) async {
+            for _ in 0 ..< 1000 {
+                if await predicate() { return }
+                await Task.yield()
+            }
+            Issue.record("Timed out waiting for asynchronous chat state")
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary

- show the existing `Thinking...` indicator immediately while Codex chat prepares a response
- hand off from the standalone indicator to the active assistant response without duplication
- keep the indicator suppressed during steering and rollout reconciliation once a response exists
- add regression coverage for initial waiting, steering, and reconciliation states

## Root cause

`isGenerating` became true before the assistant streaming placeholder was created, but the empty-chat view did not render a pending indicator. An initial implementation based on the last message could also duplicate or restore `Thinking...` during steering and rollout reconciliation. The presentation state now uses the active response ID as its source of truth.

## User impact

Users now receive immediate visual feedback after submitting a chat message, including while context, model, thread, and send setup is still in progress.

## Validation

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter CodexChat` — 133 tests in 22 suites passed
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build` — passed
- `CI=true ./scripts/lint.sh` — SwiftFormat passed; SwiftLint reported only pre-existing repository violations
- `git diff --check` — passed
- deep review across correctness, code quality, tests, performance, concurrency, accessibility, and security found no remaining actionable issues