### PR TITLE
Expand Codex stdout burst buffer

### DIFF
--- a/Sources/Dahlia/Services/CodexAppServerProcessTransport.swift
+++ b/Sources/Dahlia/Services/CodexAppServerProcessTransport.swift
@@ -13,13 +13,15 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
     private var isErrorDrainStarted = false
     private var isErrorDrainFinished = false
     private var outputLines: [Data] = []
+    private var outputLineReadIndex = 0
     private var outputWaiter: (id: UUID, continuation: CheckedContinuation<Data?, any Error>)?
     private var outputError: (any Error)?
     private var didReachOutputEOF = false
     private var pendingWrites: [UUID: CheckedContinuation<Void, any Error>] = [:]
     private var isClosed = false
     private var stderrTail = Data()
-    private let maximumBufferedOutputLines = 256
+    private let maximumBufferedOutputLines = 1024
+    private let minimumConsumedOutputLinesBeforeCompaction = 256
     #if DEBUG
         private var outputBufferOverflowWaiters: [CheckedContinuation<Void, Never>] = []
     #endif
@@ -109,8 +111,8 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
 
     func receiveLine() async throws -> Data? {
         startDrainsIfNeeded()
-        if !outputLines.isEmpty {
-            return outputLines.removeFirst()
+        if let line = dequeueOutputLine() {
+            return line
         }
         if let outputError { throw outputError }
         if isClosed || didReachOutputEOF { return nil }
@@ -171,6 +173,19 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
             await withCheckedContinuation { continuation in
                 outputBufferOverflowWaiters.append(continuation)
             }
+        }
+
+        func enqueueOutputLinesForTesting(_ lines: [Data]) {
+            for line in lines {
+                enqueueOutputLine(line)
+            }
+        }
+
+        func outputBufferStateForTesting() -> (unreadLineCount: Int, retainedByteCount: Int) {
+            (
+                outputLines.count - outputLineReadIndex,
+                outputLines.reduce(into: 0) { $0 += $1.count }
+            )
         }
     #endif
 
@@ -236,8 +251,9 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
             waiter.continuation.resume(returning: line)
         } else {
             guard outputError == nil else { return }
-            if outputLines.count >= maximumBufferedOutputLines {
+            if outputLines.count - outputLineReadIndex >= maximumBufferedOutputLines {
                 outputLines.removeAll(keepingCapacity: false)
+                outputLineReadIndex = 0
                 outputError = CodexAppServerError.outputBufferOverflow
                 #if DEBUG
                     let waiters = outputBufferOverflowWaiters
@@ -248,6 +264,23 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
             }
             outputLines.append(line)
         }
+    }
+
+    private func dequeueOutputLine() -> Data? {
+        guard outputLineReadIndex < outputLines.count else { return nil }
+        let line = outputLines[outputLineReadIndex]
+        // Release the payload now; the empty prefix is compacted less frequently.
+        outputLines[outputLineReadIndex] = Data()
+        outputLineReadIndex += 1
+        if outputLineReadIndex == outputLines.count {
+            outputLines.removeAll(keepingCapacity: true)
+            outputLineReadIndex = 0
+        } else if outputLineReadIndex >= minimumConsumedOutputLinesBeforeCompaction,
+                  outputLineReadIndex * 2 >= outputLines.count {
+            outputLines.removeFirst(outputLineReadIndex)
+            outputLineReadIndex = 0
+        }
+        return line
     }
 
     private func finishOutput(throwing error: (any Error)? = nil) async {

--- a/Tests/DahliaTests/CodexAppServerProcessTransportXCTests.swift
+++ b/Tests/DahliaTests/CodexAppServerProcessTransportXCTests.swift
@@ -61,13 +61,90 @@ import Foundation
         func stdoutBufferHasAnUpperBound() async throws {
             let transport = try CodexAppServerProcessTransport(
                 executableURL: URL(fileURLWithPath: "/bin/sh"),
-                arguments: ["-c", "i=0; while [ $i -lt 400 ]; do printf '%s\\n' $i; i=$((i+1)); done; read _"]
+                arguments: ["-c", "i=0; while [ $i -lt 1200 ]; do printf '%s\\n' $i; i=$((i+1)); done; read _"]
             )
 
             await transport.waitUntilOutputBufferOverflowForTesting()
             await #expect(throws: CodexAppServerError.outputBufferOverflow) {
                 _ = try await transport.receiveLine()
             }
+            await transport.close()
+        }
+
+        @Test
+        func stdoutBufferAcceptsDocumentedCapacityInFIFOOrder() async throws {
+            let transport = try CodexAppServerProcessTransport(
+                executableURL: URL(fileURLWithPath: "/bin/cat"),
+                arguments: []
+            )
+            let expectedLines = (0 ..< 1024).map { Data(String($0).utf8) }
+
+            await transport.enqueueOutputLinesForTesting(expectedLines)
+
+            var receivedLines: [Data] = []
+            for _ in expectedLines.indices {
+                try receivedLines.append(#require(await transport.receiveLine()))
+            }
+            #expect(receivedLines == expectedLines)
+            await transport.close()
+        }
+
+        @Test
+        func stdoutBufferRejectsLineAfterDocumentedCapacity() async throws {
+            let transport = try CodexAppServerProcessTransport(
+                executableURL: URL(fileURLWithPath: "/bin/cat"),
+                arguments: []
+            )
+            let lines = (0 ... 1024).map { Data(String($0).utf8) }
+
+            await transport.enqueueOutputLinesForTesting(lines)
+
+            await #expect(throws: CodexAppServerError.outputBufferOverflow) {
+                _ = try await transport.receiveLine()
+            }
+            await transport.close()
+        }
+
+        @Test
+        func stdoutBufferPreservesFIFOWhenReplenishedAfterCompaction() async throws {
+            let transport = try CodexAppServerProcessTransport(
+                executableURL: URL(fileURLWithPath: "/bin/cat"),
+                arguments: []
+            )
+            let initialLines = (0 ..< 1024).map { Data(String($0).utf8) }
+            let replenishedLines = (1024 ..< 1536).map { Data(String($0).utf8) }
+
+            await transport.enqueueOutputLinesForTesting(initialLines)
+            for expectedLine in initialLines.prefix(512) {
+                #expect(try await transport.receiveLine() == expectedLine)
+            }
+            await transport.enqueueOutputLinesForTesting(replenishedLines)
+
+            let expectedRemainder = Array(initialLines.dropFirst(512)) + replenishedLines
+            var receivedRemainder: [Data] = []
+            for _ in expectedRemainder.indices {
+                try receivedRemainder.append(#require(await transport.receiveLine()))
+            }
+            #expect(receivedRemainder == expectedRemainder)
+            await transport.close()
+        }
+
+        @Test
+        func stdoutBufferReleasesConsumedPayloadsBeforeCompaction() async throws {
+            let transport = try CodexAppServerProcessTransport(
+                executableURL: URL(fileURLWithPath: "/bin/cat"),
+                arguments: []
+            )
+            let line = Data(repeating: 0x61, count: 64)
+            await transport.enqueueOutputLinesForTesting(Array(repeating: line, count: 1024))
+
+            for _ in 0 ..< 256 {
+                _ = try await transport.receiveLine()
+            }
+
+            let state = await transport.outputBufferStateForTesting()
+            #expect(state.unreadLineCount == 768)
+            #expect(state.retainedByteCount == 768 * line.count)
             await transport.close()
         }
     }

--- a/docs/adr/0013-expand-codex-stdout-burst-buffer.md
+++ b/docs/adr/0013-expand-codex-stdout-burst-buffer.md
@@ -1,0 +1,35 @@
+# ADR 0013: Codex stdout の burst buffer を拡張する
+
+- Status: Accepted
+- Date: 2026-07-28
+- Amends: [ADR 0003](0003-use-a-shared-codex-app-server.md)
+
+## Context
+
+ADR 0003 は Codex app-server の未消費 stdout を最大 256 行に制限し、超過時には共有接続を破棄する
+fail-fast 方針を採用した。複数の要約を並列に再生成すると、共有 dispatcher が処理するより先に 256 行を超える
+JSONL が短時間に到着し、すべての進行中 turn が失敗することがある。
+
+一時的な burst は吸収する必要がある。一方で、message loss や無制限なメモリ使用を許容してはならない。
+また、行ごとの `removeFirst()` は、未処理配列全体を繰り返し移動する。
+
+## Decision
+
+- stdout の未消費行上限を 256 行から 1,024 行へ拡張する。
+- 上限を超えた場合は、従来どおり protocol violation として共有接続を破棄する。
+- queue の取り出しには read offset を使い、消費済みの `Data` payload は直ちに解放する。
+- 空になった prefix は一定量を消費した後にまとめて圧縮する。
+- この変更では要約生成の並列実行数に新しい上限を設けない。
+
+## Consequences
+
+- 通常の一時的な stdout burst に対する許容量は 4 倍になる。
+- 未消費行数は引き続き明示的に制限され、消費済み payload も圧縮まで保持されない。
+- 1,024 行を超える burst では共有接続が失敗するため、進行中の turn へ影響する可能性は残る。
+- 並列実行数の制御が必要になった場合は、別の挙動変更として判断する。
+
+## Alternatives considered
+
+- **buffer だけを拡張して `removeFirst()` を維持する:** 取り出しごとの配列移動が残るため採用しない。
+- **buffer を無制限にする:** 入力規模に応じてメモリ使用量が増え続けるため採用しない。
+- **同時に要約生成数を制限する:** ユーザーに見える実行挙動を変えるため、この変更には含めない。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,7 +11,7 @@ Codex は全 ADR を順番に読まず、最初にこの一覧から現在の作
 | --- | --- | --- | --- |
 | [0001](0001-summary-document-ast.md) | Summary | `SummaryDocument` AST をサマリーの正準表現にする | Accepted |
 | [0002](0002-isolate-recording-critical-path-from-main-actor.md) | Recording / Concurrency | 録音と確定データの保存を MainActor の UI projection から分離する | Accepted; partially superseded by 0006 and 0009 |
-| [0003](0003-use-a-shared-codex-app-server.md) | AI runtime | Codex app-server をアプリ共有の長寿命 backend として使う | Accepted |
+| [0003](0003-use-a-shared-codex-app-server.md) | AI runtime | Codex app-server をアプリ共有の長寿命 backend として使う | Accepted; amended by 0013 |
 | [0004](0004-protect-recordings-with-segmented-immutable-storage.md) | Recording storage | 録音データを分割された immutable segment として保全する | Accepted |
 | [0005](0005-vault-scoped-meeting-access-mcp.md) | Meeting access | Vault 固定・read-only の local MCP で meeting data を公開する | Accepted; amended by 0010 |
 | [0006](0006-bounded-transcript-projection.md) | Transcript UI | SQLite を正本とし、文字起こし表示を bounded projection と keyset pagination にする | Accepted; partially supersedes 0002 |
@@ -21,3 +21,4 @@ Codex は全 ADR を順番に読まず、最初にこの一覧から現在の作
 | [0010](0010-database-canonical-bounded-project-hierarchy.md) | Project workspace | DB 正本の2段階 Project 階層と派生 Summary 出力先を採用する | Accepted; amends 0005 |
 | [0011](0011-vault-scoped-customer-intelligence.md) | Customer intelligence | Vault単位の型付き正準データとAI示唆を分離する | Accepted; amends 0005, builds on 0010 |
 | [0012](0012-reviewable-customer-intelligence-workspace.md) | Customer intelligence / UI | 単一顧客の組織ビューと単数 CRUD による逐次AI更新を採用する | Accepted; amends 0011 |
+| [0013](0013-expand-codex-stdout-burst-buffer.md) | AI runtime | Codex stdout の burst buffer を拡張し、消費済み payload を即時解放する | Accepted; amends 0003 |


### PR DESCRIPTION
## Summary

- expand the shared Codex app-server stdout burst buffer from 256 to 1,024 unread lines
- replace per-line `removeFirst()` with a read offset and release consumed `Data` payloads immediately
- add deterministic coverage for the 1,024/1,025 boundary, FIFO behavior across compaction, replenishment, and payload release
- record the amended transport decision in ADR 0013

## Why

Regenerating many summaries in parallel can produce more than 256 JSONL lines before the shared dispatcher drains them. The previous limit then closed the shared Codex connection and failed every in-flight turn. The queue also shifted its remaining array on every dequeue.

This keeps the existing bounded, fail-fast contract while absorbing larger transient bursts and making queue removal amortized constant time.

## Validation

- `swift build`
- `swift test --filter CodexAppServerProcessTransportTests` — 8 tests passed
- SwiftFormat and SwiftLint on changed Swift files
- `git diff --check`

Two full-suite runs reached all 1,111 tests but each exposed a different unrelated timing-sensitive `CaptionViewModel` test; both failures passed when rerun individually. The changed transport suite passed in both full-suite runs.
