### PR TITLE
Improve automatic screenshot capture performance

### DIFF
--- a/Sources/Dahlia/Database/MeetingScreenshotRecord.swift
+++ b/Sources/Dahlia/Database/MeetingScreenshotRecord.swift
@@ -2,7 +2,7 @@ import Foundation
 import GRDB
 
 /// スクリーンショットを表す GRDB レコード。
-struct MeetingScreenshotRecord: Codable, FetchableRecord, PersistableRecord {
+struct MeetingScreenshotRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     static let databaseTableName = "screenshots"
 
     var id: UUID

--- a/Sources/Dahlia/Models/ScreenshotCaptureSource.swift
+++ b/Sources/Dahlia/Models/ScreenshotCaptureSource.swift
@@ -1,6 +1,6 @@
 import CoreGraphics
 
-enum ScreenshotCaptureSource: Hashable {
+enum ScreenshotCaptureSource: Hashable, Sendable {
     case none
     case entireDesktop
     case window(CGWindowID)

--- a/Sources/Dahlia/Models/ScreenshotStore.swift
+++ b/Sources/Dahlia/Models/ScreenshotStore.swift
@@ -6,19 +6,24 @@ import Foundation
 final class ScreenshotStore: ObservableObject {
     @Published private(set) var records: [MeetingScreenshotRecord] = []
     private(set) var meetingID: UUID?
+    private(set) var contentRevision: UInt64 = 0
 
     func replace(meetingID: UUID, records: [MeetingScreenshotRecord]) {
         self.meetingID = meetingID
+        contentRevision &+= 1
         self.records = records
     }
 
     func clear() {
+        guard meetingID != nil || !records.isEmpty else { return }
         meetingID = nil
+        contentRevision &+= 1
         records.removeAll()
     }
 
     func upsert(_ record: MeetingScreenshotRecord) {
         guard meetingID == record.meetingId else { return }
+        contentRevision &+= 1
         if let index = records.firstIndex(where: { $0.id == record.id }) {
             records[index] = record
             return
@@ -28,7 +33,9 @@ final class ScreenshotStore: ObservableObject {
     }
 
     func remove(ids: Set<UUID>, meetingID: UUID) {
-        guard self.meetingID == meetingID else { return }
+        guard self.meetingID == meetingID,
+              records.contains(where: { ids.contains($0.id) }) else { return }
+        contentRevision &+= 1
         records.removeAll { ids.contains($0.id) }
     }
 }

--- a/Sources/Dahlia/Models/ScreenshotStore.swift
+++ b/Sources/Dahlia/Models/ScreenshotStore.swift
@@ -1,0 +1,34 @@
+import Combine
+import Foundation
+
+/// SQLite のスクリーンショット正本を、現在表示中の meeting に限定して公開する UI projection。
+@MainActor
+final class ScreenshotStore: ObservableObject {
+    @Published private(set) var records: [MeetingScreenshotRecord] = []
+    private(set) var meetingID: UUID?
+
+    func replace(meetingID: UUID, records: [MeetingScreenshotRecord]) {
+        self.meetingID = meetingID
+        self.records = records
+    }
+
+    func clear() {
+        meetingID = nil
+        records.removeAll()
+    }
+
+    func upsert(_ record: MeetingScreenshotRecord) {
+        guard meetingID == record.meetingId else { return }
+        if let index = records.firstIndex(where: { $0.id == record.id }) {
+            records[index] = record
+            return
+        }
+        let insertIndex = records.firstIndex { $0.capturedAt > record.capturedAt } ?? records.endIndex
+        records.insert(record, at: insertIndex)
+    }
+
+    func remove(ids: Set<UUID>, meetingID: UUID) {
+        guard self.meetingID == meetingID else { return }
+        records.removeAll { ids.contains($0.id) }
+    }
+}

--- a/Sources/Dahlia/Services/AutomaticScreenshotCaptureService.swift
+++ b/Sources/Dahlia/Services/AutomaticScreenshotCaptureService.swift
@@ -1,0 +1,784 @@
+@preconcurrency import CoreMedia
+import CoreVideo
+import DahliaRuntimeSupport
+import Foundation
+import GRDB
+import os
+@preconcurrency import ScreenCaptureKit
+
+enum ScreenshotError: LocalizedError {
+    case encodingFailed
+    case displayUnavailable
+    case imageUnavailable
+    case sourceUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .encodingFailed:
+            L10n.screenshotEncodingFailed
+        case .displayUnavailable:
+            L10n.screenshotDisplayUnavailable
+        case .imageUnavailable:
+            L10n.screenshotImageUnavailable
+        case .sourceUnavailable:
+            L10n.screenshotSourceUnavailable
+        }
+    }
+}
+
+struct AutomaticScreenshotCaptureRequest: Sendable {
+    let source: ScreenshotCaptureSource
+    var intervalSeconds: Int
+    var changeThresholdRatio: Double
+    let meetingID: UUID
+    let sessionID: UUID?
+    let dbQueue: DatabaseQueue
+    let onPersisted: @MainActor @Sendable (MeetingScreenshotRecord) -> Void
+    let onFailure: @MainActor @Sendable (Error) -> Void
+}
+
+protocol AutomaticScreenshotCapturing: Sendable {
+    func start(_ request: AutomaticScreenshotCaptureRequest) async
+    func updateSettings(intervalSeconds: Int, changeThresholdRatio: Double) async
+    func updateSavedFingerprint(_ fingerprint: ScreenshotFingerprint?) async
+    func stop() async
+}
+
+/// Serializes ordinary setting changes while allowing stop to invalidate and bypass
+/// a slow ScreenCaptureKit start operation.
+@MainActor
+final class AutomaticScreenshotCaptureControl {
+    private let capture: any AutomaticScreenshotCapturing
+    private var tailTask: Task<Void, Never>?
+    private var stopGeneration: UInt64 = 0
+
+    init(capture: any AutomaticScreenshotCapturing) {
+        self.capture = capture
+    }
+
+    @discardableResult
+    func enqueue(
+        _ operation: @escaping @Sendable (any AutomaticScreenshotCapturing) async -> Void
+    ) -> Task<Void, Never> {
+        let operationGeneration = stopGeneration
+        let previousTask = tailTask
+        let capture = capture
+        let task = Task { [weak self] in
+            await previousTask?.value
+            guard !Task.isCancelled,
+                  let self,
+                  self.stopGeneration == operationGeneration else { return }
+            await operation(capture)
+        }
+        tailTask = task
+        return task
+    }
+
+    @discardableResult
+    func stop() -> Task<Void, Never> {
+        stopGeneration &+= 1
+        tailTask?.cancel()
+        let capture = capture
+        let task = Task {
+            await capture.stop()
+        }
+        tailTask = task
+        return task
+    }
+}
+
+struct AutomaticScreenshotCaptureAttempt: Equatable, Sendable {
+    let generation: UInt64
+    let id: UInt64
+}
+
+struct AutomaticScreenshotCaptureLifecycle {
+    private(set) var generation: UInt64 = 0
+    private(set) var isActive = false
+    private(set) var activeAttempt: AutomaticScreenshotCaptureAttempt?
+    private var nextAttemptID: UInt64 = 0
+    private var isCompletionInProgress = false
+
+    mutating func begin() -> UInt64? {
+        guard !isActive, activeAttempt == nil else { return nil }
+        generation &+= 1
+        isActive = true
+        isCompletionInProgress = false
+        return generation
+    }
+
+    mutating func beginReplacement() -> UInt64 {
+        generation &+= 1
+        isActive = true
+        activeAttempt = nil
+        isCompletionInProgress = false
+        return generation
+    }
+
+    mutating func stop() {
+        generation &+= 1
+        isActive = false
+        activeAttempt = nil
+        isCompletionInProgress = false
+    }
+
+    func accepts(generation: UInt64) -> Bool {
+        isActive && self.generation == generation
+    }
+
+    mutating func beginAttempt(generation: UInt64) -> AutomaticScreenshotCaptureAttempt? {
+        guard accepts(generation: generation), activeAttempt == nil else { return nil }
+        nextAttemptID &+= 1
+        let attempt = AutomaticScreenshotCaptureAttempt(generation: generation, id: nextAttemptID)
+        activeAttempt = attempt
+        isCompletionInProgress = false
+        return attempt
+    }
+
+    func accepts(attempt: AutomaticScreenshotCaptureAttempt) -> Bool {
+        accepts(generation: attempt.generation)
+            && activeAttempt == attempt
+            && !isCompletionInProgress
+    }
+
+    mutating func claimCompletion(attempt: AutomaticScreenshotCaptureAttempt) -> Bool {
+        guard accepts(attempt: attempt) else { return false }
+        isCompletionInProgress = true
+        return true
+    }
+
+    mutating func finishAttempt(_ attempt: AutomaticScreenshotCaptureAttempt) {
+        guard activeAttempt == attempt else { return }
+        activeAttempt = nil
+        isCompletionInProgress = false
+    }
+}
+
+struct CopiedScreenshotFrame: Sendable {
+    let width: Int
+    let height: Int
+    let bytesPerRow: Int
+    let pixels: Data
+    let capturedAt: Date
+
+    func makeImage() -> CGImage? {
+        guard let provider = CGDataProvider(data: pixels as CFData),
+              let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) else { return nil }
+        return CGImage(
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: CGBitmapInfo.byteOrder32Little.union(
+                CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedFirst.rawValue)
+            ),
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: true,
+            intent: .defaultIntent
+        )
+    }
+}
+
+struct AutomaticScreenshotFrameMailbox: Sendable {
+    let stream: AsyncStream<CopiedScreenshotFrame>
+    private let continuation: AsyncStream<CopiedScreenshotFrame>.Continuation
+
+    init() {
+        let pair = AsyncStream.makeStream(
+            of: CopiedScreenshotFrame.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        stream = pair.stream
+        continuation = pair.continuation
+    }
+
+    func yield(_ frame: CopiedScreenshotFrame) {
+        continuation.yield(frame)
+    }
+
+    func finish() {
+        continuation.finish()
+    }
+}
+
+struct AutomaticScreenshotProcessingState {
+    struct Operation {
+        let id: UInt64
+        let attempt: AutomaticScreenshotCaptureAttempt
+        let task: Task<Void, Never>
+    }
+
+    struct PendingFrame {
+        let attempt: AutomaticScreenshotCaptureAttempt
+        let frame: CopiedScreenshotFrame
+    }
+
+    private(set) var operation: Operation?
+    private(set) var pendingFrame: PendingFrame?
+    private var nextOperationID: UInt64 = 0
+
+    var isProcessing: Bool {
+        operation != nil
+    }
+
+    mutating func begin(
+        attempt: AutomaticScreenshotCaptureAttempt,
+        task: (UInt64) -> Task<Void, Never>
+    ) {
+        precondition(operation == nil)
+        nextOperationID &+= 1
+        let operationID = nextOperationID
+        operation = Operation(
+            id: operationID,
+            attempt: attempt,
+            task: task(operationID)
+        )
+    }
+
+    mutating func queueLatest(
+        _ frame: CopiedScreenshotFrame,
+        attempt: AutomaticScreenshotCaptureAttempt
+    ) -> Bool {
+        guard operation?.attempt == attempt else { return false }
+        pendingFrame = PendingFrame(attempt: attempt, frame: frame)
+        return true
+    }
+
+    mutating func complete(
+        operationID: UInt64,
+        attempt: AutomaticScreenshotCaptureAttempt
+    ) -> PendingFrame? {
+        guard let operation,
+              operation.id == operationID,
+              operation.attempt == attempt else { return nil }
+        self.operation = nil
+        defer { pendingFrame = nil }
+        guard pendingFrame?.attempt == attempt else { return nil }
+        return pendingFrame
+    }
+
+    mutating func take(
+        matching attempt: AutomaticScreenshotCaptureAttempt? = nil
+    ) -> Operation? {
+        if attempt == nil || pendingFrame?.attempt == attempt {
+            pendingFrame = nil
+        }
+        guard let operation,
+              attempt == nil || operation.attempt == attempt else { return nil }
+        self.operation = nil
+        return operation
+    }
+}
+
+private enum ScreenshotCaptureMetrics {
+    static let signposter = OSSignposter(subsystem: "com.dahlia", category: "AutomaticScreenshot")
+
+    static func recordSlowStage(
+        _ stage: ErrorReportingService.AutomaticScreenshotStage,
+        startedAt: ContinuousClock.Instant
+    ) {
+        let components = startedAt.duration(to: .now).components
+        let milliseconds = Int(clamping: components.seconds * 1000)
+            + Int(clamping: components.attoseconds / 1_000_000_000_000_000)
+        ErrorReportingService.recordSlowAutomaticScreenshotStage(
+            stage,
+            durationMilliseconds: milliseconds
+        )
+    }
+}
+
+private struct EncodedScreenshotFrame: Sendable {
+    let data: Data
+    let mimeType: String
+}
+
+private actor AutomaticScreenshotFrameProcessor {
+    func fingerprint(for frame: CopiedScreenshotFrame) -> ScreenshotFingerprint? {
+        guard !Task.isCancelled, let image = frame.makeImage() else { return nil }
+        let startedAt = ContinuousClock.now
+        let state = ScreenshotCaptureMetrics.signposter.beginInterval("Fingerprint")
+        let fingerprint = ScreenshotChangeDetector.fingerprint(for: image)
+        ScreenshotCaptureMetrics.signposter.endInterval("Fingerprint", state)
+        ScreenshotCaptureMetrics.recordSlowStage(.fingerprint, startedAt: startedAt)
+        return Task.isCancelled ? nil : fingerprint
+    }
+
+    func encode(_ frame: CopiedScreenshotFrame) -> EncodedScreenshotFrame? {
+        guard !Task.isCancelled, let image = frame.makeImage() else { return nil }
+        let startedAt = ContinuousClock.now
+        let state = ScreenshotCaptureMetrics.signposter.beginInterval("Encode")
+        let data = ImageEncoder.encode(image, quality: 0.70)
+        let mimeType = data.flatMap { ImageEncoder.mimeType(for: $0) }
+        ScreenshotCaptureMetrics.signposter.endInterval("Encode", state)
+        ScreenshotCaptureMetrics.recordSlowStage(.encoding, startedAt: startedAt)
+        guard !Task.isCancelled, let data, let mimeType else { return nil }
+        return EncodedScreenshotFrame(data: data, mimeType: mimeType)
+    }
+}
+
+/// Owns the periodic ScreenCaptureKit stream and keeps image-sized work off MainActor.
+actor AutomaticScreenshotCaptureService: AutomaticScreenshotCapturing {
+    private struct ActiveCapture {
+        let attempt: AutomaticScreenshotCaptureAttempt
+        let stream: SCStream
+        let adapter: AutomaticScreenshotStreamAdapter
+        let configuration: SCStreamConfiguration
+        let frameConsumerTask: Task<Void, Never>
+    }
+
+    private var lifecycle = AutomaticScreenshotCaptureLifecycle()
+    private let frameProcessor = AutomaticScreenshotFrameProcessor()
+    private let frameQueue = AutomaticScreenshotFrameQueue()
+    private var desiredRequest: AutomaticScreenshotCaptureRequest?
+    private var activeCapture: ActiveCapture?
+    private var processingState = AutomaticScreenshotProcessingState()
+    private var lastSavedFingerprint: ScreenshotFingerprint?
+    private var retryTask: Task<Void, Never>?
+
+    func start(_ request: AutomaticScreenshotCaptureRequest) async {
+        desiredRequest = Self.normalized(request)
+        retryTask?.cancel()
+        retryTask = nil
+        let generation = lifecycle.beginReplacement()
+        await stopCaptureAndProcessing()
+        guard lifecycle.accepts(generation: generation) else { return }
+        lastSavedFingerprint = nil
+        await startStream(generation: generation)
+    }
+
+    func updateSettings(intervalSeconds: Int, changeThresholdRatio: Double) async {
+        guard var request = desiredRequest else { return }
+        request.intervalSeconds = intervalSeconds
+        request.changeThresholdRatio = changeThresholdRatio
+        request = Self.normalized(request)
+        desiredRequest = request
+
+        guard let activeCapture,
+              lifecycle.accepts(attempt: activeCapture.attempt) else { return }
+        activeCapture.configuration.minimumFrameInterval = Self.frameInterval(
+            seconds: request.intervalSeconds
+        )
+        do {
+            try await activeCapture.stream.updateConfiguration(activeCapture.configuration)
+        } catch {
+            await handleRuntimeFailure(error, attempt: activeCapture.attempt)
+        }
+    }
+
+    func updateSavedFingerprint(_ fingerprint: ScreenshotFingerprint?) {
+        lastSavedFingerprint = fingerprint
+    }
+
+    func stop() async {
+        desiredRequest = nil
+        retryTask?.cancel()
+        retryTask = nil
+        lifecycle.stop()
+        await stopCaptureAndProcessing()
+    }
+
+    private func stopCaptureAndProcessing() async {
+        let processingOperation = processingState.take()
+        processingOperation?.task.cancel()
+        await stopActiveCapture()
+        await processingOperation?.task.value
+    }
+
+    private func startStream(generation: UInt64) async {
+        guard let request = desiredRequest,
+              let attempt = lifecycle.beginAttempt(generation: generation) else { return }
+
+        do {
+            let content = try await SCShareableContent.excludingDesktopWindows(
+                false,
+                onScreenWindowsOnly: false
+            )
+            guard lifecycle.accepts(attempt: attempt) else { return }
+            let filter = try Self.contentFilter(source: request.source, content: content)
+            let configuration = Self.streamConfiguration(
+                filter: filter,
+                intervalSeconds: request.intervalSeconds
+            )
+            let frameMailbox = AutomaticScreenshotFrameMailbox()
+            let adapter = AutomaticScreenshotStreamAdapter(
+                attempt: attempt,
+                frameMailbox: frameMailbox,
+                onStopped: { [weak self] attempt, error in
+                    Task {
+                        await self?.handleRuntimeFailure(error, attempt: attempt)
+                    }
+                }
+            )
+            let stream = SCStream(filter: filter, configuration: configuration, delegate: adapter)
+            try stream.addStreamOutput(
+                adapter,
+                type: .screen,
+                sampleHandlerQueue: frameQueue.sampleHandlerQueue
+            )
+            guard lifecycle.accepts(attempt: attempt) else {
+                adapter.deactivate()
+                return
+            }
+            let frameConsumerTask = Task(priority: .utility) { [weak self] in
+                for await frame in frameMailbox.stream {
+                    guard !Task.isCancelled else { break }
+                    await self?.receive(frame, attempt: attempt)
+                }
+            }
+            activeCapture = ActiveCapture(
+                attempt: attempt,
+                stream: stream,
+                adapter: adapter,
+                configuration: configuration,
+                frameConsumerTask: frameConsumerTask
+            )
+            try await stream.startCapture()
+        } catch {
+            await handleRuntimeFailure(error, attempt: attempt)
+        }
+    }
+
+    private func stopActiveCapture() async {
+        guard let activeCapture else { return }
+        self.activeCapture = nil
+        lifecycle.finishAttempt(activeCapture.attempt)
+        await stopCaptureResources(activeCapture)
+    }
+
+    private func stopCaptureResources(_ capture: ActiveCapture) async {
+        capture.adapter.deactivate()
+        capture.frameConsumerTask.cancel()
+        try? await capture.stream.stopCapture()
+        await frameQueue.drain()
+        await capture.frameConsumerTask.value
+    }
+
+    private func takeActiveCapture(matching attempt: AutomaticScreenshotCaptureAttempt) -> ActiveCapture? {
+        guard let activeCapture, activeCapture.attempt == attempt else { return nil }
+        self.activeCapture = nil
+        activeCapture.adapter.deactivate()
+        activeCapture.frameConsumerTask.cancel()
+        return activeCapture
+    }
+
+    private func handleRuntimeFailure(
+        _ error: Error,
+        attempt: AutomaticScreenshotCaptureAttempt
+    ) async {
+        guard let request = desiredRequest,
+              lifecycle.claimCompletion(attempt: attempt) else { return }
+        let capture = takeActiveCapture(matching: attempt)
+        let processingOperation = processingState.take(matching: attempt)
+        processingOperation?.task.cancel()
+        if let capture {
+            await stopCaptureResources(capture)
+        }
+        await processingOperation?.task.value
+        lifecycle.finishAttempt(attempt)
+        guard lifecycle.accepts(generation: attempt.generation),
+              desiredRequest != nil else { return }
+        await request.onFailure(error)
+        guard lifecycle.accepts(generation: attempt.generation),
+              desiredRequest != nil else { return }
+        ErrorReportingService.recordAutomaticScreenshotStreamRestart()
+        scheduleRetry(
+            generation: attempt.generation,
+            intervalSeconds: request.intervalSeconds
+        )
+    }
+
+    private func scheduleRetry(generation: UInt64, intervalSeconds: Int) {
+        retryTask?.cancel()
+        retryTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: .seconds(max(1, intervalSeconds)))
+            } catch {
+                return
+            }
+            guard let self else { return }
+            await self.retry(generation: generation)
+        }
+    }
+
+    private func retry(generation: UInt64) async {
+        guard lifecycle.accepts(generation: generation),
+              lifecycle.activeAttempt == nil,
+              desiredRequest != nil else { return }
+        retryTask = nil
+        await startStream(generation: generation)
+    }
+
+    private func receive(
+        _ frame: CopiedScreenshotFrame,
+        attempt: AutomaticScreenshotCaptureAttempt
+    ) {
+        guard lifecycle.accepts(attempt: attempt) else { return }
+        if processingState.isProcessing {
+            _ = processingState.queueLatest(frame, attempt: attempt)
+            return
+        }
+        startProcessing(frame, attempt: attempt)
+    }
+
+    private func startProcessing(
+        _ frame: CopiedScreenshotFrame,
+        attempt: AutomaticScreenshotCaptureAttempt
+    ) {
+        processingState.begin(attempt: attempt) { [weak self] operationID in
+            Task(priority: .utility) {
+                await self?.process(frame, attempt: attempt)
+                await self?.finishProcessing(operationID: operationID, attempt: attempt)
+            }
+        }
+    }
+
+    private func process(
+        _ frame: CopiedScreenshotFrame,
+        attempt: AutomaticScreenshotCaptureAttempt
+    ) async {
+        guard lifecycle.accepts(attempt: attempt),
+              let request = desiredRequest else { return }
+        let fingerprint = await frameProcessor.fingerprint(for: frame)
+        guard let fingerprint,
+              !Task.isCancelled,
+              lifecycle.accepts(attempt: attempt) else { return }
+
+        guard shouldSave(fingerprint, changeThresholdRatio: request.changeThresholdRatio) else { return }
+
+        guard let encoded = await frameProcessor.encode(frame) else {
+            guard !Task.isCancelled,
+                  lifecycle.accepts(attempt: attempt) else { return }
+            await request.onFailure(ScreenshotError.encodingFailed)
+            return
+        }
+        guard !Task.isCancelled,
+              lifecycle.accepts(attempt: attempt) else { return }
+        guard shouldSave(fingerprint, changeThresholdRatio: request.changeThresholdRatio) else { return }
+
+        let record = Self.makeRecord(
+            frame: frame,
+            meetingID: request.meetingID,
+            sessionID: request.sessionID,
+            encodedData: encoded.data,
+            mimeType: encoded.mimeType
+        )
+        let persistenceStartedAt = ContinuousClock.now
+        let persistenceState = ScreenshotCaptureMetrics.signposter.beginInterval("Persist")
+        do {
+            try await request.dbQueue.write { db in
+                try record.insert(db)
+            }
+        } catch {
+            ScreenshotCaptureMetrics.signposter.endInterval("Persist", persistenceState)
+            ScreenshotCaptureMetrics.recordSlowStage(.persistence, startedAt: persistenceStartedAt)
+            guard !Task.isCancelled,
+                  lifecycle.accepts(attempt: attempt) else { return }
+            await request.onFailure(error)
+            return
+        }
+        ScreenshotCaptureMetrics.signposter.endInterval("Persist", persistenceState)
+        ScreenshotCaptureMetrics.recordSlowStage(.persistence, startedAt: persistenceStartedAt)
+
+        guard !Task.isCancelled,
+              lifecycle.accepts(attempt: attempt) else { return }
+        lastSavedFingerprint = fingerprint
+        await request.onPersisted(record)
+    }
+
+    private func finishProcessing(
+        operationID: UInt64,
+        attempt: AutomaticScreenshotCaptureAttempt
+    ) {
+        guard let pendingFrame = processingState.complete(
+            operationID: operationID,
+            attempt: attempt
+        ) else { return }
+        guard lifecycle.accepts(attempt: attempt) else { return }
+        startProcessing(pendingFrame.frame, attempt: attempt)
+    }
+
+    private func shouldSave(
+        _ fingerprint: ScreenshotFingerprint,
+        changeThresholdRatio: Double
+    ) -> Bool {
+        guard let lastSavedFingerprint else { return true }
+        return ScreenshotChangeDetector.isSignificantlyDifferent(
+            lastSavedFingerprint,
+            fingerprint,
+            changedPixelRatioThreshold: changeThresholdRatio
+        )
+    }
+}
+
+extension AutomaticScreenshotCaptureService {
+    private static func normalized(_ request: AutomaticScreenshotCaptureRequest) -> AutomaticScreenshotCaptureRequest {
+        var request = request
+        request.intervalSeconds = max(1, request.intervalSeconds)
+        if !request.changeThresholdRatio.isFinite {
+            request.changeThresholdRatio = 0.20
+        } else {
+            request.changeThresholdRatio = min(max(request.changeThresholdRatio, 0.01), 1)
+        }
+        return request
+    }
+
+    static func makeRecord(
+        frame: CopiedScreenshotFrame,
+        meetingID: UUID,
+        sessionID: UUID?,
+        encodedData: Data,
+        mimeType: String
+    ) -> MeetingScreenshotRecord {
+        MeetingScreenshotRecord(
+            id: UUID.v7(),
+            meetingId: meetingID,
+            sessionId: sessionID,
+            capturedAt: frame.capturedAt,
+            imageData: encodedData,
+            mimeType: mimeType
+        )
+    }
+
+    private static func contentFilter(
+        source: ScreenshotCaptureSource,
+        content: SCShareableContent
+    ) throws -> SCContentFilter {
+        switch source {
+        case .none:
+            throw ScreenshotError.sourceUnavailable
+        case .entireDesktop:
+            guard let display = content.displays.first else {
+                throw ScreenshotError.displayUnavailable
+            }
+            return SCContentFilter(display: display, excludingWindows: [])
+        case let .window(windowID):
+            guard let window = content.windows.first(where: { $0.windowID == windowID }) else {
+                throw ScreenshotError.sourceUnavailable
+            }
+            return SCContentFilter(desktopIndependentWindow: window)
+        }
+    }
+
+    private static func streamConfiguration(
+        filter: SCContentFilter,
+        intervalSeconds: Int
+    ) -> SCStreamConfiguration {
+        let configuration = SCStreamConfiguration()
+        configuration.width = max(1, Int((filter.contentRect.width * Double(filter.pointPixelScale)).rounded()))
+        configuration.height = max(1, Int((filter.contentRect.height * Double(filter.pointPixelScale)).rounded()))
+        configuration.minimumFrameInterval = frameInterval(seconds: intervalSeconds)
+        configuration.queueDepth = 3
+        configuration.pixelFormat = kCVPixelFormatType_32BGRA
+        configuration.captureResolution = .best
+        configuration.scalesToFit = true
+        configuration.preservesAspectRatio = true
+        configuration.showsCursor = false
+        configuration.capturesAudio = false
+        return configuration
+    }
+
+    private static func frameInterval(seconds: Int) -> CMTime {
+        CMTime(seconds: Double(max(1, seconds)), preferredTimescale: 600)
+    }
+}
+
+private struct AutomaticScreenshotFrameQueue: Sendable {
+    let sampleHandlerQueue = DispatchQueue(
+        label: "com.dahlia.automatic-screenshot",
+        qos: .utility
+    )
+
+    func drain() async {
+        await withCheckedContinuation { continuation in
+            sampleHandlerQueue.async {
+                continuation.resume()
+            }
+        }
+    }
+}
+
+/// ScreenCaptureKit invokes this adapter only on its serial frame queue.
+private final class AutomaticScreenshotStreamAdapter: NSObject, SCStreamOutput, SCStreamDelegate, @unchecked Sendable {
+    typealias StopHandler = @Sendable (AutomaticScreenshotCaptureAttempt, Error) -> Void
+
+    private let attempt: AutomaticScreenshotCaptureAttempt
+    private let frameMailbox: AutomaticScreenshotFrameMailbox
+    private let onStopped: StopHandler
+    private let isAcceptingFrames = OSAllocatedUnfairLock(initialState: true)
+
+    init(
+        attempt: AutomaticScreenshotCaptureAttempt,
+        frameMailbox: AutomaticScreenshotFrameMailbox,
+        onStopped: @escaping StopHandler
+    ) {
+        self.attempt = attempt
+        self.frameMailbox = frameMailbox
+        self.onStopped = onStopped
+    }
+
+    func deactivate() {
+        let shouldFinish = isAcceptingFrames.withLock { isAccepting in
+            defer { isAccepting = false }
+            return isAccepting
+        }
+        if shouldFinish {
+            frameMailbox.finish()
+        }
+    }
+
+    func stream(
+        _: SCStream,
+        didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
+        of type: SCStreamOutputType
+    ) {
+        guard type == .screen,
+              isAcceptingFrames.withLock({ $0 }),
+              Self.isCompleteFrame(sampleBuffer) else { return }
+        let capturedAt = Date.now
+        let copyState = ScreenshotCaptureMetrics.signposter.beginInterval("Copy frame")
+        let frame = Self.copyFrame(sampleBuffer, capturedAt: capturedAt)
+        ScreenshotCaptureMetrics.signposter.endInterval("Copy frame", copyState)
+        guard let frame else { return }
+        frameMailbox.yield(frame)
+    }
+
+    func stream(_: SCStream, didStopWithError error: Error) {
+        deactivate()
+        onStopped(attempt, error)
+    }
+
+    private static func isCompleteFrame(_ sampleBuffer: CMSampleBuffer) -> Bool {
+        guard let attachments = CMSampleBufferGetSampleAttachmentsArray(
+            sampleBuffer,
+            createIfNecessary: false
+        ) as? [[SCStreamFrameInfo: Any]],
+            let statusRawValue = attachments.first?[.status] as? Int,
+            let status = SCFrameStatus(rawValue: statusRawValue) else { return false }
+        return status == .complete || status == .started
+    }
+
+    private static func copyFrame(
+        _ sampleBuffer: CMSampleBuffer,
+        capturedAt: Date
+    ) -> CopiedScreenshotFrame? {
+        guard let pixelBuffer = sampleBuffer.imageBuffer,
+              CVPixelBufferGetPixelFormatType(pixelBuffer) == kCVPixelFormatType_32BGRA else { return nil }
+        CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly) }
+        guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else { return nil }
+
+        let width = CVPixelBufferGetWidth(pixelBuffer)
+        let height = CVPixelBufferGetHeight(pixelBuffer)
+        let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
+        return CopiedScreenshotFrame(
+            width: width,
+            height: height,
+            bytesPerRow: bytesPerRow,
+            pixels: Data(bytes: baseAddress, count: bytesPerRow * height),
+            capturedAt: capturedAt
+        )
+    }
+}

--- a/Sources/Dahlia/Services/AutomaticScreenshotCaptureService.swift
+++ b/Sources/Dahlia/Services/AutomaticScreenshotCaptureService.swift
@@ -40,7 +40,11 @@ struct AutomaticScreenshotCaptureRequest: Sendable {
 protocol AutomaticScreenshotCapturing: Sendable {
     func start(_ request: AutomaticScreenshotCaptureRequest) async
     func updateSettings(intervalSeconds: Int, changeThresholdRatio: Double) async
-    func updateSavedFingerprint(_ fingerprint: ScreenshotFingerprint?) async
+    func fingerprintUpdateAttempt() async -> AutomaticScreenshotCaptureAttempt?
+    func updateSavedFingerprint(
+        _ fingerprint: ScreenshotFingerprint?,
+        for attempt: AutomaticScreenshotCaptureAttempt
+    ) async
     func stop() async
 }
 
@@ -85,11 +89,20 @@ final class AutomaticScreenshotCaptureControl {
         tailTask = task
         return task
     }
+
+    func fingerprintUpdateAttempt() async -> AutomaticScreenshotCaptureAttempt? {
+        await capture.fingerprintUpdateAttempt()
+    }
 }
 
 struct AutomaticScreenshotCaptureAttempt: Equatable, Sendable {
     let generation: UInt64
     let id: UInt64
+}
+
+struct AutomaticScreenshotPixelDimensions: Equatable, Sendable {
+    let width: Int
+    let height: Int
 }
 
 struct AutomaticScreenshotCaptureLifecycle {
@@ -160,6 +173,7 @@ struct CopiedScreenshotFrame: Sendable {
     let bytesPerRow: Int
     let pixels: Data
     let capturedAt: Date
+    var sourcePixelDimensions: AutomaticScreenshotPixelDimensions?
 
     func makeImage() -> CGImage? {
         guard let provider = CGDataProvider(data: pixels as CFData),
@@ -295,19 +309,25 @@ private struct EncodedScreenshotFrame: Sendable {
     let mimeType: String
 }
 
+private struct FingerprintedScreenshotFrame: Sendable {
+    let image: CGImage
+    let fingerprint: ScreenshotFingerprint
+}
+
 private actor AutomaticScreenshotFrameProcessor {
-    func fingerprint(for frame: CopiedScreenshotFrame) -> ScreenshotFingerprint? {
+    func fingerprint(for frame: CopiedScreenshotFrame) -> FingerprintedScreenshotFrame? {
         guard !Task.isCancelled, let image = frame.makeImage() else { return nil }
         let startedAt = ContinuousClock.now
         let state = ScreenshotCaptureMetrics.signposter.beginInterval("Fingerprint")
         let fingerprint = ScreenshotChangeDetector.fingerprint(for: image)
         ScreenshotCaptureMetrics.signposter.endInterval("Fingerprint", state)
         ScreenshotCaptureMetrics.recordSlowStage(.fingerprint, startedAt: startedAt)
-        return Task.isCancelled ? nil : fingerprint
+        guard !Task.isCancelled, let fingerprint else { return nil }
+        return FingerprintedScreenshotFrame(image: image, fingerprint: fingerprint)
     }
 
-    func encode(_ frame: CopiedScreenshotFrame) -> EncodedScreenshotFrame? {
-        guard !Task.isCancelled, let image = frame.makeImage() else { return nil }
+    func encode(_ image: CGImage) -> EncodedScreenshotFrame? {
+        guard !Task.isCancelled else { return nil }
         let startedAt = ContinuousClock.now
         let state = ScreenshotCaptureMetrics.signposter.beginInterval("Encode")
         let data = ImageEncoder.encode(image, quality: 0.70)
@@ -368,7 +388,17 @@ actor AutomaticScreenshotCaptureService: AutomaticScreenshotCapturing {
         }
     }
 
-    func updateSavedFingerprint(_ fingerprint: ScreenshotFingerprint?) {
+    func fingerprintUpdateAttempt() -> AutomaticScreenshotCaptureAttempt? {
+        guard let attempt = activeCapture?.attempt,
+              lifecycle.accepts(attempt: attempt) else { return nil }
+        return attempt
+    }
+
+    func updateSavedFingerprint(
+        _ fingerprint: ScreenshotFingerprint?,
+        for attempt: AutomaticScreenshotCaptureAttempt
+    ) {
+        guard lifecycle.accepts(attempt: attempt) else { return }
         lastSavedFingerprint = fingerprint
     }
 
@@ -514,8 +544,11 @@ actor AutomaticScreenshotCaptureService: AutomaticScreenshotCapturing {
     private func receive(
         _ frame: CopiedScreenshotFrame,
         attempt: AutomaticScreenshotCaptureAttempt
-    ) {
+    ) async {
         guard lifecycle.accepts(attempt: attempt) else { return }
+        if await updateStreamDimensionsIfNeeded(for: frame, attempt: attempt) {
+            return
+        }
         if processingState.isProcessing {
             _ = processingState.queueLatest(frame, attempt: attempt)
             return
@@ -541,14 +574,17 @@ actor AutomaticScreenshotCaptureService: AutomaticScreenshotCapturing {
     ) async {
         guard lifecycle.accepts(attempt: attempt),
               let request = desiredRequest else { return }
-        let fingerprint = await frameProcessor.fingerprint(for: frame)
-        guard let fingerprint,
+        let fingerprintedFrame = await frameProcessor.fingerprint(for: frame)
+        guard let fingerprintedFrame,
               !Task.isCancelled,
               lifecycle.accepts(attempt: attempt) else { return }
 
-        guard shouldSave(fingerprint, changeThresholdRatio: request.changeThresholdRatio) else { return }
+        guard shouldSave(
+            fingerprintedFrame.fingerprint,
+            changeThresholdRatio: request.changeThresholdRatio
+        ) else { return }
 
-        guard let encoded = await frameProcessor.encode(frame) else {
+        guard let encoded = await frameProcessor.encode(fingerprintedFrame.image) else {
             guard !Task.isCancelled,
                   lifecycle.accepts(attempt: attempt) else { return }
             await request.onFailure(ScreenshotError.encodingFailed)
@@ -556,7 +592,10 @@ actor AutomaticScreenshotCaptureService: AutomaticScreenshotCapturing {
         }
         guard !Task.isCancelled,
               lifecycle.accepts(attempt: attempt) else { return }
-        guard shouldSave(fingerprint, changeThresholdRatio: request.changeThresholdRatio) else { return }
+        guard shouldSave(
+            fingerprintedFrame.fingerprint,
+            changeThresholdRatio: request.changeThresholdRatio
+        ) else { return }
 
         let record = Self.makeRecord(
             frame: frame,
@@ -584,7 +623,7 @@ actor AutomaticScreenshotCaptureService: AutomaticScreenshotCapturing {
 
         guard !Task.isCancelled,
               lifecycle.accepts(attempt: attempt) else { return }
-        lastSavedFingerprint = fingerprint
+        lastSavedFingerprint = fingerprintedFrame.fingerprint
         await request.onPersisted(record)
     }
 
@@ -614,6 +653,27 @@ actor AutomaticScreenshotCaptureService: AutomaticScreenshotCapturing {
 }
 
 extension AutomaticScreenshotCaptureService {
+    private func updateStreamDimensionsIfNeeded(
+        for frame: CopiedScreenshotFrame,
+        attempt: AutomaticScreenshotCaptureAttempt
+    ) async -> Bool {
+        guard let dimensions = frame.sourcePixelDimensions,
+              let activeCapture,
+              activeCapture.attempt == attempt,
+              activeCapture.configuration.width != dimensions.width
+              || activeCapture.configuration.height != dimensions.height
+        else { return false }
+
+        activeCapture.configuration.width = dimensions.width
+        activeCapture.configuration.height = dimensions.height
+        do {
+            try await activeCapture.stream.updateConfiguration(activeCapture.configuration)
+        } catch {
+            await handleRuntimeFailure(error, attempt: attempt)
+        }
+        return true
+    }
+
     private static func normalized(_ request: AutomaticScreenshotCaptureRequest) -> AutomaticScreenshotCaptureRequest {
         var request = request
         request.intervalSeconds = max(1, request.intervalSeconds)
@@ -682,6 +742,25 @@ extension AutomaticScreenshotCaptureService {
 
     private static func frameInterval(seconds: Int) -> CMTime {
         CMTime(seconds: Double(max(1, seconds)), preferredTimescale: 600)
+    }
+
+    static func sourcePixelDimensions(
+        contentRect: CGRect,
+        contentScale: CGFloat,
+        scaleFactor: CGFloat
+    ) -> AutomaticScreenshotPixelDimensions? {
+        guard contentRect.width > 0,
+              contentRect.height > 0,
+              contentScale > 0,
+              scaleFactor > 0,
+              contentRect.width.isFinite,
+              contentRect.height.isFinite,
+              contentScale.isFinite,
+              scaleFactor.isFinite else { return nil }
+        return AutomaticScreenshotPixelDimensions(
+            width: max(1, Int((contentRect.width / contentScale * scaleFactor).rounded())),
+            height: max(1, Int((contentRect.height / contentScale * scaleFactor).rounded()))
+        )
     }
 }
 
@@ -757,7 +836,7 @@ private final class AutomaticScreenshotStreamAdapter: NSObject, SCStreamOutput, 
         ) as? [[SCStreamFrameInfo: Any]],
             let statusRawValue = attachments.first?[.status] as? Int,
             let status = SCFrameStatus(rawValue: statusRawValue) else { return false }
-        return status == .complete || status == .started
+        return status == .complete
     }
 
     private static func copyFrame(
@@ -773,12 +852,33 @@ private final class AutomaticScreenshotStreamAdapter: NSObject, SCStreamOutput, 
         let width = CVPixelBufferGetWidth(pixelBuffer)
         let height = CVPixelBufferGetHeight(pixelBuffer)
         let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
+        let sourcePixelDimensions: AutomaticScreenshotPixelDimensions? = frameAttachments(sampleBuffer).flatMap { attachments in
+            guard let contentRect = attachments[.contentRect] as? CGRect,
+                  let contentScale = attachments[.contentScale] as? CGFloat,
+                  let scaleFactor = attachments[.scaleFactor] as? CGFloat else { return nil }
+            return AutomaticScreenshotCaptureService.sourcePixelDimensions(
+                contentRect: contentRect,
+                contentScale: contentScale,
+                scaleFactor: scaleFactor
+            )
+        }
         return CopiedScreenshotFrame(
             width: width,
             height: height,
             bytesPerRow: bytesPerRow,
             pixels: Data(bytes: baseAddress, count: bytesPerRow * height),
-            capturedAt: capturedAt
+            capturedAt: capturedAt,
+            sourcePixelDimensions: sourcePixelDimensions
         )
+    }
+
+    private static func frameAttachments(
+        _ sampleBuffer: CMSampleBuffer
+    ) -> [SCStreamFrameInfo: Any]? {
+        let attachments = CMSampleBufferGetSampleAttachmentsArray(
+            sampleBuffer,
+            createIfNecessary: false
+        ) as? [[SCStreamFrameInfo: Any]]
+        return attachments?.first
     }
 }

--- a/Sources/Dahlia/Services/ErrorReportingService.swift
+++ b/Sources/Dahlia/Services/ErrorReportingService.swift
@@ -11,6 +11,12 @@ enum ErrorReportingService {
         case customerIntelligenceIngestion = "customer_intelligence_ingestion_error"
     }
 
+    enum AutomaticScreenshotStage: String {
+        case fingerprint
+        case encoding
+        case persistence
+    }
+
     struct ReleaseMetadata: Equatable {
         let name: String
         let distribution: String
@@ -83,6 +89,38 @@ enum ErrorReportingService {
             "minimum_width_bucket": String(minimumWidthBucket),
         ]
         SentrySDK.addBreadcrumb(breadcrumb)
+    }
+
+    static func recordSlowAutomaticScreenshotStage(
+        _ stage: AutomaticScreenshotStage,
+        durationMilliseconds: Int
+    ) {
+        guard isEnabled, durationMilliseconds >= 500 else { return }
+        let breadcrumb = Breadcrumb(level: .warning, category: "runtime.automatic_screenshot")
+        breadcrumb.type = "state"
+        breadcrumb.data = [
+            "event": "slow_stage",
+            "stage": stage.rawValue,
+            "duration_bucket_ms": String(automaticScreenshotDurationBucket(durationMilliseconds)),
+        ]
+        SentrySDK.addBreadcrumb(breadcrumb)
+    }
+
+    static func recordAutomaticScreenshotStreamRestart() {
+        guard isEnabled else { return }
+        let breadcrumb = Breadcrumb(level: .warning, category: "runtime.automatic_screenshot")
+        breadcrumb.type = "state"
+        breadcrumb.data = ["event": "stream_restart"]
+        SentrySDK.addBreadcrumb(breadcrumb)
+    }
+
+    static func automaticScreenshotDurationBucket(_ milliseconds: Int) -> Int {
+        switch milliseconds {
+        case ..<1000: 500
+        case ..<2000: 1000
+        case ..<5000: 2000
+        default: 5000
+        }
     }
 
     static func resolveDSN(infoDictionary: [String: Any], isDebugBuild: Bool) -> String? {

--- a/Sources/Dahlia/Utilities/ScreenshotChangeDetector.swift
+++ b/Sources/Dahlia/Utilities/ScreenshotChangeDetector.swift
@@ -1,7 +1,7 @@
 import CoreGraphics
 import Foundation
 
-struct ScreenshotFingerprint: Equatable {
+struct ScreenshotFingerprint: Equatable, Sendable {
     let width: Int
     let height: Int
     let pixels: [UInt8]

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -28,26 +28,6 @@ struct SummaryGenerationRunnerInput {
 typealias SummaryGenerationRunner = @MainActor (SummaryGenerationRunnerInput) async throws -> SummaryService.GeneratedSummary
 typealias SummaryJobSleeper = @Sendable (Duration) async throws -> Void
 
-private enum ScreenshotError: LocalizedError {
-    case encodingFailed
-    case displayUnavailable
-    case imageUnavailable
-    case sourceUnavailable
-
-    var errorDescription: String? {
-        switch self {
-        case .encodingFailed:
-            L10n.screenshotEncodingFailed
-        case .displayUnavailable:
-            L10n.screenshotDisplayUnavailable
-        case .imageUnavailable:
-            L10n.screenshotImageUnavailable
-        case .sourceUnavailable:
-            L10n.screenshotSourceUnavailable
-        }
-    }
-}
-
 /// 録音中のナビゲーション時に保持する録音コンテキスト。
 private struct RecordingContext {
     let meetingId: UUID?
@@ -81,6 +61,7 @@ private struct RecordingStartRollbackState {
 
 private struct RecordingStopContext {
     let configurationTasks: [Task<Void, Never>]
+    let automaticScreenshotStopTask: Task<Void, Never>
     let store: TranscriptStore
     let meetingId: UUID?
     let projectName: String?
@@ -227,7 +208,8 @@ final class CaptionViewModel: ObservableObject {
 
     // MARK: - Screenshot State
 
-    @Published var screenshots: [MeetingScreenshotRecord] = []
+    let screenshotStore = ScreenshotStore()
+
     @Published private(set) var isDeletingScreenshots = false {
         didSet {
             guard oldValue, !isDeletingScreenshots else { return }
@@ -241,8 +223,7 @@ final class CaptionViewModel: ObservableObject {
     @Published var screenshotCaptureSource: ScreenshotCaptureSource = .none {
         didSet {
             guard screenshotCaptureSource != oldValue else { return }
-            lastSavedAutomaticScreenshotFingerprint = nil
-            handleScreenshotCaptureSourceChange()
+            syncAutomaticScreenshotCaptureState()
         }
     }
 
@@ -281,7 +262,7 @@ final class CaptionViewModel: ObservableObject {
             document: currentSummaryDocument,
             actionItemsHeading: L10n.actionItems,
             for: destination,
-            screenshots: screenshots
+            screenshots: screenshotStore.records
         )
         guard content.markdown.nilIfBlank != nil else { return }
         SummaryPasteboardWriter.write(content)
@@ -301,7 +282,7 @@ final class CaptionViewModel: ObservableObject {
         let context = SummaryRenderContext(
             meetingId: meetingId,
             createdAt: store.timeBase,
-            screenshots: screenshots
+            screenshots: screenshotStore.records
         )
         let fileName = lastSummaryURL?.lastPathComponent
             ?? "\(document.title.nilIfBlank ?? L10n.summary).rtf"
@@ -484,13 +465,12 @@ final class CaptionViewModel: ObservableObject {
     private var transcriptionLocaleCancellable: AnyCancellable?
     private var liveSubtitleSettingsCancellable: AnyCancellable?
     private var automaticScreenshotSettingsCancellables: Set<AnyCancellable> = []
-    private var automaticScreenshotTask: Task<Void, Never>?
-    private var lastSavedAutomaticScreenshotFingerprint: ScreenshotFingerprint?
     private var meetingLoadTask: Task<Void, Never>?
     private var meetingLoadGeneration: UInt64 = 0
     private var isSynchronizingSelectedLocale = false
     private let audioHardwareQueryService: AudioHardwareQueryService
     private let transcriptTranslationService = TranscriptTranslationService()
+    private let automaticScreenshotCaptureControl: AutomaticScreenshotCaptureControl
     private let summaryGenerationRunner: SummaryGenerationRunner
     private let summaryJobSleeper: SummaryJobSleeper
 
@@ -508,6 +488,7 @@ final class CaptionViewModel: ObservableObject {
 
     init(
         audioHardwareQueryService: AudioHardwareQueryService = .shared,
+        automaticScreenshotCapture: any AutomaticScreenshotCapturing = AutomaticScreenshotCaptureService(),
         summaryGenerationRunner: @escaping SummaryGenerationRunner = { input in
             try await SummaryService.generateSummary(
                 promptContext: input.promptContext,
@@ -522,6 +503,9 @@ final class CaptionViewModel: ObservableObject {
         summaryJobSleeper: @escaping SummaryJobSleeper = { try await Task.sleep(for: $0) }
     ) {
         self.audioHardwareQueryService = audioHardwareQueryService
+        automaticScreenshotCaptureControl = AutomaticScreenshotCaptureControl(
+            capture: automaticScreenshotCapture
+        )
         self.summaryGenerationRunner = summaryGenerationRunner
         self.summaryJobSleeper = summaryJobSleeper
         bindStoreSegments()
@@ -562,7 +546,7 @@ final class CaptionViewModel: ObservableObject {
             .removeDuplicates()
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
-                self?.handleAutomaticScreenshotSettingsChange()
+                self?.syncAutomaticScreenshotCaptureState()
             }
             .store(in: &automaticScreenshotSettingsCancellables)
 
@@ -571,7 +555,16 @@ final class CaptionViewModel: ObservableObject {
             .removeDuplicates()
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
-                self?.handleAutomaticScreenshotIntervalChange()
+                self?.updateAutomaticScreenshotProcessingSettings()
+            }
+            .store(in: &automaticScreenshotSettingsCancellables)
+
+        UserDefaults.standard
+            .publisher(for: \.automaticScreenshotChangeThresholdPercent)
+            .removeDuplicates()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.updateAutomaticScreenshotProcessingSettings()
             }
             .store(in: &automaticScreenshotSettingsCancellables)
     }
@@ -1493,7 +1486,7 @@ final class CaptionViewModel: ObservableObject {
         if isListening {
             saveRecordingContextIfNeeded()
             store = TranscriptStore()
-            screenshots = []
+            screenshotStore.clear()
             resetNoteState()
             resetSummaryState()
         } else {
@@ -1524,6 +1517,7 @@ final class CaptionViewModel: ObservableObject {
         currentProjectName = ctx.projectName
         currentVaultURL = ctx.vaultURL
         currentDbQueue = ctx.dbQueue
+        replaceVisibleScreenshots(meetingID: ctx.meetingId, records: [])
         batchTranscriptionState = ctx.batchTranscriptionState
         retranscribableBatchSessionIds = []
         draftMeeting = nil
@@ -1566,7 +1560,7 @@ final class CaptionViewModel: ObservableObject {
     /// 読み込み済みデータのノート・スクリーンショット・サマリーを UI 状態に反映する。
     private func applyLoadedDetail(_ loaded: LoadedMeetingData) {
         currentMeetingHasTranscriptSegments = loaded.hasTranscriptSegments
-        screenshots = loaded.screenshots
+        replaceVisibleScreenshots(meetingID: currentMeetingId, records: loaded.screenshots)
         currentSummaryDocument = loaded.summaryDocument
         currentSummaryGoogleFileId = loaded.googleFileId
         lastSummaryURL = loaded.lastSummaryURL
@@ -1593,6 +1587,17 @@ final class CaptionViewModel: ObservableObject {
 
     // MARK: - Private Helpers
 
+    private func replaceVisibleScreenshots(
+        meetingID: UUID?,
+        records: [MeetingScreenshotRecord]
+    ) {
+        guard let meetingID else {
+            screenshotStore.clear()
+            return
+        }
+        screenshotStore.replace(meetingID: meetingID, records: records)
+    }
+
     /// 録音コンテキストをバックアップする（初回ナビゲーション時のみ）。
     private func saveRecordingContextIfNeeded() {
         guard recordingContext == nil else { return }
@@ -1614,7 +1619,7 @@ final class CaptionViewModel: ObservableObject {
         meetingLoadTask?.cancel()
         meetingLoadGeneration &+= 1
         store.clear()
-        screenshots = []
+        screenshotStore.clear()
         resetNoteState()
         resetSummaryState()
         draftMeeting = nil
@@ -1644,6 +1649,7 @@ final class CaptionViewModel: ObservableObject {
         currentProjectName = projectName
         currentVaultURL = vaultURL
         currentDbQueue = dbQueue
+        screenshotStore.replace(meetingID: id, records: [])
         draftMeeting = nil
         resetSummaryState()
         setupNoteAutoSave()
@@ -2252,7 +2258,7 @@ final class CaptionViewModel: ObservableObject {
 
         recordingLifecycle = .stopping(activeSessionId)
         isFinalizingRecording = true
-        stopAutomaticScreenshotCapture()
+        let automaticScreenshotStopTask = stopAutomaticScreenshotCapture()
         let configurationTasks = Array(recordingConfigurationTasks.values)
         configurationTasks.forEach { $0.cancel() }
         recordingConfigurationTasks.removeAll()
@@ -2263,6 +2269,7 @@ final class CaptionViewModel: ObservableObject {
         let activeStore = ctx?.store ?? store
         let stopContext = RecordingStopContext(
             configurationTasks: configurationTasks,
+            automaticScreenshotStopTask: automaticScreenshotStopTask,
             store: activeStore,
             meetingId: ctx?.meetingId ?? currentMeetingId,
             projectName: ctx?.projectName ?? selectedProjectName,
@@ -2316,6 +2323,7 @@ final class CaptionViewModel: ObservableObject {
         if persistenceResult.succeeded {
             await stoppingPipeline?.notifyPersistenceRecoveredAfterFinish()
         }
+        await context.automaticScreenshotStopTask.value
         failedPersistenceService = persistenceResult.succeeded ? nil : stoppingPersistenceService
         failedTranscriptionEventPipeline = persistenceResult.succeeded ? nil : stoppingPipeline
         persistenceService = nil
@@ -3287,29 +3295,18 @@ final class CaptionViewModel: ObservableObject {
         }
     }
 
-    private func handleAutomaticScreenshotSettingsChange() {
-        syncAutomaticScreenshotCaptureState()
-    }
-
-    private func handleAutomaticScreenshotIntervalChange() {
-        guard automaticScreenshotTask != nil else { return }
-        automaticScreenshotTask?.cancel()
-        automaticScreenshotTask = nil
-        if isListening, AppSettings.shared.automaticScreenshotEnabled, screenshotCaptureSource.isSelected {
-            startAutomaticScreenshotCapture(resetFingerprint: false)
-        } else {
-            lastSavedAutomaticScreenshotFingerprint = nil
+    private func updateAutomaticScreenshotProcessingSettings() {
+        guard isListening,
+              AppSettings.shared.automaticScreenshotEnabled,
+              screenshotCaptureSource.isSelected else { return }
+        let intervalSeconds = AppSettings.shared.automaticScreenshotIntervalSeconds
+        let changeThresholdRatio = AppSettings.shared.automaticScreenshotChangeThresholdRatio
+        automaticScreenshotCaptureControl.enqueue { capture in
+            await capture.updateSettings(
+                intervalSeconds: intervalSeconds,
+                changeThresholdRatio: changeThresholdRatio
+            )
         }
-    }
-
-    private func handleScreenshotCaptureSourceChange() {
-        guard isListening, AppSettings.shared.automaticScreenshotEnabled, screenshotCaptureSource.isSelected else {
-            stopAutomaticScreenshotCapture()
-            return
-        }
-        automaticScreenshotTask?.cancel()
-        automaticScreenshotTask = nil
-        startAutomaticScreenshotCapture()
     }
 
     private func syncAutomaticScreenshotCaptureState() {
@@ -3320,87 +3317,36 @@ final class CaptionViewModel: ObservableObject {
         }
     }
 
-    private func startAutomaticScreenshotCapture(resetFingerprint: Bool = true) {
-        guard automaticScreenshotTask == nil else { return }
-        if resetFingerprint {
-            lastSavedAutomaticScreenshotFingerprint = nil
-        }
-        automaticScreenshotTask = Task { [weak self] in
-            await self?.runAutomaticScreenshotLoop()
-        }
-    }
-
-    private func stopAutomaticScreenshotCapture() {
-        automaticScreenshotTask?.cancel()
-        automaticScreenshotTask = nil
-        lastSavedAutomaticScreenshotFingerprint = nil
-    }
-
-    private func runAutomaticScreenshotLoop() async {
-        while !Task.isCancelled {
-            await captureAutomaticScreenshotIfNeeded()
-
-            let intervalSeconds = max(1, AppSettings.shared.automaticScreenshotIntervalSeconds)
-            do {
-                try await Task.sleep(nanoseconds: UInt64(intervalSeconds) * 1_000_000_000)
-            } catch {
-                break
-            }
-        }
-    }
-
-    private func captureAutomaticScreenshotIfNeeded() async {
+    private func startAutomaticScreenshotCapture() {
         guard isListening,
               AppSettings.shared.automaticScreenshotEnabled,
               screenshotCaptureSource.isSelected,
               let meetingId = activeMeetingIdForSessionControls,
               let dbQueue = activeDbQueueForSessionControls
-        else {
-            return
+        else { return }
+        let request = AutomaticScreenshotCaptureRequest(
+            source: screenshotCaptureSource,
+            intervalSeconds: AppSettings.shared.automaticScreenshotIntervalSeconds,
+            changeThresholdRatio: AppSettings.shared.automaticScreenshotChangeThresholdRatio,
+            meetingID: meetingId,
+            sessionID: persistenceService?.recordingSessionId,
+            dbQueue: dbQueue,
+            onPersisted: { [weak self] record in
+                self?.screenshotStore.upsert(record)
+            },
+            onFailure: { [weak self] error in
+                guard let self, self.isListening else { return }
+                self.errorMessage = L10n.screenshotCaptureFailed(error.localizedDescription)
+            }
+        )
+        automaticScreenshotCaptureControl.enqueue { capture in
+            await capture.start(request)
         }
+    }
 
-        let shouldRefreshVisibleScreenshots = currentMeetingId == meetingId
-
-        do {
-            let cgImage = try await captureScreenshotImage()
-            guard !Task.isCancelled,
-                  isListening,
-                  AppSettings.shared.automaticScreenshotEnabled,
-                  screenshotCaptureSource.isSelected
-            else { return }
-            guard let fingerprint = await screenshotFingerprint(for: cgImage) else { return }
-            let changeThresholdRatio = AppSettings.shared.automaticScreenshotChangeThresholdRatio
-
-            let shouldSave = lastSavedAutomaticScreenshotFingerprint.map {
-                ScreenshotChangeDetector.isSignificantlyDifferent(
-                    $0,
-                    fingerprint,
-                    changedPixelRatioThreshold: changeThresholdRatio
-                )
-            } ?? true
-
-            guard shouldSave,
-                  !Task.isCancelled,
-                  isListening,
-                  AppSettings.shared.automaticScreenshotEnabled,
-                  screenshotCaptureSource.isSelected
-            else { return }
-
-            try await persistScreenshot(
-                cgImage,
-                meetingId: meetingId,
-                sessionId: persistenceService?.recordingSessionId,
-                dbQueue: dbQueue,
-                shouldRefreshVisibleScreenshots: shouldRefreshVisibleScreenshots
-            )
-            lastSavedAutomaticScreenshotFingerprint = fingerprint
-        } catch is CancellationError {
-            return
-        } catch {
-            // ウィンドウの一時クローズや画面ロックなど一過性の失敗でループ全体を
-            // 止めない。次の周期で再試行する。
-            errorMessage = L10n.screenshotCaptureFailed(error.localizedDescription)
-        }
+    @discardableResult
+    private func stopAutomaticScreenshotCapture() -> Task<Void, Never> {
+        automaticScreenshotCaptureControl.stop()
     }
 
     private func captureScreenshotImage() async throws -> CGImage {
@@ -3471,9 +3417,14 @@ final class CaptionViewModel: ObservableObject {
     }
 
     private func updateAutomaticScreenshotFingerprintIfNeeded(for cgImage: CGImage) async {
-        guard automaticScreenshotTask != nil,
+        guard isListening,
+              AppSettings.shared.automaticScreenshotEnabled,
+              screenshotCaptureSource.isSelected,
               let fingerprint = await screenshotFingerprint(for: cgImage) else { return }
-        lastSavedAutomaticScreenshotFingerprint = fingerprint
+        let task = automaticScreenshotCaptureControl.enqueue { capture in
+            await capture.updateSavedFingerprint(fingerprint)
+        }
+        await task.value
     }
 
     private func screenshotFingerprint(for cgImage: CGImage) async -> ScreenshotFingerprint? {
@@ -3534,13 +3485,7 @@ final class CaptionViewModel: ObservableObject {
     }
 
     private func appendVisibleScreenshot(_ screenshot: MeetingScreenshotRecord) {
-        guard currentMeetingId == screenshot.meetingId else { return }
-        if let index = screenshots.firstIndex(where: { $0.id == screenshot.id }) {
-            screenshots[index] = screenshot
-        } else {
-            let insertIndex = screenshots.firstIndex { $0.capturedAt > screenshot.capturedAt } ?? screenshots.endIndex
-            screenshots.insert(screenshot, at: insertIndex)
-        }
+        screenshotStore.upsert(screenshot)
     }
 
     func deleteScreenshot(_ screenshot: MeetingScreenshotRecord) {
@@ -3584,7 +3529,7 @@ final class CaptionViewModel: ObservableObject {
                 }
                 guard let self, self.currentMeetingId == meetingId else { return }
                 let deletedIds = Set(deletedScreenshots.map(\.id))
-                self.screenshots.removeAll { deletedIds.contains($0.id) }
+                self.screenshotStore.remove(ids: deletedIds, meetingID: meetingId)
             } catch {
                 captionViewModelLogger.error("Failed to delete screenshots: \(error)")
                 ErrorReportingService.capture(error, context: ["source": "deleteScreenshots"])

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -1971,6 +1971,7 @@ final class CaptionViewModel: ObservableObject {
         persistenceService = service
         installTranscriptionEventPipeline(persistenceService: service)
         currentMeetingId = service.meetingId
+        screenshotStore.replace(meetingID: service.meetingId, records: [])
         store.attachPagingContext(
             meetingId: service.meetingId,
             loader: TranscriptPageLoader(dbQueue: request.dbQueue)
@@ -3276,19 +3277,20 @@ final class CaptionViewModel: ObservableObject {
               let dbQueue = activeDbQueueForSessionControls,
               screenshotCaptureSource.isSelected else { return }
 
-        let shouldRefreshVisibleScreenshots = currentMeetingId == meetingId
-
         Task {
             do {
+                let fingerprintUpdateAttempt = await automaticScreenshotCaptureControl.fingerprintUpdateAttempt()
                 let cgImage = try await captureScreenshotImage()
                 try await persistScreenshot(
                     cgImage,
                     meetingId: meetingId,
                     sessionId: persistenceService?.recordingSessionId,
-                    dbQueue: dbQueue,
-                    shouldRefreshVisibleScreenshots: shouldRefreshVisibleScreenshots
+                    dbQueue: dbQueue
                 )
-                await updateAutomaticScreenshotFingerprintIfNeeded(for: cgImage)
+                await updateAutomaticScreenshotFingerprintIfNeeded(
+                    for: cgImage,
+                    attempt: fingerprintUpdateAttempt
+                )
             } catch {
                 errorMessage = L10n.screenshotCaptureFailed(error.localizedDescription)
             }
@@ -3386,8 +3388,7 @@ final class CaptionViewModel: ObservableObject {
         _ cgImage: CGImage,
         meetingId: UUID,
         sessionId: UUID?,
-        dbQueue: DatabaseQueue,
-        shouldRefreshVisibleScreenshots: Bool
+        dbQueue: DatabaseQueue
     ) async throws {
         let encodedImage: (data: Data, mimeType: String) = try await Task.detached(priority: .userInitiated) {
             guard let encoded = ImageEncoder.encode(cgImage, quality: 0.70) else {
@@ -3411,18 +3412,20 @@ final class CaptionViewModel: ObservableObject {
         try await dbQueue.write { db in
             try record.insert(db)
         }
-        if shouldRefreshVisibleScreenshots {
-            appendVisibleScreenshot(record)
-        }
+        appendVisibleScreenshot(record)
     }
 
-    private func updateAutomaticScreenshotFingerprintIfNeeded(for cgImage: CGImage) async {
+    private func updateAutomaticScreenshotFingerprintIfNeeded(
+        for cgImage: CGImage,
+        attempt: AutomaticScreenshotCaptureAttempt?
+    ) async {
         guard isListening,
               AppSettings.shared.automaticScreenshotEnabled,
               screenshotCaptureSource.isSelected,
+              let attempt,
               let fingerprint = await screenshotFingerprint(for: cgImage) else { return }
         let task = automaticScreenshotCaptureControl.enqueue { capture in
-            await capture.updateSavedFingerprint(fingerprint)
+            await capture.updateSavedFingerprint(fingerprint, for: attempt)
         }
         await task.value
     }

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -450,32 +450,15 @@ struct ControlPanelView: View {
 
     // MARK: - Tab Contents
 
-    @ViewBuilder
     private var summaryTabContent: some View {
-        if let document = viewModel.currentSummaryDocument,
-           viewModel.hasCurrentMeetingSummary {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 20) {
-                    SummaryDocumentView(
-                        document: document,
-                        imageDataProvider: { screenshotRecord(withID: $0)?.imageData },
-                        onOpenImage: openSummaryScreenshot,
-                        transcriptTextProvider: summaryTranscriptText,
-                        allowsTranscriptReferencePopovers: allowsTranscriptReferencePopovers
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .padding(16)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-        } else {
-            ContentUnavailableView {
-                Label(L10n.summary, systemImage: "list.bullet.clipboard")
-            } description: {
-                Text(L10n.noSummaryYet)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
+        SummaryTabContentView(
+            screenshotStore: viewModel.screenshotStore,
+            document: viewModel.currentSummaryDocument,
+            hasSummary: viewModel.hasCurrentMeetingSummary,
+            allowsTranscriptReferencePopovers: allowsTranscriptReferencePopovers,
+            openScreenshot: openSummaryScreenshot,
+            transcriptText: summaryTranscriptText
+        )
     }
 
     private var notesTabContent: some View {
@@ -522,46 +505,22 @@ struct ControlPanelView: View {
         return min(max(minimumHeight, preferredHeight), maximumHeight)
     }
 
-    @ViewBuilder
     private var screenshotsTabContent: some View {
-        if viewModel.screenshots.isEmpty {
-            ContentUnavailableView {
-                Label(L10n.screenshots, systemImage: "photo.on.rectangle.angled")
-            } description: {
-                Text(L10n.noScreenshotsYet)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else {
-            VStack(spacing: 0) {
-                ScreenshotManagementToolbar(
-                    minimumWidth: $screenshotMinimumWidth,
-                    isSelecting: $isSelectingScreenshots,
-                    selectedCount: selectedScreenshotIds.count,
-                    canSelectAll: selectedScreenshotIds.count < deletableScreenshotIds.count,
-                    isDeletionDisabled: viewModel.isSummaryGenerating || viewModel.isDeletingScreenshots,
-                    selectAll: selectAllScreenshots,
-                    deleteSelected: deleteSelectedScreenshots
-                )
-                .padding(12)
-
-                Divider()
-
-                ScreenshotCollectionView(
-                    meetingID: viewModel.currentMeetingId,
-                    screenshots: viewModel.screenshots,
-                    recordingSessions: viewModel.store.recordingSessions,
-                    fallbackTimeBase: screenshotTimeBase,
-                    minimumItemWidth: screenshotMinimumWidth,
-                    isSelecting: isSelectingScreenshots,
-                    referencedScreenshotIDs: referencedScreenshotIds,
-                    isDeletionDisabled: viewModel.isSummaryGenerating || viewModel.isDeletingScreenshots,
-                    selectedScreenshotIDs: $selectedScreenshotIds,
-                    open: openScreenshot,
-                    download: viewModel.downloadScreenshot,
-                    delete: viewModel.deleteScreenshot
-                )
-            }
-        }
+        ScreenshotTabContentView(
+            screenshotStore: viewModel.screenshotStore,
+            meetingID: viewModel.currentMeetingId,
+            recordingSessions: viewModel.store.recordingSessions,
+            fallbackTimeBase: screenshotTimeBase,
+            minimumItemWidth: $screenshotMinimumWidth,
+            isSelecting: $isSelectingScreenshots,
+            selectedScreenshotIDs: $selectedScreenshotIds,
+            referencedScreenshotIDs: referencedScreenshotIds,
+            isDeletionDisabled: viewModel.isSummaryGenerating || viewModel.isDeletingScreenshots,
+            open: openScreenshot,
+            download: viewModel.downloadScreenshot,
+            delete: viewModel.deleteScreenshot,
+            deleteSelected: deleteSelectedScreenshots
+        )
     }
 
     private func openScreenshot(_ screenshot: MeetingScreenshotRecord, previewImage: CGImage?) {
@@ -581,7 +540,7 @@ struct ControlPanelView: View {
     }
 
     private func screenshotRecord(withID id: UUID) -> MeetingScreenshotRecord? {
-        viewModel.screenshots.first { $0.id == id }
+        viewModel.screenshotStore.records.first { $0.id == id }
     }
 
     private func dismissExpandedScreenshot() {
@@ -589,10 +548,6 @@ struct ControlPanelView: View {
         withAnimation(.easeOut(duration: 0.15)) {
             expandedScreenshot = nil
         }
-    }
-
-    private func selectAllScreenshots() {
-        selectedScreenshotIds = deletableScreenshotIds
     }
 
     private func deleteSelectedScreenshots() {
@@ -624,10 +579,6 @@ struct ControlPanelView: View {
 
     private var referencedScreenshotIds: Set<UUID> {
         viewModel.currentSummaryDocument?.referencedScreenshotIds ?? []
-    }
-
-    private var deletableScreenshotIds: Set<UUID> {
-        Set(viewModel.screenshots.map(\.id)).subtracting(referencedScreenshotIds)
     }
 
     private func summaryTranscriptText(for reference: TranscriptReference) -> String? {

--- a/Sources/Dahlia/Views/ScreenshotCollectionView.swift
+++ b/Sources/Dahlia/Views/ScreenshotCollectionView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct ScreenshotCollectionView: NSViewRepresentable {
     let meetingID: UUID?
     let screenshots: [MeetingScreenshotRecord]
+    var contentRevision: UInt64?
     let recordingSessions: [RecordingSessionTimeline]
     let fallbackTimeBase: Date
     let minimumItemWidth: Double
@@ -68,6 +69,7 @@ extension ScreenshotCollectionView {
         private var currentScreenshotIDs: [UUID] = []
         private var screenshotIndexByID: [UUID: Int] = [:]
         private var currentScreenshotMetadata: [ScreenshotMetadata] = []
+        private var currentContentRevision: UInt64?
         private var timestampByID: [UUID: String] = [:]
         private var timestampContext: TimestampContext?
         private var lastPresentationState: PresentationState?
@@ -162,6 +164,7 @@ extension ScreenshotCollectionView {
             currentScreenshotIDs.removeAll()
             screenshotIndexByID.removeAll()
             currentScreenshotMetadata.removeAll()
+            currentContentRevision = nil
             timestampByID.removeAll()
         }
 
@@ -385,10 +388,6 @@ extension ScreenshotCollectionView.Coordinator {
         case reset
     }
 
-    static func requiresSnapshotUpdate(currentIDs: [UUID], newIDs: [UUID]) -> Bool {
-        identifierUpdate(currentIDs: currentIDs, newIDs: newIDs) != .unchanged
-    }
-
     static func identifierUpdate(currentIDs: [UUID], newIDs: [UUID]) -> IdentifierUpdate {
         guard currentIDs != newIDs else { return .unchanged }
         guard newIDs.count > currentIDs.count,
@@ -401,6 +400,15 @@ extension ScreenshotCollectionView.Coordinator {
         ids: [UUID],
         identifierUpdate: IdentifierUpdate
     ) -> Bool {
+        guard Self.shouldRebuildMetadata(
+            identifierUpdate: identifierUpdate,
+            currentContentRevision: currentContentRevision,
+            newContentRevision: parent.contentRevision
+        ) else {
+            currentScreenshotIDs = ids
+            return false
+        }
+
         switch identifierUpdate {
         case let .append(appendedIDs):
             let initialIndex = currentScreenshotIDs.count
@@ -424,7 +432,18 @@ extension ScreenshotCollectionView.Coordinator {
         let changed = currentScreenshotMetadata != screenshotMetadata
         currentScreenshotIDs = ids
         currentScreenshotMetadata = screenshotMetadata
+        currentContentRevision = parent.contentRevision
         return changed
+    }
+
+    static func shouldRebuildMetadata(
+        identifierUpdate: IdentifierUpdate,
+        currentContentRevision: UInt64?,
+        newContentRevision: UInt64?
+    ) -> Bool {
+        guard identifierUpdate == .unchanged,
+              let newContentRevision else { return true }
+        return currentContentRevision != newContentRevision
     }
 
     private func updateTimestamps(

--- a/Sources/Dahlia/Views/ScreenshotCollectionView.swift
+++ b/Sources/Dahlia/Views/ScreenshotCollectionView.swift
@@ -111,36 +111,28 @@ extension ScreenshotCollectionView {
 
             let screenshots = parent.screenshots
             let ids = screenshots.map(\.id)
-            let screenshotMetadata = screenshots.map(ScreenshotMetadata.init)
             let meetingChanged = currentMeetingID != parent.meetingID
-            let identifiersChanged = Self.requiresSnapshotUpdate(
+            let identifierUpdate = Self.identifierUpdate(
                 currentIDs: currentScreenshotIDs,
                 newIDs: ids
             )
-            if identifiersChanged {
-                screenshotIndexByID = Dictionary(
-                    uniqueKeysWithValues: ids.enumerated().map { ($0.element, $0.offset) }
-                )
-            }
-            let metadataChanged = currentScreenshotMetadata != screenshotMetadata
-            currentMeetingID = parent.meetingID
-            currentScreenshotIDs = ids
-            currentScreenshotMetadata = screenshotMetadata
-
-            let currentTimestampContext = TimestampContext(
-                recordingSessions: parent.recordingSessions,
-                fallbackTimeBase: parent.fallbackTimeBase
+            let metadataChanged = updateProjection(
+                screenshots: screenshots,
+                ids: ids,
+                identifierUpdate: identifierUpdate
             )
-            if meetingChanged || metadataChanged || timestampContext != currentTimestampContext {
-                timestampByID = Dictionary(uniqueKeysWithValues: screenshots.map { ($0.id, timestamp(for: $0)) })
-                timestampContext = currentTimestampContext
-                timestampCacheGeneration &+= 1
-            }
+            currentMeetingID = parent.meetingID
+            updateTimestamps(
+                screenshots: screenshots,
+                meetingChanged: meetingChanged,
+                metadataChanged: metadataChanged,
+                identifierUpdate: identifierUpdate
+            )
 
             applySnapshotIfNeeded(
                 ids: ids,
                 collectionView: collectionView,
-                identifiersChanged: identifiersChanged,
+                identifierUpdate: identifierUpdate,
                 resetsScrollPosition: meetingChanged
             )
 
@@ -194,15 +186,27 @@ extension ScreenshotCollectionView {
         private func applySnapshotIfNeeded(
             ids: [UUID],
             collectionView: NSCollectionView,
-            identifiersChanged: Bool,
+            identifierUpdate: IdentifierUpdate,
             resetsScrollPosition: Bool
         ) {
             guard let dataSource else { return }
-            guard identifiersChanged else {
+            switch identifierUpdate {
+            case .unchanged:
                 if resetsScrollPosition {
                     Self.scrollToTop(collectionView)
                 }
                 return
+            case let .append(appendedIDs):
+                snapshotGeneration &+= 1
+                var snapshot = dataSource.snapshot()
+                if snapshot.sectionIdentifiers.isEmpty {
+                    snapshot.appendSections([0])
+                }
+                snapshot.appendItems(appendedIDs, toSection: 0)
+                dataSource.apply(snapshot, animatingDifferences: false)
+                return
+            case .reset:
+                break
             }
 
             let preservedOrigin = collectionView.enclosingScrollView?.contentView.bounds.origin
@@ -333,10 +337,6 @@ extension ScreenshotCollectionView {
             Int((width / 10).rounded()) * 10
         }
 
-        static func requiresSnapshotUpdate(currentIDs: [UUID], newIDs: [UUID]) -> Bool {
-            currentIDs != newIDs
-        }
-
         static func requiresVisibleItemUpdate(
             previous: PresentationState?,
             current: PresentationState
@@ -374,6 +374,79 @@ extension ScreenshotCollectionView {
         private struct BreadcrumbState: Equatable {
             let countBucket: Int
             let minimumWidthBucket: Int
+        }
+    }
+}
+
+extension ScreenshotCollectionView.Coordinator {
+    enum IdentifierUpdate: Equatable {
+        case unchanged
+        case append([UUID])
+        case reset
+    }
+
+    static func requiresSnapshotUpdate(currentIDs: [UUID], newIDs: [UUID]) -> Bool {
+        identifierUpdate(currentIDs: currentIDs, newIDs: newIDs) != .unchanged
+    }
+
+    static func identifierUpdate(currentIDs: [UUID], newIDs: [UUID]) -> IdentifierUpdate {
+        guard currentIDs != newIDs else { return .unchanged }
+        guard newIDs.count > currentIDs.count,
+              newIDs.starts(with: currentIDs) else { return .reset }
+        return .append(Array(newIDs.dropFirst(currentIDs.count)))
+    }
+
+    private func updateProjection(
+        screenshots: [MeetingScreenshotRecord],
+        ids: [UUID],
+        identifierUpdate: IdentifierUpdate
+    ) -> Bool {
+        switch identifierUpdate {
+        case let .append(appendedIDs):
+            let initialIndex = currentScreenshotIDs.count
+            for (offset, id) in appendedIDs.enumerated() {
+                screenshotIndexByID[id] = initialIndex + offset
+            }
+        case .reset:
+            screenshotIndexByID = Dictionary(
+                uniqueKeysWithValues: ids.enumerated().map { ($0.element, $0.offset) }
+            )
+        case .unchanged:
+            break
+        }
+
+        let screenshotMetadata = if case let .append(appendedIDs) = identifierUpdate {
+            currentScreenshotMetadata
+                + screenshots.suffix(appendedIDs.count).map(ScreenshotMetadata.init)
+        } else {
+            screenshots.map(ScreenshotMetadata.init)
+        }
+        let changed = currentScreenshotMetadata != screenshotMetadata
+        currentScreenshotIDs = ids
+        currentScreenshotMetadata = screenshotMetadata
+        return changed
+    }
+
+    private func updateTimestamps(
+        screenshots: [MeetingScreenshotRecord],
+        meetingChanged: Bool,
+        metadataChanged: Bool,
+        identifierUpdate: IdentifierUpdate
+    ) {
+        let currentContext = TimestampContext(
+            recordingSessions: parent.recordingSessions,
+            fallbackTimeBase: parent.fallbackTimeBase
+        )
+        if case let .append(appendedIDs) = identifierUpdate,
+           !meetingChanged,
+           timestampContext == currentContext {
+            for screenshot in screenshots.suffix(appendedIDs.count) {
+                timestampByID[screenshot.id] = timestamp(for: screenshot)
+            }
+        } else if meetingChanged || metadataChanged || timestampContext != currentContext {
+            timestampByID = Dictionary(uniqueKeysWithValues: screenshots.map { ($0.id, timestamp(for: $0)) })
+            timestampContext = currentContext
+            timestampCacheGeneration &+= 1
         }
     }
 }

--- a/Sources/Dahlia/Views/ScreenshotTabContentView.swift
+++ b/Sources/Dahlia/Views/ScreenshotTabContentView.swift
@@ -41,6 +41,7 @@ struct ScreenshotTabContentView: View {
                 ScreenshotCollectionView(
                     meetingID: meetingID,
                     screenshots: screenshotStore.records,
+                    contentRevision: screenshotStore.contentRevision,
                     recordingSessions: recordingSessions,
                     fallbackTimeBase: fallbackTimeBase,
                     minimumItemWidth: minimumItemWidth,

--- a/Sources/Dahlia/Views/ScreenshotTabContentView.swift
+++ b/Sources/Dahlia/Views/ScreenshotTabContentView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct ScreenshotTabContentView: View {
+    @ObservedObject var screenshotStore: ScreenshotStore
+    let meetingID: UUID?
+    let recordingSessions: [RecordingSessionTimeline]
+    let fallbackTimeBase: Date
+    @Binding var minimumItemWidth: Double
+    @Binding var isSelecting: Bool
+    @Binding var selectedScreenshotIDs: Set<UUID>
+    let referencedScreenshotIDs: Set<UUID>
+    let isDeletionDisabled: Bool
+    let open: (MeetingScreenshotRecord, CGImage?) -> Void
+    let download: (MeetingScreenshotRecord) -> Void
+    let delete: (MeetingScreenshotRecord) -> Void
+    let deleteSelected: () -> Void
+
+    var body: some View {
+        if screenshotStore.records.isEmpty {
+            ContentUnavailableView {
+                Label(L10n.screenshots, systemImage: "photo.on.rectangle.angled")
+            } description: {
+                Text(L10n.noScreenshotsYet)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            VStack(spacing: 0) {
+                ScreenshotManagementToolbar(
+                    minimumWidth: $minimumItemWidth,
+                    isSelecting: $isSelecting,
+                    selectedCount: selectedScreenshotIDs.count,
+                    canSelectAll: selectedScreenshotIDs.count < deletableScreenshotIDs.count,
+                    isDeletionDisabled: isDeletionDisabled,
+                    selectAll: selectAllScreenshots,
+                    deleteSelected: deleteSelected
+                )
+                .padding(12)
+
+                Divider()
+
+                ScreenshotCollectionView(
+                    meetingID: meetingID,
+                    screenshots: screenshotStore.records,
+                    recordingSessions: recordingSessions,
+                    fallbackTimeBase: fallbackTimeBase,
+                    minimumItemWidth: minimumItemWidth,
+                    isSelecting: isSelecting,
+                    referencedScreenshotIDs: referencedScreenshotIDs,
+                    isDeletionDisabled: isDeletionDisabled,
+                    selectedScreenshotIDs: $selectedScreenshotIDs,
+                    open: open,
+                    download: download,
+                    delete: delete
+                )
+            }
+        }
+    }
+
+    private var deletableScreenshotIDs: Set<UUID> {
+        Set(screenshotStore.records.map(\.id)).subtracting(referencedScreenshotIDs)
+    }
+
+    private func selectAllScreenshots() {
+        selectedScreenshotIDs = deletableScreenshotIDs
+    }
+}

--- a/Sources/Dahlia/Views/SummaryTabContentView.swift
+++ b/Sources/Dahlia/Views/SummaryTabContentView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct SummaryTabContentView: View {
+    @ObservedObject var screenshotStore: ScreenshotStore
+    let document: SummaryDocument?
+    let hasSummary: Bool
+    let allowsTranscriptReferencePopovers: Bool
+    let openScreenshot: (UUID, CGImage) -> Void
+    let transcriptText: (TranscriptReference) -> String?
+
+    var body: some View {
+        if let document, hasSummary {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    SummaryDocumentView(
+                        document: document,
+                        imageDataProvider: imageData,
+                        onOpenImage: openScreenshot,
+                        transcriptTextProvider: transcriptText,
+                        allowsTranscriptReferencePopovers: allowsTranscriptReferencePopovers
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        } else {
+            ContentUnavailableView {
+                Label(L10n.summary, systemImage: "list.bullet.clipboard")
+            } description: {
+                Text(L10n.noSummaryYet)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func imageData(for screenshotID: UUID) -> Data? {
+        screenshotStore.records.first { $0.id == screenshotID }?.imageData
+    }
+}

--- a/Tests/DahliaTests/AutomaticScreenshotCaptureServiceTests.swift
+++ b/Tests/DahliaTests/AutomaticScreenshotCaptureServiceTests.swift
@@ -1,0 +1,239 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+import Testing
+
+struct AutomaticScreenshotCaptureServiceTests {
+    @Test
+    func lifecycleRejectsFramesFromStoppedAndReplacedStreams() throws {
+        var lifecycle = AutomaticScreenshotCaptureLifecycle()
+
+        let firstGenerationResult = lifecycle.begin()
+        let firstGeneration = try #require(firstGenerationResult)
+        #expect(lifecycle.accepts(generation: firstGeneration))
+
+        lifecycle.stop()
+        #expect(!lifecycle.accepts(generation: firstGeneration))
+
+        let secondGenerationResult = lifecycle.begin()
+        let secondGeneration = try #require(secondGenerationResult)
+        #expect(secondGeneration != firstGeneration)
+        #expect(!lifecycle.accepts(generation: firstGeneration))
+        #expect(lifecycle.accepts(generation: secondGeneration))
+    }
+
+    @Test
+    func lifecycleAllowsOnlyOneCompletionOwnerPerStreamAttempt() throws {
+        var lifecycle = AutomaticScreenshotCaptureLifecycle()
+        let generationResult = lifecycle.begin()
+        let generation = try #require(generationResult)
+        let firstAttemptResult = lifecycle.beginAttempt(generation: generation)
+        let firstAttempt = try #require(firstAttemptResult)
+
+        let overlappingAttempt = lifecycle.beginAttempt(generation: generation)
+        let firstClaim = lifecycle.claimCompletion(attempt: firstAttempt)
+        let duplicateClaim = lifecycle.claimCompletion(attempt: firstAttempt)
+        #expect(overlappingAttempt == nil)
+        #expect(firstClaim)
+        #expect(!duplicateClaim)
+        #expect(!lifecycle.accepts(attempt: firstAttempt))
+
+        lifecycle.finishAttempt(firstAttempt)
+        let retryAttemptResult = lifecycle.beginAttempt(generation: generation)
+        let retryAttempt = try #require(retryAttemptResult)
+        #expect(retryAttempt != firstAttempt)
+        #expect(lifecycle.accepts(attempt: retryAttempt))
+    }
+
+    @Test
+    func replacementStartRejectsAnEarlierStartResumingAfterCleanup() throws {
+        var lifecycle = AutomaticScreenshotCaptureLifecycle()
+        let staleGeneration = lifecycle.beginReplacement()
+        let staleAttemptResult = lifecycle.beginAttempt(generation: staleGeneration)
+        let staleAttempt = try #require(staleAttemptResult)
+
+        let replacementGeneration = lifecycle.beginReplacement()
+        let replacementAttemptResult = lifecycle.beginAttempt(generation: replacementGeneration)
+        let replacementAttempt = try #require(replacementAttemptResult)
+        lifecycle.finishAttempt(staleAttempt)
+
+        #expect(!lifecycle.accepts(generation: staleGeneration))
+        #expect(!lifecycle.accepts(attempt: staleAttempt))
+        #expect(lifecycle.accepts(generation: replacementGeneration))
+        #expect(lifecycle.accepts(attempt: replacementAttempt))
+    }
+
+    @Test
+    func staleProcessingCompletionPreservesReplacementOperationAndPendingFrame() throws {
+        var state = AutomaticScreenshotProcessingState()
+        let staleAttempt = AutomaticScreenshotCaptureAttempt(generation: 1, id: 1)
+        let replacementAttempt = AutomaticScreenshotCaptureAttempt(generation: 2, id: 2)
+        state.begin(attempt: staleAttempt) { _ in Task {} }
+        _ = state.queueLatest(
+            makeFrame(byte: 1, capturedAt: Date(timeIntervalSince1970: 100)),
+            attempt: staleAttempt
+        )
+        let staleOperationResult = state.take(matching: staleAttempt)
+        let staleOperation = try #require(staleOperationResult)
+
+        state.begin(attempt: replacementAttempt) { _ in Task {} }
+        let replacementDate = Date(timeIntervalSince1970: 200)
+        let queuedReplacement = state.queueLatest(
+            makeFrame(byte: 2, capturedAt: replacementDate),
+            attempt: replacementAttempt
+        )
+        #expect(queuedReplacement)
+        let stalePending = state.complete(
+            operationID: staleOperation.id,
+            attempt: staleAttempt
+        )
+
+        #expect(stalePending == nil)
+        #expect(state.operation?.attempt == replacementAttempt)
+        #expect(state.pendingFrame?.attempt == replacementAttempt)
+        #expect(state.pendingFrame?.frame.capturedAt == replacementDate)
+    }
+
+    @Test
+    func frameMailboxRetainsOnlyTheNewestPendingFullResolutionFrame() async throws {
+        let mailbox = AutomaticScreenshotFrameMailbox()
+        let firstDate = Date(timeIntervalSince1970: 100)
+        let latestDate = Date(timeIntervalSince1970: 300)
+        mailbox.yield(makeFrame(byte: 1, capturedAt: firstDate))
+        mailbox.yield(makeFrame(byte: 2, capturedAt: Date(timeIntervalSince1970: 200)))
+        mailbox.yield(makeFrame(byte: 3, capturedAt: latestDate))
+        mailbox.finish()
+
+        var iterator = mailbox.stream.makeAsyncIterator()
+        let received = try #require(await iterator.next())
+        #expect(received.pixels == Data(repeating: 3, count: 4))
+        #expect(received.capturedAt == latestDate)
+        #expect(await iterator.next() == nil)
+    }
+
+    @Test
+    func persistedRecordUsesFrameReceiptTime() {
+        let capturedAt = Date(timeIntervalSince1970: 123)
+        let frame = makeFrame(byte: 1, capturedAt: capturedAt)
+        let record = AutomaticScreenshotCaptureService.makeRecord(
+            frame: frame,
+            meetingID: .v7(),
+            sessionID: .v7(),
+            encodedData: Data([9]),
+            mimeType: "image/jpeg"
+        )
+
+        #expect(record.capturedAt == capturedAt)
+    }
+
+    @Test
+    @MainActor
+    func stopBypassesBlockedStartAndInvalidatesPendingSettings() async throws {
+        let capture = BlockingAutomaticScreenshotCapture()
+        let control = AutomaticScreenshotCaptureControl(capture: capture)
+        let request = AutomaticScreenshotCaptureRequest(
+            source: .entireDesktop,
+            intervalSeconds: 5,
+            changeThresholdRatio: 0.20,
+            meetingID: .v7(),
+            sessionID: .v7(),
+            dbQueue: try DatabaseQueue(),
+            onPersisted: { _ in },
+            onFailure: { _ in }
+        )
+        let startTask = control.enqueue { capture in
+            await capture.start(request)
+        }
+        await capture.waitUntilStartBegins()
+        let settingsTask = control.enqueue { capture in
+            await capture.updateSettings(intervalSeconds: 10, changeThresholdRatio: 0.30)
+        }
+
+        let stopTask = control.stop()
+        var stopBypassedStart = false
+        for _ in 0 ..< 100 {
+            if await capture.stopCount() == 1 {
+                stopBypassedStart = true
+                break
+            }
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        #expect(stopBypassedStart)
+
+        await capture.resumeStart()
+        await startTask.value
+        await settingsTask.value
+        await stopTask.value
+        #expect(await capture.settingsUpdateCount() == 0)
+    }
+
+    @Test
+    func slowStageDurationsUseBoundedBuckets() {
+        #expect(ErrorReportingService.automaticScreenshotDurationBucket(500) == 500)
+        #expect(ErrorReportingService.automaticScreenshotDurationBucket(999) == 500)
+        #expect(ErrorReportingService.automaticScreenshotDurationBucket(1_000) == 1_000)
+        #expect(ErrorReportingService.automaticScreenshotDurationBucket(2_500) == 2_000)
+        #expect(ErrorReportingService.automaticScreenshotDurationBucket(8_000) == 5_000)
+    }
+
+    private func makeFrame(byte: UInt8, capturedAt: Date) -> CopiedScreenshotFrame {
+        CopiedScreenshotFrame(
+            width: 1,
+            height: 1,
+            bytesPerRow: 4,
+            pixels: Data(repeating: byte, count: 4),
+            capturedAt: capturedAt
+        )
+    }
+}
+
+private actor BlockingAutomaticScreenshotCapture: AutomaticScreenshotCapturing {
+    private var startContinuation: CheckedContinuation<Void, Never>?
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var didBeginStart = false
+    private var observedStopCount = 0
+    private var observedSettingsUpdateCount = 0
+
+    func start(_: AutomaticScreenshotCaptureRequest) async {
+        didBeginStart = true
+        let waiters = startWaiters
+        startWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        await withCheckedContinuation { continuation in
+            startContinuation = continuation
+        }
+    }
+
+    func updateSettings(intervalSeconds _: Int, changeThresholdRatio _: Double) {
+        observedSettingsUpdateCount += 1
+    }
+
+    func updateSavedFingerprint(_: ScreenshotFingerprint?) {}
+
+    func stop() {
+        observedStopCount += 1
+    }
+
+    func waitUntilStartBegins() async {
+        guard !didBeginStart else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append(continuation)
+        }
+    }
+
+    func resumeStart() {
+        startContinuation?.resume()
+        startContinuation = nil
+    }
+
+    func stopCount() -> Int {
+        observedStopCount
+    }
+
+    func settingsUpdateCount() -> Int {
+        observedSettingsUpdateCount
+    }
+}
+#endif

--- a/Tests/DahliaTests/AutomaticScreenshotCaptureServiceTests.swift
+++ b/Tests/DahliaTests/AutomaticScreenshotCaptureServiceTests.swift
@@ -129,6 +129,22 @@ struct AutomaticScreenshotCaptureServiceTests {
     }
 
     @Test
+    func sourcePixelDimensionsRecoverNativeSizeFromScaledSurface() throws {
+        let dimensions = try #require(AutomaticScreenshotCaptureService.sourcePixelDimensions(
+            contentRect: CGRect(x: 0, y: 0, width: 600, height: 400),
+            contentScale: 0.5,
+            scaleFactor: 2
+        ))
+
+        #expect(dimensions == AutomaticScreenshotPixelDimensions(width: 2_400, height: 1_600))
+        #expect(AutomaticScreenshotCaptureService.sourcePixelDimensions(
+            contentRect: .zero,
+            contentScale: 1,
+            scaleFactor: 2
+        ) == nil)
+    }
+
+    @Test
     @MainActor
     func stopBypassesBlockedStartAndInvalidatesPendingSettings() async throws {
         let capture = BlockingAutomaticScreenshotCapture()
@@ -210,7 +226,14 @@ private actor BlockingAutomaticScreenshotCapture: AutomaticScreenshotCapturing {
         observedSettingsUpdateCount += 1
     }
 
-    func updateSavedFingerprint(_: ScreenshotFingerprint?) {}
+    func fingerprintUpdateAttempt() -> AutomaticScreenshotCaptureAttempt? {
+        nil
+    }
+
+    func updateSavedFingerprint(
+        _: ScreenshotFingerprint?,
+        for _: AutomaticScreenshotCaptureAttempt
+    ) {}
 
     func stop() {
         observedStopCount += 1

--- a/Tests/DahliaTests/ScreenshotCollectionIncrementalUpdateTests.swift
+++ b/Tests/DahliaTests/ScreenshotCollectionIncrementalUpdateTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+import Testing
+
+@MainActor
+struct ScreenshotCollectionIncrementalUpdateTests {
+    @Test
+    func appendOnlyIdentifierUpdatesStayIncremental() {
+        let first = UUID.v7()
+        let second = UUID.v7()
+        let third = UUID.v7()
+
+        #expect(
+            ScreenshotCollectionView.Coordinator.identifierUpdate(
+                currentIDs: [first],
+                newIDs: [first, second, third]
+            ) == .append([second, third])
+        )
+        #expect(
+            ScreenshotCollectionView.Coordinator.identifierUpdate(
+                currentIDs: [first, second],
+                newIDs: [second]
+            ) == .reset
+        )
+        #expect(
+            ScreenshotCollectionView.Coordinator.identifierUpdate(
+                currentIDs: [first],
+                newIDs: [first]
+            ) == .unchanged
+        )
+    }
+}
+#endif

--- a/Tests/DahliaTests/ScreenshotCollectionIncrementalUpdateTests.swift
+++ b/Tests/DahliaTests/ScreenshotCollectionIncrementalUpdateTests.swift
@@ -31,5 +31,49 @@ struct ScreenshotCollectionIncrementalUpdateTests {
             ) == .unchanged
         )
     }
+
+    @Test
+    func snapshotUpdatesOnlyWhenIdentifiersChange() {
+        let first = UUID.v7()
+        let second = UUID.v7()
+        let otherMeeting = UUID.v7()
+
+        #expect(ScreenshotCollectionView.Coordinator.identifierUpdate(currentIDs: [], newIDs: [first]) == .append([first]))
+        #expect(ScreenshotCollectionView.Coordinator.identifierUpdate(currentIDs: [first], newIDs: [first]) == .unchanged)
+        #expect(
+            ScreenshotCollectionView.Coordinator.identifierUpdate(
+                currentIDs: [first],
+                newIDs: [first, second]
+            ) == .append([second])
+        )
+        #expect(ScreenshotCollectionView.Coordinator.identifierUpdate(currentIDs: [first, second], newIDs: [second]) == .reset)
+        #expect(ScreenshotCollectionView.Coordinator.identifierUpdate(currentIDs: [first, second], newIDs: [otherMeeting]) == .reset)
+    }
+
+    @Test
+    func metadataRebuildUsesContentRevisionForUnchangedIdentifiers() {
+        let first = UUID.v7()
+
+        #expect(!ScreenshotCollectionView.Coordinator.shouldRebuildMetadata(
+            identifierUpdate: .unchanged,
+            currentContentRevision: 4,
+            newContentRevision: 4
+        ))
+        #expect(ScreenshotCollectionView.Coordinator.shouldRebuildMetadata(
+            identifierUpdate: .unchanged,
+            currentContentRevision: 4,
+            newContentRevision: 5
+        ))
+        #expect(ScreenshotCollectionView.Coordinator.shouldRebuildMetadata(
+            identifierUpdate: .unchanged,
+            currentContentRevision: nil,
+            newContentRevision: nil
+        ))
+        #expect(ScreenshotCollectionView.Coordinator.shouldRebuildMetadata(
+            identifierUpdate: .append([first]),
+            currentContentRevision: 4,
+            newContentRevision: 4
+        ))
+    }
 }
 #endif

--- a/Tests/DahliaTests/ScreenshotCollectionViewIntegrationTests.swift
+++ b/Tests/DahliaTests/ScreenshotCollectionViewIntegrationTests.swift
@@ -67,7 +67,11 @@ extension ScreenshotCollectionViewTests {
     func coordinatorSkipsTimestampRebuildForUnrelatedAndSelectionUpdates() {
         let meetingID = UUID.v7()
         let screenshots = makeScreenshots(count: 20, meetingID: meetingID)
-        let initialInput = makeCollectionInput(meetingID: meetingID, screenshots: screenshots)
+        let initialInput = makeCollectionInput(
+            meetingID: meetingID,
+            screenshots: screenshots,
+            contentRevision: 1
+        )
         let harness = ScreenshotCollectionHarness(parent: initialInput)
         let initialGeneration = harness.coordinator.timestampCacheGeneration
 
@@ -77,6 +81,7 @@ extension ScreenshotCollectionViewTests {
         harness.update(parent: makeCollectionInput(
             meetingID: meetingID,
             screenshots: screenshots,
+            contentRevision: 1,
             selectedScreenshotIDs: [screenshots[0].id]
         ))
         #expect(harness.coordinator.timestampCacheGeneration == initialGeneration)
@@ -90,6 +95,7 @@ extension ScreenshotCollectionViewTests {
         harness.update(parent: makeCollectionInput(
             meetingID: meetingID,
             screenshots: screenshots,
+            contentRevision: 1,
             recordingSessions: [session]
         ))
         #expect(harness.coordinator.timestampCacheGeneration == initialGeneration + 1)
@@ -103,6 +109,7 @@ extension ScreenshotCollectionViewTests {
         let harness = ScreenshotCollectionHarness(parent: makeCollectionInput(
             meetingID: meetingID,
             screenshots: [original],
+            contentRevision: 1,
             actionRecorder: actionRecorder
         ))
         let initialGeneration = harness.coordinator.timestampCacheGeneration
@@ -113,6 +120,7 @@ extension ScreenshotCollectionViewTests {
         harness.update(parent: makeCollectionInput(
             meetingID: meetingID,
             screenshots: [updated],
+            contentRevision: 2,
             actionRecorder: actionRecorder
         ))
 
@@ -169,6 +177,7 @@ extension ScreenshotCollectionViewTests {
     private func makeCollectionInput(
         meetingID: UUID,
         screenshots: [MeetingScreenshotRecord],
+        contentRevision: UInt64? = nil,
         recordingSessions: [RecordingSessionTimeline] = [],
         selectedScreenshotIDs: Set<UUID> = [],
         actionRecorder: CollectionActionRecorder? = nil
@@ -177,6 +186,7 @@ extension ScreenshotCollectionViewTests {
         return ScreenshotCollectionView(
             meetingID: meetingID,
             screenshots: screenshots,
+            contentRevision: contentRevision,
             recordingSessions: recordingSessions,
             fallbackTimeBase: Date(timeIntervalSince1970: 0),
             minimumItemWidth: ScreenshotGridSizing.defaultMinimumWidth,

--- a/Tests/DahliaTests/ScreenshotCollectionViewTests.swift
+++ b/Tests/DahliaTests/ScreenshotCollectionViewTests.swift
@@ -30,19 +30,6 @@ struct ScreenshotCollectionViewTests {
     }
 
     @Test
-    func snapshotUpdatesOnlyWhenIdentifiersChange() {
-        let first = UUID.v7()
-        let second = UUID.v7()
-        let otherMeeting = UUID.v7()
-
-        #expect(ScreenshotCollectionView.Coordinator.requiresSnapshotUpdate(currentIDs: [], newIDs: [first]))
-        #expect(!ScreenshotCollectionView.Coordinator.requiresSnapshotUpdate(currentIDs: [first], newIDs: [first]))
-        #expect(ScreenshotCollectionView.Coordinator.requiresSnapshotUpdate(currentIDs: [first], newIDs: [first, second]))
-        #expect(ScreenshotCollectionView.Coordinator.requiresSnapshotUpdate(currentIDs: [first, second], newIDs: [second]))
-        #expect(ScreenshotCollectionView.Coordinator.requiresSnapshotUpdate(currentIDs: [first, second], newIDs: [otherMeeting]))
-    }
-
-    @Test
     func sameIdentifierStateChangesOnlyReconfigureVisibleItems() {
         let screenshotID = UUID.v7()
         let unchanged = ScreenshotCollectionView.Coordinator.PresentationState(

--- a/Tests/DahliaTests/ScreenshotStoreTests.swift
+++ b/Tests/DahliaTests/ScreenshotStoreTests.swift
@@ -19,16 +19,19 @@ struct ScreenshotStoreTests {
         let otherMeeting = makeScreenshot(meetingID: UUID.v7(), capturedAt: .now)
 
         store.replace(meetingID: meetingID, records: [])
+        let replacementRevision = store.contentRevision
         store.upsert(later)
         store.upsert(earlier)
         store.upsert(otherMeeting)
 
         #expect(store.records.map(\.id) == [earlier.id, later.id])
+        #expect(store.contentRevision == replacementRevision + 2)
 
         var updated = later
         updated.mimeType = "image/jpeg"
         store.upsert(updated)
         #expect(try #require(store.records.last).mimeType == "image/jpeg")
+        #expect(store.contentRevision == replacementRevision + 3)
     }
 
     @Test

--- a/Tests/DahliaTests/ScreenshotStoreTests.swift
+++ b/Tests/DahliaTests/ScreenshotStoreTests.swift
@@ -1,0 +1,93 @@
+import Combine
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+import Testing
+
+@MainActor
+struct ScreenshotStoreTests {
+    @Test
+    func upsertMaintainsOrderAndRejectsAnotherMeeting() throws {
+        let store = ScreenshotStore()
+        let meetingID = UUID.v7()
+        let later = makeScreenshot(meetingID: meetingID, capturedAt: .now)
+        let earlier = makeScreenshot(
+            meetingID: meetingID,
+            capturedAt: later.capturedAt.addingTimeInterval(-10)
+        )
+        let otherMeeting = makeScreenshot(meetingID: UUID.v7(), capturedAt: .now)
+
+        store.replace(meetingID: meetingID, records: [])
+        store.upsert(later)
+        store.upsert(earlier)
+        store.upsert(otherMeeting)
+
+        #expect(store.records.map(\.id) == [earlier.id, later.id])
+
+        var updated = later
+        updated.mimeType = "image/jpeg"
+        store.upsert(updated)
+        #expect(try #require(store.records.last).mimeType == "image/jpeg")
+    }
+
+    @Test
+    func removeAndClearStayScopedToTheDisplayedMeeting() {
+        let store = ScreenshotStore()
+        let meetingID = UUID.v7()
+        let first = makeScreenshot(meetingID: meetingID, capturedAt: .now)
+        let second = makeScreenshot(
+            meetingID: meetingID,
+            capturedAt: first.capturedAt.addingTimeInterval(1)
+        )
+        store.replace(meetingID: meetingID, records: [first, second])
+
+        store.remove(ids: [first.id], meetingID: UUID.v7())
+        #expect(store.records.map(\.id) == [first.id, second.id])
+
+        store.remove(ids: [first.id], meetingID: meetingID)
+        #expect(store.records.map(\.id) == [second.id])
+
+        store.clear()
+        #expect(store.meetingID == nil)
+        #expect(store.records.isEmpty)
+    }
+
+    @Test
+    func screenshotProjectionDoesNotPublishThroughCaptionViewModel() {
+        let viewModel = CaptionViewModel(
+            audioHardwareQueryService: AudioHardwareQueryService(
+                availableInputDevicesProvider: { [] },
+                defaultInputDeviceIDProvider: { nil }
+            )
+        )
+        var captionViewModelChangeCount = 0
+        var screenshotStoreChangeCount = 0
+        let captionViewModelCancellable = viewModel.objectWillChange.sink {
+            captionViewModelChangeCount += 1
+        }
+        let screenshotStoreCancellable = viewModel.screenshotStore.objectWillChange.sink {
+            screenshotStoreChangeCount += 1
+        }
+
+        let meetingID = UUID.v7()
+        viewModel.screenshotStore.replace(meetingID: meetingID, records: [
+            makeScreenshot(meetingID: meetingID, capturedAt: .now),
+        ])
+
+        #expect(captionViewModelChangeCount == 0)
+        #expect(screenshotStoreChangeCount == 1)
+        withExtendedLifetime((captionViewModelCancellable, screenshotStoreCancellable)) {}
+    }
+
+    private func makeScreenshot(meetingID: UUID, capturedAt: Date) -> MeetingScreenshotRecord {
+        MeetingScreenshotRecord(
+            id: .v7(),
+            meetingId: meetingID,
+            capturedAt: capturedAt,
+            imageData: Data([0]),
+            mimeType: "image/png"
+        )
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- replace the periodic one-shot screenshot loop with a persistent ScreenCaptureKit stream and bounded latest-frame processing
- move fingerprinting, encoding, and persistence away from the main actor while preserving stop and retry ordering
- isolate screenshot UI projection state and update the collection incrementally to reduce unrelated redraws
- add Sentry breadcrumbs, signposts, and regression coverage for lifecycle, backpressure, timestamps, and stale completions

## Root cause

Automatic screenshots were captured by repeatedly creating full-screen capture operations. The resulting frame copy, change detection, encoding, persistence, and UI publication could overlap with main-actor work and make sidebar scrolling stutter. Stop, restart, and failure callbacks also had timing windows where an older operation could interfere with a replacement capture.

## Impact

Automatic screenshot capture now keeps at most the newest pending full-resolution frame, performs image-sized work off the main actor, and prevents stale capture generations from updating replacement state. Manual screenshot behavior and the persistent screenshot data contract remain unchanged.

## Validation

- `swift build`
- 21 related tests across 5 suites
- 8 automatic screenshot capture regression tests after the final simplification
- `CI=true ./scripts/lint.sh` (SwiftFormat clean; repository-wide SwiftLint violations remain non-blocking)
- full suite executed 1,119 tests; four unrelated Codex App Server timeout flakes passed when rerun separately
