### PR TITLE
Add descriptions to organizations

### DIFF
--- a/Sources/Dahlia/Database/AppDatabaseManager.swift
+++ b/Sources/Dahlia/Database/AppDatabaseManager.swift
@@ -162,6 +162,10 @@ final class AppDatabaseManager: Sendable {
             try CustomerIntelligenceDirectCRUDMigration.migrate(in: db)
         }
 
+        migrator.registerMigration("v30_organizationDescription") { db in
+            try OrganizationDescriptionMigration.migrate(in: db)
+        }
+
         return migrator
     }()
 

--- a/Sources/Dahlia/Database/MeetingRepository+CustomerIntelligence.swift
+++ b/Sources/Dahlia/Database/MeetingRepository+CustomerIntelligence.swift
@@ -127,6 +127,7 @@ extension MeetingRepository {
         parentOrganizationId: UUID?,
         nodeKind: OrganizationNodeKind,
         name: String,
+        description: String = "",
         now: Date = .now
     ) throws -> OrganizationRecord {
         try dbQueue.write { db in
@@ -142,6 +143,7 @@ extension MeetingRepository {
                 parentOrganizationId: parentOrganizationId,
                 nodeKind: nodeKind,
                 name: name,
+                description: description,
                 revision: 1,
                 createdAt: now,
                 updatedAt: now
@@ -188,6 +190,7 @@ extension MeetingRepository {
         vaultId: UUID,
         name: String,
         parentOrganizationId: UUID?,
+        description: String? = nil,
         expectedRevision: Int,
         now: Date = .now
     ) throws -> OrganizationRecord {
@@ -206,6 +209,9 @@ extension MeetingRepository {
             }
             organization.name = name
             organization.parentOrganizationId = parentOrganizationId
+            if let description {
+                organization.description = description
+            }
             organization.revision += 1
             organization.updatedAt = now
             do {

--- a/Sources/Dahlia/Database/MeetingRepository+CustomerIntelligenceWorkspace.swift
+++ b/Sources/Dahlia/Database/MeetingRepository+CustomerIntelligenceWorkspace.swift
@@ -172,7 +172,10 @@ extension MeetingRepository {
                     SELECT organizations.*
                     FROM organizations
                     JOIN subtree ON subtree.id = organizations.id
-                    WHERE organizations.name LIKE ?
+                    WHERE (
+                        organizations.name LIKE ?
+                        OR organizations.description LIKE ?
+                    )
                     ORDER BY organizations.name COLLATE NOCASE, organizations.id
                     LIMIT ?
                     """,
@@ -181,13 +184,17 @@ extension MeetingRepository {
                         vaultId,
                         vaultId,
                         "%\(query)%",
+                        "%\(query)%",
                         min(max(limit, 1), 100),
                     ]
                 )
             }
             return try OrganizationRecord
                 .filter(Column("vaultId") == vaultId)
-                .filter(Column("name").like("%\(query)%"))
+                .filter(
+                    Column("name").like("%\(query)%")
+                        || Column("description").like("%\(query)%")
+                )
                 .order(Column("name").asc, Column("id").asc)
                 .limit(min(max(limit, 1), 100))
                 .fetchAll(db)

--- a/Sources/Dahlia/Database/OrganizationDescriptionMigration.swift
+++ b/Sources/Dahlia/Database/OrganizationDescriptionMigration.swift
@@ -1,0 +1,12 @@
+import GRDB
+
+enum OrganizationDescriptionMigration {
+    static func migrate(in db: Database) throws {
+        let columns = try db.columns(in: OrganizationRecord.databaseTableName)
+        guard !columns.contains(where: { $0.name == "description" }) else { return }
+
+        try db.alter(table: OrganizationRecord.databaseTableName) {
+            $0.add(column: "description", .text).notNull().defaults(to: "")
+        }
+    }
+}

--- a/Sources/Dahlia/Database/OrganizationRecord.swift
+++ b/Sources/Dahlia/Database/OrganizationRecord.swift
@@ -9,6 +9,7 @@ struct OrganizationRecord: Codable, FetchableRecord, PersistableRecord, Identifi
     var parentOrganizationId: UUID?
     var nodeKind: OrganizationNodeKind
     var name: String
+    var description = ""
     var revision: Int
     var createdAt: Date
     var updatedAt: Date

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -164,6 +164,7 @@
 "The Summary output destination must resolve inside the Vault without symlink or file path components." = "The Summary output destination must resolve inside the Vault without symlink or file path components.";
 "The Summary output folder has not been created yet." = "The Summary output folder has not been created yet.";
 "Project Description" = "Project Description";
+"Organization Description" = "Organization Description";
 "This description is included when summaries are generated for this project." = "This description is included when summaries are generated for this project.";
 "Describe this project..." = "Describe this project...";
 "Could not save the project description." = "Could not save the project description.";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -164,6 +164,7 @@
 "The Summary output destination must resolve inside the Vault without symlink or file path components." = "Summary の書き出し先は Vault 内に解決され、パス上にシンボリックリンクやファイルを含めることはできません。";
 "The Summary output folder has not been created yet." = "Summary の書き出しフォルダはまだ作成されていません。";
 "Project Description" = "プロジェクトの説明";
+"Organization Description" = "組織・部門の説明";
 "This description is included when summaries are generated for this project." = "このプロジェクトの要約生成時に説明を含めます。";
 "Describe this project..." = "このプロジェクトについて説明してください...";
 "Could not save the project description." = "プロジェクトの説明を保存できませんでした。";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -267,6 +267,7 @@ enum L10n {
     }
 
     static var customerIntelligenceNoDescription: String { String(localized: "No description", bundle: bundle) }
+    static var organizationDescription: String { String(localized: "Organization Description", bundle: bundle) }
     static var customerIntelligenceManageInProjects: String {
         String(localized: "Manage in Projects", bundle: bundle)
     }

--- a/Sources/Dahlia/ViewModels/CustomerIntelligenceWorkspaceViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CustomerIntelligenceWorkspaceViewModel.swift
@@ -232,7 +232,7 @@ final class CustomerIntelligenceWorkspaceViewModel {
         updateSelection(id, at: \.insightID)
     }
 
-    func createRootOrganization(name: String) async -> Bool {
+    func createRootOrganization(name: String, description: String = "") async -> Bool {
         guard let dbQueue, let vaultID, name.nilIfBlank != nil else { return false }
         let previousLocation = currentLocation
         do {
@@ -241,7 +241,8 @@ final class CustomerIntelligenceWorkspaceViewModel {
                     vaultId: vaultID,
                     parentOrganizationId: nil,
                     nodeKind: .organization,
-                    name: name
+                    name: name,
+                    description: description
                 )
             }.value
             scope = .organization(organization.id)

--- a/Sources/Dahlia/ViewModels/OrganizationWorkspaceViewModel.swift
+++ b/Sources/Dahlia/ViewModels/OrganizationWorkspaceViewModel.swift
@@ -88,7 +88,10 @@ final class OrganizationWorkspaceViewModel {
     var filteredRoots: [OrganizationWorkspaceNode] {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else { return roots }
-        return roots.filter { $0.organization.name.localizedCaseInsensitiveContains(query) }
+        return roots.filter {
+            $0.organization.name.localizedCaseInsensitiveContains(query)
+                || $0.organization.description.localizedCaseInsensitiveContains(query)
+        }
     }
 
     func load(selectingRootID requestedRootID: UUID? = nil) async {
@@ -291,7 +294,7 @@ final class OrganizationWorkspaceViewModel {
         }
     }
 
-    func updateSelectedOrganization(name: String, parentID: UUID?) async -> Bool {
+    func updateSelectedOrganization(name: String, parentID: UUID?, description: String) async -> Bool {
         guard let id = selectedNodeID, id != parentID, let node = loadedNodes[id], let vaultID else {
             return false
         }
@@ -301,19 +304,21 @@ final class OrganizationWorkspaceViewModel {
                 vaultId: vaultID,
                 name: name,
                 parentOrganizationId: parentID,
+                description: description,
                 expectedRevision: node.organization.revision
             )
         }
     }
 
-    func createRootOrganization(name: String) async {
+    func createRootOrganization(name: String, description: String = "") async {
         guard let vaultID else { return }
         await mutate(vaultID: vaultID, operation: {
             try $0.createOrganization(
                 vaultId: vaultID,
                 parentOrganizationId: nil,
                 nodeKind: .organization,
-                name: name
+                name: name,
+                description: description
             )
         }, onSuccess: { organization in
             selectedRootID = organization.id

--- a/Sources/Dahlia/Views/CustomerIntelligenceCreationSheet.swift
+++ b/Sources/Dahlia/Views/CustomerIntelligenceCreationSheet.swift
@@ -7,7 +7,7 @@ struct CustomerIntelligenceCreationSheet: View {
     let roots: [OrganizationWorkspaceNode]
     let scope: CustomerIntelligenceScope
     let sidebarViewModel: SidebarViewModel
-    let onCreateOrganization: (String, UUID?) async -> Bool
+    let onCreateOrganization: (String, UUID?, String) async -> Bool
     let onCreateContact: (String, String, UUID?) async -> Bool
     let onCreateProject: (String, UUID?, ProjectType, String, UUID) async -> Bool
     let onCreateTopic: (String, String, UUID) async -> Bool
@@ -61,6 +61,8 @@ struct CustomerIntelligenceCreationSheet: View {
         case let .organization(parentID):
             Section {
                 TextField(L10n.name, text: $name)
+                TextField(L10n.organizationDescription, text: $details, axis: .vertical)
+                    .lineLimit(4 ... 8)
                 if parentID != nil {
                     organizationPicker(title: L10n.parentDepartment)
                         .disabled(true)
@@ -199,7 +201,7 @@ struct CustomerIntelligenceCreationSheet: View {
 
     private var sheetHeight: Double {
         switch request {
-        case .organization: 300
+        case .organization: 400
         case .contact: 400
         case .project: 560
         case .topic: 440
@@ -212,7 +214,7 @@ struct CustomerIntelligenceCreationSheet: View {
         let didCreate: Bool
         switch request {
         case let .organization(parentID):
-            didCreate = await onCreateOrganization(name, parentID)
+            didCreate = await onCreateOrganization(name, parentID, details)
         case .contact:
             didCreate = await onCreateContact(name, email, selectedOrganizationID)
         case .project:

--- a/Sources/Dahlia/Views/CustomerIntelligenceCustomerCard.swift
+++ b/Sources/Dahlia/Views/CustomerIntelligenceCustomerCard.swift
@@ -11,6 +11,13 @@ struct CustomerIntelligenceCustomerCard: View {
                     .font(.headline)
                     .lineLimit(2)
 
+                if let description = customer.root.organization.description.nilIfBlank {
+                    Text(description)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+
                 HStack(spacing: 16) {
                     count(customer.organizationCount, title: L10n.organizations, systemImage: "rectangle.3.group")
                     count(customer.contactCount, title: L10n.people, systemImage: "person.2")

--- a/Sources/Dahlia/Views/CustomerIntelligenceScopePicker.swift
+++ b/Sources/Dahlia/Views/CustomerIntelligenceScopePicker.swift
@@ -76,7 +76,10 @@ private struct CustomerIntelligenceScopePopover: View {
 
     private var filteredRoots: [OrganizationWorkspaceNode] {
         guard let query = searchText.nilIfBlank else { return roots }
-        return roots.filter { $0.organization.name.localizedStandardContains(query) }
+        return roots.filter {
+            $0.organization.name.localizedStandardContains(query)
+                || $0.organization.description.localizedStandardContains(query)
+        }
     }
 
     private func scopeButton(

--- a/Sources/Dahlia/Views/CustomerIntelligenceWorkspaceView.swift
+++ b/Sources/Dahlia/Views/CustomerIntelligenceWorkspaceView.swift
@@ -222,9 +222,9 @@ private extension OrganizationWorkspaceView {
         MainWindowOpener.shared.openMainWindow()
     }
 
-    private func createOrganization(name: String, parentID: UUID?) async -> Bool {
+    private func createOrganization(name: String, parentID: UUID?, description: String) async -> Bool {
         guard let parentID else {
-            return await model.createRootOrganization(name: name)
+            return await model.createRootOrganization(name: name, description: description)
         }
         guard let dbQueue = sidebarViewModel.dbQueue, let vaultID = sidebarViewModel.currentVault?.id else {
             return false
@@ -235,7 +235,8 @@ private extension OrganizationWorkspaceView {
                     vaultId: vaultID,
                     parentOrganizationId: parentID,
                     nodeKind: .unit,
-                    name: name
+                    name: name,
+                    description: description
                 )
             }.value
             model.selection.organizationID = organization.id

--- a/Sources/Dahlia/Views/OrganizationEditorSheet.swift
+++ b/Sources/Dahlia/Views/OrganizationEditorSheet.swift
@@ -5,22 +5,24 @@ struct OrganizationEditorSheet: View {
 
     let organization: OrganizationWorkspaceNode
     let parentCandidates: [OrganizationRecord]
-    let onSave: (String, UUID?) async -> Bool
+    let onSave: (String, UUID?, String) async -> Bool
 
     @State private var name: String
     @State private var parentID: UUID?
+    @State private var description: String
     @State private var isSaving = false
 
     init(
         organization: OrganizationWorkspaceNode,
         parentCandidates: [OrganizationRecord],
-        onSave: @escaping (String, UUID?) async -> Bool
+        onSave: @escaping (String, UUID?, String) async -> Bool
     ) {
         self.organization = organization
         self.parentCandidates = parentCandidates
         self.onSave = onSave
         _name = State(initialValue: organization.organization.name)
         _parentID = State(initialValue: organization.organization.parentOrganizationId)
+        _description = State(initialValue: organization.organization.description)
     }
 
     var body: some View {
@@ -36,6 +38,8 @@ struct OrganizationEditorSheet: View {
                             Text(candidate.name).tag(Optional(candidate.id))
                         }
                     }
+                    TextField(L10n.organizationDescription, text: $description, axis: .vertical)
+                        .lineLimit(4 ... 8)
                 }
             }
             .formStyle(.grouped)
@@ -64,12 +68,13 @@ struct OrganizationEditorSheet: View {
     private var hasChanges: Bool {
         name != organization.organization.name
             || parentID != organization.organization.parentOrganizationId
+            || description != organization.organization.description
     }
 
     private func save() async {
         isSaving = true
         defer { isSaving = false }
-        if await onSave(name, parentID) {
+        if await onSave(name, parentID, description) {
             dismiss()
         }
     }

--- a/Sources/Dahlia/Views/OrganizationWorkspaceView.swift
+++ b/Sources/Dahlia/Views/OrganizationWorkspaceView.swift
@@ -232,6 +232,13 @@ struct OrganizationHierarchyView: View {
     private func organizationSection(_ node: OrganizationWorkspaceNode) -> some View {
         Section(L10n.department) {
             LabeledContent(L10n.name, value: node.organization.name)
+            if let description = node.organization.description.nilIfBlank {
+                LabeledContent(L10n.organizationDescription) {
+                    Text(description)
+                        .multilineTextAlignment(.trailing)
+                        .textSelection(.enabled)
+                }
+            }
             if let parentID = node.organization.parentOrganizationId,
                let parent = model.loadedNodes[parentID] {
                 LabeledContent(L10n.parentDepartment, value: parent.organization.name)

--- a/Sources/DahliaMeetingAccess/CustomerIntelligenceAccessModels.swift
+++ b/Sources/DahliaMeetingAccess/CustomerIntelligenceAccessModels.swift
@@ -48,6 +48,7 @@ public struct OrganizationAccessMetadata: Codable, Sendable, Equatable {
     public let parentOrganizationID: UUID?
     public let nodeKind: OrganizationAccessNodeKind
     public let name: String
+    public let description: String
     public let primaryDomain: String?
     public let domainCount: Int
     public let memberCount: Int

--- a/Sources/DahliaMeetingAccess/CustomerIntelligenceAccessStore.swift
+++ b/Sources/DahliaMeetingAccess/CustomerIntelligenceAccessStore.swift
@@ -36,6 +36,7 @@ public extension MeetingAccessStore {
                 predicates.append("""
                 (
                     organizations.name LIKE ? ESCAPE '\\' COLLATE NOCASE
+                    OR organizations.description LIKE ? ESCAPE '\\' COLLATE NOCASE
                     OR EXISTS (
                         SELECT 1
                         FROM organization_domains
@@ -44,7 +45,7 @@ public extension MeetingAccessStore {
                     )
                 )
                 """)
-                arguments += [pattern, pattern]
+                arguments += [pattern, pattern, pattern]
             }
             if let cursor {
                 predicates.append("""
@@ -457,7 +458,7 @@ extension MeetingAccessStore {
         guard try Bool.fetchOne(
             db,
             sql: "SELECT EXISTS(SELECT 1 FROM grdb_migrations WHERE identifier = ?)",
-            arguments: ["v29_customerIntelligenceDirectCRUD"]
+            arguments: ["v30_organizationDescription"]
         ) == true else {
             throw MeetingAccessError.databaseUpgradeRequired
         }
@@ -540,6 +541,7 @@ extension MeetingAccessStore {
             parentOrganizationID: row["parentOrganizationId"],
             nodeKind: nodeKind,
             name: row["name"],
+            description: row["description"],
             primaryDomain: row["primaryDomain"],
             domainCount: row["domainCount"],
             memberCount: row["memberCount"],

--- a/Sources/DahliaMeetingAccess/CustomerIntelligenceWorkspaceAccessModels.swift
+++ b/Sources/DahliaMeetingAccess/CustomerIntelligenceWorkspaceAccessModels.swift
@@ -18,6 +18,7 @@ public struct OrganizationChartAccessNode: Codable, Sendable, Equatable {
     public let parentOrganizationID: UUID?
     public let nodeKind: OrganizationAccessNodeKind
     public let name: String
+    public let description: String
     public let depth: Int
     public let revision: Int
     public let memberCount: Int

--- a/Sources/DahliaMeetingAccess/CustomerIntelligenceWorkspaceAccessStore.swift
+++ b/Sources/DahliaMeetingAccess/CustomerIntelligenceWorkspaceAccessStore.swift
@@ -95,6 +95,7 @@ public extension MeetingAccessStore {
                     parentOrganizationID: row["parentOrganizationId"],
                     nodeKind: kind,
                     name: row["name"],
+                    description: row["description"],
                     depth: row["depth"],
                     revision: row["revision"],
                     memberCount: row["memberCount"],

--- a/Sources/DahliaMeetingAccess/CustomerIntelligenceWriteStore.swift
+++ b/Sources/DahliaMeetingAccess/CustomerIntelligenceWriteStore.swift
@@ -27,7 +27,7 @@ public extension MeetingAccessStore {
         else {
             throw MeetingAccessError.invalidCustomerIntelligenceMutation
         }
-        let vault = try scopedVault()
+        let vault = try database.read(fetchCustomerIntelligenceVault(in:))
         let id = customerIntelligenceUUIDv7()
         try database.write { db in
             try db.execute(
@@ -81,7 +81,7 @@ public extension MeetingAccessStore {
         guard normalizedName != nil || normalizedDescription != nil || parent != .unchanged else {
             throw MeetingAccessError.invalidCustomerIntelligenceMutation
         }
-        let vault = try scopedVault()
+        let vault = try database.read(fetchCustomerIntelligenceVault(in:))
         let result = try database.write { db -> (Int, Bool) in
             guard let row = try Row.fetchOne(
                 db,
@@ -534,7 +534,7 @@ public extension MeetingAccessStore {
         expectedRevision: Int
     ) throws -> CustomerIntelligenceRecordDeletionResult {
         try requireCustomerIntelligenceWriteAccess()
-        let vault = try scopedVault()
+        let vault = try database.read(fetchCustomerIntelligenceVault(in:))
         try database.write { db in
             _ = try requiredRevision(
                 table: "organizations",

--- a/Sources/DahliaMeetingAccess/CustomerIntelligenceWriteStore.swift
+++ b/Sources/DahliaMeetingAccess/CustomerIntelligenceWriteStore.swift
@@ -6,6 +6,7 @@ import GRDB
 enum CustomerIntelligenceWriteLimits {
     static let email = 320
     static let shortText = 256
+    static let description = 4000
     static let topicState = 4000
     static let topicNote = 2000
     static let insightContent = 10000
@@ -16,10 +17,12 @@ public extension MeetingAccessStore {
     func createOrganization(
         name: String,
         nodeKind: OrganizationAccessNodeKind,
-        parentOrganizationID: UUID?
+        parentOrganizationID: UUID?,
+        description: String = ""
     ) throws -> CustomerIntelligenceRecordMutationResult {
         try requireCustomerIntelligenceWriteAccess()
         guard let name = normalizedCustomerText(name),
+              let description = normalizedCustomerDescription(description),
               parentOrganizationID != nil || nodeKind == .organization
         else {
             throw MeetingAccessError.invalidCustomerIntelligenceMutation
@@ -30,10 +33,19 @@ public extension MeetingAccessStore {
             try db.execute(
                 sql: """
                 INSERT INTO organizations
-                    (id, vaultId, parentOrganizationId, nodeKind, name, revision, createdAt, updatedAt)
-                VALUES (?, ?, ?, ?, ?, 1, ?, ?)
+                    (id, vaultId, parentOrganizationId, nodeKind, name, description, revision, createdAt, updatedAt)
+                VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?)
                 """,
-                arguments: [id, vaultID, parentOrganizationID, nodeKind.rawValue, name, Date.now, Date.now]
+                arguments: [
+                    id,
+                    vaultID,
+                    parentOrganizationID,
+                    nodeKind.rawValue,
+                    name,
+                    description,
+                    Date.now,
+                    Date.now,
+                ]
             )
         }
         postCustomerIntelligenceChange()
@@ -50,6 +62,7 @@ public extension MeetingAccessStore {
         id: UUID,
         expectedRevision: Int,
         name: String?,
+        description: String? = nil,
         parent: OrganizationParentMutation
     ) throws -> CustomerIntelligenceRecordMutationResult {
         try requireCustomerIntelligenceWriteAccess()
@@ -59,7 +72,13 @@ public extension MeetingAccessStore {
             }
             return value
         }
-        guard normalizedName != nil || parent != .unchanged else {
+        let normalizedDescription = try description.map {
+            guard let value = normalizedCustomerDescription($0) else {
+                throw MeetingAccessError.invalidCustomerIntelligenceMutation
+            }
+            return value
+        }
+        guard normalizedName != nil || normalizedDescription != nil || parent != .unchanged else {
             throw MeetingAccessError.invalidCustomerIntelligenceMutation
         }
         let vault = try scopedVault()
@@ -67,7 +86,7 @@ public extension MeetingAccessStore {
             guard let row = try Row.fetchOne(
                 db,
                 sql: """
-                SELECT name, parentOrganizationId, revision
+                SELECT name, description, parentOrganizationId, revision
                 FROM organizations WHERE id = ? AND vaultId = ?
                 """,
                 arguments: [id, vaultID]
@@ -78,23 +97,29 @@ public extension MeetingAccessStore {
             guard revision == expectedRevision else {
                 throw MeetingAccessError.customerIntelligenceRevisionConflict
             }
+            let currentName: String = row["name"]
+            let currentDescription: String = row["description"]
             let currentParent: UUID? = row["parentOrganizationId"]
             let nextParent: UUID? = switch parent {
             case .unchanged: currentParent
             case .root: nil
             case let .organization(parentID): parentID
             }
-            let nextName = normalizedName ?? (row["name"] as String)
-            guard nextName != (row["name"] as String) || nextParent != currentParent else {
+            let nextName = normalizedName ?? currentName
+            let nextDescription = normalizedDescription ?? currentDescription
+            guard nextName != currentName
+                || nextDescription != currentDescription
+                || nextParent != currentParent
+            else {
                 return (revision, false)
             }
             try db.execute(
                 sql: """
                 UPDATE organizations
-                SET name = ?, parentOrganizationId = ?, revision = revision + 1, updatedAt = ?
+                SET name = ?, description = ?, parentOrganizationId = ?, revision = revision + 1, updatedAt = ?
                 WHERE id = ? AND vaultId = ? AND revision = ?
                 """,
-                arguments: [nextName, nextParent, Date.now, id, vaultID, expectedRevision]
+                arguments: [nextName, nextDescription, nextParent, Date.now, id, vaultID, expectedRevision]
             )
             guard db.changesCount == 1 else {
                 throw MeetingAccessError.customerIntelligenceRevisionConflict
@@ -1348,6 +1373,11 @@ private extension MeetingAccessStore {
         guard let value else { return nil }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty || trimmed.count > maximumLength ? nil : trimmed
+    }
+
+    func normalizedCustomerDescription(_ value: String) -> String? {
+        guard value.count <= CustomerIntelligenceWriteLimits.description else { return nil }
+        return value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     func normalizedCustomerMetadata(_ value: String?) -> String? {

--- a/Sources/DahliaMeetingAccess/DahliaMCPServer.swift
+++ b/Sources/DahliaMeetingAccess/DahliaMCPServer.swift
@@ -302,16 +302,17 @@ public final class DahliaMCPServer {
                 description: description
             ))
         case "create_organization":
-            try validate(arguments, allowedKeys: ["name", "node_kind", "parent_organization_id"])
+            try validate(arguments, allowedKeys: ["name", "node_kind", "parent_organization_id", "description"])
             let nodeKind = try requiredOrganizationNodeKind(arguments)
             return try toolResult(store.createOrganization(
                 name: requiredString(arguments, key: "name"),
                 nodeKind: nodeKind,
-                parentOrganizationID: optionalUUID(arguments, key: "parent_organization_id")
+                parentOrganizationID: optionalUUID(arguments, key: "parent_organization_id"),
+                description: string(arguments, key: "description") ?? ""
             ))
         case "update_organization":
             try validate(arguments, allowedKeys: [
-                "organization_id", "revision", "name", "parent_organization_id",
+                "organization_id", "revision", "name", "parent_organization_id", "description",
             ])
             let parent: OrganizationParentMutation = if !arguments.keys.contains("parent_organization_id") {
                 .unchanged
@@ -324,6 +325,7 @@ public final class DahliaMCPServer {
                 id: requiredUUID(arguments, key: "organization_id"),
                 expectedRevision: requiredRevision(arguments),
                 name: optionalNonNullString(arguments, key: "name"),
+                description: optionalNonNullString(arguments, key: "description"),
                 parent: parent
             ))
         case "delete_organization":
@@ -1117,6 +1119,7 @@ private extension DahliaMCPServer {
                 "parent_organization_id": ["type": "string", "format": "uuid"],
                 "node_kind": organizationNodeKindSchema,
                 "name": ["type": "string"],
+                "description": ["type": "string"],
                 "primary_domain": ["type": "string"],
                 "domain_count": ["type": "integer", "minimum": 0],
                 "member_count": ["type": "integer", "minimum": 0],
@@ -1126,7 +1129,7 @@ private extension DahliaMCPServer {
                 "updated_at": ["type": "string", "format": "date-time"],
             ],
             required: [
-                "id", "node_kind", "name", "domain_count", "member_count", "child_count", "revision",
+                "id", "node_kind", "name", "description", "domain_count", "member_count", "child_count", "revision",
                 "created_at", "updated_at",
             ]
         )
@@ -1241,6 +1244,7 @@ private extension DahliaMCPServer {
                 "parent_organization_id": ["type": "string", "format": "uuid"],
                 "node_kind": organizationNodeKindSchema,
                 "name": ["type": "string"],
+                "description": ["type": "string"],
                 "depth": ["type": "integer", "minimum": 0],
                 "revision": ["type": "integer", "minimum": 1],
                 "member_count": ["type": "integer", "minimum": 0],
@@ -1252,7 +1256,7 @@ private extension DahliaMCPServer {
                 "children_truncated": ["type": "boolean"],
             ],
             required: [
-                "id", "node_kind", "name", "depth", "revision", "member_count",
+                "id", "node_kind", "name", "description", "depth", "revision", "member_count",
                 "project_count", "topic_count", "meeting_count", "child_count", "children_truncated",
             ]
         )
@@ -1848,23 +1852,26 @@ private extension DahliaMCPServer {
             customerWriteTool(
                 "create_organization",
                 "Create organization",
-                "Create one Organization or unit. A unit requires parent_organization_id.",
+                "Create one Organization or unit with an optional description. A unit requires parent_organization_id.",
                 [
                     "name": shortText,
                     "node_kind": organizationNodeKindSchema,
                     "parent_organization_id": uuid,
+                    "description": ["type": "string", "maxLength": CustomerIntelligenceWriteLimits.description],
                 ],
                 required: ["name", "node_kind"]
             ),
             customerWriteTool(
                 "update_organization",
                 "Update organization",
-                "Update one Organization. Omitted fields stay unchanged; parent_organization_id:null moves it to the root.",
+                "Update one Organization's name, description, or parent. Omitted fields stay unchanged; "
+                    + "parent_organization_id:null moves it to the root.",
                 [
                     "organization_id": uuid,
                     "revision": revision,
                     "name": shortText,
                     "parent_organization_id": nullableUUID,
+                    "description": ["type": "string", "maxLength": CustomerIntelligenceWriteLimits.description],
                 ],
                 required: ["organization_id", "revision"],
                 destructive: true

--- a/Tests/DahliaTests/CustomerIntelligenceOrganizationEditingTests.swift
+++ b/Tests/DahliaTests/CustomerIntelligenceOrganizationEditingTests.swift
@@ -30,7 +30,8 @@
                 vaultId: fixture.vault.id,
                 parentOrganizationId: firstParent.id,
                 nodeKind: .unit,
-                name: "Old Name"
+                name: "Old Name",
+                description: "Old description"
             )
 
             let updated = try fixture.repository.updateOrganization(
@@ -38,21 +39,39 @@
                 vaultId: fixture.vault.id,
                 name: "New Name",
                 parentOrganizationId: secondParent.id,
+                description: "Owns the platform roadmap",
                 expectedRevision: department.revision
             )
 
             #expect(updated.name == "New Name")
             #expect(updated.parentOrganizationId == secondParent.id)
+            #expect(updated.description == "Owns the platform roadmap")
             #expect(updated.revision == department.revision + 1)
+            let renamed = try fixture.repository.updateOrganization(
+                id: department.id,
+                vaultId: fixture.vault.id,
+                name: "Newest Name",
+                parentOrganizationId: secondParent.id,
+                expectedRevision: updated.revision
+            )
+            #expect(renamed.description == "Owns the platform roadmap")
             #expect(throws: CustomerIntelligenceError.revisionConflict) {
                 try fixture.repository.updateOrganization(
                     id: department.id,
                     vaultId: fixture.vault.id,
                     name: "Stale",
                     parentOrganizationId: firstParent.id,
+                    description: "Stale description",
                     expectedRevision: department.revision
                 )
             }
+
+            let matches = try fixture.repository.searchOrganizationWorkspaceNodes(
+                vaultId: fixture.vault.id,
+                rootOrganizationId: root.id,
+                query: "platform roadmap"
+            )
+            #expect(matches.map(\.id) == [department.id])
         }
 
         @Test

--- a/Tests/DahliaTests/MeetingAccessStoreTests.swift
+++ b/Tests/DahliaTests/MeetingAccessStoreTests.swift
@@ -2109,6 +2109,54 @@ import ImageIO
         }
 
         @Test
+        func v29DatabaseRejectsOrganizationWritesWithUpgradeError() throws {
+            let databaseURL = URL.temporaryDirectory
+                .appending(path: "dahlia-meeting-access-v29-\(UUID.v7().uuidString)")
+                .appendingPathExtension("sqlite")
+            defer { try? FileManager.default.removeItem(at: databaseURL) }
+            let vault = customerIntelligenceVault(name: "Before v30")
+            let organizationID = UUID.v7()
+            let queue = try DatabaseQueue(path: databaseURL.path)
+            try AppDatabaseManager.migrator.migrate(queue, upTo: "v29_customerIntelligenceDirectCRUD")
+            try queue.write { db in
+                try vault.insert(db)
+                try db.execute(
+                    sql: """
+                    INSERT INTO organizations (
+                        id, vaultId, parentOrganizationId, nodeKind, name, revision, createdAt, updatedAt
+                    )
+                    VALUES (?, ?, NULL, 'organization', 'Acme', 1, ?, ?)
+                    """,
+                    arguments: [organizationID, vault.id, Date.now, Date.now]
+                )
+            }
+            let store = try MeetingAccessStore(
+                databaseURL: databaseURL,
+                vaultID: vault.id,
+                allowsWrites: true
+            )
+
+            #expect(throws: MeetingAccessError.databaseUpgradeRequired) {
+                try store.createOrganization(
+                    name: "New",
+                    nodeKind: .organization,
+                    parentOrganizationID: nil
+                )
+            }
+            #expect(throws: MeetingAccessError.databaseUpgradeRequired) {
+                try store.updateOrganization(
+                    id: organizationID,
+                    expectedRevision: 1,
+                    name: "Updated",
+                    parent: .unchanged
+                )
+            }
+            #expect(throws: MeetingAccessError.databaseUpgradeRequired) {
+                try store.deleteOrganization(id: organizationID, expectedRevision: 1)
+            }
+        }
+
+        @Test
         func projectSchemaWithoutNameKeyRequiresOpeningDahliaForMigration() throws {
             let databaseURL = URL.temporaryDirectory
                 .appending(path: "dahlia-meeting-access-project-schema-\(UUID.v7().uuidString)")

--- a/Tests/DahliaTests/MeetingAccessStoreTests.swift
+++ b/Tests/DahliaTests/MeetingAccessStoreTests.swift
@@ -764,7 +764,8 @@ import ImageIO
                 vaultId: fixture.primaryVaultID,
                 parentOrganizationId: nil,
                 nodeKind: .organization,
-                name: "Acme"
+                name: "Acme",
+                description: "Strategic customer"
             )
             let unit = try repository.createOrganization(
                 vaultId: fixture.primaryVaultID,
@@ -853,8 +854,13 @@ import ImageIO
                 unit.id,
             ])
             let organizationDetail = try store.organization(id: organization.id)
+            #expect(organizationDetail.organization.description == "Strategic customer")
             #expect(organizationDetail.domains.map(\.domainName) == ["acme.example"])
             #expect(organizationDetail.projectResources.map(\.relationLabel) == ["customer"])
+            #expect(
+                try store.queryOrganizations(.init(query: "Strategic customer")).organizations.map(\.id)
+                    == [organization.id]
+            )
 
             let contacts = try store.queryContacts()
             #expect(contacts.contacts.map(\.id) == [contact.id])
@@ -1561,7 +1567,21 @@ import ImageIO
             let root = try store.createOrganization(
                 name: "Acme Customer",
                 nodeKind: .organization,
-                parentOrganizationID: nil
+                parentOrganizationID: nil,
+                description: "Enterprise account"
+            )
+            #expect(try store.organization(id: root.resourceID).organization.description == "Enterprise account")
+            let updatedRoot = try store.updateOrganization(
+                id: root.resourceID,
+                expectedRevision: root.revision,
+                name: nil,
+                description: "Strategic enterprise account",
+                parent: .unchanged
+            )
+            #expect(updatedRoot.changed)
+            #expect(
+                try store.organization(id: root.resourceID).organization.description
+                    == "Strategic enterprise account"
             )
             let unit = try store.createOrganization(
                 name: "Data",

--- a/Tests/DahliaTests/OrganizationDescriptionMigrationTests.swift
+++ b/Tests/DahliaTests/OrganizationDescriptionMigrationTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct OrganizationDescriptionMigrationTests {
+        @Test
+        func preservesExistingOrganizations() throws {
+            let queue = try DatabaseQueue()
+            try AppDatabaseManager.migrator.migrate(queue, upTo: "v29_customerIntelligenceDirectCRUD")
+            let vault = VaultRecord(
+                id: .v7(),
+                path: "/tmp/organization-description-vault",
+                name: "Vault",
+                createdAt: .now,
+                lastOpenedAt: .now
+            )
+            let organizationID = UUID.v7()
+            try queue.write { db in
+                try vault.insert(db)
+                try db.execute(
+                    sql: """
+                    INSERT INTO organizations (
+                        id, vaultId, parentOrganizationId, nodeKind, name, revision, createdAt, updatedAt
+                    )
+                    VALUES (?, ?, NULL, 'organization', 'Acme', 3, ?, ?)
+                    """,
+                    arguments: [organizationID, vault.id, Date.now, Date.now]
+                )
+            }
+
+            try AppDatabaseManager.migrator.migrate(queue)
+
+            let migrated = try queue.read { db in
+                try OrganizationRecord.fetchOne(db, key: organizationID)
+            }
+            #expect(migrated?.name == "Acme")
+            #expect(migrated?.description.isEmpty == true)
+            #expect(migrated?.revision == 3)
+        }
+    }
+#endif

--- a/docs/adr/0012-reviewable-customer-intelligence-workspace.md
+++ b/docs/adr/0012-reviewable-customer-intelligence-workspace.md
@@ -60,8 +60,9 @@ create Glossary, proposal, import, or development-only idempotency tables. The a
 `v28_customerIntelligenceTopicReferenceTimestamp` migration makes reference cleanup update the Topic timestamp as well
 as its revision. `v29_customerIntelligenceDirectCRUD` reconciles QA databases opened against an earlier pre-release
 schema: it maps string Insight review state to Boolean acceptance, supplies revision values, removes retired staging
-tables, and restores the current validation and cleanup triggers. The MCP contract requires v29 so it never treats a
-partially upgraded QA database as current.
+tables, and restores the validation and cleanup triggers current at the time of this decision. The MCP contract
+required v29 at that point so it never treated a partially upgraded QA database as current. The
+[workspace documentation](../customer-intelligence-workspace.md#mcp) records the current schema requirement.
 
 App and MCP database queues wait up to five seconds for a writer. A single failed call never partially commits.
 Calendar facts retain a stronger provenance boundary than AI-derived organization knowledge.

--- a/docs/customer-intelligence-workspace.md
+++ b/docs/customer-intelligence-workspace.md
@@ -25,6 +25,7 @@ Dahlia の「顧客インテリジェンス」画面は、選択中の Vault に
   ドメイン、人物、部署、Project、Topic、Insight の参照を選択中の Organization へ一括統合します。
   統合先の名称と主ドメインを維持し、重複する所属や参照では統合先の情報を優先して、元の Organization
   を削除します。統合先に主ドメインがない場合は、元の Organization の主ドメインを引き継ぎます。
+- Organization と部門には説明を保存でき、作成・編集・詳細表示と組織検索で利用できます。
 - Organization、暫定人物、Topic の削除はインスペクタ最下部の Danger Zone にだけ表示します。
 - ズームは50〜200%です。ツールバー操作に加えてトラックパッドのピンチで連続的に変更できます。
   座標は保存せず、親子関係から毎回派生します。
@@ -72,7 +73,8 @@ Insight の参照がすべて解除されている場合だけ削除できます
 
 読み取りセッションでは Organization、Contact、Topic、Insight、Project、Meeting を `query_*`／`get_*`
 で取得できます。`query_organization_chart` は一つのルートを最大500ノードまで返し、
-`nodes_truncated` が絞り込みの必要性を示します。
+`nodes_truncated` が絞り込みの必要性を示します。Organization の読み取り応答は `description` を含み、
+`query_organizations` は名称、説明、ドメインを検索します。
 
 `--write` セッションだけが以下を追加公開します。
 
@@ -94,4 +96,5 @@ Topic と Insight の削除は所有する参照だけを削除し、参照先�
 
 開発途中の旧スキーマを適用済みの QA データベースは、Dahlia 起動時の
 `v29_customerIntelligenceDirectCRUD` で現在の Insight 列と cleanup trigger へ前方修復されます。
-MCP は v29 完了前のデータベースを開かず、Dahlia を一度起動してアップグレードするよう案内します。
+続く `v30_organizationDescription` は既存 Organization を保持したまま説明列を追加します。MCP は v30
+完了前のデータベースを開かず、Dahlia を一度起動してアップグレードするよう案内します。


### PR DESCRIPTION
## Summary

- add a persisted description field to organizations and departments through the v30 additive migration
- support description editing, display, and search in the organization workspace
- expose organization descriptions through Customer Intelligence MCP read/write tools with bounded input validation
- add migration, repository, search, and MCP coverage, plus update the current workspace documentation

## Why

Organizations and departments currently only carry a name, which leaves users without a place to record their purpose, ownership, or other context. This adds that context while preserving existing rows and relationships.

## Validation

- `swift build`
- related database, editing, and MCP tests: 71 tests in 6 suites passed
- `CI=true ./scripts/lint.sh` (SwiftFormat: 0/542 files require formatting; SwiftLint retains existing non-blocking repository violations)
- `git diff --check`

The full suite was also exercised during implementation; 1 unrelated asynchronous navigation test failed and reproduced in isolation.