### PR TITLE
Improve sidebar scrolling while recording

### DIFF
--- a/Sources/Dahlia/Views/MeetingListSidebarView.swift
+++ b/Sources/Dahlia/Views/MeetingListSidebarView.swift
@@ -25,59 +25,59 @@ struct MeetingListSidebarView: View {
     }
 
     var body: some View {
-        List(selection: meetingSelection) {
-            if let selectedMeeting = sidebarViewModel.selectedMeetingOutsideDisplayedItems {
-                Section(L10n.selectedMeeting) {
-                    meetingRow(selectedMeeting)
-                }
-            }
-
-            ForEach(sidebarViewModel.displayedMeetingGroups) { group in
-                Section(group.title) {
-                    ForEach(group.meetings) { item in
-                        meetingRow(item)
+        VStack(spacing: 0) {
+            List(selection: meetingSelection) {
+                if let selectedMeeting = sidebarViewModel.selectedMeetingOutsideDisplayedItems {
+                    Section(L10n.selectedMeeting) {
+                        meetingRow(selectedMeeting)
                     }
                 }
+
+                ForEach(sidebarViewModel.displayedMeetingGroups) { group in
+                    Section(group.title) {
+                        ForEach(group.meetings) { item in
+                            meetingRow(item)
+                        }
+                    }
+                }
+
+                MeetingListPaginationRow(
+                    error: sidebarViewModel.displayedMeetingListLoadError,
+                    hasItems: !sidebarViewModel.displayedMeetingItems.isEmpty,
+                    isLoadingMore: sidebarViewModel.isDisplayedMeetingListLoadingMore,
+                    hasMore: sidebarViewModel.hasMoreDisplayedMeetings,
+                    limitMessage: meetingListLimitMessage,
+                    loadTrigger: "meeting-page-\(sidebarViewModel.meetingSearchQuery)-\(sidebarViewModel.displayedMeetingItems.count)",
+                    onRetry: sidebarViewModel.retryDisplayedMeetingLoading,
+                    onLoadMore: sidebarViewModel.loadMoreDisplayedMeetings
+                )
+            }
+            .listStyle(.sidebar)
+            .overlay {
+                MeetingListStatusOverlay(
+                    isLoaded: sidebarViewModel.isDisplayedMeetingListLoaded,
+                    error: sidebarViewModel.displayedMeetingListLoadError,
+                    isEmpty: sidebarViewModel.displayedMeetingItems.isEmpty,
+                    isSearching: sidebarViewModel.isSearchingMeetings,
+                    onRetry: sidebarViewModel.retryDisplayedMeetingLoading
+                )
+            }
+            .searchable(text: $searchText, placement: .sidebar, prompt: L10n.searchMeetings)
+            .contextMenu(forSelectionType: UUID.self) { selection in
+                contextMenu(for: selection)
+            }
+            .onDeleteCommand {
+                requestDeletion(of: sidebarViewModel.selectedMeetingIds)
             }
 
-            MeetingListPaginationRow(
-                error: sidebarViewModel.displayedMeetingListLoadError,
-                hasItems: !sidebarViewModel.displayedMeetingItems.isEmpty,
-                isLoadingMore: sidebarViewModel.isDisplayedMeetingListLoadingMore,
-                hasMore: sidebarViewModel.hasMoreDisplayedMeetings,
-                limitMessage: meetingListLimitMessage,
-                loadTrigger: "meeting-page-\(sidebarViewModel.meetingSearchQuery)-\(sidebarViewModel.displayedMeetingItems.count)",
-                onRetry: sidebarViewModel.retryDisplayedMeetingLoading,
-                onLoadMore: sidebarViewModel.loadMoreDisplayedMeetings
-            )
-        }
-        .listStyle(.sidebar)
-        .overlay {
-            MeetingListStatusOverlay(
-                isLoaded: sidebarViewModel.isDisplayedMeetingListLoaded,
-                error: sidebarViewModel.displayedMeetingListLoadError,
-                isEmpty: sidebarViewModel.displayedMeetingItems.isEmpty,
-                isSearching: sidebarViewModel.isSearchingMeetings,
-                onRetry: sidebarViewModel.retryDisplayedMeetingLoading
-            )
-        }
-        .overlay(alignment: .bottom) {
             if viewModel.isListening {
                 RecordingStatusBar(
                     viewModel: viewModel,
                     sidebarViewModel: sidebarViewModel,
                     recordingCoordinator: recordingCoordinator
                 )
-                .padding(.horizontal, 8)
-                .padding(.bottom, 8)
+                .padding(8)
             }
-        }
-        .searchable(text: $searchText, placement: .sidebar, prompt: L10n.searchMeetings)
-        .contextMenu(forSelectionType: UUID.self) { selection in
-            contextMenu(for: selection)
-        }
-        .onDeleteCommand {
-            requestDeletion(of: sidebarViewModel.selectedMeetingIds)
         }
         .onAppear {
             renderedMeetingSelection = sidebarViewModel.selectedMeetingIds
@@ -288,13 +288,15 @@ private struct RecordingStatusBar: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .background(
+            Color(nsColor: .controlBackgroundColor),
+            in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+        )
         .overlay {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .stroke(.quaternary, lineWidth: 1)
                 .allowsHitTesting(false)
         }
-        .shadow(color: .black.opacity(0.12), radius: 16, y: 4)
         .onAppear(perform: retainCurrentRecordingMeetingItem)
         .onChange(of: currentRecordingMeetingItem) {
             retainCurrentRecordingMeetingItem()

--- a/Sources/Dahlia/Views/MeetingListSidebarView.swift
+++ b/Sources/Dahlia/Views/MeetingListSidebarView.swift
@@ -62,12 +62,8 @@ struct MeetingListSidebarView: View {
                     onRetry: sidebarViewModel.retryDisplayedMeetingLoading
                 )
             }
-            .searchable(text: $searchText, placement: .sidebar, prompt: L10n.searchMeetings)
             .contextMenu(forSelectionType: UUID.self) { selection in
                 contextMenu(for: selection)
-            }
-            .onDeleteCommand {
-                requestDeletion(of: sidebarViewModel.selectedMeetingIds)
             }
 
             if viewModel.isListening {
@@ -78,6 +74,10 @@ struct MeetingListSidebarView: View {
                 )
                 .padding(8)
             }
+        }
+        .searchable(text: $searchText, placement: .sidebar, prompt: L10n.searchMeetings)
+        .onDeleteCommand {
+            requestDeletion(of: sidebarViewModel.selectedMeetingIds)
         }
         .onAppear {
             renderedMeetingSelection = sidebarViewModel.selectedMeetingIds

--- a/Sources/Dahlia/Views/RecordingActivityIcon.swift
+++ b/Sources/Dahlia/Views/RecordingActivityIcon.swift
@@ -3,18 +3,11 @@ import SwiftUI
 struct RecordingActivityIcon: View {
     let mode: TranscriptionMode
 
-    @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
-
     var body: some View {
         Image(systemName: systemImage)
             .font(.body)
             .symbolRenderingMode(.hierarchical)
             .foregroundStyle(.red)
-            .symbolEffect(
-                .breathe.pulse,
-                options: .repeat(.periodic(delay: 0.8)).speed(0.7),
-                isActive: !accessibilityReduceMotion
-            )
             .frame(width: 18)
             .accessibilityHidden(true)
     }


### PR DESCRIPTION
## Summary

- Move the recording status panel out of the sidebar `List` overlay into a fixed footer region.
- Replace the live material and large shadow with an opaque, appearance-aware background and the existing border.
- Remove the continuously repeating recording symbol effect while preserving the red recording indicator, status text, elapsed time, source controls, return action, and stop action.

## Root cause

While recording, the status panel was composited directly over scrolling list content using `regularMaterial`, a large shadow, and an infinite symbol animation. That added continuous rendering work regardless of transcription mode, enabled audio source, or screenshot capture settings.

## Impact

The list no longer scrolls behind a live translucent surface, and the one-second elapsed-time refresh remains confined to the fixed recording panel. Recording, transcription, persistence, settings, localization, and database behavior are unchanged.

## Validation

- `swift build`
- `swift test --filter RecordingCommandStateTests` — 5 tests passed
- `swift test` — 3 XCTest tests and 1,134 Swift Testing tests passed
- `CI=true ./scripts/lint.sh` — SwiftFormat clean; existing repository-wide SwiftLint violations remain non-blocking
- `git diff --check`
- Signed debug app: recording start, elapsed-time updates, fixed panel, sidebar scrolling, and recording stop; screenshot source unset; microphone + system audio and microphone-only configurations
- Deep review across SwiftUI performance, correctness, accessibility, security, tests, and documentation found no actionable issues