### PR TITLE
Fix organization deletion confirmation

### DIFF
--- a/Sources/Dahlia/Database/MeetingRepository+CustomerIntelligenceWorkspace.swift
+++ b/Sources/Dahlia/Database/MeetingRepository+CustomerIntelligenceWorkspace.swift
@@ -335,6 +335,24 @@ extension MeetingRepository {
         }
     }
 
+    nonisolated func organizationDeletionPreview(
+        id: UUID,
+        vaultId: UUID
+    ) throws -> (organization: OrganizationRecord, impact: OrganizationDeletionImpact) {
+        try dbQueue.read { db in
+            guard let organization = try OrganizationRecord
+                .filter(Column("id") == id && Column("vaultId") == vaultId)
+                .fetchOne(db)
+            else {
+                throw CustomerIntelligenceError.organizationNotFound
+            }
+            return try (
+                organization: organization,
+                impact: Self.organizationDeletionImpact(id: id, vaultId: vaultId, in: db)
+            )
+        }
+    }
+
     // MARK: - Conversation topics
 
     nonisolated func fetchConversationTopics(vaultId: UUID) throws -> [ConversationTopicOverview] {

--- a/Sources/Dahlia/ViewModels/OrganizationWorkspaceViewModel.swift
+++ b/Sources/Dahlia/ViewModels/OrganizationWorkspaceViewModel.swift
@@ -35,6 +35,7 @@ final class OrganizationWorkspaceViewModel {
     private(set) var loadingChildNodeIDs: Set<UUID> = []
     var searchText = ""
     var isLoading = false
+    private(set) var isPreparingDeletion = false
     private(set) var isMutating = false
     var errorMessage: String?
     var pendingDeletion: PendingOrganizationDeletion?
@@ -48,6 +49,7 @@ final class OrganizationWorkspaceViewModel {
     private var topicGeneration = 0
     private var searchGeneration = 0
     private var layoutGeneration = 0
+    private var needsReload = false
     private let notificationSenderID = UUID().uuidString
 
     init(dbQueue: DatabaseQueue?, vaultID: UUID?) {
@@ -95,7 +97,18 @@ final class OrganizationWorkspaceViewModel {
     }
 
     func load(selectingRootID requestedRootID: UUID? = nil) async {
-        guard dbQueue != nil, let vaultID else { return }
+        while true {
+            let iterationIsCurrent = await loadWorkspaceIteration(preferredRootID: requestedRootID)
+            if iterationIsCurrent {
+                isLoading = false
+            }
+            guard needsReload else { return }
+            needsReload = false
+        }
+    }
+
+    private func loadWorkspaceIteration(preferredRootID: UUID?) async -> Bool {
+        guard dbQueue != nil, let vaultID else { return true }
         let previouslySelectedNodeID = selectedNodeID
         loadGeneration += 1
         detailGeneration += 1
@@ -103,37 +116,52 @@ final class OrganizationWorkspaceViewModel {
         searchGeneration += 1
         let generation = loadGeneration
         isLoading = true
-        defer { if generation == loadGeneration { isLoading = false } }
         do {
             let result = try await performRead { repository in
                 try (
-                    repository.fetchRootOrganizationWorkspaceNodes(vaultId: vaultID),
-                    repository.fetchContacts(vaultId: vaultID)
+                    roots: repository.fetchRootOrganizationWorkspaceNodes(vaultId: vaultID),
+                    contacts: repository.fetchContacts(vaultId: vaultID)
                 )
             }
-            guard generation == loadGeneration else { return }
-            roots = result.0
-            contacts = result.1
-            errorMessage = nil
-            if let rootID = requestedRootID, roots.contains(where: { $0.id == rootID }) {
-                await selectRoot(rootID)
-            } else if let rootID = selectedRootID, roots.contains(where: { $0.id == rootID }) {
-                await selectRoot(rootID)
-                if let previouslySelectedNodeID, previouslySelectedNodeID != rootID {
-                    await revealOrganization(previouslySelectedNodeID)
-                }
-            } else if let first = roots.first {
-                await selectRoot(first.id)
-            } else {
-                selectedRootID = nil
-                selectedNodeID = nil
-                selectedDetail = nil
-                loadedNodes = [:]
-                canvasLayout = OrganizationCanvasLayoutResult(positions: [:], size: .zero)
-            }
+            guard generation == loadGeneration else { return false }
+            await applyLoadedWorkspace(
+                result,
+                preferredRootID: preferredRootID,
+                previouslySelectedNodeID: previouslySelectedNodeID,
+                generation: generation
+            )
         } catch {
-            guard generation == loadGeneration else { return }
+            guard generation == loadGeneration else { return false }
             setError(error)
+        }
+        return generation == loadGeneration
+    }
+
+    private func applyLoadedWorkspace(
+        _ result: (roots: [OrganizationWorkspaceNode], contacts: [ContactRecord]),
+        preferredRootID: UUID?,
+        previouslySelectedNodeID: UUID?,
+        generation: Int
+    ) async {
+        roots = result.roots
+        contacts = result.contacts
+        errorMessage = nil
+        if let rootID = preferredRootID, roots.contains(where: { $0.id == rootID }) {
+            await selectRoot(rootID, expectedLoadGeneration: generation)
+        } else if let rootID = selectedRootID, roots.contains(where: { $0.id == rootID }) {
+            await selectRoot(rootID, expectedLoadGeneration: generation)
+            guard generation == loadGeneration else { return }
+            if let previouslySelectedNodeID, previouslySelectedNodeID != rootID {
+                await revealOrganization(previouslySelectedNodeID)
+            }
+        } else if let first = roots.first {
+            await selectRoot(first.id, expectedLoadGeneration: generation)
+        } else {
+            selectedRootID = nil
+            selectedNodeID = nil
+            selectedDetail = nil
+            loadedNodes = [:]
+            canvasLayout = OrganizationCanvasLayoutResult(positions: [:], size: .zero)
         }
     }
 
@@ -150,6 +178,11 @@ final class OrganizationWorkspaceViewModel {
     }
 
     func selectRoot(_ id: UUID) async {
+        await selectRoot(id, expectedLoadGeneration: nil)
+    }
+
+    private func selectRoot(_ id: UUID, expectedLoadGeneration: Int?) async {
+        guard expectedLoadGeneration == nil || expectedLoadGeneration == loadGeneration else { return }
         guard let root = roots.first(where: { $0.id == id }) else { return }
         selectedRootID = id
         selectedNodeID = id
@@ -163,8 +196,11 @@ final class OrganizationWorkspaceViewModel {
         loadedChildCounts = [:]
         expandedNodeIDs = []
         await loadOrganizationCandidates(for: id)
+        guard expectedLoadGeneration == nil || expectedLoadGeneration == loadGeneration else { return }
         await loadTopics(for: id)
-        await expand(id)
+        guard expectedLoadGeneration == nil || expectedLoadGeneration == loadGeneration else { return }
+        await expand(id, expectedLoadGeneration: expectedLoadGeneration)
+        guard expectedLoadGeneration == nil || expectedLoadGeneration == loadGeneration else { return }
         await loadDetail()
     }
 
@@ -401,21 +437,33 @@ final class OrganizationWorkspaceViewModel {
     }
 
     func prepareOrganizationDeletion() async {
-        guard let id = selectedNodeID, let organization = loadedNodes[id]?.organization,
-              dbQueue != nil, let vaultID else { return }
+        guard let id = selectedNodeID, loadedNodes[id] != nil,
+              dbQueue != nil, let vaultID, !isPreparingDeletion else { return }
+        isPreparingDeletion = true
+        let result: Result<(organization: OrganizationRecord, impact: OrganizationDeletionImpact), Error>
         do {
-            let impact = try await performRead {
-                try $0.organizationDeletionImpact(id: id, vaultId: vaultID)
+            let preview = try await performRead { repository in
+                try repository.organizationDeletionPreview(id: id, vaultId: vaultID)
             }
-            guard selectedNodeID == id,
-                  loadedNodes[id]?.organization.revision == organization.revision else {
-                return
-            }
-            pendingDeletion = PendingOrganizationDeletion(
-                organization: organization,
-                impact: impact
-            )
+            result = .success(preview)
         } catch {
+            result = .failure(error)
+        }
+        isPreparingDeletion = false
+        if needsReload {
+            await reloadIfNeeded()
+            guard selectedNodeID == id else { return }
+            await prepareOrganizationDeletion()
+            return
+        }
+        switch result {
+        case let .success(preview):
+            guard self.vaultID == vaultID, selectedNodeID == id else { return }
+            pendingDeletion = PendingOrganizationDeletion(
+                organization: preview.organization,
+                impact: preview.impact
+            )
+        case let .failure(error):
             setError(error)
         }
     }
@@ -437,10 +485,11 @@ final class OrganizationWorkspaceViewModel {
         await confirmOrganizationDeletion(pending)
     }
 
-    private func expand(_ id: UUID) async {
+    private func expand(_ id: UUID, expectedLoadGeneration: Int? = nil) async {
         if loadedChildCounts[id] == nil {
             await loadChildren(of: id, offset: 0)
         }
+        guard expectedLoadGeneration == nil || expectedLoadGeneration == loadGeneration else { return }
         expandedNodeIDs.insert(id)
         await updateLayout()
     }
@@ -518,19 +567,24 @@ final class OrganizationWorkspaceViewModel {
 
     func revealOrganization(_ id: UUID) async {
         guard dbQueue != nil, let vaultID else { return }
+        let generation = loadGeneration
         do {
             let path = try await performRead {
                 try $0.fetchOrganizationWorkspacePath(id: id, vaultId: vaultID)
             }
-            guard path.first?.id == selectedRootID, let selected = path.last else { return }
+            guard generation == loadGeneration,
+                  path.first?.id == selectedRootID,
+                  let selected = path.last else { return }
             for node in path {
                 loadedNodes[node.id] = node
             }
             expandedNodeIDs.formUnion(path.dropLast().map(\.id))
             selectedNodeID = selected.id
             await updateLayout()
+            guard generation == loadGeneration, selectedNodeID == selected.id else { return }
             await loadDetail()
         } catch {
+            guard generation == loadGeneration, self.vaultID == vaultID else { return }
             setError(error)
         }
     }
@@ -608,8 +662,31 @@ final class OrganizationWorkspaceViewModel {
         canvasLayout = OrganizationCanvasLayoutResult(positions: [:], size: .zero)
         pendingDeletion = nil
         pendingMerge = nil
+        needsReload = false
         errorMessage = nil
         isLoading = false
+        isPreparingDeletion = false
+    }
+
+    private func reloadIfNeeded() async {
+        guard needsReload, !isLoading, !isPreparingDeletion else { return }
+        needsReload = false
+        await load()
+    }
+
+    @discardableResult
+    func handleWorkspaceChange() async -> Bool {
+        loadGeneration += 1
+        detailGeneration += 1
+        topicGeneration += 1
+        searchGeneration += 1
+        layoutGeneration += 1
+        if isLoading || isPreparingDeletion {
+            needsReload = true
+            return true
+        }
+        await load()
+        return false
     }
 
     private func observeWorkspaceChanges() {
@@ -621,7 +698,7 @@ final class OrganizationWorkspaceViewModel {
         ) { [weak self, notificationSenderID] notification in
             guard notification.object as? String != notificationSenderID else { return }
             Task { @MainActor [weak self] in
-                await self?.load()
+                await self?.handleWorkspaceChange()
             }
         }
     }

--- a/Sources/Dahlia/ViewModels/OrganizationWorkspaceViewModel.swift
+++ b/Sources/Dahlia/ViewModels/OrganizationWorkspaceViewModel.swift
@@ -97,8 +97,12 @@ final class OrganizationWorkspaceViewModel {
     }
 
     func load(selectingRootID requestedRootID: UUID? = nil) async {
+        let previouslySelectedNodeID = selectedNodeID
         while true {
-            let iterationIsCurrent = await loadWorkspaceIteration(preferredRootID: requestedRootID)
+            let iterationIsCurrent = await loadWorkspaceIteration(
+                preferredRootID: requestedRootID,
+                previouslySelectedNodeID: previouslySelectedNodeID
+            )
             if iterationIsCurrent {
                 isLoading = false
             }
@@ -107,9 +111,11 @@ final class OrganizationWorkspaceViewModel {
         }
     }
 
-    private func loadWorkspaceIteration(preferredRootID: UUID?) async -> Bool {
+    private func loadWorkspaceIteration(
+        preferredRootID: UUID?,
+        previouslySelectedNodeID: UUID?
+    ) async -> Bool {
         guard dbQueue != nil, let vaultID else { return true }
-        let previouslySelectedNodeID = selectedNodeID
         loadGeneration += 1
         detailGeneration += 1
         topicGeneration += 1

--- a/Sources/Dahlia/Views/OrganizationDeletionSection.swift
+++ b/Sources/Dahlia/Views/OrganizationDeletionSection.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct OrganizationDeletionSection: View {
-    let onDelete: () -> Void
+    let onRequestDeletion: () -> Void
 
     var body: some View {
         Section {
@@ -9,7 +9,7 @@ struct OrganizationDeletionSection: View {
                 L10n.deleteOrganizationAction,
                 systemImage: "trash",
                 role: .destructive,
-                action: onDelete
+                action: onRequestDeletion
             )
         } header: {
             Text(L10n.dangerZone)

--- a/Sources/Dahlia/Views/OrganizationWorkspaceView.swift
+++ b/Sources/Dahlia/Views/OrganizationWorkspaceView.swift
@@ -53,8 +53,11 @@ struct OrganizationHierarchyView: View {
         canvasColumn
             .frame(minWidth: 460, idealWidth: 760)
             .inspector(isPresented: $showsInspector) {
-                inspector
-                    .inspectorColumnWidth(min: 300, ideal: 380, max: 520)
+                VStack(spacing: 0) {
+                    inspector
+                }
+                .inspectorColumnWidth(min: 300, ideal: 380, max: 520)
+                .alert(item: $model.pendingDeletion, content: deletionAlert)
             }
             .navigationTitle(L10n.organizations)
             .disabled(model.isMutating)
@@ -103,7 +106,6 @@ struct OrganizationHierarchyView: View {
                     await model.addDomain($0, to: target)
                 }
             }
-            .alert(item: $model.pendingDeletion, content: deletionAlert)
             .alert(item: $model.pendingMerge, content: mergeAlert)
             .customerIntelligenceErrorAlert(
                 title: L10n.organizationWorkspaceError,
@@ -222,7 +224,10 @@ struct OrganizationHierarchyView: View {
                     topicEvidenceSection
                 }
 
-                OrganizationDeletionSection(onDelete: requestOrganizationDeletion)
+                OrganizationDeletionSection(
+                    onRequestDeletion: requestOrganizationDeletion
+                )
+                .disabled(model.isLoading || model.isPreparingDeletion)
             }
         } else {
             ContentUnavailableView(L10n.selectOrganization, systemImage: "building.2")

--- a/Tests/DahliaTests/OrganizationWorkspaceDeletionTests.swift
+++ b/Tests/DahliaTests/OrganizationWorkspaceDeletionTests.swift
@@ -1,6 +1,7 @@
 @testable import Dahlia
 
 #if canImport(Testing)
+    import Dispatch
     import Testing
 
     @MainActor
@@ -50,6 +51,61 @@
             #expect(deletedOrganization == nil)
         }
 
+        @Test(.timeLimit(.minutes(1)))
+        func workspaceChangeDuringDeletionPreparationStillPresentsConfirmation() async throws {
+            let (fixture, organization, model) = try await makeDeletionFixture()
+
+            let databaseLockStarted = AsyncStream.makeStream(of: Void.self)
+            let releaseDatabaseLock = DispatchSemaphore(value: 0)
+            let dbQueue = fixture.manager.dbQueue
+            let databaseLockTask = Task.detached {
+                try dbQueue.write { db in
+                    guard var changedOrganization = try OrganizationRecord.fetchOne(db, key: organization.id) else {
+                        throw CustomerIntelligenceError.organizationNotFound
+                    }
+                    changedOrganization.name = "Acme Japan Updated"
+                    changedOrganization.revision += 1
+                    changedOrganization.updatedAt = .now
+                    try changedOrganization.update(db)
+                    databaseLockStarted.continuation.yield()
+                    databaseLockStarted.continuation.finish()
+                    releaseDatabaseLock.wait()
+                }
+            }
+            var databaseLockEvents = databaseLockStarted.stream.makeAsyncIterator()
+            _ = await databaseLockEvents.next()
+            var databaseLockReleased = false
+            defer {
+                if !databaseLockReleased {
+                    releaseDatabaseLock.signal()
+                }
+            }
+
+            let preparation = Task { await model.prepareOrganizationDeletion() }
+            while !model.isPreparingDeletion {
+                await Task.yield()
+            }
+            let reloadWasDeferred = await withTaskCancellationHandler {
+                await model.handleWorkspaceChange()
+            } onCancel: {
+                releaseDatabaseLock.signal()
+            }
+            #expect(reloadWasDeferred)
+            releaseDatabaseLock.signal()
+            databaseLockReleased = true
+
+            await preparation.value
+            try await databaseLockTask.value
+            let confirmation = try #require(model.pendingDeletion)
+            #expect(confirmation.id == organization.id)
+            try await confirmAndVerifyDeletion(
+                confirmation,
+                originalOrganization: organization,
+                model: model,
+                fixture: fixture
+            )
+        }
+
         @Test
         func organizationHierarchyOnlyOffersTopicsInTheSelectedCustomerScope() async throws {
             let fixture = try CustomerIntelligenceFixture()
@@ -89,6 +145,44 @@
             await model.selectTopic(secondTopic.id)
             #expect(model.selectedTopicID == nil)
             #expect(model.selectedTopicEvidence.isEmpty)
+        }
+
+        private func makeDeletionFixture() async throws
+            -> (CustomerIntelligenceFixture, OrganizationRecord, OrganizationWorkspaceViewModel) {
+            let fixture = try CustomerIntelligenceFixture()
+            let root = try fixture.repository.createOrganization(
+                vaultId: fixture.vault.id,
+                parentOrganizationId: nil,
+                nodeKind: .organization,
+                name: "Acme"
+            )
+            let organization = try fixture.repository.createOrganization(
+                vaultId: fixture.vault.id,
+                parentOrganizationId: root.id,
+                nodeKind: .organization,
+                name: "Acme Japan"
+            )
+            let model = OrganizationWorkspaceViewModel(
+                dbQueue: fixture.manager.dbQueue,
+                vaultID: fixture.vault.id
+            )
+            await model.load()
+            await model.revealOrganization(organization.id)
+            return (fixture, organization, model)
+        }
+
+        private func confirmAndVerifyDeletion(
+            _ confirmation: OrganizationWorkspaceViewModel.PendingOrganizationDeletion,
+            originalOrganization: OrganizationRecord,
+            model: OrganizationWorkspaceViewModel,
+            fixture: CustomerIntelligenceFixture
+        ) async throws {
+            #expect(confirmation.organization.revision == originalOrganization.revision + 1)
+            await model.confirmDeletion(confirmation)
+            let deletedOrganization = try await fixture.manager.dbQueue.read {
+                try OrganizationRecord.fetchOne($0, key: originalOrganization.id)
+            }
+            #expect(deletedOrganization == nil)
         }
     }
 #endif


### PR DESCRIPTION
## Summary

- keep the organization deletion alert attached to a stable inspector presenter
- coalesce workspace notifications while deletion confirmation is being prepared
- reject stale asynchronous workspace projections using load generations
- generate deletion previews from one database snapshot
- add a deterministic regression test covering an external revision update during confirmation preparation

## Root cause

The alert presenter lived inside conditional organization detail content, so a workspace reload could remove it before SwiftUI presented the confirmation. Concurrent workspace notifications could also apply stale selection data or leave the pending deletion preview out of sync with the latest organization revision and deletion impact.

## Impact

Organization deletion now reliably presents its confirmation dialog. If workspace data changes while the preview is being prepared, Dahlia reloads the latest state and regenerates an atomic preview before allowing deletion.

## Validation

- `swift build`
- `swift test --filter 'DahliaTests.OrganizationWorkspaceDeletionTests'` — 3 tests passed
- `swift test` — 1,148 Swift Testing tests and 3 XCTest tests passed
- SwiftFormat — 0 files require formatting
- `git diff --check`
- deep review across SwiftUI, concurrency, and test quality — no remaining actionable findings