### PR TITLE
Fix contact membership approvals

### DIFF
--- a/Sources/Dahlia/Services/CodexChatService.swift
+++ b/Sources/Dahlia/Services/CodexChatService.swift
@@ -94,7 +94,7 @@ actor CodexChatService: CodexChatServicing {
         let result = try await appServer.request(
             method: "thread/resume",
             params: .object([
-                "approvalPolicy": .string("never"),
+                "approvalPolicy": .string("on-request"),
                 "config": config,
                 "cwd": .string(workspaceURL.path),
                 "developerInstructions": .string(Self.developerInstructions),
@@ -134,7 +134,7 @@ actor CodexChatService: CodexChatServicing {
         let result = try await appServer.request(
             method: "thread/start",
             params: .object([
-                "approvalPolicy": .string("never"),
+                "approvalPolicy": .string("on-request"),
                 "config": config,
                 "cwd": .string(workspaceURL.path),
                 "developerInstructions": .string(Self.developerInstructions),

--- a/Tests/DahliaTests/CodexChatServiceTests.swift
+++ b/Tests/DahliaTests/CodexChatServiceTests.swift
@@ -45,7 +45,7 @@ import Foundation
                 $0.objectValue?["method"]?.stringValue == "thread/start"
             }?.objectValue?["params"]?.objectValue)
             #expect(threadParams["ephemeral"] == .bool(false))
-            #expect(threadParams["approvalPolicy"] == .string("never"))
+            #expect(threadParams["approvalPolicy"] == .string("on-request"))
             #expect(threadParams["sandbox"] == .string("read-only"))
             #expect(threadParams["cwd"] == .string(workspace.appending(path: vaultID.uuidString.lowercased()).path))
             let config = try #require(threadParams["config"]?.objectValue)
@@ -239,6 +239,10 @@ import Foundation
             #expect(listParams["sourceKinds"] == .array([.string("vscode")]))
             #expect(listParams["sortKey"] == .string("recency_at"))
             #expect(listParams["sortDirection"] == .string("desc"))
+            let resumeParams = try #require(await transport.messages().first {
+                $0.objectValue?["method"]?.stringValue == "thread/resume"
+            }?.objectValue?["params"]?.objectValue)
+            #expect(resumeParams["approvalPolicy"] == .string("on-request"))
             await appServer.shutdown()
         }
 

--- a/docs/adr/0012-reviewable-customer-intelligence-workspace.md
+++ b/docs/adr/0012-reviewable-customer-intelligence-workspace.md
@@ -32,7 +32,8 @@ Dahlia exposes small, composable MCP tools. Canonical records use `query/get/cre
   the failed record.
 - Proposal queues, mutation DSLs, imports, batches, caller-local dependency keys, and persisted idempotency staging are
   not part of the contract.
-- Codex app-server `auto_review` evaluates each write tool. Dahlia adds no separate permission-mode switch.
+- Codex app-server uses interactive `on-request` approvals so `auto_review` can evaluate each write tool. Dahlia adds no separate
+  permission-mode switch.
 - `meeting_participants` has no mutation tool, structurally preventing AI-generated calendar participation.
 - Project and Meeting participant deletion are not exposed by customer-intelligence MCP tools.
 - Insight acceptance is a Bool (`isAccepted`); AI-created Insights default to false.

--- a/docs/customer-intelligence-workspace.md
+++ b/docs/customer-intelligence-workspace.md
@@ -56,8 +56,8 @@ AI は書き込み前に `query_*` または `get_*` で現在値と revision �
 
 一回の呼び出しが変更するのは一つのレコードまたは一つの関係だけです。一件が失敗しても、それまでの成功分は
 維持され、独立した後続処理を続けられます。失敗した対象だけを再取得し、最新 revision で再試行します。
-proposal、import、batch、永続 idempotency staging は使いません。Codex の `auto_review` が各 MCP
-書き込みの危険度を判定します。
+proposal、import、batch、永続 idempotency staging は使いません。Codex の対話的な `on-request`
+承認ポリシーから `auto_review` へ各 MCP 書き込みを送り、危険度を判定します。
 
 暫定人物はメールがない Contact です。メールだけで Contact を作る場合、表示名にはメールの `@` より前を
 使用します。未使用メールが判明した場合は `update_contact`、既存 Contact と同一人物だと判明した場合は


### PR DESCRIPTION
## Summary

- use interactive `on-request` approval policy for new and resumed Dahlia chat threads
- keep `auto_review` as the reviewer for side-effecting MCP calls
- cover both thread start and resume configuration in tests
- clarify the approval flow in the customer-intelligence documentation and ADR

## Root cause

Dahlia combined `approvalPolicy: never` with `approvalsReviewer: auto_review`. Destructive MCP tools such as removing and setting Contact organization memberships require an interactive approval request, but `never` leaves nothing for Auto-review to evaluate. Codex therefore returned `user rejected MCP tool call` before the Dahlia MCP server handled the mutation.

## Impact

Contact organization memberships can be changed through Dahlia chat while retaining automatic risk review for side-effecting MCP calls.

## Validation

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --skip-build --filter DahliaTests.CodexChatServiceTests` — 7 tests passed
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build` — passed
- `CI=true DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/lint.sh` — SwiftFormat passed; SwiftLint reported pre-existing violations outside the changed files
- `git diff --check` — passed