### PR TITLE
Fix AI chat Thinking indicator state transitions

### DIFF
--- a/Sources/Dahlia/Models/CodexChatConversationItem.swift
+++ b/Sources/Dahlia/Models/CodexChatConversationItem.swift
@@ -36,7 +36,13 @@ enum CodexChatConversationItem: Identifiable, Equatable {
                 previousUserContext = message.context
                 hasPreviousUserMessage = true
             }
-            items.append(.message(message))
+            let isEmptyStreamingResponse = message.role == .assistant
+                && message.isStreaming
+                && message.text.isEmpty
+                && message.reasoning.isEmpty
+            if !showsStandaloneThinking || !isEmptyStreamingResponse {
+                items.append(.message(message))
+            }
         }
         if showsStandaloneThinking {
             items.append(.thinking)

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel+SteeringCompletion.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel+SteeringCompletion.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+struct CodexChatSteerCompletionState {
+    let submissionID: UUID
+    let threadID: String
+    let turnID: String
+    let includesLiveModeContext: Bool
+    let liveModeGeneration: UInt
+    let outputGeneration: UInt
+}
+
+extension CodexChatSessionModel {
+    func completeSuccessfulSteer(
+        _ input: CodexChatPendingInput,
+        context: CodexChatContext?,
+        state: CodexChatSteerCompletionState
+    ) async {
+        guard !Task.isCancelled,
+              isGenerating,
+              activeSubmissionID == state.submissionID,
+              activeTurnID == state.turnID,
+              backendThreadID == state.threadID else { return }
+        if input.isLiveTranscript {
+            guard isLiveModeEnabled,
+                  liveModeGeneration == state.liveModeGeneration else { return }
+        }
+        if state.includesLiveModeContext {
+            didSendLiveModeContext = true
+        }
+        await applySuccessfulSteer(
+            input,
+            context: context,
+            awaitsOutput: turnOutputGeneration == state.outputGeneration
+        )
+    }
+}

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel+Submission.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel+Submission.swift
@@ -54,6 +54,7 @@ extension CodexChatSessionModel {
         }
         prepareFailureStateForSubmission(liveTranscript: liveTranscript)
         isGenerating = true
+        isAwaitingTurnOutput = true
         errorMessage = nil
         isActiveTurnLiveTranscript = liveTranscript != nil
         let isLiveModeSnapshot = liveTranscript != nil || isLiveModeEnabled
@@ -134,6 +135,28 @@ extension CodexChatSessionModel {
         if attachedImages == snapshot.images {
             attachedImages = []
         }
+    }
+
+    func retryManualSubmission(_ submission: CodexChatManualSubmission) {
+        let currentText = CodexChatMeetingReference.serializedText(
+            referenceIDs: selectedMeetingReferenceIDs,
+            draft: draft
+        )
+        let composerSnapshot: CodexChatComposerSnapshot? = if currentText == submission.text,
+                                                              attachedImages == submission.images {
+            CodexChatComposerSnapshot(
+                draft: draft,
+                referenceIDs: selectedMeetingReferenceIDs,
+                images: attachedImages
+            )
+        } else {
+            nil
+        }
+        submit(
+            submission.text,
+            images: submission.images,
+            composerSnapshot: composerSnapshot
+        )
     }
 
     func resolveContext(if isRequired: Bool) async throws -> CodexChatContext? {

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel+ThinkingPresentation.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel+ThinkingPresentation.swift
@@ -1,0 +1,10 @@
+extension CodexChatSessionModel {
+    func publishStreamingOutput(using updateLimiter: CodexChatStreamingUpdateLimiter) {
+        turnOutputGeneration &+= 1
+        let wasAwaitingOutput = isAwaitingTurnOutput
+        updateLimiter.submit(force: wasAwaitingOutput)
+        if wasAwaitingOutput {
+            isAwaitingTurnOutput = false
+        }
+    }
+}

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel+ThinkingPresentation.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel+ThinkingPresentation.swift
@@ -1,10 +1,23 @@
 extension CodexChatSessionModel {
-    func publishStreamingOutput(using updateLimiter: CodexChatStreamingUpdateLimiter) {
+    func publishStreamingOutput(
+        itemID: String,
+        using updateLimiter: CodexChatStreamingUpdateLimiter
+    ) {
+        activeOutputItemIDs.insert(itemID)
         turnOutputGeneration &+= 1
         let wasAwaitingOutput = isAwaitingTurnOutput
         updateLimiter.submit(force: wasAwaitingOutput)
         if wasAwaitingOutput {
             isAwaitingTurnOutput = false
         }
+    }
+
+    func completeStreamingOutput(
+        itemID: String,
+        using updateLimiter: CodexChatStreamingUpdateLimiter
+    ) {
+        activeOutputItemIDs.remove(itemID)
+        updateLimiter.submit(force: true)
+        isAwaitingTurnOutput = activeOutputItemIDs.isEmpty
     }
 }

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -25,7 +25,7 @@ final class CodexChatSessionModel: Identifiable {
     var errorMessage: String?
     var noticeMessage: String?
     private(set) var activeTurnID: String?
-    private var activeResponseID: String?
+    var isAwaitingTurnOutput = false
     var lastSubmittedText: String?
     var attachedImages: [CodexChatImageAttachment] = []
     private(set) var pendingImagePreparationCount = 0
@@ -41,9 +41,7 @@ final class CodexChatSessionModel: Identifiable {
         set { setLiveModeEnabled(newValue) }
     }
 
-    var showsStandaloneThinking: Bool {
-        isGenerating && activeResponseID == nil
-    }
+    var showsStandaloneThinking: Bool { isGenerating && isAwaitingTurnOutput }
 
     @ObservationIgnored private let service: any CodexChatServicing
     @ObservationIgnored let settings: AppSettings
@@ -63,6 +61,8 @@ final class CodexChatSessionModel: Identifiable {
     @ObservationIgnored private var activeSteeringManualSubmission: CodexChatManualSubmission?
     @ObservationIgnored private var activeTurnSupportsImages: Bool?
     @ObservationIgnored var activeSubmissionID: UUID?
+    @ObservationIgnored private var activeResponseID: String?
+    @ObservationIgnored var turnOutputGeneration: UInt = 0
     @ObservationIgnored var turnTask: Task<Void, Never>?
     @ObservationIgnored private var steerTask: Task<Void, Never>?
     @ObservationIgnored private var failedSubmission: CodexChatFailedSubmission?
@@ -438,23 +438,31 @@ extension CodexChatSessionModel {
             processPendingInputIfPossible()
         case let .delta(itemID, text):
             accumulator.appendResponseDelta(itemID: itemID, text: text)
-            updateLimiter.submit()
+            publishStreamingOutput(using: updateLimiter)
         case let .completed(itemID?, text):
             accumulator.completeResponse(itemID: itemID, text: text)
             updateLimiter.submit(force: true)
+            isAwaitingTurnOutput = true
         case .completed(itemID: nil, text: _):
             updateLimiter.submit(force: true)
+            isAwaitingTurnOutput = false
+            activeTurnID = nil
         case let .reasoningDelta(itemID, summaryIndex, text):
             accumulator.appendReasoningDelta(itemID: itemID, summaryIndex: summaryIndex, text: text)
-            updateLimiter.submit()
+            publishStreamingOutput(using: updateLimiter)
         case let .reasoningCompleted(itemID, text):
             accumulator.completeReasoning(itemID: itemID, text: text)
             updateLimiter.submit(force: true)
+            isAwaitingTurnOutput = true
         case .interrupted:
             updateLimiter.submit(force: true)
+            isAwaitingTurnOutput = false
+            activeTurnID = nil
         case let .failed(message):
             errorMessage = CodexAppServerError.turnFailed(message).localizedDescription
             updateLimiter.submit(force: true)
+            isAwaitingTurnOutput = false
+            activeTurnID = nil
         }
     }
 
@@ -536,6 +544,7 @@ extension CodexChatSessionModel {
     ) {
         guard activeSubmissionID == submissionID else { return }
         isGenerating = false
+        isAwaitingTurnOutput = false
         activeTurnID = nil
         isStopRequested = false
         isActiveTurnLiveTranscript = false
@@ -591,28 +600,6 @@ extension CodexChatSessionModel {
         guard liveTranscript == nil || isLiveModeEnabled, !isStopRequested else {
             throw CancellationError()
         }
-    }
-
-    func retryManualSubmission(_ submission: CodexChatManualSubmission) {
-        let currentText = CodexChatMeetingReference.serializedText(
-            referenceIDs: selectedMeetingReferenceIDs,
-            draft: draft
-        )
-        let composerSnapshot: CodexChatComposerSnapshot? = if currentText == submission.text,
-                                                              attachedImages == submission.images {
-            CodexChatComposerSnapshot(
-                draft: draft,
-                referenceIDs: selectedMeetingReferenceIDs,
-                images: attachedImages
-            )
-        } else {
-            nil
-        }
-        submit(
-            submission.text,
-            images: submission.images,
-            composerSnapshot: composerSnapshot
-        )
     }
 
     func prepareFailureStateForSubmission(liveTranscript: String?) {
@@ -800,6 +787,7 @@ extension CodexChatSessionModel {
             let context = try await resolveContext(if: shouldResolveContext)
             guard !Task.isCancelled,
                   isGenerating,
+                  let submissionID = activeSubmissionID,
                   activeTurnID == turnID,
                   backendThreadID == threadID else {
                 requeue(input, liveModeGenerationSnapshot: liveModeGenerationSnapshot)
@@ -814,20 +802,20 @@ extension CodexChatSessionModel {
                 liveTranscript: liveTranscript,
                 images: images
             )
-            try await service.steer(
-                threadID: threadID,
-                turnID: turnID,
-                inputs: inputs
+            let outputGeneration = turnOutputGeneration
+            try await service.steer(threadID: threadID, turnID: turnID, inputs: inputs)
+            await completeSuccessfulSteer(
+                input,
+                context: promptContext,
+                state: CodexChatSteerCompletionState(
+                    submissionID: submissionID,
+                    threadID: threadID,
+                    turnID: turnID,
+                    includesLiveModeContext: includesLiveModeContext,
+                    liveModeGeneration: liveModeGenerationSnapshot,
+                    outputGeneration: outputGeneration
+                )
             )
-            if input.isLiveTranscript {
-                guard !Task.isCancelled,
-                      isLiveModeEnabled,
-                      liveModeGeneration == liveModeGenerationSnapshot else { return }
-            }
-            if includesLiveModeContext {
-                didSendLiveModeContext = true
-            }
-            await applySuccessfulSteer(input, context: promptContext)
         } catch is CancellationError {
             requeue(input, liveModeGenerationSnapshot: liveModeGenerationSnapshot)
         } catch {
@@ -872,7 +860,14 @@ extension CodexChatSessionModel {
         finishGeneration(submissionID: activeSubmissionID)
     }
 
-    func applySuccessfulSteer(_ input: CodexChatPendingInput, context: CodexChatContext?) async {
+    func applySuccessfulSteer(
+        _ input: CodexChatPendingInput,
+        context: CodexChatContext?,
+        awaitsOutput: Bool
+    ) async {
+        if awaitsOutput {
+            isAwaitingTurnOutput = true
+        }
         switch input {
         case let .manual(submission):
             clearComposer(ifMatching: submission.composerSnapshot)

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -62,6 +62,7 @@ final class CodexChatSessionModel: Identifiable {
     @ObservationIgnored private var activeTurnSupportsImages: Bool?
     @ObservationIgnored var activeSubmissionID: UUID?
     @ObservationIgnored private var activeResponseID: String?
+    @ObservationIgnored var activeOutputItemIDs: Set<String> = []
     @ObservationIgnored var turnOutputGeneration: UInt = 0
     @ObservationIgnored var turnTask: Task<Void, Never>?
     @ObservationIgnored private var steerTask: Task<Void, Never>?
@@ -438,29 +439,30 @@ extension CodexChatSessionModel {
             processPendingInputIfPossible()
         case let .delta(itemID, text):
             accumulator.appendResponseDelta(itemID: itemID, text: text)
-            publishStreamingOutput(using: updateLimiter)
+            publishStreamingOutput(itemID: itemID, using: updateLimiter)
         case let .completed(itemID?, text):
             accumulator.completeResponse(itemID: itemID, text: text)
-            updateLimiter.submit(force: true)
-            isAwaitingTurnOutput = true
+            completeStreamingOutput(itemID: itemID, using: updateLimiter)
         case .completed(itemID: nil, text: _):
             updateLimiter.submit(force: true)
+            activeOutputItemIDs.removeAll()
             isAwaitingTurnOutput = false
             activeTurnID = nil
         case let .reasoningDelta(itemID, summaryIndex, text):
             accumulator.appendReasoningDelta(itemID: itemID, summaryIndex: summaryIndex, text: text)
-            publishStreamingOutput(using: updateLimiter)
+            publishStreamingOutput(itemID: itemID, using: updateLimiter)
         case let .reasoningCompleted(itemID, text):
             accumulator.completeReasoning(itemID: itemID, text: text)
-            updateLimiter.submit(force: true)
-            isAwaitingTurnOutput = true
+            completeStreamingOutput(itemID: itemID, using: updateLimiter)
         case .interrupted:
             updateLimiter.submit(force: true)
+            activeOutputItemIDs.removeAll()
             isAwaitingTurnOutput = false
             activeTurnID = nil
         case let .failed(message):
             errorMessage = CodexAppServerError.turnFailed(message).localizedDescription
             updateLimiter.submit(force: true)
+            activeOutputItemIDs.removeAll()
             isAwaitingTurnOutput = false
             activeTurnID = nil
         }
@@ -544,6 +546,7 @@ extension CodexChatSessionModel {
     ) {
         guard activeSubmissionID == submissionID else { return }
         isGenerating = false
+        activeOutputItemIDs.removeAll()
         isAwaitingTurnOutput = false
         activeTurnID = nil
         isStopRequested = false

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
@@ -39,9 +39,7 @@ struct CodexChatMessageRow: View {
                         )
                     }
 
-                    if message.text.isEmpty, message.isStreaming {
-                        CodexChatThinkingIndicator()
-                    } else if !displayText.isEmpty {
+                    if !displayText.isEmpty {
                         CodexChatMarkdownView(
                             markdown: displayText,
                             isStreaming: message.isStreaming

--- a/Tests/DahliaTests/CodexChatConversationItemTests.swift
+++ b/Tests/DahliaTests/CodexChatConversationItemTests.swift
@@ -20,17 +20,28 @@ import Foundation
                 from: [previousMessage],
                 showsStandaloneThinking: true
             )
-
-            #expect(emptyConversation == [.thinking])
-            #expect(existingConversation == [.message(previousMessage), .thinking])
-        }
-
-        @Test
-        func steeredConversationDoesNotDuplicateActiveResponseThinking() {
-            let response = CodexChatMessage(
+            let emptyStreamingResponse = CodexChatMessage(
                 id: "response",
                 role: .assistant,
                 text: "",
+                isStreaming: true
+            )
+            let streamingConversation = CodexChatConversationItem.build(
+                from: [emptyStreamingResponse],
+                showsStandaloneThinking: true
+            )
+
+            #expect(emptyConversation == [.thinking])
+            #expect(existingConversation == [.message(previousMessage), .thinking])
+            #expect(streamingConversation == [.thinking])
+        }
+
+        @Test
+        func steeredConversationPlacesSingleThinkingIndicatorAfterLatestMessage() {
+            let response = CodexChatMessage(
+                id: "response",
+                role: .assistant,
+                text: "Partial",
                 isStreaming: true
             )
             let followUp = CodexChatMessage(
@@ -41,10 +52,10 @@ import Foundation
 
             let items = CodexChatConversationItem.build(
                 from: [response, followUp],
-                showsStandaloneThinking: false
+                showsStandaloneThinking: true
             )
 
-            #expect(items == [.message(response), .message(followUp)])
+            #expect(items == [.message(response), .message(followUp), .thinking])
         }
 
         @Test

--- a/Tests/DahliaTests/CodexChatImageSessionTests.swift
+++ b/Tests/DahliaTests/CodexChatImageSessionTests.swift
@@ -111,6 +111,56 @@ import Foundation
         }
 
         @Test
+        func steerCompletionDoesNotRestoreThinkingAfterOutputStarts() async {
+            let service = ImageChatService(supportsImages: true, sendBehavior: .blockSteer)
+            let session = makeSession(service: service)
+
+            session.draft = "Start"
+            session.sendDraft()
+            await waitUntil { session.activeTurnID != nil }
+
+            session.draft = "Follow up"
+            session.sendDraft()
+            await waitUntilAsync { await service.isSteerWaiting }
+
+            await service.yieldBlockedEvent(.delta(itemID: "response", text: "Output while steering"))
+            await waitUntil { session.messages.last?.text == "Output while steering" }
+            #expect(!session.showsStandaloneThinking)
+
+            await service.resumeDelayedSteer()
+            await waitUntil { session.messages.filter { $0.role == .user }.count == 2 }
+            #expect(!session.showsStandaloneThinking)
+
+            await service.completeBlockedTurn()
+            await waitUntil { !session.isGenerating }
+        }
+
+        @Test
+        func staleSteerCompletionDoesNotMutateStoppedSession() async {
+            let service = ImageChatService(supportsImages: true, sendBehavior: .blockSteer)
+            let session = makeSession(service: service)
+
+            session.draft = "Start"
+            session.sendDraft()
+            await waitUntil { session.activeTurnID != nil }
+
+            session.draft = "Follow up"
+            session.sendDraft()
+            await waitUntilAsync { await service.isSteerWaiting }
+
+            session.stop()
+            await waitUntil { !session.isGenerating }
+            await service.resumeDelayedSteer()
+            for _ in 0 ..< 10 {
+                await Task.yield()
+            }
+
+            #expect(session.messages.filter { $0.role == .user }.map(\.text) == ["Start"])
+            #expect(session.draft == "Follow up")
+            #expect(!session.showsStandaloneThinking)
+        }
+
+        @Test
         func incompatiblePendingImageDoesNotBlockLiveTranscript() async throws {
             let service = ImageChatService(supportsImages: true, sendBehavior: .delayFirstWithoutTurn)
             let session = makeSession(service: service)
@@ -372,6 +422,10 @@ import Foundation
         func resumeDelayedSteer() {
             delayedSteerContinuation?.resume()
             delayedSteerContinuation = nil
+        }
+
+        func yieldBlockedEvent(_ event: CodexChatTurnEvent) {
+            blockedTurnContinuation?.yield(event)
         }
 
         func completeBlockedTurn() {

--- a/Tests/DahliaTests/CodexChatSessionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatSessionModelTests.swift
@@ -879,6 +879,10 @@ import Foundation
             blockedContinuation = nil
         }
 
+        func yieldBlockedEvent(_ event: CodexChatTurnEvent) {
+            blockedContinuation?.yield(event)
+        }
+
         func resumeDelayedSend() {
             delayedSendContinuation?.resume()
             delayedSendContinuation = nil

--- a/Tests/DahliaTests/CodexChatSteeringTests.swift
+++ b/Tests/DahliaTests/CodexChatSteeringTests.swift
@@ -48,8 +48,10 @@ import Foundation
                 "Follow-up while responding",
             ])
             #expect(await service.steeredTextBlocks == [["Follow-up while responding"]])
+            #expect(session.showsStandaloneThinking)
             session.stop()
             await waitUntil { !session.isGenerating }
+            #expect(!session.showsStandaloneThinking)
         }
 
         @Test

--- a/Tests/DahliaTests/CodexChatThinkingPresentationTests.swift
+++ b/Tests/DahliaTests/CodexChatThinkingPresentationTests.swift
@@ -26,8 +26,28 @@ import Foundation
             #expect(session.showsStandaloneThinking)
 
             contextProvider.resume()
-            await waitUntil { session.activeTurnID != nil }
+            await waitUntil { session.messages.last?.text == "Partial" }
             #expect(!session.showsStandaloneThinking)
+
+            await service.yieldBlockedEvent(.completed(itemID: "item-1", text: "Partial"))
+            await waitUntil { session.showsStandaloneThinking }
+            #expect(session.messages.last?.text == "Partial")
+            #expect(session.messages.last?.isStreaming == true)
+
+            await service.yieldBlockedEvent(.reasoningDelta(
+                itemID: "reasoning-1",
+                summaryIndex: 0,
+                text: "More reasoning"
+            ))
+            await waitUntil { !session.showsStandaloneThinking }
+            #expect(session.messages.last?.reasoning == "More reasoning")
+
+            await service.yieldBlockedEvent(.reasoningCompleted(itemID: "reasoning-1", text: "More reasoning"))
+            await waitUntil { session.showsStandaloneThinking }
+
+            await service.yieldBlockedEvent(.delta(itemID: "item-2", text: "Next"))
+            await waitUntil { !session.showsStandaloneThinking }
+            #expect(session.messages.last?.text == "Partial\n\nNext")
 
             session.stop()
             await waitUntil { !session.isGenerating }

--- a/Tests/DahliaTests/CodexChatThinkingPresentationTests.swift
+++ b/Tests/DahliaTests/CodexChatThinkingPresentationTests.swift
@@ -55,6 +55,43 @@ import Foundation
         }
 
         @Test
+        func completedReasoningDoesNotShowThinkingWhileResponseStreams() async {
+            let service = TestCodexChatService(mode: .block)
+            let settings = AppSettings()
+            settings.currentVault = Self.testVault()
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings,
+                streamingUpdateInterval: .zero
+            )
+            session.draft = "Question"
+
+            session.sendDraft()
+            await waitUntil { session.messages.last?.text == "Partial" }
+
+            await service.yieldBlockedEvent(.reasoningDelta(
+                itemID: "reasoning-1",
+                summaryIndex: 0,
+                text: "More reasoning"
+            ))
+            await waitUntil { session.messages.last?.reasoning == "More reasoning" }
+
+            await service.yieldBlockedEvent(.reasoningCompleted(itemID: "reasoning-1", text: "More reasoning"))
+            for _ in 0 ..< 10 {
+                await Task.yield()
+            }
+            #expect(!session.showsStandaloneThinking)
+
+            await service.yieldBlockedEvent(.completed(itemID: "item-1", text: "Partial"))
+            await waitUntil { session.showsStandaloneThinking }
+
+            session.stop()
+            await waitUntil { !session.isGenerating }
+        }
+
+        @Test
         func completedResponseDoesNotShowThinkingDuringReconciliation() async {
             let service = TestCodexChatService(mode: .complete, delaysLoad: true)
             let settings = AppSettings()


### PR DESCRIPTION
## Summary

- Show `Thinking...` only while the chat is waiting for the next response or reasoning item.
- Hide it immediately on the first delta while preserving the existing 50 ms streaming update limiter for subsequent deltas.
- Render one indicator at the latest conversation position, including after partial responses and steering.
- Prevent stale steer completions from restoring waiting state or mutating a stopped session.

## Root cause

The presentation state was inferred from the active response placeholder rather than the Codex stream event boundaries. That made the indicator disappear during valid waiting intervals. The initial fix also exposed two races: same-value observable writes on every delta could invalidate SwiftUI continuously, and a delayed steer completion could restore stale waiting state after output had already started or the session had stopped.

## Impact

AI chat now consistently communicates when it is waiting for Codex output without duplicating the indicator or showing it while content is streaming.

## Validation

- `swift test --filter CodexChat` — 148 tests in 23 suites passed
- `swift build` — passed
- `CI=true ./scripts/lint.sh` — completed; SwiftFormat reports 0/552 files requiring formatting, while repository-existing SwiftLint violations remain non-blocking
- `git diff --check` — passed