### PR TITLE
Make AI chat composer scrollable

### DIFF
--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
@@ -126,6 +126,7 @@ struct CodexChatComposerTextEditor: View {
                             .padding(.leading, 8)
                             .padding(.top, 6)
                             .allowsHitTesting(false)
+                            .accessibilityHidden(true)
                     }
                 }
                 .contentShape(.rect)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct CodexChatComposerInputRow: View {
@@ -44,22 +45,14 @@ struct CodexChatComposerInputRow: View {
                 .onExitCommand(perform: onExitCommand)
                 .zIndex(showsAddPanel ? 1 : 0)
 
-            TextField(L10n.messageCodex, text: $session.draft, axis: .vertical)
-                .font(.body)
-                .textFieldStyle(.plain)
-                .lineLimit(1 ... 5)
-                .padding(.leading, 8)
-                .padding(.vertical, 6)
-                .contentShape(.rect)
-                .onContinuousHover(perform: onHover)
-                .accessibilityLabel(L10n.messageCodex)
-                .onSubmit(onSubmit)
-                .onMoveCommand(perform: onMoveCommand)
-                .onExitCommand(perform: onExitCommand)
-                .onKeyPress("v", phases: .down) { keyPress in
-                    guard keyPress.modifiers.contains(.command), onPasteImages() else { return .ignored }
-                    return .handled
-                }
+            CodexChatComposerTextEditor(
+                text: $session.draft,
+                onSubmit: onSubmit,
+                onMoveCommand: onMoveCommand,
+                onExitCommand: onExitCommand,
+                onPasteImages: onPasteImages,
+                onHover: onHover
+            )
 
             if session.isLoading, session.models.isEmpty {
                 ProgressView()
@@ -86,5 +79,92 @@ struct CodexChatComposerInputRow: View {
                 )
             }
         }
+    }
+}
+
+struct CodexChatComposerTextEditor: View {
+    @Binding var text: String
+    let onSubmit: () -> Void
+    let onMoveCommand: (MoveCommandDirection) -> Void
+    let onExitCommand: () -> Void
+    let onPasteImages: () -> Bool
+    let onHover: (HoverPhase) -> Void
+
+    private static let maximumLineCount = 5
+
+    var body: some View {
+        // The capped Text supplies intrinsic height while TextEditor owns native scrolling.
+        Text(text.isEmpty ? " " : text)
+            .font(.body)
+            .lineLimit(Self.maximumLineCount)
+            .padding(.leading, 8)
+            .padding(.vertical, 6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityHidden(true)
+            .hidden()
+            .overlay(alignment: .topLeading) {
+                ZStack(alignment: .topLeading) {
+                    TextEditor(text: $text)
+                        .font(.body)
+                        .scrollContentBackground(.hidden)
+                        .padding(.leading, 3)
+                        .padding(.vertical, 6)
+                        .accessibilityLabel(L10n.messageCodex)
+                        .onMoveCommand(perform: onMoveCommand)
+                        .onExitCommand(perform: onExitCommand)
+                        .onKeyPress(.return, phases: .down, action: handleReturnKey)
+                        .onKeyPress(.tab, phases: .down, action: handleTabKey)
+                        .onKeyPress("v", phases: .down) { keyPress in
+                            guard keyPress.modifiers.contains(.command), onPasteImages() else { return .ignored }
+                            return .handled
+                        }
+
+                    if text.isEmpty {
+                        Text(L10n.messageCodex)
+                            .font(.body)
+                            .foregroundStyle(.tertiary)
+                            .padding(.leading, 8)
+                            .padding(.top, 6)
+                            .allowsHitTesting(false)
+                    }
+                }
+                .contentShape(.rect)
+                .onContinuousHover(perform: onHover)
+            }
+    }
+
+    private func handleReturnKey(_: KeyPress) -> KeyPress.Result {
+        if activeTextView?.hasMarkedText() == true {
+            return .ignored
+        }
+        onSubmit()
+        return .handled
+    }
+
+    private func handleTabKey(_ keyPress: KeyPress) -> KeyPress.Result {
+        guard !keyPress.modifiers.contains(.option),
+              !keyPress.modifiers.contains(.command),
+              !keyPress.modifiers.contains(.control)
+        else {
+            return .ignored
+        }
+
+        let textView = activeTextView
+        if textView?.hasMarkedText() == true {
+            return .ignored
+        }
+        if let textView, let window = textView.window {
+            if keyPress.modifiers.contains(.shift) {
+                window.selectPreviousKeyView(textView)
+            } else {
+                window.selectNextKeyView(textView)
+            }
+        }
+        return .handled
+    }
+
+    private var activeTextView: NSTextView? {
+        let window = NSApp.currentEvent?.window ?? NSApp.keyWindow
+        return window?.firstResponder as? NSTextView
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
@@ -134,7 +134,10 @@ struct CodexChatComposerTextEditor: View {
             }
     }
 
-    private func handleReturnKey(_: KeyPress) -> KeyPress.Result {
+    private func handleReturnKey(_ keyPress: KeyPress) -> KeyPress.Result {
+        if keyPress.modifiers.contains(.shift) {
+            return .ignored
+        }
         if activeTextView?.hasMarkedText() == true {
             return .ignored
         }

--- a/Tests/DahliaTests/CodexChatComposerTextEditorTests.swift
+++ b/Tests/DahliaTests/CodexChatComposerTextEditorTests.swift
@@ -49,6 +49,16 @@ import SwiftUI
             #expect(harness.state.submissionCount == 1)
             #expect(harness.state.text == "Draft")
         }
+
+        @Test
+        func shiftReturnInsertsNewlineWithoutSubmitting() throws {
+            let harness = ComposerTextEditorHarness(text: "Draft")
+            harness.textView.setSelectedRange(NSRange(location: harness.textView.string.utf16.count, length: 0))
+            try harness.sendKeyDown(characters: "\r", modifierFlags: .shift, keyCode: 36)
+
+            #expect(harness.state.submissionCount == 0)
+            #expect(harness.state.text == "Draft\n")
+        }
     }
 
     @MainActor
@@ -83,12 +93,16 @@ import SwiftUI
             self.textView = textView
         }
 
-        func sendKeyDown(characters: String, keyCode: UInt16) throws {
+        func sendKeyDown(
+            characters: String,
+            modifierFlags: NSEvent.ModifierFlags = [],
+            keyCode: UInt16
+        ) throws {
             #expect(window.makeFirstResponder(textView))
             let event = try #require(NSEvent.keyEvent(
                 with: .keyDown,
                 location: .zero,
-                modifierFlags: [],
+                modifierFlags: modifierFlags,
                 timestamp: 0,
                 windowNumber: window.windowNumber,
                 context: nil,

--- a/Tests/DahliaTests/CodexChatComposerTextEditorTests.swift
+++ b/Tests/DahliaTests/CodexChatComposerTextEditorTests.swift
@@ -1,0 +1,145 @@
+import AppKit
+import SwiftUI
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct CodexChatComposerTextEditorTests {
+        @Test
+        func editorGrowsWithContentAndCapsItsVisibleHeight() throws {
+            let singleLine = ComposerTextEditorHarness(text: "One line")
+            let longDraft = ComposerTextEditorHarness(text: String(repeating: "Line\n", count: 20))
+
+            let singleLineScrollView = try #require(singleLine.textView.enclosingScrollView)
+            let longDraftScrollView = try #require(longDraft.textView.enclosingScrollView)
+
+            #expect(singleLineScrollView.frame.height < longDraftScrollView.frame.height)
+            #expect(singleLineScrollView.frame.height < 40)
+            #expect(longDraftScrollView.frame.height < 100)
+        }
+
+        @Test
+        func longDraftScrollsToKeepTheCaretVisible() throws {
+            let harness = ComposerTextEditorHarness(text: String(repeating: "Line\n", count: 20))
+            let scrollView = try #require(harness.textView.enclosingScrollView)
+            scrollView.contentView.scroll(to: .zero)
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+
+            harness.textView.setSelectedRange(NSRange(location: harness.textView.string.utf16.count, length: 0))
+            harness.textView.scrollRangeToVisible(harness.textView.selectedRange())
+
+            #expect(scrollView.documentVisibleRect.origin.y > 0)
+        }
+
+        @Test
+        func tabDoesNotChangeTheDraft() throws {
+            let harness = ComposerTextEditorHarness(text: "Draft")
+            try harness.sendKeyDown(characters: "\t", keyCode: 48)
+
+            #expect(harness.state.text == "Draft")
+        }
+
+        @Test
+        func returnSubmitsWithoutChangingTheDraft() throws {
+            let harness = ComposerTextEditorHarness(text: "Draft")
+            try harness.sendKeyDown(characters: "\r", keyCode: 36)
+
+            #expect(harness.state.submissionCount == 1)
+            #expect(harness.state.text == "Draft")
+        }
+    }
+
+    @MainActor
+    private final class ComposerTextEditorHarness {
+        let state: ComposerTextEditorState
+        let window: NSWindow
+        let hostingView: NSHostingView<ComposerTextEditorFixture>
+        let textView: NSTextView
+
+        init(text: String) {
+            let state = ComposerTextEditorState(text: text)
+            self.state = state
+            let fixture = ComposerTextEditorFixture(
+                text: Binding(
+                    get: { state.text },
+                    set: { state.text = $0 }
+                ),
+                onSubmit: { state.submissionCount += 1 }
+            )
+            hostingView = NSHostingView(rootView: fixture)
+            window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+                styleMask: [.titled],
+                backing: .buffered,
+                defer: false
+            )
+            window.contentView = hostingView
+            hostingView.layoutSubtreeIfNeeded()
+            guard let textView = hostingView.firstDescendant(ofType: NSTextView.self) else {
+                preconditionFailure("Composer TextEditor must provide an NSTextView")
+            }
+            self.textView = textView
+        }
+
+        func sendKeyDown(characters: String, keyCode: UInt16) throws {
+            #expect(window.makeFirstResponder(textView))
+            let event = try #require(NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: [],
+                timestamp: 0,
+                windowNumber: window.windowNumber,
+                context: nil,
+                characters: characters,
+                charactersIgnoringModifiers: characters,
+                isARepeat: false,
+                keyCode: keyCode
+            ))
+            window.sendEvent(event)
+        }
+    }
+
+    @MainActor
+    private final class ComposerTextEditorState {
+        var text: String
+        var submissionCount = 0
+
+        init(text: String) {
+            self.text = text
+        }
+    }
+
+    private struct ComposerTextEditorFixture: View {
+        @Binding var text: String
+        let onSubmit: () -> Void
+
+        var body: some View {
+            CodexChatComposerTextEditor(
+                text: $text,
+                onSubmit: onSubmit,
+                onMoveCommand: { _ in },
+                onExitCommand: {},
+                onPasteImages: { false },
+                onHover: { _ in }
+            )
+            .frame(width: 300)
+            .padding()
+        }
+    }
+
+    private extension NSView {
+        func firstDescendant<ViewType: NSView>(ofType _: ViewType.Type) -> ViewType? {
+            if let view = self as? ViewType {
+                return view
+            }
+            for subview in subviews {
+                if let view = subview.firstDescendant(ofType: ViewType.self) {
+                    return view
+                }
+            }
+            return nil
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary

- Replace the multiline chat input with a native `TextEditor` that grows from one to five visible lines and then scrolls.
- Preserve Return-to-send, Shift+Return newlines, IME marked text, Tab focus traversal, image paste, and mention cursor movement.
- Add regression coverage for height capping, caret visibility, Tab handling, and Return submission.

## Why

The SwiftUI multiline `TextField` relied on a private field editor and did not provide reliable mouse or trackpad scrolling for long drafts. Letting one native `TextEditor` own both editing and scrolling keeps the caret visible while preventing the composer from permanently occupying its maximum height.

## Validation

- `swift build --disable-sandbox`
- `swift test --disable-sandbox --filter CodexChatComposerTextEditorTests` — 4 tests passed
- SwiftFormat and SwiftLint passed for the changed files