### PR TITLE
Add Projects Optimizer preset and bump version to 0.7.1

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>35</string>
+    <string>36</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.7.0</string>
+    <string>0.7.1</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/Resources/Skills/projects-optimizer/SKILL.md
+++ b/Sources/Dahlia/Resources/Skills/projects-optimizer/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: projects-optimizer
+description: Optimize Dahlia Projects and Meeting assignments through the vault-scoped Dahlia tools. Use when the user asks to classify or tidy Meetings, create or restructure Projects, rename or reparent Projects, assign or unassign Meetings, review unorganized recent Meetings, or audit the Project hierarchy.
+---
+
+# Projects Optimizer
+
+Organize the active Dahlia Vault without treating directories as Projects or guessing from weak evidence.
+
+## Workflow
+
+### 1. Choose the Meeting period
+
+- Honor explicit Meeting references, Project IDs, filters, and date boundaries from the user.
+- For a broad request without dates, use the most recent 90 days and state the assumed period in the result.
+
+### 2. Understand the Meetings
+
+- Call `query_meetings` with the period as `created_from` / `created_before` and `limit: 100`; follow every cursor.
+- For a nonblank `ical_uid`, call `query_meetings` with that UID and follow its cursors when series history can clarify
+  the Meeting's purpose. Deduplicate the combined results by Meeting ID.
+- Call `get_meeting` for Meetings that may need classification. Review the description, stored summary, and available
+  calendar event metadata together, including the calendar title and `ical_uid`.
+- Call `get_meeting_transcript` or `get_meeting_screenshots` only when the available metadata and summary do not provide
+  enough evidence for the requested decision.
+
+### 3. Inspect the existing Projects
+
+- Call `query_projects` once to inspect the complete two-level hierarchy.
+- Treat Project IDs and parent relationships as canonical. Never infer Projects from directories.
+
+### 4. Decide the target organization
+
+- Compare the existing hierarchy with all Meetings in scope before making changes.
+- Reuse a clearly matching Project before creating one. Preserve an existing assignment when the evidence does not
+  clearly support a better destination.
+- Define the desired Project changes and Meeting-to-Project mapping together so Project structure is settled before
+  assignments move.
+- Separate uncertain Meetings from confident changes. Ask one focused question only when unresolved ambiguity
+  materially changes the target organization.
+
+### 5. Create or update Projects
+
+Execute changes when the user asked to organize the Vault; do not stop after proposing a plan unless the user requested
+analysis only.
+
+- Call `create_project` with one name component, an optional root `parent_project_id`, and a root `project_type` when
+  appropriate. Never submit a Project path.
+- Before `update_project`, call `get_project` and pass its current `revision`. Omit unchanged properties. Use
+  `parent_project_id: null` only to move a Project to the Vault root.
+- Finish the supported Project changes before moving Meeting assignments.
+
+### 6. Move Meeting assignments
+
+- Use the latest read of each Meeting's current assignment as `expected_project_id`, including explicit `null`.
+- Call `set_meeting_project_assignment` for one Meeting at a time. Call `remove_meeting_project_assignment` only when the
+  user wants the Meeting unassigned.
+- After a stale-state failure, re-fetch only that Project or Meeting and retry once if the requested intent remains
+  valid. Continue independent changes when one item fails.
+
+## Organization guidelines
+
+- Keep the hierarchy to a root and one subproject level. Use a root type matching the durable activity: `customer`,
+  `internal`, `personal`, or `undefined`; let subprojects inherit it.
+- Organize customer work with one `customer` root per company. Use subprojects for a department or a durable engagement
+  such as an opportunity, implementation, or named initiative.
+- Prefer an engagement subproject when a Meeting clearly belongs to specific work. Otherwise, use a department
+  subproject when that relationship is clear.
+- Infer internal Meeting groups dynamically from calendar titles, descriptions, summaries, and recurrence history.
+  `QBR`, one-on-ones, planning, reviews, and team syncs are examples, not a fixed taxonomy.
+- Use one `internal` root for a stable recurring Meeting family when supported by the evidence. For person-centered
+  recurring Meetings, use one subproject per counterpart only when the accessible evidence explicitly identifies that
+  person. Otherwise, keep the Meeting unchanged or ask who the counterpart is. For other families, use a team, subject,
+  or series-specific subproject only when it makes the root more useful.
+- Treat a shared `ical_uid` as strong evidence of the same calendar-event series and usually a consistent assignment.
+  Confirm its purpose from metadata or summaries because a series can change purpose.
+- Do not treat different or missing `ical_uid` values as proof of different Projects. Separate calendar events can still
+  support the same customer, engagement, department, or internal Meeting family.
+- Create a Project only for a coherent, durable stream of work. Do not create one for a single ambiguous Meeting.
+- Never claim to delete or merge Projects: Dahlia does not expose those operations. Explain the limitation and complete
+  independently requested supported changes.
+
+## Report the result
+
+Summarize the inspected scope, Projects created or updated, Meetings moved or unassigned, unchanged ambiguous items, and
+any failed or unsupported operations. Use Project names for readability and include IDs only when they help resolve
+ambiguity or retry a failure.

--- a/Sources/Dahlia/Resources/Skills/projects-optimizer/agents/openai.yaml
+++ b/Sources/Dahlia/Resources/Skills/projects-optimizer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Projects Optimizer"
+  short_description: "Optimize Dahlia Projects and meeting assignments"
+  default_prompt: "Use $projects-optimizer to review and optimize my Dahlia Projects and Meetings."

--- a/Sources/Dahlia/Services/CodexAppServerLauncher.swift
+++ b/Sources/Dahlia/Services/CodexAppServerLauncher.swift
@@ -7,17 +7,21 @@ protocol CodexAppServerLaunching: Sendable {
 struct BundledCodexAppServerLauncher: CodexAppServerLaunching {
     private let executableLocator: any CodexExecutableLocating
     private let homeLocator: any CodexHomeLocating
+    private let presetSkillInstaller: any CodexPresetSkillInstalling
 
     init(
         executableLocator: any CodexExecutableLocating = BundleCodexExecutableLocator(),
-        homeLocator: any CodexHomeLocating = ApplicationSupportCodexHomeLocator()
+        homeLocator: any CodexHomeLocating = ApplicationSupportCodexHomeLocator(),
+        presetSkillInstaller: any CodexPresetSkillInstalling = BundledCodexPresetSkillInstaller()
     ) {
         self.executableLocator = executableLocator
         self.homeLocator = homeLocator
+        self.presetSkillInstaller = presetSkillInstaller
     }
 
     func launch() throws -> any CodexAppServerTransport {
         let homeURL = try homeLocator.homeURL()
+        try presetSkillInstaller.install(into: homeURL)
         var environment = ProcessInfo.processInfo.environment
         environment["CODEX_HOME"] = homeURL.path
         environment["PATH"] = CommandLineToolLocator.searchPath(environment: environment)

--- a/Sources/Dahlia/Services/CodexAppServerService.swift
+++ b/Sources/Dahlia/Services/CodexAppServerService.swift
@@ -418,6 +418,7 @@ actor CodexAppServerService {
             runtimeProfile: runtimeProfile
         )
         config["mcp_servers"] = .object(servers)
+        config["skills.include_instructions"] = .bool(true)
         config["web_search"] = .string("live")
         return .object(config)
     }

--- a/Sources/Dahlia/Services/CodexPresetSkillInstaller.swift
+++ b/Sources/Dahlia/Services/CodexPresetSkillInstaller.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+protocol CodexPresetSkillInstalling: Sendable {
+    func install(into homeURL: URL) throws
+}
+
+struct BundledCodexPresetSkillInstaller: CodexPresetSkillInstalling {
+    nonisolated static let skillName = "projects-optimizer"
+    nonisolated static let obsoleteSkillName = "organize-projects-meetings"
+
+    private static let bundledFilePaths = [
+        "SKILL.md",
+        "agents/openai.yaml",
+    ]
+
+    func install(into homeURL: URL) throws {
+        let skillsURL = homeURL.appending(path: "skills", directoryHint: .isDirectory)
+        let destinationURL = skillsURL
+            .appending(path: Self.skillName, directoryHint: .isDirectory)
+        let obsoleteSkillURL = skillsURL
+            .appending(path: Self.obsoleteSkillName, directoryHint: .isDirectory)
+
+        do {
+            let bundledFiles = try Self.bundledFilePaths.map { relativePath in
+                try (relativePath, Data(contentsOf: sourceFileURL(relativePath: relativePath)))
+            }
+            try validatePrivateDirectory(homeURL)
+            try createPrivateDirectory(skillsURL)
+            try removeItemIfPresent(at: obsoleteSkillURL)
+            try removeItemIfPresent(at: destinationURL)
+            try createPrivateDirectory(destinationURL)
+            for (relativePath, data) in bundledFiles {
+                let destinationFileURL = destinationURL.appending(path: relativePath)
+                try createPrivateDirectory(destinationFileURL.deletingLastPathComponent())
+                try data.write(to: destinationFileURL, options: .atomic)
+                try FileManager.default.setAttributes(
+                    [.posixPermissions: 0o600],
+                    ofItemAtPath: destinationFileURL.path
+                )
+            }
+        } catch let error as CodexAppServerError {
+            throw error
+        } catch {
+            throw CodexAppServerError.launchFailed(error.localizedDescription)
+        }
+    }
+
+    private func sourceFileURL(relativePath: String) throws -> URL {
+        let relativeURL = URL(filePath: relativePath)
+        let resourceName = relativeURL.deletingPathExtension().lastPathComponent
+        let resourceExtension = relativeURL.pathExtension
+        guard let url = Bundle.appModule.url(forResource: resourceName, withExtension: resourceExtension) else {
+            throw CodexAppServerError.launchFailed("The bundled Codex preset skill is missing.")
+        }
+        return url
+    }
+
+    private func createPrivateDirectory(_ url: URL) throws {
+        if FileManager.default.fileExists(atPath: url.path) {
+            try validatePrivateDirectory(url)
+        } else {
+            if isSymbolicLink(url) {
+                throw CodexAppServerError.launchFailed("A Codex skill directory is a symbolic link.")
+            }
+            try FileManager.default.createDirectory(
+                at: url,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            try validatePrivateDirectory(url)
+        }
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: url.path
+        )
+    }
+
+    private func validatePrivateDirectory(_ url: URL) throws {
+        let values = try url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+        guard values.isDirectory == true, values.isSymbolicLink != true else {
+            throw CodexAppServerError.launchFailed("A Codex skill directory is not a private directory.")
+        }
+    }
+
+    private func removeItemIfPresent(at url: URL) throws {
+        guard FileManager.default.fileExists(atPath: url.path) || isSymbolicLink(url) else { return }
+        try FileManager.default.removeItem(at: url)
+    }
+
+    private func isSymbolicLink(_ url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink) == true
+    }
+}

--- a/Tests/DahliaTests/CodexAppServerLauncherTests.swift
+++ b/Tests/DahliaTests/CodexAppServerLauncherTests.swift
@@ -18,6 +18,23 @@ import Foundation
 
             let homeLocator = ApplicationSupportCodexHomeLocator(applicationSupportURL: rootURL)
             let expectedHomeURL = try homeLocator.homeURL()
+            let installedSkillURL = expectedHomeURL
+                .appending(path: "skills", directoryHint: .isDirectory)
+                .appending(path: BundledCodexPresetSkillInstaller.skillName, directoryHint: .isDirectory)
+            let obsoleteSkillURL = expectedHomeURL
+                .appending(path: "skills", directoryHint: .isDirectory)
+                .appending(
+                    path: BundledCodexPresetSkillInstaller.obsoleteSkillName,
+                    directoryHint: .isDirectory
+                )
+            try FileManager.default.createDirectory(
+                at: installedSkillURL.appending(path: "agents", directoryHint: .isDirectory),
+                withIntermediateDirectories: true
+            )
+            try FileManager.default.createDirectory(at: obsoleteSkillURL, withIntermediateDirectories: true)
+            try Data("stale skill".utf8).write(to: installedSkillURL.appending(path: "SKILL.md"))
+            try Data("stale metadata".utf8).write(to: installedSkillURL.appending(path: "agents/openai.yaml"))
+            try Data("obsolete preset".utf8).write(to: obsoleteSkillURL.appending(path: "SKILL.md"))
             let launcher = BundledCodexAppServerLauncher(
                 executableLocator: FixedCodexExecutableLocator(url: executableURL),
                 homeLocator: homeLocator
@@ -30,7 +47,68 @@ import Foundation
                 URL(filePath: workingDirectory, directoryHint: .isDirectory).resolvingSymlinksInPath()
                     == expectedHomeURL.resolvingSymlinksInPath()
             )
+            let skill = try String(contentsOf: installedSkillURL.appending(path: "SKILL.md"), encoding: .utf8)
+            let metadata = try String(
+                contentsOf: installedSkillURL.appending(path: "agents/openai.yaml"),
+                encoding: .utf8
+            )
+            #expect(skill.contains("name: projects-optimizer"))
+            #expect(metadata.contains("$projects-optimizer"))
+            #expect(!FileManager.default.fileExists(atPath: obsoleteSkillURL.path))
+            #expect(try permissions(of: installedSkillURL) == 0o700)
+            #expect(try permissions(of: installedSkillURL.appending(path: "agents")) == 0o700)
+            #expect(try permissions(of: installedSkillURL.appending(path: "SKILL.md")) == 0o600)
+            #expect(try permissions(of: installedSkillURL.appending(path: "agents/openai.yaml")) == 0o600)
             await transport.close()
+        }
+
+        @Test
+        func replacesSymlinkedPresetWithoutModifyingItsTarget() throws {
+            let rootURL = URL.temporaryDirectory
+                .appending(path: "dahlia-codex-skill-link-\(UUID().uuidString)", directoryHint: .isDirectory)
+            defer { try? FileManager.default.removeItem(at: rootURL) }
+
+            let homeURL = try ApplicationSupportCodexHomeLocator(applicationSupportURL: rootURL).homeURL()
+            let skillsURL = homeURL.appending(path: "skills", directoryHint: .isDirectory)
+            let installedSkillURL = skillsURL
+                .appending(path: BundledCodexPresetSkillInstaller.skillName, directoryHint: .isDirectory)
+            let externalURL = rootURL.appending(path: "external-skill", directoryHint: .isDirectory)
+            let externalSkillURL = externalURL.appending(path: "SKILL.md")
+            try FileManager.default.createDirectory(at: skillsURL, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: externalURL, withIntermediateDirectories: true)
+            try Data("external skill".utf8).write(to: externalSkillURL)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: externalURL.path)
+            try FileManager.default.createSymbolicLink(at: installedSkillURL, withDestinationURL: externalURL)
+
+            try BundledCodexPresetSkillInstaller().install(into: homeURL)
+
+            #expect(try String(contentsOf: externalSkillURL, encoding: .utf8) == "external skill")
+            #expect(try permissions(of: externalURL) == 0o755)
+            let values = try installedSkillURL.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+            #expect(values.isDirectory == true)
+            #expect(values.isSymbolicLink == false)
+        }
+
+        @Test
+        func rejectsSymlinkedSkillsDirectoryWithoutModifyingItsTarget() throws {
+            let rootURL = URL.temporaryDirectory
+                .appending(path: "dahlia-codex-skills-link-\(UUID().uuidString)", directoryHint: .isDirectory)
+            defer { try? FileManager.default.removeItem(at: rootURL) }
+
+            let homeURL = try ApplicationSupportCodexHomeLocator(applicationSupportURL: rootURL).homeURL()
+            let skillsURL = homeURL.appending(path: "skills", directoryHint: .isDirectory)
+            let externalURL = rootURL.appending(path: "external-skills", directoryHint: .isDirectory)
+            let sentinelURL = externalURL.appending(path: "sentinel")
+            try FileManager.default.createDirectory(at: externalURL, withIntermediateDirectories: true)
+            try Data("preserve".utf8).write(to: sentinelURL)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: externalURL.path)
+            try FileManager.default.createSymbolicLink(at: skillsURL, withDestinationURL: externalURL)
+
+            #expect(throws: CodexAppServerError.self) {
+                try BundledCodexPresetSkillInstaller().install(into: homeURL)
+            }
+            #expect(try String(contentsOf: sentinelURL, encoding: .utf8) == "preserve")
+            #expect(try permissions(of: externalURL) == 0o755)
         }
     }
 
@@ -40,5 +118,10 @@ import Foundation
         func executableURL() throws -> URL {
             url
         }
+    }
+
+    private func permissions(of url: URL) throws -> Int {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return try #require(attributes[.posixPermissions] as? NSNumber).intValue
     }
 #endif

--- a/Tests/DahliaTests/CodexAppServerServiceTests.swift
+++ b/Tests/DahliaTests/CodexAppServerServiceTests.swift
@@ -469,6 +469,7 @@ import Foundation
             let threadConfig = try #require(threadParams["config"]?.objectValue)
             #expect(threadConfig["features.apps"] == .bool(false))
             #expect(threadConfig["features.plugins"] == .bool(false))
+            #expect(threadConfig["skills.include_instructions"] == .bool(false))
             #expect(threadConfig["mcp_oauth_credentials_store"] == .string("file"))
             #expect(threadConfig["model_reasoning_effort"] == .string("medium"))
             #expect(threadConfig["mcp_servers"] == .object([

--- a/Tests/DahliaTests/CodexChatServiceTests.swift
+++ b/Tests/DahliaTests/CodexChatServiceTests.swift
@@ -280,7 +280,7 @@ import Foundation
             #expect(config["memories.dedicated_tools"] == .bool(false))
             #expect(config["memories.use_memories"] == .bool(false))
             #expect(config["orchestrator.mcp.enabled"] == .bool(false))
-            #expect(config["skills.include_instructions"] == .bool(false))
+            #expect(config["skills.include_instructions"] == .bool(true))
             #expect(config["web_search"] == .string("live"))
             #expect(config["mcp_servers"] == .object([
                 "dahlia": .object([

--- a/docs/adr/0015-preset-projects-optimizer-skill.md
+++ b/docs/adr/0015-preset-projects-optimizer-skill.md
@@ -1,0 +1,43 @@
+# ADR 0015: Projects Optimizer skill をアプリ内 Codex にプリセットする
+
+- Status: Accepted
+- Date: 2026-07-29
+- Amends: ADR 0003
+- Builds on: ADR 0010
+
+## Context
+
+Dahlia の Project 階層と Meeting assignment は、DB 正本、2段階 hierarchy、revision、期待する現在の
+assignment を使う MCP write contract を持つ。汎用チャットの developer instruction だけでは、広い整理依頼の
+既定期間、既存 Project の再利用、summary を優先した根拠確認、曖昧な Meeting の扱いまでを再利用可能な
+workflow として提示できない。
+
+ADR 0003 は要約とチャットの両方で skills を無効にした。要約の structured output と隔離は維持しながら、
+Vault 全体へアクセスできる対話チャットにだけ Dahlia 固有の整理 workflow を提供する。
+
+## Decision
+
+- `projects-optimizer` skill を Dahlia の application resource として同梱する。
+- app-server 起動前に、skill の `SKILL.md` と `agents/openai.yaml` を Dahlia 専用
+  `CODEX_HOME/skills/projects-optimizer` へ同期する。この preset と未リリース時に使った旧名の directory は
+  stateless な app-owned path として置換し、同期先の古い files を残さない。`skills` 自体が symbolic link
+  の場合は外部 directory を変更せず起動を失敗させる。
+- chat thread config では `skills.include_instructions` を有効にする。apps、hooks、memory、plugins、
+  orchestrator MCP、ユーザー設定の MCP は引き続き無効にし、Dahlia MCP だけを Vault 固定の `--write`
+  session として追加する。
+- summary thread config では skills を引き続き無効にする。Meeting 限定 MCP、structured output、
+  temporary working directory、`approvalPolicy: never` の契約を変更しない。
+- `~/.codex` の skills、設定、認証、session はコピーも参照もしない。
+
+skill は Project と Meeting の読み取り、分類、対応する単数 write tool の順序を定義する。Project deletion
+や merge など MCP が公開しない操作は実行可能と扱わない。
+
+## Consequences
+
+- 広い整理依頼でも、既定90日、既存 Project 優先、summary-first、曖昧な assignment の保持という一貫した
+  workflow を再利用できる。
+- preset 更新は次回 app-server 起動時に専用 `CODEX_HOME` へ反映される。
+- skill instruction は chat の tool choice に影響するため、skill 本体と chat／summary config の分離を
+  テストし、Dahlia MCP の Vault 境界と write validation を最終 authority とする。
+- app-server 起動は preset files の同期に失敗した場合も失敗として扱い、skill が利用可能に見えて実際には
+  欠落している状態を作らない。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,7 +11,7 @@ Codex は全 ADR を順番に読まず、最初にこの一覧から現在の作
 | --- | --- | --- | --- |
 | [0001](0001-summary-document-ast.md) | Summary | `SummaryDocument` AST をサマリーの正準表現にする | Accepted |
 | [0002](0002-isolate-recording-critical-path-from-main-actor.md) | Recording / Concurrency | 録音と確定データの保存を MainActor の UI projection から分離する | Accepted; partially superseded by 0006 and 0009 |
-| [0003](0003-use-a-shared-codex-app-server.md) | AI runtime | Codex app-server をアプリ共有の長寿命 backend として使う | Accepted; amended by 0013 |
+| [0003](0003-use-a-shared-codex-app-server.md) | AI runtime | Codex app-server をアプリ共有の長寿命 backend として使う | Accepted; amended by 0013 and 0015 |
 | [0004](0004-protect-recordings-with-segmented-immutable-storage.md) | Recording storage | 録音データを分割された immutable segment として保全する | Accepted |
 | [0005](0005-vault-scoped-meeting-access-mcp.md) | Meeting access | Vault 固定・read-only の local MCP で meeting data を公開する | Accepted; amended by 0010 |
 | [0006](0006-bounded-transcript-projection.md) | Transcript UI | SQLite を正本とし、文字起こし表示を bounded projection と keyset pagination にする | Accepted; partially supersedes 0002 |
@@ -23,3 +23,4 @@ Codex は全 ADR を順番に読まず、最初にこの一覧から現在の作
 | [0012](0012-reviewable-customer-intelligence-workspace.md) | Customer intelligence / UI | 単一顧客の組織ビューと単数 CRUD による逐次AI更新を採用する | Accepted; amends 0011 |
 | [0013](0013-expand-codex-stdout-burst-buffer.md) | AI runtime | Codex stdout の burst buffer を拡張し、消費済み payload を即時解放する | Accepted; amends 0003 |
 | [0014](0014-domain-driven-organization-merge.md) | Customer intelligence / Identity | メールドメイン追加を入口にルート組織を完全統合する | Accepted; amends 0011 and 0012 |
+| [0015](0015-preset-projects-optimizer-skill.md) | AI runtime / Project workspace | Projects Optimizer skill をアプリ内チャットへプリセットする | Accepted; amends 0003, builds on 0010 |

--- a/docs/project-workspaces.md
+++ b/docs/project-workspaces.md
@@ -98,6 +98,8 @@ Meeting–Project is an exclusive assignment: a Meeting has zero or one `project
 `dahlia-mcp --vault-id <UUID>` is read-only. Adding the sole capability flag, `--write`, publishes update tools. A
 meeting-limited MCP process cannot combine `--meeting-id` with `--write`.
 Full-Vault in-app chat starts the helper with `--write`; meeting-limited summary sessions remain read-only.
+The in-app chat presets the `projects-optimizer` skill in Dahlia's private `CODEX_HOME` and enables skill
+instructions for chat threads. Summary-generation threads keep skills disabled.
 
 Read tools:
 


### PR DESCRIPTION
## Summary

- bundle a `projects-optimizer` skill for organizing Dahlia Projects and Meeting assignments
- install the preset into Dahlia's private `CODEX_HOME` before launching the shared app-server
- enable skill instructions for Vault-wide chat while keeping summary threads isolated
- document the workflow and architecture decision
- bump the release version to `0.7.1` with build number `36`

## Why

Dahlia's Project hierarchy and Meeting assignment tools have strict two-level, revision, and expected-assignment contracts. The preset gives Codex a reusable workflow for reviewing a time range, interpreting summaries and calendar metadata, reusing or restructuring Projects, and moving Meetings safely.

This is a backward-compatible addition after the published `0.7.0` release, so the release policy requires a patch increment. Build `36` follows published build `35`.

## Safety and review fixes

- resolve resources with `Bundle.appModule` so packaged apps find the SwiftPM resource bundle
- replace only the stateless app-owned preset directories and preflight bundled data before removal
- reject a symlinked `skills` root and replace preset symlinks without modifying their external targets
- rely only on Meeting metadata actually exposed by the MCP and avoid guessing a one-on-one counterpart

## Validation

- `swift build`
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter 'Codex(ChatService|AppServerService|AppServerLauncher)Tests'` — 45 tests passed
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter CodexAppServerLauncherTests` — 3 tests passed
- `env CI=true ./scripts/lint.sh` — SwiftFormat clean; existing non-blocking SwiftLint violations remain
- `./scripts/test-release-scripts.sh`
- `plutil -lint Resources/Info.plist`
- skill YAML/metadata validation
- `git diff --check`
