### PR TITLE
Add screenshot image copy actions

### DIFF
--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -49,6 +49,7 @@
 "Apply" = "Apply";
 "Clear" = "Clear";
 "Close" = "Close";
+"Copy Image" = "Copy Image";
 "Done" = "Done";
 "Select" = "Select";
 "Select All" = "Select All";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -49,6 +49,7 @@
 "Apply" = "適用";
 "Clear" = "クリア";
 "Close" = "閉じる";
+"Copy Image" = "画像をコピー";
 "Done" = "完了";
 "Select" = "選択";
 "Select All" = "すべて選択";

--- a/Sources/Dahlia/Services/ScreenshotPasteboardWriter.swift
+++ b/Sources/Dahlia/Services/ScreenshotPasteboardWriter.swift
@@ -1,0 +1,53 @@
+import AppKit
+import DahliaRuntimeSupport
+import Foundation
+import UniformTypeIdentifiers
+
+private actor ScreenshotPasteboardImageValidator {
+    func detectedMIMEType(for data: Data) -> String? {
+        ImageEncoder.mimeType(for: data)
+    }
+}
+
+@MainActor
+enum ScreenshotPasteboardWriter {
+    private static let validator = ScreenshotPasteboardImageValidator()
+
+    @discardableResult
+    static func write(
+        _ screenshot: MeetingScreenshotRecord,
+        to pasteboard: NSPasteboard = .general
+    ) async -> Bool {
+        guard !screenshot.imageData.isEmpty,
+              let declaredContentType = contentType(for: screenshot.mimeType),
+              let detectedMIMEType = await validator.detectedMIMEType(for: screenshot.imageData),
+              let detectedContentType = contentType(for: detectedMIMEType),
+              declaredContentType == detectedContentType else { return false }
+
+        let item = NSPasteboardItem()
+        guard item.setData(
+            screenshot.imageData,
+            forType: NSPasteboard.PasteboardType(detectedContentType.identifier)
+        ) else { return false }
+
+        pasteboard.clearContents()
+        return pasteboard.writeObjects([item])
+    }
+
+    private static func contentType(for mimeType: String) -> UTType? {
+        switch mimeType.lowercased() {
+        case "image/png":
+            .png
+        case "image/jpeg", "image/jpg":
+            .jpeg
+        case "image/gif":
+            .gif
+        case "image/tiff":
+            .tiff
+        case "image/webp":
+            .webP
+        default:
+            nil
+        }
+    }
+}

--- a/Sources/Dahlia/Services/ScreenshotPasteboardWriter.swift
+++ b/Sources/Dahlia/Services/ScreenshotPasteboardWriter.swift
@@ -18,11 +18,24 @@ enum ScreenshotPasteboardWriter {
         _ screenshot: MeetingScreenshotRecord,
         to pasteboard: NSPasteboard = .general
     ) async -> Bool {
+        await write(screenshot, to: pasteboard) { data in
+            await validator.detectedMIMEType(for: data)
+        }
+    }
+
+    @discardableResult
+    static func write(
+        _ screenshot: MeetingScreenshotRecord,
+        to pasteboard: NSPasteboard,
+        detectMIMEType: (Data) async -> String?
+    ) async -> Bool {
+        let initialChangeCount = pasteboard.changeCount
         guard !screenshot.imageData.isEmpty,
               let declaredContentType = contentType(for: screenshot.mimeType),
-              let detectedMIMEType = await validator.detectedMIMEType(for: screenshot.imageData),
+              let detectedMIMEType = await detectMIMEType(screenshot.imageData),
               let detectedContentType = contentType(for: detectedMIMEType),
-              declaredContentType == detectedContentType else { return false }
+              declaredContentType == detectedContentType,
+              pasteboard.changeCount == initialChangeCount else { return false }
 
         let item = NSPasteboardItem()
         guard item.setData(

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -44,6 +44,7 @@ enum L10n {
     static var edit: String { String(localized: "Edit", bundle: bundle) }
     static var reload: String { String(localized: "Reload", bundle: bundle) }
     static var close: String { String(localized: "Close", bundle: bundle) }
+    static var copyImage: String { String(localized: "Copy Image", bundle: bundle) }
     static var done: String { String(localized: "Done", bundle: bundle) }
     static var select: String { String(localized: "Select", bundle: bundle) }
     static var selectAll: String { String(localized: "Select All", bundle: bundle) }

--- a/Sources/Dahlia/Views/ScreenshotCollectionView.swift
+++ b/Sources/Dahlia/Views/ScreenshotCollectionView.swift
@@ -256,6 +256,7 @@ extension ScreenshotCollectionView {
                     activate: { [weak self] previewImage in
                         self?.activate(id: id, previewImage: previewImage)
                     },
+                    copy: { [weak self] in self?.copy(id: id) },
                     download: { [weak self] in self?.download(id: id) },
                     delete: { [weak self] in self?.delete(id: id) }
                 )
@@ -279,6 +280,13 @@ extension ScreenshotCollectionView {
         private func download(id: UUID) {
             guard let screenshot = screenshot(for: id) else { return }
             parent.download(screenshot)
+        }
+
+        private func copy(id: UUID) {
+            guard let screenshot = screenshot(for: id) else { return }
+            Task {
+                await ScreenshotPasteboardWriter.write(screenshot)
+            }
         }
 
         private func delete(id: UUID) {

--- a/Sources/Dahlia/Views/ScreenshotCollectionViewItem.swift
+++ b/Sources/Dahlia/Views/ScreenshotCollectionViewItem.swift
@@ -74,6 +74,7 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
 
     struct Actions {
         let activate: (CGImage?) -> Void
+        let copy: () -> Void
         let download: () -> Void
         let delete: () -> Void
     }
@@ -82,6 +83,7 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
         let isThumbnailEnabled: Bool
         let isLockVisible: Bool
         let selectionSymbolName: String?
+        let isCopyHidden: Bool
         let isDeleteHidden: Bool
         let isDeleteEnabled: Bool
     }
@@ -92,12 +94,14 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
     private let timestampLabel = NSTextField(labelWithString: "")
     private let lockImageView = NSImageView()
     private let selectionImageView = PassthroughImageView()
+    private let copyButton = NSButton()
     private let downloadButton = NSButton()
     private let deleteButton = NSButton()
     private var thumbnailTask: Task<Void, Never>?
     private var thumbnailLoadState = ThumbnailLoadState.idle
     private var loadGeneration: UInt64 = 0
     private var activationHandler: ((CGImage?) -> Void)?
+    private var copyHandler: (() -> Void)?
     private var downloadHandler: (() -> Void)?
     private var deleteHandler: (() -> Void)?
     private var representedImageIdentity: ScreenshotImageContentIdentity?
@@ -107,7 +111,10 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
     private(set) var renderedState: RenderedState?
     var loadedThumbnailSize: NSSize? { thumbnailButton.image?.size }
     var isLoadingThumbnail: Bool { thumbnailTask != nil }
-    var hasCallbacks: Bool { activationHandler != nil || downloadHandler != nil || deleteHandler != nil }
+    var hasCallbacks: Bool {
+        activationHandler != nil || copyHandler != nil || downloadHandler != nil || deleteHandler != nil
+    }
+
     var selectionIndicatorAcceptsHitTesting: Bool { selectionImageView.hitTest(.zero) != nil }
     var selectionIndicatorIsAccessibilityElement: Bool { selectionImageView.isAccessibilityElement() }
 
@@ -122,7 +129,7 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
         configureThumbnailButton()
         configureMetadataControls()
 
-        let metadataStack = NSStackView(views: [timestampLabel, lockImageView, downloadButton, deleteButton])
+        let metadataStack = NSStackView(views: [timestampLabel, lockImageView, copyButton, downloadButton, deleteButton])
         metadataStack.orientation = .horizontal
         metadataStack.alignment = .centerY
         metadataStack.spacing = 6
@@ -171,6 +178,7 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
         representedImageIdentity = nil
         renderedState = nil
         activationHandler = nil
+        copyHandler = nil
         downloadHandler = nil
         deleteHandler = nil
         timestampLabel.stringValue = ""
@@ -195,6 +203,7 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
         timestampLabel.stringValue = configuration.timestamp
         timestampLabel.toolTip = configuration.timestamp
         activationHandler = actions.activate
+        copyHandler = actions.copy
         downloadHandler = actions.download
         deleteHandler = actions.delete
 
@@ -227,6 +236,7 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
                 : .controlAccentColor
         }
 
+        copyButton.isHidden = configuration.isSelecting
         downloadButton.isHidden = configuration.isSelecting
         deleteButton.isHidden = configuration.isSelecting
         deleteButton.isEnabled = !configuration.isReferencedBySummary && !configuration.isDeletionDisabled
@@ -235,6 +245,7 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
             isThumbnailEnabled: thumbnailButton.isEnabled,
             isLockVisible: !lockImageView.isHidden,
             selectionSymbolName: selectionSymbolName,
+            isCopyHidden: copyButton.isHidden,
             isDeleteHidden: deleteButton.isHidden,
             isDeleteEnabled: deleteButton.isEnabled
         )
@@ -263,6 +274,7 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
         thumbnailButton.layer?.cornerRadius = 6
         thumbnailButton.layer?.masksToBounds = true
         thumbnailButton.updateBackgroundColor()
+        configureContextMenu()
     }
 
     private func configureMetadataControls() {
@@ -274,6 +286,7 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
         lockImageView.contentTintColor = .secondaryLabelColor
         lockImageView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 12, weight: .regular)
 
+        configureIconButton(copyButton, symbolName: "doc.on.doc", label: L10n.copyImage, action: #selector(copyScreenshot))
         configureIconButton(downloadButton, symbolName: "arrow.down.circle", label: L10n.download, action: #selector(downloadScreenshot))
         configureIconButton(deleteButton, symbolName: "trash", label: L10n.delete, action: #selector(deleteScreenshot))
         deleteButton.contentTintColor = .secondaryLabelColor
@@ -287,6 +300,19 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
         button.action = action
         button.toolTip = label
         button.setAccessibilityLabel(label)
+    }
+
+    private func configureContextMenu() {
+        let menu = NSMenu()
+        let copyItem = NSMenuItem(
+            title: L10n.copyImage,
+            action: #selector(copyScreenshot),
+            keyEquivalent: ""
+        )
+        copyItem.image = NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: L10n.copyImage)
+        copyItem.target = self
+        menu.addItem(copyItem)
+        thumbnailButton.menu = menu
     }
 
     private func startThumbnailLoad(for screenshot: MeetingScreenshotRecord, provider: @escaping ThumbnailProvider) {
@@ -328,6 +354,10 @@ final class ScreenshotCollectionViewItem: NSCollectionViewItem {
 
     @objc private func activateThumbnail() {
         activationHandler?(loadedThumbnailImage)
+    }
+
+    @objc private func copyScreenshot() {
+        copyHandler?()
     }
 
     @objc private func downloadScreenshot() {

--- a/Sources/Dahlia/Views/ScreenshotOverlayView.swift
+++ b/Sources/Dahlia/Views/ScreenshotOverlayView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 enum ScreenshotOverlayLayout {
@@ -74,6 +75,7 @@ struct ScreenshotOverlayView: View {
                 .padding(16)
                 .buttonStyle(.plain)
                 .pointerStyle(.link)
+                .help(L10n.close)
         }
         .onAppear {
             ScreenshotImageDecodeWorker.recordOverlayPresented(
@@ -105,6 +107,22 @@ struct ScreenshotOverlayView: View {
             .resizable()
             .frame(width: imageSize.width, height: imageSize.height)
             .clipShape(.rect(cornerRadius: 8))
+            .overlay(alignment: .topTrailing) {
+                Button(L10n.copyImage, systemImage: "doc.on.doc", action: copyImageToGeneralPasteboard)
+                    .labelStyle(.iconOnly)
+                    .font(.title2)
+                    .foregroundStyle(.black)
+                    .padding(8)
+                    .background(.white, in: .circle)
+                    .shadow(color: .black.opacity(0.35), radius: 4, y: 2)
+                    .padding(12)
+                    .buttonStyle(.plain)
+                    .pointerStyle(.link)
+                    .help(L10n.copyImage)
+            }
+            .contextMenu {
+                Button(L10n.copyImage, systemImage: "doc.on.doc", action: copyImageToGeneralPasteboard)
+            }
             .background {
                 ScreenshotOverlayInputMonitor(onDismiss: onDismiss)
             }
@@ -115,5 +133,15 @@ struct ScreenshotOverlayView: View {
             .background {
                 ScreenshotOverlayInputMonitor(onDismiss: onDismiss)
             }
+    }
+
+    private func copyImageToGeneralPasteboard() {
+        Task {
+            await copyImage(to: .general)
+        }
+    }
+
+    func copyImage(to pasteboard: NSPasteboard = .general) async {
+        await ScreenshotPasteboardWriter.write(screenshot, to: pasteboard)
     }
 }

--- a/Sources/Dahlia/Views/SummaryDocumentView.swift
+++ b/Sources/Dahlia/Views/SummaryDocumentView.swift
@@ -1,21 +1,22 @@
+import AppKit
 import SwiftUI
 
 struct SummaryDocumentView: View {
     let document: SummaryDocument
-    let imageDataProvider: (UUID) -> Data?
+    let screenshotProvider: (UUID) -> MeetingScreenshotRecord?
     let onOpenImage: (UUID, CGImage) -> Void
     let transcriptTextProvider: (TranscriptReference) -> String?
     let allowsTranscriptReferencePopovers: Bool
 
     init(
         document: SummaryDocument,
-        imageDataProvider: @escaping (UUID) -> Data?,
+        screenshotProvider: @escaping (UUID) -> MeetingScreenshotRecord?,
         onOpenImage: @escaping (UUID, CGImage) -> Void,
         transcriptTextProvider: @escaping (TranscriptReference) -> String? = { _ in nil },
         allowsTranscriptReferencePopovers: Bool = true
     ) {
         self.document = document
-        self.imageDataProvider = imageDataProvider
+        self.screenshotProvider = screenshotProvider
         self.onOpenImage = onOpenImage
         self.transcriptTextProvider = transcriptTextProvider
         self.allowsTranscriptReferencePopovers = allowsTranscriptReferencePopovers
@@ -154,10 +155,9 @@ struct SummaryDocumentView: View {
 
     private func imageView(screenshotId: UUID, caption: SummaryText) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            if let data = imageDataProvider(screenshotId) {
+            if let screenshot = screenshotProvider(screenshotId) {
                 SummaryScreenshotImageView(
-                    screenshotID: screenshotId,
-                    data: data,
+                    screenshot: screenshot,
                     accessibilityLabel: L10n.enlargeScreenshot(caption: caption.text.nilIfBlank),
                     onOpen: onOpenImage
                 )
@@ -258,8 +258,7 @@ struct SummaryDocumentView: View {
 }
 
 struct SummaryScreenshotImageView: View {
-    let screenshotID: UUID
-    let data: Data
+    let screenshot: MeetingScreenshotRecord
     let accessibilityLabel: String
     let onOpen: (UUID, CGImage) -> Void
     @StateObject private var imageLoader = ScreenshotImageLoadModel()
@@ -267,17 +266,30 @@ struct SummaryScreenshotImageView: View {
     var body: some View {
         Group {
             if case let .loaded(image) = imageLoader.state {
-                Button {
-                    activate(image)
-                } label: {
-                    Image(decorative: image, scale: 1)
-                        .resizable()
-                        .scaledToFit()
+                ZStack(alignment: .topTrailing) {
+                    Button {
+                        activate(image)
+                    } label: {
+                        Image(decorative: image, scale: 1)
+                            .resizable()
+                            .scaledToFit()
+                    }
+                    .buttonStyle(.plain)
+                    .pointerStyle(.link)
+                    .accessibilityLabel(accessibilityLabel)
+                    .help(accessibilityLabel)
+
+                    Button(L10n.copyImage, systemImage: "doc.on.doc", action: copyImageToGeneralPasteboard)
+                        .labelStyle(.iconOnly)
+                        .buttonStyle(.plain)
+                        .padding(6)
+                        .background(.regularMaterial, in: .circle)
+                        .padding(8)
+                        .help(L10n.copyImage)
                 }
-                .buttonStyle(.plain)
-                .pointerStyle(.link)
-                .accessibilityLabel(accessibilityLabel)
-                .help(accessibilityLabel)
+                .contextMenu {
+                    Button(L10n.copyImage, systemImage: "doc.on.doc", action: copyImageToGeneralPasteboard)
+                }
             } else if case .failed = imageLoader.state {
                 Text(L10n.summaryImageUnavailable)
                     .font(.callout)
@@ -289,17 +301,27 @@ struct SummaryScreenshotImageView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: 360, alignment: .leading)
         .clipShape(RoundedRectangle(cornerRadius: 6))
-        .task(id: screenshotID) {
+        .task(id: screenshot.id) {
             await imageLoader.load(
-                screenshotID: screenshotID,
-                data: data,
+                screenshotID: screenshot.id,
+                data: screenshot.imageData,
                 maxPixelSize: 1200
             )
         }
     }
 
     func activate(_ image: CGImage) {
-        onOpen(screenshotID, image)
+        onOpen(screenshot.id, image)
+    }
+
+    private func copyImageToGeneralPasteboard() {
+        Task {
+            await copyImage(to: .general)
+        }
+    }
+
+    func copyImage(to pasteboard: NSPasteboard = .general) async {
+        await ScreenshotPasteboardWriter.write(screenshot, to: pasteboard)
     }
 }
 

--- a/Sources/Dahlia/Views/SummaryTabContentView.swift
+++ b/Sources/Dahlia/Views/SummaryTabContentView.swift
@@ -14,7 +14,7 @@ struct SummaryTabContentView: View {
                 VStack(alignment: .leading, spacing: 20) {
                     SummaryDocumentView(
                         document: document,
-                        imageDataProvider: imageData,
+                        screenshotProvider: screenshot,
                         onOpenImage: openScreenshot,
                         transcriptTextProvider: transcriptText,
                         allowsTranscriptReferencePopovers: allowsTranscriptReferencePopovers
@@ -34,7 +34,7 @@ struct SummaryTabContentView: View {
         }
     }
 
-    private func imageData(for screenshotID: UUID) -> Data? {
-        screenshotStore.records.first { $0.id == screenshotID }?.imageData
+    private func screenshot(for screenshotID: UUID) -> MeetingScreenshotRecord? {
+        screenshotStore.records.first { $0.id == screenshotID }
     }
 }

--- a/Tests/DahliaTests/ScreenshotCollectionViewTests.swift
+++ b/Tests/DahliaTests/ScreenshotCollectionViewTests.swift
@@ -69,7 +69,7 @@ struct ScreenshotCollectionViewTests {
         let screenshot = makeScreenshot()
         let image = try #require(makeImage(width: 32, height: 18))
 
-        configure(item, screenshot: screenshot) { _, _, _ in image }
+        configure(item, screenshot: screenshot, provider: { _, _, _ in image })
         await waitUntil { item.loadedThumbnailSize != nil }
         #expect(item.loadedThumbnailSize == NSSize(width: 32, height: 18))
 
@@ -85,7 +85,7 @@ struct ScreenshotCollectionViewTests {
         let screenshot = makeScreenshot()
         let image = try #require(makeImage(width: 32, height: 18))
 
-        configure(item, screenshot: screenshot) { _, _, _ in image }
+        configure(item, screenshot: screenshot, provider: { _, _, _ in image })
         await waitUntil { item.loadedThumbnailSize != nil }
 
         item.didEndDisplaying()
@@ -114,6 +114,7 @@ struct ScreenshotCollectionViewTests {
             isThumbnailEnabled: false,
             isLockVisible: true,
             selectionSymbolName: "lock.circle.fill",
+            isCopyHidden: true,
             isDeleteHidden: true,
             isDeleteEnabled: false
         ))
@@ -129,6 +130,7 @@ struct ScreenshotCollectionViewTests {
             isThumbnailEnabled: true,
             isLockVisible: false,
             selectionSymbolName: "checkmark.circle.fill",
+            isCopyHidden: true,
             isDeleteHidden: true,
             isDeleteEnabled: true
         ))
@@ -143,13 +145,14 @@ struct ScreenshotCollectionViewTests {
             isThumbnailEnabled: true,
             isLockVisible: false,
             selectionSymbolName: nil,
+            isCopyHidden: false,
             isDeleteHidden: false,
             isDeleteEnabled: false
         ))
     }
 
     @Test
-    func nativeButtonsRouteOpenDownloadAndDeleteActionsWithImmediatePreview() async throws {
+    func nativeButtonsAndContextMenuRouteImageActionsWithImmediatePreview() async throws {
         let item = ScreenshotCollectionViewItem()
         let screenshot = makeScreenshot()
         let preview = try #require(makeImage(width: 32, height: 18))
@@ -170,6 +173,7 @@ struct ScreenshotCollectionViewTests {
                     activatedPreviewSize = image.map { CGSize(width: $0.width, height: $0.height) }
                     invokedActions.append("open")
                 },
+                copy: { invokedActions.append("copy") },
                 download: { invokedActions.append("download") },
                 delete: { invokedActions.append("delete") }
             )
@@ -178,14 +182,17 @@ struct ScreenshotCollectionViewTests {
 
         let buttons = descendantViews(of: item.view).compactMap { $0 as? NSButton }
         let openButton = try #require(buttons.first { $0.accessibilityLabel() == L10n.open })
+        let copyButton = try #require(buttons.first { $0.accessibilityLabel() == L10n.copyImage })
         let downloadButton = try #require(buttons.first { $0.accessibilityLabel() == L10n.download })
         let deleteButton = try #require(buttons.first { $0.accessibilityLabel() == L10n.delete })
 
         openButton.performClick(nil)
+        copyButton.performClick(nil)
         downloadButton.performClick(nil)
         deleteButton.performClick(nil)
+        try #require(openButton.menu).performActionForItem(at: 0)
 
-        #expect(invokedActions == ["open", "download", "delete"])
+        #expect(invokedActions == ["open", "copy", "download", "delete", "copy"])
         #expect(activatedPreviewSize == CGSize(width: 32, height: 18))
     }
 
@@ -270,6 +277,7 @@ struct ScreenshotCollectionViewTests {
         _ item: ScreenshotCollectionViewItem,
         screenshot: MeetingScreenshotRecord,
         state: TestControlState = .init(),
+        copy: @escaping () -> Void = {},
         provider: @escaping ScreenshotCollectionViewItem.ThumbnailProvider
     ) {
         item.configure(
@@ -282,7 +290,7 @@ struct ScreenshotCollectionViewTests {
                 isDeletionDisabled: state.isDeletionDisabled
             ),
             thumbnailProvider: provider,
-            actions: .init(activate: { _ in }, download: {}, delete: {})
+            actions: .init(activate: { _ in }, copy: copy, download: {}, delete: {})
         )
     }
 
@@ -339,6 +347,39 @@ struct ScreenshotCollectionViewTests {
 }
 
 extension ScreenshotCollectionViewTests {
+    @Test
+    func reconfiguredContextMenuUsesCurrentCopyAction() throws {
+        let item = ScreenshotCollectionViewItem()
+        let first = makeScreenshot()
+        let second = makeScreenshot()
+        var copiedIDs: [UUID] = []
+
+        let provider: ScreenshotCollectionViewItem.ThumbnailProvider = { _, _, _ in nil }
+        configure(
+            item,
+            screenshot: first,
+            copy: { copiedIDs.append(first.id) },
+            provider: provider
+        )
+        let openButton = try #require(
+            descendantViews(of: item.view)
+                .compactMap { $0 as? NSButton }
+                .first { $0.accessibilityLabel() == L10n.open }
+        )
+        let contextMenu = try #require(openButton.menu)
+        contextMenu.performActionForItem(at: 0)
+
+        configure(
+            item,
+            screenshot: second,
+            copy: { copiedIDs.append(second.id) },
+            provider: provider
+        )
+        contextMenu.performActionForItem(at: 0)
+
+        #expect(copiedIDs == [first.id, second.id])
+    }
+
     @Test
     func imageIdentityMatchesSharedBackingStorage() {
         var first = makeScreenshot()

--- a/Tests/DahliaTests/ScreenshotOverlayViewTests.swift
+++ b/Tests/DahliaTests/ScreenshotOverlayViewTests.swift
@@ -1,6 +1,7 @@
 #if canImport(Testing)
 import AppKit
 import Testing
+import UniformTypeIdentifiers
 @testable import Dahlia
 
 @MainActor
@@ -27,6 +28,42 @@ struct ScreenshotOverlayViewTests {
             imageSize: CGSize(width: 1_600, height: 900),
             availableSize: .zero
         ) == .zero)
+    }
+
+    @Test
+    func copyWritesOriginalImageWithoutDismissingOverlay() async throws {
+        let mouseFixture = try makeMouseFixture(
+            eventType: .leftMouseDown,
+            eventLocation: CGPoint(x: 50, y: 50)
+        )
+        let pasteboard = NSPasteboard(name: .init("ScreenshotOverlayViewTests-\(UUID().uuidString)"))
+        let imageData = try #require(TestScreenshotImageFixture.data(using: .jpeg))
+        let screenshot = MeetingScreenshotRecord(
+            id: .v7(),
+            meetingId: .v7(),
+            capturedAt: .now,
+            imageData: imageData,
+            mimeType: "image/jpeg"
+        )
+        var dismissCount = 0
+        let view = ScreenshotOverlayView(
+            screenshot: screenshot,
+            previewImage: nil,
+            requestedAt: .now
+        ) {
+            dismissCount += 1
+        }
+        let coordinator = ScreenshotOverlayInputMonitor.Coordinator {
+            dismissCount += 1
+        }
+
+        let handledEvent = coordinator.handle(mouseFixture.event, in: mouseFixture.view)
+        await view.copyImage(to: pasteboard)
+
+        let type = NSPasteboard.PasteboardType(UTType.jpeg.identifier)
+        #expect(handledEvent === mouseFixture.event)
+        #expect(pasteboard.data(forType: type) == screenshot.imageData)
+        #expect(dismissCount == 0)
     }
 
     @Test

--- a/Tests/DahliaTests/ScreenshotPasteboardWriterTests.swift
+++ b/Tests/DahliaTests/ScreenshotPasteboardWriterTests.swift
@@ -37,6 +37,32 @@ struct ScreenshotPasteboardWriterTests {
     }
 
     @Test
+    func newerPasteboardContentsArePreservedDuringValidation() async throws {
+        let pasteboard = makePasteboard()
+        let imageData = try #require(TestScreenshotImageFixture.data(using: .png))
+        let screenshot = makeScreenshot(data: imageData, mimeType: "image/png")
+        let validationGate = ValidationGate()
+
+        let copyTask = Task {
+            await ScreenshotPasteboardWriter.write(
+                screenshot,
+                to: pasteboard
+            ) { _ in
+                await validationGate.suspend()
+                return "image/png"
+            }
+        }
+        await validationGate.waitUntilStarted()
+        pasteboard.clearContents()
+        pasteboard.setString("new value", forType: .string)
+        await validationGate.release()
+
+        let didWrite = await copyTask.value
+        #expect(!didWrite)
+        #expect(pasteboard.string(forType: .string) == "new value")
+    }
+
+    @Test
     func corruptImageDataDoesNotReplaceExistingPasteboardContents() async {
         let pasteboard = makePasteboard()
         pasteboard.setString("keep me", forType: .string)
@@ -85,6 +111,34 @@ struct ScreenshotPasteboardWriterTests {
             imageData: data,
             mimeType: mimeType
         )
+    }
+}
+
+private actor ValidationGate {
+    private var isStarted = false
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    func suspend() async {
+        isStarted = true
+        let waiters = startWaiters
+        startWaiters = []
+        waiters.forEach { $0.resume() }
+        await withCheckedContinuation { continuation in
+            releaseContinuation = continuation
+        }
+    }
+
+    func waitUntilStarted() async {
+        guard !isStarted else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append(continuation)
+        }
+    }
+
+    func release() {
+        releaseContinuation?.resume()
+        releaseContinuation = nil
     }
 }
 #endif

--- a/Tests/DahliaTests/ScreenshotPasteboardWriterTests.swift
+++ b/Tests/DahliaTests/ScreenshotPasteboardWriterTests.swift
@@ -1,0 +1,90 @@
+#if canImport(Testing)
+import AppKit
+import Testing
+import UniformTypeIdentifiers
+@testable import Dahlia
+
+@MainActor
+struct ScreenshotPasteboardWriterTests {
+    @Test(arguments: [
+        "image/png",
+        "image/jpeg",
+    ])
+    func writesOriginalDataUsingTheStoredImageType(mimeType: String) async throws {
+        let pasteboard = makePasteboard()
+        let fileType: NSBitmapImageRep.FileType = mimeType == "image/png" ? .png : .jpeg
+        let contentType: UTType = mimeType == "image/png" ? .png : .jpeg
+        let imageData = try #require(TestScreenshotImageFixture.data(using: fileType))
+        let screenshot = makeScreenshot(data: imageData, mimeType: mimeType)
+
+        #expect(await ScreenshotPasteboardWriter.write(screenshot, to: pasteboard))
+
+        let item = try #require(pasteboard.pasteboardItems?.first)
+        let pasteboardType = NSPasteboard.PasteboardType(contentType.identifier)
+        #expect(pasteboard.pasteboardItems?.count == 1)
+        #expect(item.data(forType: pasteboardType) == screenshot.imageData)
+    }
+
+    @Test
+    func successfulWriteReplacesExistingPasteboardContents() async throws {
+        let pasteboard = makePasteboard()
+        pasteboard.setString("old value", forType: .string)
+        let imageData = try #require(TestScreenshotImageFixture.data(using: .png))
+        let screenshot = makeScreenshot(data: imageData, mimeType: "image/png")
+
+        #expect(await ScreenshotPasteboardWriter.write(screenshot, to: pasteboard))
+        #expect(pasteboard.string(forType: .string) == nil)
+    }
+
+    @Test
+    func corruptImageDataDoesNotReplaceExistingPasteboardContents() async {
+        let pasteboard = makePasteboard()
+        pasteboard.setString("keep me", forType: .string)
+        let screenshot = makeScreenshot(data: Data([1, 2, 3]), mimeType: "image/png")
+
+        let didWrite = await ScreenshotPasteboardWriter.write(screenshot, to: pasteboard)
+        #expect(!didWrite)
+        #expect(pasteboard.string(forType: .string) == "keep me")
+    }
+
+    @Test
+    func mismatchedMIMETypeDoesNotReplaceExistingPasteboardContents() async throws {
+        let pasteboard = makePasteboard()
+        pasteboard.setString("keep me", forType: .string)
+        let imageData = try #require(TestScreenshotImageFixture.data(using: .png))
+        let screenshot = makeScreenshot(data: imageData, mimeType: "image/jpeg")
+
+        let didWrite = await ScreenshotPasteboardWriter.write(screenshot, to: pasteboard)
+        #expect(!didWrite)
+        #expect(pasteboard.string(forType: .string) == "keep me")
+    }
+
+    @Test
+    func unsupportedMIMETypeDoesNotReplaceExistingPasteboardContents() async throws {
+        let pasteboard = makePasteboard()
+        pasteboard.setString("keep me", forType: .string)
+        let imageData = try #require(TestScreenshotImageFixture.data(using: .png))
+        let screenshot = makeScreenshot(data: imageData, mimeType: "application/octet-stream")
+
+        let didWrite = await ScreenshotPasteboardWriter.write(screenshot, to: pasteboard)
+        #expect(!didWrite)
+        #expect(pasteboard.string(forType: .string) == "keep me")
+    }
+
+    private func makePasteboard() -> NSPasteboard {
+        let pasteboard = NSPasteboard(name: .init("ScreenshotPasteboardWriterTests-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        return pasteboard
+    }
+
+    private func makeScreenshot(data: Data, mimeType: String) -> MeetingScreenshotRecord {
+        MeetingScreenshotRecord(
+            id: .v7(),
+            meetingId: .v7(),
+            capturedAt: .now,
+            imageData: data,
+            mimeType: mimeType
+        )
+    }
+}
+#endif

--- a/Tests/DahliaTests/SummaryDocumentViewTests.swift
+++ b/Tests/DahliaTests/SummaryDocumentViewTests.swift
@@ -1,7 +1,9 @@
 #if canImport(Testing)
+import AppKit
 import CoreGraphics
 import Foundation
 import Testing
+import UniformTypeIdentifiers
 @testable import Dahlia
 
 @MainActor
@@ -13,9 +15,15 @@ struct SummaryDocumentViewTests {
         var openedScreenshotID: UUID?
         var openedImage: CGImage?
         var openCount = 0
+        let screenshot = MeetingScreenshotRecord(
+            id: screenshotID,
+            meetingId: .v7(),
+            capturedAt: .now,
+            imageData: Data([1, 2, 3]),
+            mimeType: "image/png"
+        )
         let view = SummaryScreenshotImageView(
-            screenshotID: screenshotID,
-            data: Data(),
+            screenshot: screenshot,
             accessibilityLabel: "Enlarge screenshot"
         ) { id, previewImage in
             openedScreenshotID = id
@@ -28,6 +36,32 @@ struct SummaryDocumentViewTests {
         #expect(openedScreenshotID == screenshotID)
         #expect(openedImage === image)
         #expect(openCount == 1)
+    }
+
+    @Test
+    func screenshotCopyWritesOriginalDataWithoutOpeningImage() async throws {
+        let pasteboard = NSPasteboard(name: .init("SummaryDocumentViewTests-\(UUID().uuidString)"))
+        let imageData = try #require(TestScreenshotImageFixture.data(using: .png))
+        let screenshot = MeetingScreenshotRecord(
+            id: .v7(),
+            meetingId: .v7(),
+            capturedAt: .now,
+            imageData: imageData,
+            mimeType: "image/png"
+        )
+        var openCount = 0
+        let view = SummaryScreenshotImageView(
+            screenshot: screenshot,
+            accessibilityLabel: "Enlarge screenshot"
+        ) { _, _ in
+            openCount += 1
+        }
+
+        await view.copyImage(to: pasteboard)
+
+        let type = NSPasteboard.PasteboardType(UTType.png.identifier)
+        #expect(pasteboard.data(forType: type) == screenshot.imageData)
+        #expect(openCount == 0)
     }
 
     private func makeImage() -> CGImage? {

--- a/Tests/DahliaTests/TestScreenshotImageFixture.swift
+++ b/Tests/DahliaTests/TestScreenshotImageFixture.swift
@@ -1,0 +1,28 @@
+#if canImport(Testing)
+import AppKit
+import Foundation
+
+enum TestScreenshotImageFixture {
+    @MainActor
+    static func data(using fileType: NSBitmapImageRep.FileType) -> Data? {
+        guard let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: 1,
+            pixelsHigh: 1,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ), let pixels = bitmap.bitmapData else { return nil }
+
+        pixels[0] = 255
+        pixels[1] = 0
+        pixels[2] = 0
+        pixels[3] = 255
+        return bitmap.representation(using: fileType, properties: [:])
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- add image copy actions to screenshot tiles, summary images, and the expanded image overlay
- support both copy icon buttons and context menus with localized accessibility labels
- preserve original image data and pasteboard type after validating the stored MIME type against the image contents

## Why

Screenshots can now be copied directly into Slack and other applications without downloading them first.

## Validation

- `swift build`
- related Swift Testing suites: 38 tests across 4 suites
- `CI=true ./scripts/lint.sh`
- `git diff --check`

SwiftFormat is clean. The lint script continues to report the repository's existing non-blocking SwiftLint violations.
