### PR TITLE
Fix automatic screenshot resolution updates

### DIFF
--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -267,9 +267,7 @@
 "Source" = "Source";
 "Not Selected" = "Not Selected";
 "Entire Desktop" = "Entire Desktop";
-"Take Screenshot" = "Take Screenshot";
 "Display not found" = "Display not found";
-"Screenshot image was unavailable" = "Screenshot image was unavailable";
 "Screenshot download failed: %@" = "Screenshot download failed: %@";
 "Screenshot encoding failed" = "Screenshot encoding failed";
 "Screenshot source is not selected or is unavailable" = "Screenshot source is not selected or is unavailable";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -267,9 +267,7 @@
 "Source" = "ソース";
 "Not Selected" = "未設定";
 "Entire Desktop" = "デスクトップ全体";
-"Take Screenshot" = "スクリーンショットを撮影";
 "Display not found" = "ディスプレイが見つかりません";
-"Screenshot image was unavailable" = "スクリーンショット画像を取得できませんでした";
 "Screenshot download failed: %@" = "スクリーンショットのダウンロードに失敗しました: %@";
 "Screenshot encoding failed" = "スクリーンショットのエンコードに失敗しました";
 "Screenshot source is not selected or is unavailable" = "スクリーンショット対象が未設定、または利用できません";

--- a/Sources/Dahlia/Services/AutomaticScreenshotCaptureService.swift
+++ b/Sources/Dahlia/Services/AutomaticScreenshotCaptureService.swift
@@ -9,7 +9,6 @@ import os
 enum ScreenshotError: LocalizedError {
     case encodingFailed
     case displayUnavailable
-    case imageUnavailable
     case sourceUnavailable
 
     var errorDescription: String? {
@@ -18,8 +17,6 @@ enum ScreenshotError: LocalizedError {
             L10n.screenshotEncodingFailed
         case .displayUnavailable:
             L10n.screenshotDisplayUnavailable
-        case .imageUnavailable:
-            L10n.screenshotImageUnavailable
         case .sourceUnavailable:
             L10n.screenshotSourceUnavailable
         }
@@ -40,11 +37,6 @@ struct AutomaticScreenshotCaptureRequest: Sendable {
 protocol AutomaticScreenshotCapturing: Sendable {
     func start(_ request: AutomaticScreenshotCaptureRequest) async
     func updateSettings(intervalSeconds: Int, changeThresholdRatio: Double) async
-    func fingerprintUpdateAttempt() async -> AutomaticScreenshotCaptureAttempt?
-    func updateSavedFingerprint(
-        _ fingerprint: ScreenshotFingerprint?,
-        for attempt: AutomaticScreenshotCaptureAttempt
-    ) async
     func stop() async
 }
 
@@ -89,10 +81,6 @@ final class AutomaticScreenshotCaptureControl {
         tailTask = task
         return task
     }
-
-    func fingerprintUpdateAttempt() async -> AutomaticScreenshotCaptureAttempt? {
-        await capture.fingerprintUpdateAttempt()
-    }
 }
 
 struct AutomaticScreenshotCaptureAttempt: Equatable, Sendable {
@@ -103,6 +91,12 @@ struct AutomaticScreenshotCaptureAttempt: Equatable, Sendable {
 struct AutomaticScreenshotPixelDimensions: Equatable, Sendable {
     let width: Int
     let height: Int
+}
+
+enum AutomaticScreenshotFrameResolutionAction: Equatable, Sendable {
+    case process
+    case discard
+    case updateConfiguration(AutomaticScreenshotPixelDimensions)
 }
 
 struct AutomaticScreenshotCaptureLifecycle {
@@ -174,6 +168,10 @@ struct CopiedScreenshotFrame: Sendable {
     let pixels: Data
     let capturedAt: Date
     var sourcePixelDimensions: AutomaticScreenshotPixelDimensions?
+
+    var pixelDimensions: AutomaticScreenshotPixelDimensions {
+        AutomaticScreenshotPixelDimensions(width: width, height: height)
+    }
 
     func makeImage() -> CGImage? {
         guard let provider = CGDataProvider(data: pixels as CFData),
@@ -259,6 +257,11 @@ struct AutomaticScreenshotProcessingState {
         guard operation?.attempt == attempt else { return false }
         pendingFrame = PendingFrame(attempt: attempt, frame: frame)
         return true
+    }
+
+    mutating func discardPendingFrame(matching attempt: AutomaticScreenshotCaptureAttempt) {
+        guard pendingFrame?.attempt == attempt else { return }
+        pendingFrame = nil
     }
 
     mutating func complete(
@@ -386,20 +389,6 @@ actor AutomaticScreenshotCaptureService: AutomaticScreenshotCapturing {
         } catch {
             await handleRuntimeFailure(error, attempt: activeCapture.attempt)
         }
-    }
-
-    func fingerprintUpdateAttempt() -> AutomaticScreenshotCaptureAttempt? {
-        guard let attempt = activeCapture?.attempt,
-              lifecycle.accepts(attempt: attempt) else { return nil }
-        return attempt
-    }
-
-    func updateSavedFingerprint(
-        _ fingerprint: ScreenshotFingerprint?,
-        for attempt: AutomaticScreenshotCaptureAttempt
-    ) {
-        guard lifecycle.accepts(attempt: attempt) else { return }
-        lastSavedFingerprint = fingerprint
     }
 
     func stop() async {
@@ -546,7 +535,7 @@ actor AutomaticScreenshotCaptureService: AutomaticScreenshotCapturing {
         attempt: AutomaticScreenshotCaptureAttempt
     ) async {
         guard lifecycle.accepts(attempt: attempt) else { return }
-        if await updateStreamDimensionsIfNeeded(for: frame, attempt: attempt) {
+        if await shouldDiscardFrameForResolution(for: frame, attempt: attempt) {
             return
         }
         if processingState.isProcessing {
@@ -653,25 +642,38 @@ actor AutomaticScreenshotCaptureService: AutomaticScreenshotCapturing {
 }
 
 extension AutomaticScreenshotCaptureService {
-    private func updateStreamDimensionsIfNeeded(
+    private func shouldDiscardFrameForResolution(
         for frame: CopiedScreenshotFrame,
         attempt: AutomaticScreenshotCaptureAttempt
     ) async -> Bool {
-        guard let dimensions = frame.sourcePixelDimensions,
-              let activeCapture,
-              activeCapture.attempt == attempt,
-              activeCapture.configuration.width != dimensions.width
-              || activeCapture.configuration.height != dimensions.height
-        else { return false }
-
-        activeCapture.configuration.width = dimensions.width
-        activeCapture.configuration.height = dimensions.height
-        do {
-            try await activeCapture.stream.updateConfiguration(activeCapture.configuration)
-        } catch {
-            await handleRuntimeFailure(error, attempt: attempt)
+        guard let activeCapture, activeCapture.attempt == attempt else { return false }
+        let configuredDimensions = AutomaticScreenshotPixelDimensions(
+            width: activeCapture.configuration.width,
+            height: activeCapture.configuration.height
+        )
+        switch Self.frameResolutionAction(
+            frameDimensions: frame.pixelDimensions,
+            sourcePixelDimensions: frame.sourcePixelDimensions,
+            configuredDimensions: configuredDimensions
+        ) {
+        case .process:
+            return false
+        case .discard:
+            return true
+        case let .updateConfiguration(dimensions):
+            processingState.discardPendingFrame(matching: attempt)
+            activeCapture.configuration.width = dimensions.width
+            activeCapture.configuration.height = dimensions.height
+            do {
+                try await activeCapture.stream.updateConfiguration(activeCapture.configuration)
+            } catch {
+                // Failure cleanup joins the frame consumer, so it must run from another task.
+                Task { [weak self] in
+                    await self?.handleRuntimeFailure(error, attempt: attempt)
+                }
+            }
+            return true
         }
-        return true
     }
 
     private static func normalized(_ request: AutomaticScreenshotCaptureRequest) -> AutomaticScreenshotCaptureRequest {
@@ -761,6 +763,42 @@ extension AutomaticScreenshotCaptureService {
             width: max(1, Int((contentRect.width / contentScale * scaleFactor).rounded())),
             height: max(1, Int((contentRect.height / contentScale * scaleFactor).rounded()))
         )
+    }
+
+    static func sourcePixelDimensions(
+        from attachments: [SCStreamFrameInfo: Any]
+    ) -> AutomaticScreenshotPixelDimensions? {
+        guard let contentRect = contentRect(from: attachments[.contentRect]),
+              let contentScale = attachments[.contentScale] as? CGFloat,
+              let scaleFactor = attachments[.scaleFactor] as? CGFloat else { return nil }
+        return sourcePixelDimensions(
+            contentRect: contentRect,
+            contentScale: contentScale,
+            scaleFactor: scaleFactor
+        )
+    }
+
+    static func contentRect(from value: Any?) -> CGRect? {
+        guard let value else { return nil }
+        if let contentRect = value as? CGRect {
+            return contentRect
+        }
+        guard let dictionary = value as? NSDictionary else { return nil }
+        return CGRect(dictionaryRepresentation: dictionary)
+    }
+
+    static func frameResolutionAction(
+        frameDimensions: AutomaticScreenshotPixelDimensions,
+        sourcePixelDimensions: AutomaticScreenshotPixelDimensions?,
+        configuredDimensions: AutomaticScreenshotPixelDimensions
+    ) -> AutomaticScreenshotFrameResolutionAction {
+        guard frameDimensions == configuredDimensions else {
+            return .discard
+        }
+        if let sourcePixelDimensions, sourcePixelDimensions != configuredDimensions {
+            return .updateConfiguration(sourcePixelDimensions)
+        }
+        return .process
     }
 }
 
@@ -852,15 +890,8 @@ private final class AutomaticScreenshotStreamAdapter: NSObject, SCStreamOutput, 
         let width = CVPixelBufferGetWidth(pixelBuffer)
         let height = CVPixelBufferGetHeight(pixelBuffer)
         let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
-        let sourcePixelDimensions: AutomaticScreenshotPixelDimensions? = frameAttachments(sampleBuffer).flatMap { attachments in
-            guard let contentRect = attachments[.contentRect] as? CGRect,
-                  let contentScale = attachments[.contentScale] as? CGFloat,
-                  let scaleFactor = attachments[.scaleFactor] as? CGFloat else { return nil }
-            return AutomaticScreenshotCaptureService.sourcePixelDimensions(
-                contentRect: contentRect,
-                contentScale: contentScale,
-                scaleFactor: scaleFactor
-            )
+        let sourcePixelDimensions = frameAttachments(sampleBuffer).flatMap {
+            AutomaticScreenshotCaptureService.sourcePixelDimensions(from: $0)
         }
         return CopiedScreenshotFrame(
             width: width,

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1012,9 +1012,7 @@ enum L10n {
     static var source: String { String(localized: "Source", bundle: bundle) }
     static var notSelected: String { String(localized: "Not Selected", bundle: bundle) }
     static var entireDesktop: String { String(localized: "Entire Desktop", bundle: bundle) }
-    static var takeScreenshot: String { String(localized: "Take Screenshot", bundle: bundle) }
     static var screenshotDisplayUnavailable: String { String(localized: "Display not found", bundle: bundle) }
-    static var screenshotImageUnavailable: String { String(localized: "Screenshot image was unavailable", bundle: bundle) }
     static var screenshotEncodingFailed: String { String(localized: "Screenshot encoding failed", bundle: bundle) }
     static var screenshotSourceUnavailable: String { String(localized: "Screenshot source is not selected or is unavailable", bundle: bundle) }
     static func screenshotCaptureFailed(_ reason: String) -> String { String(localized: "Screenshot capture failed: \(reason)", bundle: bundle) }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -427,12 +427,6 @@ final class CaptionViewModel: ObservableObject {
         recordingContext?.store ?? store
     }
 
-    var canTakeScreenshot: Bool {
-        activeMeetingIdForSessionControls != nil
-            && activeDbQueueForSessionControls != nil
-            && screenshotCaptureSource.isSelected
-    }
-
     // MARK: - Private
 
     private var currentDbQueue: DatabaseQueue?
@@ -3272,31 +3266,6 @@ final class CaptionViewModel: ObservableObject {
         }
     }
 
-    func takeScreenshot() {
-        guard let meetingId = activeMeetingIdForSessionControls,
-              let dbQueue = activeDbQueueForSessionControls,
-              screenshotCaptureSource.isSelected else { return }
-
-        Task {
-            do {
-                let fingerprintUpdateAttempt = await automaticScreenshotCaptureControl.fingerprintUpdateAttempt()
-                let cgImage = try await captureScreenshotImage()
-                try await persistScreenshot(
-                    cgImage,
-                    meetingId: meetingId,
-                    sessionId: persistenceService?.recordingSessionId,
-                    dbQueue: dbQueue
-                )
-                await updateAutomaticScreenshotFingerprintIfNeeded(
-                    for: cgImage,
-                    attempt: fingerprintUpdateAttempt
-                )
-            } catch {
-                errorMessage = L10n.screenshotCaptureFailed(error.localizedDescription)
-            }
-        }
-    }
-
     private func updateAutomaticScreenshotProcessingSettings() {
         guard isListening,
               AppSettings.shared.automaticScreenshotEnabled,
@@ -3349,91 +3318,6 @@ final class CaptionViewModel: ObservableObject {
     @discardableResult
     private func stopAutomaticScreenshotCapture() -> Task<Void, Never> {
         automaticScreenshotCaptureControl.stop()
-    }
-
-    private func captureScreenshotImage() async throws -> CGImage {
-        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
-        let filter = try screenshotContentFilter(from: content)
-        let config = SCScreenshotConfiguration()
-        config.showsCursor = false
-        config.dynamicRange = .sdr
-
-        // 対象の実サイズに合わせて ScreenCaptureKit に出力サイズを決めさせる。
-        // `window.frame * 2` のような固定スケールは、非 Retina の拡張モニタで余白を生む。
-        let output = try await SCScreenshotManager.captureScreenshot(contentFilter: filter, configuration: config)
-        guard let cgImage = output.sdrImage else {
-            throw ScreenshotError.imageUnavailable
-        }
-        return cgImage
-    }
-
-    private func screenshotContentFilter(from content: SCShareableContent) throws -> SCContentFilter {
-        switch screenshotCaptureSource {
-        case .none:
-            throw ScreenshotError.sourceUnavailable
-        case .entireDesktop:
-            guard let display = content.displays.first else {
-                throw ScreenshotError.displayUnavailable
-            }
-            return SCContentFilter(display: display, excludingWindows: [])
-        case let .window(windowID):
-            guard let window = content.windows.first(where: { $0.windowID == windowID }) else {
-                throw ScreenshotError.sourceUnavailable
-            }
-            return SCContentFilter(desktopIndependentWindow: window)
-        }
-    }
-
-    private func persistScreenshot(
-        _ cgImage: CGImage,
-        meetingId: UUID,
-        sessionId: UUID?,
-        dbQueue: DatabaseQueue
-    ) async throws {
-        let encodedImage: (data: Data, mimeType: String) = try await Task.detached(priority: .userInitiated) {
-            guard let encoded = ImageEncoder.encode(cgImage, quality: 0.70) else {
-                throw ScreenshotError.encodingFailed
-            }
-            guard let mimeType = ImageEncoder.mimeType(for: encoded) else {
-                throw ScreenshotError.encodingFailed
-            }
-            return (encoded, mimeType)
-        }.value
-
-        let record = MeetingScreenshotRecord(
-            id: UUID.v7(),
-            meetingId: meetingId,
-            sessionId: sessionId,
-            capturedAt: Date(),
-            imageData: encodedImage.data,
-            mimeType: encodedImage.mimeType
-        )
-
-        try await dbQueue.write { db in
-            try record.insert(db)
-        }
-        appendVisibleScreenshot(record)
-    }
-
-    private func updateAutomaticScreenshotFingerprintIfNeeded(
-        for cgImage: CGImage,
-        attempt: AutomaticScreenshotCaptureAttempt?
-    ) async {
-        guard isListening,
-              AppSettings.shared.automaticScreenshotEnabled,
-              screenshotCaptureSource.isSelected,
-              let attempt,
-              let fingerprint = await screenshotFingerprint(for: cgImage) else { return }
-        let task = automaticScreenshotCaptureControl.enqueue { capture in
-            await capture.updateSavedFingerprint(fingerprint, for: attempt)
-        }
-        await task.value
-    }
-
-    private func screenshotFingerprint(for cgImage: CGImage) async -> ScreenshotFingerprint? {
-        await Task.detached(priority: .utility) {
-            ScreenshotChangeDetector.fingerprint(for: cgImage)
-        }.value
     }
 
     // MARK: - Note Auto-Save

--- a/Tests/DahliaTests/AutomaticScreenshotCaptureServiceTests.swift
+++ b/Tests/DahliaTests/AutomaticScreenshotCaptureServiceTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import GRDB
 @testable import Dahlia
+@preconcurrency import ScreenCaptureKit
 
 #if canImport(Testing)
 import Testing
@@ -145,6 +146,100 @@ struct AutomaticScreenshotCaptureServiceTests {
     }
 
     @Test
+    func sourcePixelDimensionsDecodeDictionaryContentRect() throws {
+        let contentRect = CGRect(x: 0, y: 0, width: 600, height: 400)
+        let attachments: [SCStreamFrameInfo: Any] = [
+            .contentRect: contentRect.dictionaryRepresentation,
+            .contentScale: CGFloat(0.5),
+            .scaleFactor: CGFloat(2),
+        ]
+
+        let dimensions = try #require(AutomaticScreenshotCaptureService.sourcePixelDimensions(
+            from: attachments
+        ))
+
+        #expect(dimensions == AutomaticScreenshotPixelDimensions(width: 2_400, height: 1_600))
+    }
+
+    @Test
+    func sourcePixelDimensionsDecodeDirectContentRectAndRejectInvalidMetadata() throws {
+        let directAttachments: [SCStreamFrameInfo: Any] = [
+            .contentRect: CGRect(x: 0, y: 0, width: 1_358, height: 1_219),
+            .contentScale: CGFloat(1),
+            .scaleFactor: CGFloat(1),
+        ]
+        let dimensions = try #require(AutomaticScreenshotCaptureService.sourcePixelDimensions(
+            from: directAttachments
+        ))
+
+        #expect(dimensions == AutomaticScreenshotPixelDimensions(width: 1_358, height: 1_219))
+        #expect(AutomaticScreenshotCaptureService.sourcePixelDimensions(from: [
+            .contentRect: "invalid",
+            .contentScale: CGFloat(1),
+            .scaleFactor: CGFloat(1),
+        ]) == nil)
+        #expect(AutomaticScreenshotCaptureService.sourcePixelDimensions(from: [
+            .contentRect: CGRect(x: 0, y: 0, width: 1_358, height: 1_219).dictionaryRepresentation,
+            .contentScale: CGFloat(0),
+            .scaleFactor: CGFloat(1),
+        ]) == nil)
+    }
+
+    @Test
+    func resolutionActionUpdatesThenDiscardsStaleSurfaceBeforeProcessingNativeFrame() {
+        let staleDimensions = AutomaticScreenshotPixelDimensions(width: 1_104, height: 932)
+        let nativeDimensions = AutomaticScreenshotPixelDimensions(width: 1_358, height: 1_219)
+
+        #expect(AutomaticScreenshotCaptureService.frameResolutionAction(
+            frameDimensions: staleDimensions,
+            sourcePixelDimensions: nativeDimensions,
+            configuredDimensions: staleDimensions
+        ) == .updateConfiguration(nativeDimensions))
+        #expect(AutomaticScreenshotCaptureService.frameResolutionAction(
+            frameDimensions: staleDimensions,
+            sourcePixelDimensions: nativeDimensions,
+            configuredDimensions: nativeDimensions
+        ) == .discard)
+        #expect(AutomaticScreenshotCaptureService.frameResolutionAction(
+            frameDimensions: staleDimensions,
+            sourcePixelDimensions: staleDimensions,
+            configuredDimensions: nativeDimensions
+        ) == .discard)
+        #expect(AutomaticScreenshotCaptureService.frameResolutionAction(
+            frameDimensions: nativeDimensions,
+            sourcePixelDimensions: nativeDimensions,
+            configuredDimensions: nativeDimensions
+        ) == .process)
+        #expect(AutomaticScreenshotCaptureService.frameResolutionAction(
+            frameDimensions: staleDimensions,
+            sourcePixelDimensions: nil,
+            configuredDimensions: nativeDimensions
+        ) == .discard)
+        #expect(AutomaticScreenshotCaptureService.frameResolutionAction(
+            frameDimensions: nativeDimensions,
+            sourcePixelDimensions: nil,
+            configuredDimensions: nativeDimensions
+        ) == .process)
+    }
+
+    @Test
+    func resolutionUpdateDiscardsPendingFrameWithoutRemovingActiveOperation() {
+        var state = AutomaticScreenshotProcessingState()
+        let attempt = AutomaticScreenshotCaptureAttempt(generation: 1, id: 1)
+        state.begin(attempt: attempt) { _ in Task {} }
+        let didQueuePendingFrame = state.queueLatest(
+            makeFrame(byte: 1, capturedAt: Date(timeIntervalSince1970: 100)),
+            attempt: attempt
+        )
+        #expect(didQueuePendingFrame)
+
+        state.discardPendingFrame(matching: attempt)
+
+        #expect(state.operation?.attempt == attempt)
+        #expect(state.pendingFrame == nil)
+    }
+
+    @Test
     @MainActor
     func stopBypassesBlockedStartAndInvalidatesPendingSettings() async throws {
         let capture = BlockingAutomaticScreenshotCapture()
@@ -225,15 +320,6 @@ private actor BlockingAutomaticScreenshotCapture: AutomaticScreenshotCapturing {
     func updateSettings(intervalSeconds _: Int, changeThresholdRatio _: Double) {
         observedSettingsUpdateCount += 1
     }
-
-    func fingerprintUpdateAttempt() -> AutomaticScreenshotCaptureAttempt? {
-        nil
-    }
-
-    func updateSavedFingerprint(
-        _: ScreenshotFingerprint?,
-        for _: AutomaticScreenshotCaptureAttempt
-    ) {}
 
     func stop() {
         observedStopCount += 1


### PR DESCRIPTION
## Summary

- Decode ScreenCaptureKit `contentRect` metadata from both direct `CGRect` and dictionary representations.
- Reconfigure the persistent `SCStream` to the native source dimensions and reject stale pixel-buffer surfaces until their dimensions match the active configuration.
- Prevent queued stale frames from bypassing resolution validation, avoid stale metadata rolling the configuration backward, and keep configuration-failure cleanup from self-joining the frame consumer.
- Remove the unreachable one-shot manual screenshot path, its fingerprint synchronization API, error case, and localization keys.

## Root cause

After the persistent `SCStream` change in #190, a window-size transition could leave the stream producing frames on its previous output surface. ScreenCaptureKit scaled the new content into that surface, producing blur and padding before JPEG encoding. The existing metadata parser also did not reliably decode the dictionary form of `contentRect`.

## Impact

Automatic screenshots now wait for a native-sized pixel buffer after stream reconfiguration, so old 1104×932 surfaces cannot be persisted as resized versions of 1358×1219 content. JPEG quality, database schema, screenshot viewing/export/deletion, and automatic capture settings are unchanged.

## Validation

- `swift test --disable-sandbox --filter AutomaticScreenshotCaptureServiceTests` — 13 tests passed
- `swift build --disable-sandbox` — passed
- `CI=true ./scripts/lint.sh` — passed; SwiftFormat found no formatting changes, and only existing non-blocking SwiftLint violations were reported
- Full suite attempted: the screenshot suite passed, but the repository-wide run was not clean because unrelated environment-sensitive audio/batch tests reported disk-space and timeout failures

## Manual validation

- [ ] Verify Google Meet before, during, and after a meeting in the signed debug app on a non-Retina display
- [ ] Repeat on a Retina display
