### PR TITLE
Move summary tab to left edge

### DIFF
--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -9,10 +9,10 @@ private enum NotesEditorLayout {
 
 /// メイン領域のタブ種別。
 enum DetailTab: String, CaseIterable, Identifiable {
+    case summary
     case notes
     case screenshots
     case transcript
-    case summary
     case conversationAnalytics
 
     var id: String { rawValue }

--- a/Sources/Dahlia/Views/DetailTabBar.swift
+++ b/Sources/Dahlia/Views/DetailTabBar.swift
@@ -3,10 +3,10 @@ import SwiftUI
 private extension DetailTab {
     var keyboardShortcut: KeyEquivalent {
         switch self {
-        case .notes: "1"
-        case .screenshots: "2"
-        case .transcript: "3"
-        case .summary: "4"
+        case .summary: "1"
+        case .notes: "2"
+        case .screenshots: "3"
+        case .transcript: "4"
         case .conversationAnalytics: "5"
         }
     }

--- a/Tests/DahliaTests/SettingsCategoryTests.swift
+++ b/Tests/DahliaTests/SettingsCategoryTests.swift
@@ -70,7 +70,7 @@
             #expect(SettingsGroup.advanced.categories == [.betaFeatures, .developer, .audioDiagnostics])
             #expect(!AppSettings.defaultCustomerIntelligenceBetaEnabled)
             #expect(!AppSettings.defaultConversationAnalyticsBetaEnabled)
-            #expect(DetailTab.allCases == [.notes, .screenshots, .transcript, .summary, .conversationAnalytics])
+            #expect(DetailTab.allCases == [.summary, .notes, .screenshots, .transcript, .conversationAnalytics])
         }
 
         @Test


### PR DESCRIPTION
## Summary

- Move the Summary tab to the left edge of the meeting detail tabs.
- Realign Command+1 through Command+4 shortcuts with the new visual tab order.
- Update the tab-order regression expectation.

## Why

The Summary view should be the first tab in the meeting detail navigation so it is easier to find and access.

## User impact

The tab order is now Summary, Notes, Screenshots, Transcript, and Conversation Analytics. The default selected tab remains unchanged.

## Validation

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --enable-swift-testing --filter SettingsCategoryTests` — 7 tests passed
- `swift build` — passed
- `git diff --check` — passed