### PR TITLE
Join fixed-language batch audio runs

### DIFF
--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator+WorkPlanning.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator+WorkPlanning.swift
@@ -15,7 +15,6 @@ extension BatchTranscriptionCoordinator {
 
     struct TranscriptionWorkResult: Sendable {
         let index: Int
-        let fileIndices: [Int]
         var segments: [TranscriptSegment]
         let localeIdentifier: String
     }
@@ -43,10 +42,14 @@ extension BatchTranscriptionCoordinator {
             let coveredFileIndices = Set(runs.flatMap(\.fileIndices))
             for (fileIndex, verified) in verifiedSegments.enumerated()
                 where !coveredFileIndices.contains(fileIndex) {
+                guard let localeIdentifier = verified.ranges.first?.localeIdentifier,
+                      !localeIdentifier.isEmpty else {
+                    throw BatchSpeechTranscriberError.invalidAudioRange
+                }
                 workItems.append(TranscriptionWorkItem(
                     index: workItems.count,
                     fileIndices: [fileIndex],
-                    request: .noAudio(localeIdentifier: verified.ranges.first?.localeIdentifier ?? "")
+                    request: .noAudio(localeIdentifier: localeIdentifier)
                 ))
             }
             return workItems

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator+WorkPlanning.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator+WorkPlanning.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+extension BatchTranscriptionCoordinator {
+    enum TranscriptionRequest: Sendable {
+        case automatic(BatchSpeechTranscriptionRequest)
+        case manual(BatchManualTranscriptionRun)
+        case noAudio(localeIdentifier: String)
+    }
+
+    struct TranscriptionWorkItem: Sendable {
+        let index: Int
+        let fileIndices: [Int]
+        let request: TranscriptionRequest
+    }
+
+    struct TranscriptionWorkResult: Sendable {
+        let index: Int
+        let fileIndices: [Int]
+        var segments: [TranscriptSegment]
+        let localeIdentifier: String
+    }
+
+    func transcriptionWorkItems(
+        verifiedSegments: [RecordingAudioStore.VerifiedSegment],
+        job: Job,
+        supportedLocales: [Locale],
+        automaticLanguageCandidateLocales: [Locale]?,
+        automaticLanguageCandidates: BatchLanguageDetectionCandidateSnapshot?
+    ) throws -> [TranscriptionWorkItem] {
+        switch job.session.batchLanguageDetectionMode {
+        case .manual:
+            let runs = try BatchManualTranscriptionRunPlanner.runs(
+                verifiedSegments: verifiedSegments,
+                recordingStartTime: job.session.startedAt
+            )
+            var workItems = runs.enumerated().map { index, run in
+                TranscriptionWorkItem(
+                    index: index,
+                    fileIndices: run.fileIndices,
+                    request: .manual(run)
+                )
+            }
+            let coveredFileIndices = Set(runs.flatMap(\.fileIndices))
+            for (fileIndex, verified) in verifiedSegments.enumerated()
+                where !coveredFileIndices.contains(fileIndex) {
+                workItems.append(TranscriptionWorkItem(
+                    index: workItems.count,
+                    fileIndices: [fileIndex],
+                    request: .noAudio(localeIdentifier: verified.ranges.first?.localeIdentifier ?? "")
+                ))
+            }
+            return workItems
+        case .automatic:
+            return try automaticTranscriptionWorkItems(
+                verifiedSegments: verifiedSegments,
+                job: job,
+                supportedLocales: supportedLocales,
+                automaticLanguageCandidateLocales: automaticLanguageCandidateLocales,
+                automaticLanguageCandidates: automaticLanguageCandidates
+            )
+        }
+    }
+
+    private func automaticTranscriptionWorkItems(
+        verifiedSegments: [RecordingAudioStore.VerifiedSegment],
+        job: Job,
+        supportedLocales: [Locale],
+        automaticLanguageCandidateLocales: [Locale]?,
+        automaticLanguageCandidates: BatchLanguageDetectionCandidateSnapshot?
+    ) throws -> [TranscriptionWorkItem] {
+        var workItems: [TranscriptionWorkItem] = []
+        for (fileIndex, verified) in verifiedSegments.enumerated() {
+            let ranges = try BatchTranscriptionAudioRangePlanner.ranges(
+                for: verified,
+                mode: .automatic
+            )
+            for range in ranges {
+                workItems.append(
+                    TranscriptionWorkItem(
+                        index: workItems.count,
+                        fileIndices: [fileIndex],
+                        request: .automatic(BatchSpeechTranscriptionRequest(
+                            audioURL: verified.url,
+                            startFrame: range.startFrame,
+                            frameCount: range.frameCount,
+                            recordedLocaleIdentifiers: range.recordedLocaleIdentifiers,
+                            languageDetectionMode: .automatic,
+                            supportedLocales: supportedLocales,
+                            automaticLanguageCandidateLocales: automaticLanguageCandidateLocales,
+                            allowedLanguageIdentifiers: automaticLanguageCandidates?.identifierSet,
+                            source: verified.segment.source,
+                            recordingSessionId: job.session.id,
+                            recordingStartTime: job.session.startedAt,
+                            sessionOffsetSeconds: range.sessionOffsetSeconds
+                        ))
+                    )
+                )
+            }
+        }
+        return workItems
+    }
+}

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -383,11 +383,13 @@ actor BatchTranscriptionCoordinator {
 
     private func transcribe(
         workItem: TranscriptionWorkItem,
-        fallbackCollector: BatchLanguageFallbackCollector
+        fallbackCollector: BatchLanguageFallbackCollector,
+        onFileConsumed: @escaping @Sendable (Int) async -> Void
     ) async throws -> TranscriptionWorkResult {
-        let result: BatchSpeechTranscriptionResult = switch workItem.request {
+        let result: BatchSpeechTranscriptionResult
+        switch workItem.request {
         case let .automatic(request):
-            try await BatchSpeechTranscriberService.transcribe(
+            result = try await BatchSpeechTranscriberService.transcribe(
                 request,
                 languageDetector: languageDetector,
                 speechRecognizer: speechRecognizer,
@@ -395,21 +397,27 @@ actor BatchTranscriptionCoordinator {
                     await fallbackCollector.record(fallback)
                 }
             )
+            for fileIndex in workItem.fileIndices {
+                await onFileConsumed(fileIndex)
+            }
         case let .manual(run):
-            try await BatchManualSpeechTranscriberService.transcribe(
+            result = try await BatchManualSpeechTranscriberService.transcribe(
                 run,
-                speechRecognizer: speechRecognizer
+                speechRecognizer: speechRecognizer,
+                onFileConsumed: onFileConsumed
             )
         case let .noAudio(localeIdentifier):
-            BatchSpeechTranscriptionResult(
+            result = BatchSpeechTranscriptionResult(
                 segments: [],
                 localeIdentifier: localeIdentifier,
                 languageFallback: nil
             )
+            for fileIndex in workItem.fileIndices {
+                await onFileConsumed(fileIndex)
+            }
         }
         return TranscriptionWorkResult(
             index: workItem.index,
-            fileIndices: workItem.fileIndices,
             segments: result.segments,
             localeIdentifier: result.localeIdentifier
         )
@@ -531,49 +539,49 @@ extension BatchTranscriptionCoordinator {
         totalFileCount: Int
     ) async throws -> [TranscriptionWorkResult] {
         try await withThrowingTaskGroup(of: TranscriptionWorkResult.self) { group in
+            let progressTracker = BatchTranscriptionFileProgressTracker(workItems: workItems)
+            let reportFileConsumed: @Sendable (Int, Int) async -> Void = { [weak self] workItemIndex, fileIndex in
+                guard let completedFileCount = await progressTracker.consume(
+                    workItemIndex: workItemIndex,
+                    fileIndex: fileIndex
+                ) else { return }
+                await self?.enqueueProgressNotification(
+                    meetingId: meetingId,
+                    sessionId: sessionId,
+                    completedFileCount: completedFileCount,
+                    totalFileCount: totalFileCount
+                )
+            }
             let initialCount = min(BatchTranscriptionConcurrency.appleSpeechMaximum, workItems.count)
             for workItem in workItems.prefix(initialCount) {
                 group.addTask { [self] in
-                    try await transcribe(workItem: workItem, fallbackCollector: fallbackCollector)
+                    try await transcribe(
+                        workItem: workItem,
+                        fallbackCollector: fallbackCollector,
+                        onFileConsumed: { fileIndex in
+                            await reportFileConsumed(workItem.index, fileIndex)
+                        }
+                    )
                 }
             }
 
             var nextIndex = initialCount
             var results: [TranscriptionWorkResult] = []
-            var remainingWorkItemCountByFile: [Int: Int] = [:]
-            for workItem in workItems {
-                for fileIndex in workItem.fileIndices {
-                    remainingWorkItemCountByFile[fileIndex, default: 0] += 1
-                }
-            }
-            var completedFileCount = 0
             do {
                 while let result = try await group.next() {
                     results.append(result)
-                    var newlyCompletedFileCount = 0
-                    for fileIndex in result.fileIndices {
-                        if remainingWorkItemCountByFile[fileIndex] == 1 {
-                            remainingWorkItemCountByFile[fileIndex] = nil
-                            newlyCompletedFileCount += 1
-                        } else if let remainingCount = remainingWorkItemCountByFile[fileIndex] {
-                            remainingWorkItemCountByFile[fileIndex] = remainingCount - 1
-                        }
-                    }
-                    completedFileCount += newlyCompletedFileCount
                     if nextIndex < workItems.count {
                         let workItem = workItems[nextIndex]
                         nextIndex += 1
                         group.addTask { [self] in
-                            try await transcribe(workItem: workItem, fallbackCollector: fallbackCollector)
+                            try await transcribe(
+                                workItem: workItem,
+                                fallbackCollector: fallbackCollector,
+                                onFileConsumed: { fileIndex in
+                                    await reportFileConsumed(workItem.index, fileIndex)
+                                }
+                            )
                         }
-                    }
-                    if newlyCompletedFileCount > 0 {
-                        enqueueProgressNotification(
-                            meetingId: meetingId,
-                            sessionId: sessionId,
-                            completedFileCount: completedFileCount,
-                            totalFileCount: totalFileCount
-                        )
                     }
                 }
                 await finishProgressNotifications()
@@ -734,5 +742,39 @@ extension BatchTranscriptionCoordinator {
             }
             return (session.meetingId, session.isBatchRetranscriptionPending)
         }
+    }
+}
+
+private actor BatchTranscriptionFileProgressTracker {
+    private struct Portion: Hashable {
+        let workItemIndex: Int
+        let fileIndex: Int
+    }
+
+    private var remainingWorkItemCountByFile: [Int: Int] = [:]
+    private var consumedPortions: Set<Portion> = []
+    private var completedFileCount = 0
+
+    init(workItems: [BatchTranscriptionCoordinator.TranscriptionWorkItem]) {
+        for workItem in workItems {
+            for fileIndex in workItem.fileIndices {
+                remainingWorkItemCountByFile[fileIndex, default: 0] += 1
+            }
+        }
+    }
+
+    func consume(workItemIndex: Int, fileIndex: Int) -> Int? {
+        let portion = Portion(workItemIndex: workItemIndex, fileIndex: fileIndex)
+        guard consumedPortions.insert(portion).inserted,
+              let remainingCount = remainingWorkItemCountByFile[fileIndex] else {
+            return nil
+        }
+        if remainingCount == 1 {
+            remainingWorkItemCountByFile[fileIndex] = nil
+            completedFileCount += 1
+            return completedFileCount
+        }
+        remainingWorkItemCountByFile[fileIndex] = remainingCount - 1
+        return nil
     }
 }

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -38,7 +38,7 @@ actor BatchTranscriptionCoordinator {
     static let maximumAutomaticAttemptCount = 3
     private static let signposter = OSSignposter(subsystem: "com.dahlia", category: "BatchTranscription")
 
-    private struct Job {
+    struct Job {
         let session: RecordingSessionRecord
         let meeting: MeetingRecord
         let vault: VaultRecord
@@ -48,19 +48,6 @@ actor BatchTranscriptionCoordinator {
     private struct TranslationConfiguration: Sendable {
         let isEnabled: Bool
         let targetLanguage: String
-    }
-
-    private struct TranscriptionWorkItem: Sendable {
-        let index: Int
-        let fileIndex: Int
-        let request: BatchSpeechTranscriptionRequest
-    }
-
-    private struct TranscriptionWorkResult: Sendable {
-        let index: Int
-        let fileIndex: Int
-        var segments: [TranscriptSegment]
-        let localeIdentifier: String
     }
 
     private let dbQueue: DatabaseQueue
@@ -297,42 +284,20 @@ actor BatchTranscriptionCoordinator {
             BatchLanguageDetectionCandidateResolver.candidates(snapshot: $0, supportedLocales: supportedLocales).locales
         }
         let totalFileCount = verifiedSegments.count
-        var workItems: [TranscriptionWorkItem] = []
-        for (fileIndex, verified) in verifiedSegments.enumerated() {
-            let ranges = try BatchTranscriptionAudioRangePlanner.ranges(
-                for: verified,
-                mode: job.session.batchLanguageDetectionMode
-            )
-            for range in ranges {
-                workItems.append(
-                    TranscriptionWorkItem(
-                        index: workItems.count,
-                        fileIndex: fileIndex,
-                        request: BatchSpeechTranscriptionRequest(
-                            audioURL: verified.url,
-                            startFrame: range.startFrame,
-                            frameCount: range.frameCount,
-                            recordedLocaleIdentifiers: range.recordedLocaleIdentifiers,
-                            languageDetectionMode: job.session.batchLanguageDetectionMode,
-                            supportedLocales: supportedLocales,
-                            automaticLanguageCandidateLocales: automaticLanguageCandidateLocales,
-                            allowedLanguageIdentifiers: automaticLanguageCandidates?.identifierSet,
-                            source: verified.segment.source,
-                            recordingSessionId: job.session.id,
-                            recordingStartTime: job.session.startedAt,
-                            sessionOffsetSeconds: range.sessionOffsetSeconds
-                        )
-                    )
-                )
-            }
-        }
+        let workItems = try transcriptionWorkItems(
+            verifiedSegments: verifiedSegments,
+            job: job,
+            supportedLocales: supportedLocales,
+            automaticLanguageCandidateLocales: automaticLanguageCandidateLocales,
+            automaticLanguageCandidates: automaticLanguageCandidates
+        )
         await notifyProgress(
             meetingId: job.meeting.id,
             sessionId: job.session.id,
             completedFileCount: 0,
             totalFileCount: totalFileCount
         )
-        let recognitionState = Self.signposter.beginInterval("Recognize CAF files")
+        let recognitionState = Self.signposter.beginInterval("Recognize audio runs")
         let fallbackCollector = BatchLanguageFallbackCollector()
         var workResults: [TranscriptionWorkResult]
         do {
@@ -344,9 +309,9 @@ actor BatchTranscriptionCoordinator {
                 totalFileCount: totalFileCount
             )
             .sorted { $0.index < $1.index }
-            Self.signposter.endInterval("Recognize CAF files", recognitionState)
+            Self.signposter.endInterval("Recognize audio runs", recognitionState)
         } catch {
-            Self.signposter.endInterval("Recognize CAF files", recognitionState)
+            Self.signposter.endInterval("Recognize audio runs", recognitionState)
             await reportLanguageFallbacks(
                 fallbackCollector.snapshot(),
                 candidates: automaticLanguageCandidates
@@ -420,17 +385,31 @@ actor BatchTranscriptionCoordinator {
         workItem: TranscriptionWorkItem,
         fallbackCollector: BatchLanguageFallbackCollector
     ) async throws -> TranscriptionWorkResult {
-        let result = try await BatchSpeechTranscriberService.transcribe(
-            workItem.request,
-            languageDetector: languageDetector,
-            speechRecognizer: speechRecognizer,
-            onLanguageFallback: { fallback in
-                await fallbackCollector.record(fallback)
-            }
-        )
+        let result: BatchSpeechTranscriptionResult = switch workItem.request {
+        case let .automatic(request):
+            try await BatchSpeechTranscriberService.transcribe(
+                request,
+                languageDetector: languageDetector,
+                speechRecognizer: speechRecognizer,
+                onLanguageFallback: { fallback in
+                    await fallbackCollector.record(fallback)
+                }
+            )
+        case let .manual(run):
+            try await BatchManualSpeechTranscriberService.transcribe(
+                run,
+                speechRecognizer: speechRecognizer
+            )
+        case let .noAudio(localeIdentifier):
+            BatchSpeechTranscriptionResult(
+                segments: [],
+                localeIdentifier: localeIdentifier,
+                languageFallback: nil
+            )
+        }
         return TranscriptionWorkResult(
             index: workItem.index,
-            fileIndex: workItem.fileIndex,
+            fileIndices: workItem.fileIndices,
             segments: result.segments,
             localeIdentifier: result.localeIdentifier
         )
@@ -561,25 +540,26 @@ extension BatchTranscriptionCoordinator {
 
             var nextIndex = initialCount
             var results: [TranscriptionWorkResult] = []
-            var remainingWorkItemCountByFile = Dictionary(
-                grouping: workItems,
-                by: \.fileIndex
-            ).mapValues(\.count)
+            var remainingWorkItemCountByFile: [Int: Int] = [:]
+            for workItem in workItems {
+                for fileIndex in workItem.fileIndices {
+                    remainingWorkItemCountByFile[fileIndex, default: 0] += 1
+                }
+            }
             var completedFileCount = 0
             do {
                 while let result = try await group.next() {
                     results.append(result)
-                    let didCompleteFile: Bool
-                    if remainingWorkItemCountByFile[result.fileIndex] == 1 {
-                        remainingWorkItemCountByFile[result.fileIndex] = nil
-                        completedFileCount += 1
-                        didCompleteFile = true
-                    } else if let remainingCount = remainingWorkItemCountByFile[result.fileIndex] {
-                        remainingWorkItemCountByFile[result.fileIndex] = remainingCount - 1
-                        didCompleteFile = false
-                    } else {
-                        didCompleteFile = false
+                    var newlyCompletedFileCount = 0
+                    for fileIndex in result.fileIndices {
+                        if remainingWorkItemCountByFile[fileIndex] == 1 {
+                            remainingWorkItemCountByFile[fileIndex] = nil
+                            newlyCompletedFileCount += 1
+                        } else if let remainingCount = remainingWorkItemCountByFile[fileIndex] {
+                            remainingWorkItemCountByFile[fileIndex] = remainingCount - 1
+                        }
                     }
+                    completedFileCount += newlyCompletedFileCount
                     if nextIndex < workItems.count {
                         let workItem = workItems[nextIndex]
                         nextIndex += 1
@@ -587,7 +567,7 @@ extension BatchTranscriptionCoordinator {
                             try await transcribe(workItem: workItem, fallbackCollector: fallbackCollector)
                         }
                     }
-                    if didCompleteFile {
+                    if newlyCompletedFileCount > 0 {
                         enqueueProgressNotification(
                             meetingId: meetingId,
                             sessionId: sessionId,

--- a/Sources/Dahlia/Speech/BatchManualSpeechTranscriberService.swift
+++ b/Sources/Dahlia/Speech/BatchManualSpeechTranscriberService.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum BatchManualSpeechTranscriberService {
+    static func transcribe(
+        _ run: BatchManualTranscriptionRun,
+        speechRecognizer: any BatchSpeechRecognizing
+    ) async throws -> BatchSpeechTranscriptionResult {
+        guard !run.slices.isEmpty else {
+            throw BatchSpeechTranscriberError.invalidAudioRange
+        }
+        let recognitions = try await speechRecognizer.recognize(
+            audioSlices: run.slices,
+            locale: Locale(identifier: run.localeIdentifier)
+        )
+        let segments = BatchSpeechTranscriberService.transcriptSegments(
+            from: recognitions,
+            recordingSessionId: run.recordingSessionId,
+            recordingStartTime: run.recordingStartTime,
+            sessionOffsetSeconds: run.sessionOffsetSeconds,
+            source: run.source
+        )
+        return BatchSpeechTranscriptionResult(
+            segments: segments,
+            localeIdentifier: run.localeIdentifier,
+            languageFallback: nil
+        )
+    }
+}

--- a/Sources/Dahlia/Speech/BatchManualSpeechTranscriberService.swift
+++ b/Sources/Dahlia/Speech/BatchManualSpeechTranscriberService.swift
@@ -3,14 +3,26 @@ import Foundation
 enum BatchManualSpeechTranscriberService {
     static func transcribe(
         _ run: BatchManualTranscriptionRun,
-        speechRecognizer: any BatchSpeechRecognizing
+        speechRecognizer: any BatchSpeechRecognizing,
+        onFileConsumed: @escaping @Sendable (Int) async -> Void = { _ in }
     ) async throws -> BatchSpeechTranscriptionResult {
-        guard !run.slices.isEmpty else {
+        guard !run.slices.isEmpty,
+              run.slices.count == run.sliceFileIndices.count else {
             throw BatchSpeechTranscriberError.invalidAudioRange
         }
+        let lastSliceIndexByFile = Dictionary(
+            run.sliceFileIndices.enumerated().map { ($0.element, $0.offset) },
+            uniquingKeysWith: { _, last in last }
+        )
         let recognitions = try await speechRecognizer.recognize(
             audioSlices: run.slices,
-            locale: Locale(identifier: run.localeIdentifier)
+            locale: Locale(identifier: run.localeIdentifier),
+            onSliceConsumed: { sliceIndex in
+                guard run.sliceFileIndices.indices.contains(sliceIndex) else { return }
+                let fileIndex = run.sliceFileIndices[sliceIndex]
+                guard lastSliceIndexByFile[fileIndex] == sliceIndex else { return }
+                await onFileConsumed(fileIndex)
+            }
         )
         let segments = BatchSpeechTranscriberService.transcriptSegments(
             from: recognitions,

--- a/Sources/Dahlia/Speech/BatchManualTranscriptionRun.swift
+++ b/Sources/Dahlia/Speech/BatchManualTranscriptionRun.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct BatchManualTranscriptionRun: Sendable {
     let slices: [BatchSpeechAudioSlice]
+    let sliceFileIndices: [Int]
     let localeIdentifier: String
     let source: RecordingAudioSource
     let recordingSessionId: UUID

--- a/Sources/Dahlia/Speech/BatchManualTranscriptionRun.swift
+++ b/Sources/Dahlia/Speech/BatchManualTranscriptionRun.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct BatchManualTranscriptionRun: Sendable {
+    let slices: [BatchSpeechAudioSlice]
+    let localeIdentifier: String
+    let source: RecordingAudioSource
+    let recordingSessionId: UUID
+    let recordingStartTime: Date
+    let sessionOffsetSeconds: TimeInterval
+    let fileIndices: [Int]
+}

--- a/Sources/Dahlia/Speech/BatchManualTranscriptionRunPlanner.swift
+++ b/Sources/Dahlia/Speech/BatchManualTranscriptionRunPlanner.swift
@@ -1,0 +1,93 @@
+@preconcurrency import AVFoundation
+import Foundation
+
+enum BatchManualTranscriptionRunPlanner {
+    typealias AudioFormatProvider = (RecordingAudioStore.VerifiedSegment) throws -> AVAudioFormat
+
+    private struct Candidate {
+        let slice: BatchSpeechAudioSlice
+        let localeIdentifier: String
+        let source: RecordingAudioSource
+        let recordingSessionId: UUID
+        let sessionOffsetSeconds: TimeInterval
+        let audioFormat: AVAudioFormat
+        let fileIndex: Int
+
+        var endOffsetSeconds: TimeInterval {
+            sessionOffsetSeconds + Double(slice.frameCount) / audioFormat.sampleRate
+        }
+    }
+
+    static func runs(
+        verifiedSegments: [RecordingAudioStore.VerifiedSegment],
+        recordingStartTime: Date,
+        audioFormatProvider: AudioFormatProvider = {
+            try AVAudioFile(forReading: $0.url).processingFormat
+        }
+    ) throws -> [BatchManualTranscriptionRun] {
+        let candidates = try verifiedSegments.enumerated().flatMap { fileIndex, verified in
+            let audioFormat = try audioFormatProvider(verified)
+            return try verified.ranges.compactMap { range -> Candidate? in
+                guard let frameCount = range.frameCount,
+                      range.startFrame >= 0,
+                      frameCount >= 0,
+                      audioFormat.sampleRate > 0 else {
+                    throw BatchSpeechTranscriberError.invalidAudioRange
+                }
+                guard frameCount > 0 else { return nil }
+                return Candidate(
+                    slice: BatchSpeechAudioSlice(
+                        audioURL: verified.url,
+                        startFrame: range.startFrame,
+                        frameCount: frameCount
+                    ),
+                    localeIdentifier: range.localeIdentifier,
+                    source: verified.segment.source,
+                    recordingSessionId: verified.segment.recordingSessionId,
+                    sessionOffsetSeconds: range.sessionOffsetSeconds,
+                    audioFormat: audioFormat,
+                    fileIndex: fileIndex
+                )
+            }
+        }
+        .sorted { lhs, rhs in
+            if lhs.source == rhs.source {
+                return lhs.sessionOffsetSeconds < rhs.sessionOffsetSeconds
+            }
+            return lhs.source.rawValue < rhs.source.rawValue
+        }
+
+        var grouped: [[Candidate]] = []
+        for candidate in candidates {
+            if let previous = grouped.last?.last,
+               canJoin(previous, candidate) {
+                grouped[grouped.count - 1].append(candidate)
+            } else {
+                grouped.append([candidate])
+            }
+        }
+        return grouped.compactMap { candidates in
+            guard let first = candidates.first else { return nil }
+            return BatchManualTranscriptionRun(
+                slices: candidates.map(\.slice),
+                localeIdentifier: first.localeIdentifier,
+                source: first.source,
+                recordingSessionId: first.recordingSessionId,
+                recordingStartTime: recordingStartTime,
+                sessionOffsetSeconds: first.sessionOffsetSeconds,
+                fileIndices: Array(Set(candidates.map(\.fileIndex))).sorted()
+            )
+        }
+    }
+
+    private static func canJoin(_ lhs: Candidate, _ rhs: Candidate) -> Bool {
+        guard lhs.recordingSessionId == rhs.recordingSessionId,
+              lhs.source == rhs.source,
+              lhs.localeIdentifier == rhs.localeIdentifier,
+              lhs.audioFormat == rhs.audioFormat else {
+            return false
+        }
+        let tolerance = 0.5 / lhs.audioFormat.sampleRate
+        return abs(lhs.endOffsetSeconds - rhs.sessionOffsetSeconds) <= tolerance
+    }
+}

--- a/Sources/Dahlia/Speech/BatchManualTranscriptionRunPlanner.swift
+++ b/Sources/Dahlia/Speech/BatchManualTranscriptionRunPlanner.swift
@@ -54,7 +54,7 @@ enum BatchManualTranscriptionRunPlanner {
             if lhs.source == rhs.source {
                 return lhs.sessionOffsetSeconds < rhs.sessionOffsetSeconds
             }
-            return lhs.source.rawValue < rhs.source.rawValue
+            return sourceOrder(lhs.source) < sourceOrder(rhs.source)
         }
 
         var grouped: [[Candidate]] = []
@@ -70,6 +70,7 @@ enum BatchManualTranscriptionRunPlanner {
             guard let first = candidates.first else { return nil }
             return BatchManualTranscriptionRun(
                 slices: candidates.map(\.slice),
+                sliceFileIndices: candidates.map(\.fileIndex),
                 localeIdentifier: first.localeIdentifier,
                 source: first.source,
                 recordingSessionId: first.recordingSessionId,
@@ -87,7 +88,14 @@ enum BatchManualTranscriptionRunPlanner {
               lhs.audioFormat == rhs.audioFormat else {
             return false
         }
-        let tolerance = 0.5 / lhs.audioFormat.sampleRate
+        let tolerance = 1 / lhs.audioFormat.sampleRate
         return abs(lhs.endOffsetSeconds - rhs.sessionOffsetSeconds) <= tolerance
+    }
+
+    private static func sourceOrder(_ source: RecordingAudioSource) -> Int {
+        switch source {
+        case .microphone: 0
+        case .system: 1
+        }
     }
 }

--- a/Sources/Dahlia/Speech/BatchSpeechAnalyzerInputSequence.swift
+++ b/Sources/Dahlia/Speech/BatchSpeechAnalyzerInputSequence.swift
@@ -20,6 +20,7 @@ struct BatchSpeechAnalyzerInputSequence: AsyncSequence, Sendable {
         slices: [BatchSpeechAudioSlice],
         sourceFormat: AVAudioFormat,
         analyzerFormat: AVAudioFormat,
+        onSliceConsumed: @escaping @Sendable (Int) async -> Void = { _ in },
         converterFactory: AnalyzerInputConverterFactory = { sourceFormat, analyzerFormat in
             try AVAudioAnalyzerInputConverter(
                 sourceFormat: sourceFormat,
@@ -31,7 +32,8 @@ struct BatchSpeechAnalyzerInputSequence: AsyncSequence, Sendable {
             slices: slices,
             sourceFormat: sourceFormat,
             analyzerFormat: analyzerFormat,
-            converter: converterFactory(sourceFormat, analyzerFormat)
+            converter: converterFactory(sourceFormat, analyzerFormat),
+            onSliceConsumed: onSliceConsumed
         )
     }
 
@@ -47,18 +49,21 @@ actor BatchSpeechAudioSliceReader {
     private let sourceFormat: AVAudioFormat
     private let analyzerFormat: AVAudioFormat
     private let converter: any AnalyzerInputConverting
+    private let onSliceConsumed: @Sendable (Int) async -> Void
     private var sliceIndex = 0
     private var currentFile: AVAudioFile?
     private var remainingFrameCount: Int64 = 0
     private var nextAnalyzerFrame: Int64 = 0
     private var pendingInputs: [AnalyzerInput] = []
+    private var pendingCompletedSliceIndex: Int?
     private var didFinishConverter = false
 
     init(
         slices: [BatchSpeechAudioSlice],
         sourceFormat: AVAudioFormat,
         analyzerFormat: AVAudioFormat,
-        converter: any AnalyzerInputConverting
+        converter: any AnalyzerInputConverting,
+        onSliceConsumed: @escaping @Sendable (Int) async -> Void
     ) throws {
         guard !slices.isEmpty else {
             throw BatchSpeechTranscriberError.invalidAudioRange
@@ -67,14 +72,21 @@ actor BatchSpeechAudioSliceReader {
         self.sourceFormat = sourceFormat
         self.analyzerFormat = analyzerFormat
         self.converter = converter
+        self.onSliceConsumed = onSliceConsumed
     }
 
-    func next() throws -> AnalyzerInput? {
-        try Task.checkCancellation()
-        if !pendingInputs.isEmpty {
-            return pendingInputs.removeFirst()
-        }
+    func next() async throws -> AnalyzerInput? {
         while true {
+            try Task.checkCancellation()
+            if !pendingInputs.isEmpty {
+                return pendingInputs.removeFirst()
+            }
+            if let completedSliceIndex = pendingCompletedSliceIndex {
+                pendingCompletedSliceIndex = nil
+                currentFile = nil
+                await onSliceConsumed(completedSliceIndex)
+                continue
+            }
             if remainingFrameCount > 0 {
                 if let input = try readNextBuffer() {
                     return input
@@ -129,6 +141,9 @@ actor BatchSpeechAudioSliceReader {
             throw BatchSpeechTranscriberError.invalidAudioRange
         }
         remainingFrameCount -= Int64(buffer.frameLength)
+        if remainingFrameCount == 0 {
+            pendingCompletedSliceIndex = sliceIndex - 1
+        }
         let startTime = CMTime(
             value: nextAnalyzerFrame,
             timescale: CMTimeScale(analyzerFormat.sampleRate.rounded())

--- a/Sources/Dahlia/Speech/BatchSpeechAnalyzerInputSequence.swift
+++ b/Sources/Dahlia/Speech/BatchSpeechAnalyzerInputSequence.swift
@@ -1,0 +1,142 @@
+@preconcurrency import AVFoundation
+import CoreMedia
+import Foundation
+import Speech
+
+struct BatchSpeechAnalyzerInputSequence: AsyncSequence, Sendable {
+    typealias Element = AnalyzerInput
+
+    struct AsyncIterator: AsyncIteratorProtocol {
+        let reader: BatchSpeechAudioSliceReader
+
+        mutating func next() async throws -> AnalyzerInput? {
+            try await reader.next()
+        }
+    }
+
+    private let reader: BatchSpeechAudioSliceReader
+
+    init(
+        slices: [BatchSpeechAudioSlice],
+        sourceFormat: AVAudioFormat,
+        analyzerFormat: AVAudioFormat,
+        converterFactory: AnalyzerInputConverterFactory = { sourceFormat, analyzerFormat in
+            try AVAudioAnalyzerInputConverter(
+                sourceFormat: sourceFormat,
+                analyzerFormat: analyzerFormat
+            )
+        }
+    ) throws {
+        reader = try BatchSpeechAudioSliceReader(
+            slices: slices,
+            sourceFormat: sourceFormat,
+            analyzerFormat: analyzerFormat,
+            converter: converterFactory(sourceFormat, analyzerFormat)
+        )
+    }
+
+    func makeAsyncIterator() -> AsyncIterator {
+        AsyncIterator(reader: reader)
+    }
+}
+
+actor BatchSpeechAudioSliceReader {
+    private static let bufferCapacity: AVAudioFrameCount = 16384
+
+    private let slices: [BatchSpeechAudioSlice]
+    private let sourceFormat: AVAudioFormat
+    private let analyzerFormat: AVAudioFormat
+    private let converter: any AnalyzerInputConverting
+    private var sliceIndex = 0
+    private var currentFile: AVAudioFile?
+    private var remainingFrameCount: Int64 = 0
+    private var nextAnalyzerFrame: Int64 = 0
+    private var pendingInputs: [AnalyzerInput] = []
+    private var didFinishConverter = false
+
+    init(
+        slices: [BatchSpeechAudioSlice],
+        sourceFormat: AVAudioFormat,
+        analyzerFormat: AVAudioFormat,
+        converter: any AnalyzerInputConverting
+    ) throws {
+        guard !slices.isEmpty else {
+            throw BatchSpeechTranscriberError.invalidAudioRange
+        }
+        self.slices = slices
+        self.sourceFormat = sourceFormat
+        self.analyzerFormat = analyzerFormat
+        self.converter = converter
+    }
+
+    func next() throws -> AnalyzerInput? {
+        try Task.checkCancellation()
+        if !pendingInputs.isEmpty {
+            return pendingInputs.removeFirst()
+        }
+        while true {
+            if remainingFrameCount > 0 {
+                if let input = try readNextBuffer() {
+                    return input
+                }
+                continue
+            }
+            currentFile = nil
+            if sliceIndex < slices.count {
+                try openNextSlice()
+                continue
+            }
+            guard !didFinishConverter else { return nil }
+            didFinishConverter = true
+            pendingInputs = try converter.finish()
+            guard !pendingInputs.isEmpty else { return nil }
+            return pendingInputs.removeFirst()
+        }
+    }
+
+    private func openNextSlice() throws {
+        let slice = slices[sliceIndex]
+        sliceIndex += 1
+        guard slice.startFrame >= 0, slice.frameCount > 0 else {
+            throw BatchSpeechTranscriberError.invalidAudioRange
+        }
+        let audioFile = try AVAudioFile(forReading: slice.audioURL)
+        guard audioFile.processingFormat == sourceFormat,
+              slice.startFrame < audioFile.length,
+              slice.frameCount <= audioFile.length - slice.startFrame else {
+            throw BatchSpeechTranscriberError.invalidAudioRange
+        }
+        audioFile.framePosition = slice.startFrame
+        currentFile = audioFile
+        remainingFrameCount = slice.frameCount
+    }
+
+    private func readNextBuffer() throws -> AnalyzerInput? {
+        guard let currentFile else {
+            throw BatchSpeechTranscriberError.invalidAudioRange
+        }
+        let requestedFrameCount = AVAudioFrameCount(
+            min(Int64(Self.bufferCapacity), remainingFrameCount)
+        )
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: sourceFormat,
+            frameCapacity: requestedFrameCount
+        ) else {
+            throw BatchSpeechTranscriberError.audioFormatUnavailable
+        }
+        try currentFile.read(into: buffer, frameCount: requestedFrameCount)
+        guard buffer.frameLength > 0 else {
+            throw BatchSpeechTranscriberError.invalidAudioRange
+        }
+        remainingFrameCount -= Int64(buffer.frameLength)
+        let startTime = CMTime(
+            value: nextAnalyzerFrame,
+            timescale: CMTimeScale(analyzerFormat.sampleRate.rounded())
+        )
+        pendingInputs = try converter.convert(buffer, at: startTime)
+        nextAnalyzerFrame += pendingInputs.reduce(0) { frames, input in
+            frames + Int64(input.buffer.frameLength)
+        }
+        return pendingInputs.isEmpty ? nil : pendingInputs.removeFirst()
+    }
+}

--- a/Sources/Dahlia/Speech/BatchSpeechAudioSlice.swift
+++ b/Sources/Dahlia/Speech/BatchSpeechAudioSlice.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// A frame range in one immutable CAF used as part of a logical batch-recognition run.
+struct BatchSpeechAudioSlice: Sendable {
+    let audioURL: URL
+    let startFrame: Int64
+    let frameCount: Int64
+}

--- a/Sources/Dahlia/Speech/BatchSpeechRecognizing.swift
+++ b/Sources/Dahlia/Speech/BatchSpeechRecognizing.swift
@@ -12,12 +12,29 @@ struct BatchSpeechRecognition: Sendable {
 protocol BatchSpeechRecognizing: Sendable {
     func recognize(audioURL: URL, locale: Locale) async throws -> [BatchSpeechRecognition]
     func recognize(audioSlices: [BatchSpeechAudioSlice], locale: Locale) async throws -> [BatchSpeechRecognition]
+    func recognize(
+        audioSlices: [BatchSpeechAudioSlice],
+        locale: Locale,
+        onSliceConsumed: @escaping @Sendable (Int) async -> Void
+    ) async throws -> [BatchSpeechRecognition]
     func unload() async
 }
 
 extension BatchSpeechRecognizing {
     func recognize(audioSlices _: [BatchSpeechAudioSlice], locale _: Locale) async throws -> [BatchSpeechRecognition] {
         throw BatchSpeechTranscriberError.invalidAudioRange
+    }
+
+    func recognize(
+        audioSlices: [BatchSpeechAudioSlice],
+        locale: Locale,
+        onSliceConsumed: @escaping @Sendable (Int) async -> Void
+    ) async throws -> [BatchSpeechRecognition] {
+        let recognitions = try await recognize(audioSlices: audioSlices, locale: locale)
+        for sliceIndex in audioSlices.indices {
+            await onSliceConsumed(sliceIndex)
+        }
+        return recognitions
     }
 
     func unload() async {}
@@ -43,22 +60,34 @@ struct AppleBatchSpeechRecognizer: BatchSpeechRecognizing {
     }
 
     func recognize(audioSlices: [BatchSpeechAudioSlice], locale: Locale) async throws -> [BatchSpeechRecognition] {
+        try await recognize(audioSlices: audioSlices, locale: locale, onSliceConsumed: { _ in })
+    }
+
+    func recognize(
+        audioSlices: [BatchSpeechAudioSlice],
+        locale: Locale,
+        onSliceConsumed: @escaping @Sendable (Int) async -> Void
+    ) async throws -> [BatchSpeechRecognition] {
         guard let firstSlice = audioSlices.first else {
             throw BatchSpeechTranscriberError.invalidAudioRange
         }
         let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
         try await assetPreparer.prepare(transcriber: transcriber, localeIdentifier: locale.identifier)
-        let firstFile = try AVAudioFile(forReading: firstSlice.audioURL)
+        let sourceFormat = try {
+            let firstFile = try AVAudioFile(forReading: firstSlice.audioURL)
+            return firstFile.processingFormat
+        }()
         guard let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
             compatibleWith: [transcriber],
-            considering: firstFile.processingFormat
+            considering: sourceFormat
         ) else {
             throw BatchSpeechTranscriberError.audioFormatUnavailable
         }
         let inputSequence = try BatchSpeechAnalyzerInputSequence(
             slices: audioSlices,
-            sourceFormat: firstFile.processingFormat,
-            analyzerFormat: analyzerFormat
+            sourceFormat: sourceFormat,
+            analyzerFormat: analyzerFormat,
+            onSliceConsumed: onSliceConsumed
         )
         return try await recognize(
             transcriber: transcriber,

--- a/Sources/Dahlia/Speech/BatchSpeechRecognizing.swift
+++ b/Sources/Dahlia/Speech/BatchSpeechRecognizing.swift
@@ -11,10 +11,15 @@ struct BatchSpeechRecognition: Sendable {
 
 protocol BatchSpeechRecognizing: Sendable {
     func recognize(audioURL: URL, locale: Locale) async throws -> [BatchSpeechRecognition]
+    func recognize(audioSlices: [BatchSpeechAudioSlice], locale: Locale) async throws -> [BatchSpeechRecognition]
     func unload() async
 }
 
 extension BatchSpeechRecognizing {
+    func recognize(audioSlices _: [BatchSpeechAudioSlice], locale _: Locale) async throws -> [BatchSpeechRecognition] {
+        throw BatchSpeechTranscriberError.invalidAudioRange
+    }
+
     func unload() async {}
 }
 
@@ -29,11 +34,50 @@ struct AppleBatchSpeechRecognizer: BatchSpeechRecognizing {
         let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
         try await assetPreparer.prepare(transcriber: transcriber, localeIdentifier: locale.identifier)
         let audioFile = try AVAudioFile(forReading: audioURL)
+        return try await recognize(
+            transcriber: transcriber,
+            audioFormat: audioFile.processingFormat
+        ) { analyzer in
+            try await analyzer.analyzeSequence(from: audioFile)
+        }
+    }
+
+    func recognize(audioSlices: [BatchSpeechAudioSlice], locale: Locale) async throws -> [BatchSpeechRecognition] {
+        guard let firstSlice = audioSlices.first else {
+            throw BatchSpeechTranscriberError.invalidAudioRange
+        }
+        let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
+        try await assetPreparer.prepare(transcriber: transcriber, localeIdentifier: locale.identifier)
+        let firstFile = try AVAudioFile(forReading: firstSlice.audioURL)
+        guard let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
+            compatibleWith: [transcriber],
+            considering: firstFile.processingFormat
+        ) else {
+            throw BatchSpeechTranscriberError.audioFormatUnavailable
+        }
+        let inputSequence = try BatchSpeechAnalyzerInputSequence(
+            slices: audioSlices,
+            sourceFormat: firstFile.processingFormat,
+            analyzerFormat: analyzerFormat
+        )
+        return try await recognize(
+            transcriber: transcriber,
+            audioFormat: analyzerFormat
+        ) { analyzer in
+            try await analyzer.analyzeSequence(inputSequence)
+        }
+    }
+
+    private func recognize(
+        transcriber: SpeechTranscriber,
+        audioFormat: AVAudioFormat,
+        analyze: @escaping @Sendable (SpeechAnalyzer) async throws -> CMTime?
+    ) async throws -> [BatchSpeechRecognition] {
         let analyzer = SpeechAnalyzer(
             modules: [transcriber],
             options: SpeechAnalyzer.Options(priority: .userInitiated, modelRetention: .lingering)
         )
-        try await analyzer.prepareToAnalyze(in: audioFile.processingFormat)
+        try await analyzer.prepareToAnalyze(in: audioFormat)
 
         let resultTask = Task<[BatchSpeechRecognition], Error> {
             var recognitions: [BatchSpeechRecognition] = []
@@ -50,7 +94,7 @@ struct AppleBatchSpeechRecognizer: BatchSpeechRecognizing {
         }
 
         do {
-            guard let lastSampleTime = try await analyzer.analyzeSequence(from: audioFile) else {
+            guard let lastSampleTime = try await analyze(analyzer) else {
                 throw BatchSpeechTranscriberError.analysisDidNotAdvance
             }
             try await analyzer.finalizeAndFinish(through: lastSampleTime)

--- a/Sources/Dahlia/Speech/BatchSpeechTranscriberService.swift
+++ b/Sources/Dahlia/Speech/BatchSpeechTranscriberService.swift
@@ -49,28 +49,44 @@ enum BatchSpeechTranscriberService {
             await onLanguageFallback(fallback)
         }
         let recognitions = try await speechRecognizer.recognize(audioURL: preparedAudio.url, locale: resolution.locale)
-        let segments = recognitions.compactMap { recognition -> TranscriptSegment? in
-            guard let text = SpeechTranscriberService.normalizedTranscriptText(recognition.text) else { return nil }
-            let absoluteStart = request.recordingStartTime.addingTimeInterval(
-                request.sessionOffsetSeconds + (recognition.startSeconds.isFinite ? recognition.startSeconds : 0)
-            )
-            let absoluteEnd = request.recordingStartTime.addingTimeInterval(
-                request.sessionOffsetSeconds + (recognition.endSeconds.isFinite ? recognition.endSeconds : 0)
-            )
-            return TranscriptSegment(
-                sessionId: request.recordingSessionId,
-                startTime: absoluteStart,
-                endTime: absoluteEnd,
-                text: text,
-                isConfirmed: true,
-                speakerLabel: request.source.speakerLabel
-            )
-        }
+        let segments = transcriptSegments(
+            from: recognitions,
+            recordingSessionId: request.recordingSessionId,
+            recordingStartTime: request.recordingStartTime,
+            sessionOffsetSeconds: request.sessionOffsetSeconds,
+            source: request.source
+        )
         return BatchSpeechTranscriptionResult(
             segments: segments,
             localeIdentifier: resolution.locale.identifier,
             languageFallback: resolution.fallback
         )
+    }
+
+    static func transcriptSegments(
+        from recognitions: [BatchSpeechRecognition],
+        recordingSessionId: UUID,
+        recordingStartTime: Date,
+        sessionOffsetSeconds: TimeInterval,
+        source: RecordingAudioSource
+    ) -> [TranscriptSegment] {
+        recognitions.compactMap { recognition -> TranscriptSegment? in
+            guard let text = SpeechTranscriberService.normalizedTranscriptText(recognition.text) else { return nil }
+            let absoluteStart = recordingStartTime.addingTimeInterval(
+                sessionOffsetSeconds + (recognition.startSeconds.isFinite ? recognition.startSeconds : 0)
+            )
+            let absoluteEnd = recordingStartTime.addingTimeInterval(
+                sessionOffsetSeconds + (recognition.endSeconds.isFinite ? recognition.endSeconds : 0)
+            )
+            return TranscriptSegment(
+                sessionId: recordingSessionId,
+                startTime: absoluteStart,
+                endTime: absoluteEnd,
+                text: text,
+                isConfirmed: true,
+                speakerLabel: source.speakerLabel
+            )
+        }
     }
 
     private static func resolvedLocale(

--- a/Sources/Dahlia/Speech/BatchTranscriptionConcurrency.swift
+++ b/Sources/Dahlia/Speech/BatchTranscriptionConcurrency.swift
@@ -148,6 +148,16 @@ struct AdaptiveBatchSpeechRecognizer: BatchSpeechRecognizing {
         }
     }
 
+    func recognize(audioSlices: [BatchSpeechAudioSlice], locale: Locale) async throws -> [BatchSpeechRecognition] {
+        do {
+            return try await performRecognition(audioSlices: audioSlices, locale: locale)
+        } catch where Self.isInsufficientResources(error) {
+            await limiter.reduceLimit(to: 1)
+            try Task.checkCancellation()
+            return try await performRecognition(audioSlices: audioSlices, locale: locale)
+        }
+    }
+
     func currentConcurrencyLimit() async -> Int {
         await limiter.currentLimit()
     }
@@ -162,6 +172,15 @@ struct AdaptiveBatchSpeechRecognizer: BatchSpeechRecognizing {
     private func performRecognition(audioURL: URL, locale: Locale) async throws -> [BatchSpeechRecognition] {
         try await limiter.perform {
             try await recognizer.recognize(audioURL: audioURL, locale: locale)
+        }
+    }
+
+    private func performRecognition(
+        audioSlices: [BatchSpeechAudioSlice],
+        locale: Locale
+    ) async throws -> [BatchSpeechRecognition] {
+        try await limiter.perform {
+            try await recognizer.recognize(audioSlices: audioSlices, locale: locale)
         }
     }
 

--- a/Sources/Dahlia/Speech/BatchTranscriptionConcurrency.swift
+++ b/Sources/Dahlia/Speech/BatchTranscriptionConcurrency.swift
@@ -149,12 +149,28 @@ struct AdaptiveBatchSpeechRecognizer: BatchSpeechRecognizing {
     }
 
     func recognize(audioSlices: [BatchSpeechAudioSlice], locale: Locale) async throws -> [BatchSpeechRecognition] {
+        try await recognize(audioSlices: audioSlices, locale: locale, onSliceConsumed: { _ in })
+    }
+
+    func recognize(
+        audioSlices: [BatchSpeechAudioSlice],
+        locale: Locale,
+        onSliceConsumed: @escaping @Sendable (Int) async -> Void
+    ) async throws -> [BatchSpeechRecognition] {
         do {
-            return try await performRecognition(audioSlices: audioSlices, locale: locale)
+            return try await performRecognition(
+                audioSlices: audioSlices,
+                locale: locale,
+                onSliceConsumed: onSliceConsumed
+            )
         } catch where Self.isInsufficientResources(error) {
             await limiter.reduceLimit(to: 1)
             try Task.checkCancellation()
-            return try await performRecognition(audioSlices: audioSlices, locale: locale)
+            return try await performRecognition(
+                audioSlices: audioSlices,
+                locale: locale,
+                onSliceConsumed: onSliceConsumed
+            )
         }
     }
 
@@ -177,10 +193,15 @@ struct AdaptiveBatchSpeechRecognizer: BatchSpeechRecognizing {
 
     private func performRecognition(
         audioSlices: [BatchSpeechAudioSlice],
-        locale: Locale
+        locale: Locale,
+        onSliceConsumed: @escaping @Sendable (Int) async -> Void
     ) async throws -> [BatchSpeechRecognition] {
         try await limiter.perform {
-            try await recognizer.recognize(audioSlices: audioSlices, locale: locale)
+            try await recognizer.recognize(
+                audioSlices: audioSlices,
+                locale: locale,
+                onSliceConsumed: onSliceConsumed
+            )
         }
     }
 

--- a/Tests/DahliaTests/BatchManualTranscriptionRunPlannerTests.swift
+++ b/Tests/DahliaTests/BatchManualTranscriptionRunPlannerTests.swift
@@ -23,7 +23,7 @@ import Foundation
                     sessionID: sessionID,
                     segmentIndex: 1,
                     source: .microphone,
-                    startOffset: 0.01,
+                    startOffset: 0.01 + 0.75 / 16000,
                     frameCount: 320,
                     locale: "ja_JP"
                 ),

--- a/Tests/DahliaTests/BatchManualTranscriptionRunPlannerTests.swift
+++ b/Tests/DahliaTests/BatchManualTranscriptionRunPlannerTests.swift
@@ -1,0 +1,209 @@
+@preconcurrency import AVFoundation
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct BatchManualTranscriptionRunPlannerTests {
+        @Test
+        func joinsContiguousPhysicalSegmentsWithMatchingSourceFormatAndLocale() throws {
+            let sessionID = UUID.v7()
+            let recordingStart = Date(timeIntervalSince1970: 1_776_384_000)
+            let verified = [
+                makeVerified(
+                    sessionID: sessionID,
+                    segmentIndex: 0,
+                    source: .microphone,
+                    startOffset: 0,
+                    frameCount: 160,
+                    locale: "ja_JP"
+                ),
+                makeVerified(
+                    sessionID: sessionID,
+                    segmentIndex: 1,
+                    source: .microphone,
+                    startOffset: 0.01,
+                    frameCount: 320,
+                    locale: "ja_JP"
+                ),
+            ]
+
+            let runs = try BatchManualTranscriptionRunPlanner.runs(
+                verifiedSegments: verified,
+                recordingStartTime: recordingStart,
+                audioFormatProvider: { try audioFormat(for: $0) }
+            )
+
+            #expect(runs.count == 1)
+            #expect(runs[0].slices.count == 2)
+            #expect(runs[0].fileIndices == [0, 1])
+            #expect(runs[0].localeIdentifier == "ja_JP")
+            #expect(runs[0].sessionOffsetSeconds == 0)
+        }
+
+        @Test
+        func splitsRunsAtLocaleSourceGapAndFormatBoundaries() throws {
+            let sessionID = UUID.v7()
+            let recordingStart = Date(timeIntervalSince1970: 1_776_384_000)
+            let verified = [
+                makeVerified(
+                    sessionID: sessionID,
+                    segmentIndex: 0,
+                    source: .microphone,
+                    startOffset: 0,
+                    frameCount: 160,
+                    locale: "ja_JP"
+                ),
+                makeVerified(
+                    sessionID: sessionID,
+                    segmentIndex: 1,
+                    source: .microphone,
+                    startOffset: 0.01,
+                    frameCount: 160,
+                    locale: "en_US"
+                ),
+                makeVerified(
+                    sessionID: sessionID,
+                    segmentIndex: 2,
+                    source: .microphone,
+                    startOffset: 0.03,
+                    frameCount: 160,
+                    locale: "en_US"
+                ),
+                makeVerified(
+                    sessionID: sessionID,
+                    segmentIndex: 3,
+                    source: .microphone,
+                    startOffset: 0.04,
+                    frameCount: 320,
+                    sampleRate: 32000,
+                    locale: "en_US"
+                ),
+                makeVerified(
+                    sessionID: sessionID,
+                    segmentIndex: 0,
+                    source: .system,
+                    startOffset: 0,
+                    frameCount: 160,
+                    locale: "ja_JP"
+                ),
+            ]
+
+            let runs = try BatchManualTranscriptionRunPlanner.runs(
+                verifiedSegments: verified,
+                recordingStartTime: recordingStart,
+                audioFormatProvider: { try audioFormat(for: $0) }
+            )
+
+            #expect(runs.count == 5)
+            #expect(runs.map(\.localeIdentifier) == ["ja_JP", "en_US", "en_US", "en_US", "ja_JP"])
+            #expect(runs.map(\.source) == [.microphone, .microphone, .microphone, .microphone, .system])
+        }
+
+        @Test
+        func splitsRunsWhenCAFProcessingFormatsDiffer() throws {
+            let sessionID = UUID.v7()
+            let recordingStart = Date(timeIntervalSince1970: 1_776_384_000)
+            let verified = [
+                makeVerified(
+                    sessionID: sessionID,
+                    segmentIndex: 0,
+                    source: .microphone,
+                    startOffset: 0,
+                    frameCount: 160,
+                    locale: "ja_JP"
+                ),
+                makeVerified(
+                    sessionID: sessionID,
+                    segmentIndex: 1,
+                    source: .microphone,
+                    startOffset: 0.01,
+                    frameCount: 160,
+                    locale: "ja_JP"
+                ),
+            ]
+
+            let runs = try BatchManualTranscriptionRunPlanner.runs(
+                verifiedSegments: verified,
+                recordingStartTime: recordingStart,
+                audioFormatProvider: { segment in
+                    try audioFormat(
+                        for: segment,
+                        commonFormat: segment.segment.segmentIndex == 0 ? .pcmFormatInt16 : .pcmFormatFloat32
+                    )
+                }
+            )
+
+            #expect(runs.count == 2)
+            #expect(runs.map(\.slices.count) == [1, 1])
+        }
+
+        private func audioFormat(
+            for verified: RecordingAudioStore.VerifiedSegment,
+            commonFormat: AVAudioCommonFormat = .pcmFormatInt16
+        ) throws -> AVAudioFormat {
+            try #require(AVAudioFormat(
+                commonFormat: commonFormat,
+                sampleRate: verified.segment.sampleRate,
+                channels: AVAudioChannelCount(verified.segment.channelCount),
+                interleaved: false
+            ))
+        }
+
+        private func makeVerified(
+            sessionID: UUID,
+            segmentIndex: Int,
+            source: RecordingAudioSource,
+            startOffset: TimeInterval,
+            frameCount: Int64,
+            sampleRate: Double = 16000,
+            channelCount: Int = 1,
+            locale: String
+        ) -> RecordingAudioStore.VerifiedSegment {
+            let now = Date(timeIntervalSince1970: 1_776_384_000)
+            let segmentID = UUID.v7()
+            let segment = RecordingAudioSegmentRecord(
+                id: segmentID,
+                recordingSessionId: sessionID,
+                source: source,
+                segmentIndex: segmentIndex,
+                generationId: .v7(),
+                state: .ready,
+                partialRelativePath: "\(source.rawValue)-\(segmentIndex).partial.caf",
+                finalRelativePath: "\(source.rawValue)-\(segmentIndex).caf",
+                sampleRate: sampleRate,
+                channelCount: channelCount,
+                sealedFrameCount: frameCount,
+                sessionStartOffsetSeconds: startOffset,
+                sessionEndOffsetSeconds: startOffset + Double(frameCount) / sampleRate,
+                byteCount: frameCount * Int64(channelCount) * 2,
+                sha256: Data(),
+                finalizationStartedAt: now,
+                integrityVerifiedAt: now,
+                finalizedAt: now,
+                purgeRequestedAt: nil,
+                purgedAt: nil,
+                failureStage: nil,
+                failureCode: nil,
+                createdAt: now,
+                updatedAt: now
+            )
+            let range = RecordingAudioSegmentRangeRecord(
+                id: .v7(),
+                audioSegmentId: segmentID,
+                startFrame: 0,
+                frameCount: frameCount,
+                sessionOffsetSeconds: startOffset,
+                localeIdentifier: locale,
+                createdAt: now,
+                updatedAt: now
+            )
+            return RecordingAudioStore.VerifiedSegment(
+                segment: segment,
+                url: URL(fileURLWithPath: "/tmp/\(segment.finalRelativePath)"),
+                ranges: [range]
+            )
+        }
+    }
+#endif

--- a/Tests/DahliaTests/BatchSpeechAnalyzerInputSequenceTests.swift
+++ b/Tests/DahliaTests/BatchSpeechAnalyzerInputSequenceTests.swift
@@ -23,6 +23,7 @@ import Speech
                 try? FileManager.default.removeItem(at: secondURL)
             }
             let readFormat = try AVAudioFile(forReading: firstURL).processingFormat
+            let consumedSliceProbe = ConsumedSliceProbe()
             let sequence = try BatchSpeechAnalyzerInputSequence(
                 slices: [
                     BatchSpeechAudioSlice(audioURL: firstURL, startFrame: 40, frameCount: 80),
@@ -30,6 +31,9 @@ import Speech
                 ],
                 sourceFormat: readFormat,
                 analyzerFormat: readFormat,
+                onSliceConsumed: { sliceIndex in
+                    await consumedSliceProbe.record(sliceIndex)
+                },
                 converterFactory: { _, _ in PassthroughAnalyzerInputConverter() }
             )
 
@@ -47,6 +51,7 @@ import Speech
             #expect(first.bufferStartTime == .zero)
             #expect(second.bufferStartTime?.seconds == 0.005)
             #expect(end == nil)
+            #expect(await consumedSliceProbe.sliceIndices == [0, 1])
         }
 
         @Test
@@ -120,6 +125,14 @@ import Speech
 
         func finish() -> [AnalyzerInput] {
             []
+        }
+    }
+
+    private actor ConsumedSliceProbe {
+        private(set) var sliceIndices: [Int] = []
+
+        func record(_ sliceIndex: Int) {
+            sliceIndices.append(sliceIndex)
         }
     }
 #endif

--- a/Tests/DahliaTests/BatchSpeechAnalyzerInputSequenceTests.swift
+++ b/Tests/DahliaTests/BatchSpeechAnalyzerInputSequenceTests.swift
@@ -1,0 +1,125 @@
+@preconcurrency import AVFoundation
+import CoreMedia
+import Foundation
+import Speech
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct BatchSpeechAnalyzerInputSequenceTests {
+        @Test
+        func readsSlicesLazilyAndAssignsOneContinuousTimeline() async throws {
+            let format = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatInt16,
+                sampleRate: 16000,
+                channels: 1,
+                interleaved: false
+            ))
+            let firstURL = try makeAudioFile(name: "first", format: format, values: Array(0 ..< 200))
+            let secondURL = try makeAudioFile(name: "second", format: format, values: Array(1000 ..< 1200))
+            defer {
+                try? FileManager.default.removeItem(at: firstURL)
+                try? FileManager.default.removeItem(at: secondURL)
+            }
+            let readFormat = try AVAudioFile(forReading: firstURL).processingFormat
+            let sequence = try BatchSpeechAnalyzerInputSequence(
+                slices: [
+                    BatchSpeechAudioSlice(audioURL: firstURL, startFrame: 40, frameCount: 80),
+                    BatchSpeechAudioSlice(audioURL: secondURL, startFrame: 20, frameCount: 60),
+                ],
+                sourceFormat: readFormat,
+                analyzerFormat: readFormat,
+                converterFactory: { _, _ in PassthroughAnalyzerInputConverter() }
+            )
+
+            var iterator = sequence.makeAsyncIterator()
+            let first = try #require(try await iterator.next())
+            let second = try #require(try await iterator.next())
+            let end = try await iterator.next()
+            let firstSample = try #require(sampleValue(in: first.buffer, at: 0))
+            let secondSample = try #require(sampleValue(in: second.buffer, at: 0))
+
+            #expect(first.buffer.frameLength == 80)
+            #expect(second.buffer.frameLength == 60)
+            #expect(abs(firstSample - Double(40) / Double(Int16.max)) < 0.0001)
+            #expect(abs(secondSample - Double(1020) / Double(Int16.max)) < 0.0001)
+            #expect(first.bufferStartTime == .zero)
+            #expect(second.bufferStartTime?.seconds == 0.005)
+            #expect(end == nil)
+        }
+
+        @Test
+        func rejectsSliceThatExtendsPastVerifiedFileLength() async throws {
+            let format = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatInt16,
+                sampleRate: 16000,
+                channels: 1,
+                interleaved: false
+            ))
+            let audioURL = try makeAudioFile(name: "short", format: format, values: Array(0 ..< 80))
+            defer { try? FileManager.default.removeItem(at: audioURL) }
+            let readFormat = try AVAudioFile(forReading: audioURL).processingFormat
+            let sequence = try BatchSpeechAnalyzerInputSequence(
+                slices: [
+                    BatchSpeechAudioSlice(audioURL: audioURL, startFrame: 40, frameCount: 80),
+                ],
+                sourceFormat: readFormat,
+                analyzerFormat: readFormat,
+                converterFactory: { _, _ in PassthroughAnalyzerInputConverter() }
+            )
+            var iterator = sequence.makeAsyncIterator()
+
+            await #expect(throws: BatchSpeechTranscriberError.self) {
+                _ = try await iterator.next()
+            }
+        }
+
+        private func makeAudioFile(
+            name: String,
+            format: AVAudioFormat,
+            values: [Int]
+        ) throws -> URL {
+            let url = FileManager.default.temporaryDirectory
+                .appending(path: "dahlia-batch-sequence-\(name)-\(UUID.v7().uuidString).caf")
+            var file: AVAudioFile? = try AVAudioFile(
+                forWriting: url,
+                settings: format.settings,
+                commonFormat: .pcmFormatInt16,
+                interleaved: false
+            )
+            let buffer = try #require(AVAudioPCMBuffer(
+                pcmFormat: format,
+                frameCapacity: AVAudioFrameCount(values.count)
+            ))
+            buffer.frameLength = AVAudioFrameCount(values.count)
+            let channel = try #require(buffer.int16ChannelData?[0])
+            for (index, value) in values.enumerated() {
+                channel[index] = Int16(value)
+            }
+            try file?.write(from: buffer)
+            file = nil
+            return url
+        }
+
+        private func sampleValue(in buffer: AVAudioPCMBuffer, at index: Int) -> Double? {
+            if let channel = buffer.floatChannelData?[0] {
+                return Double(channel[index])
+            }
+            if let channel = buffer.int16ChannelData?[0] {
+                return Double(channel[index]) / Double(Int16.max)
+            }
+            return nil
+        }
+    }
+
+    private final class PassthroughAnalyzerInputConverter: AnalyzerInputConverting {
+        func convert(_ buffer: AVAudioPCMBuffer, at startTime: CMTime) -> [AnalyzerInput] {
+            [AnalyzerInput(buffer: buffer, bufferStartTime: startTime)]
+        }
+
+        func finish() -> [AnalyzerInput] {
+            []
+        }
+    }
+#endif

--- a/Tests/DahliaTests/BatchTranscriptionProgressTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionProgressTests.swift
@@ -29,6 +29,56 @@ import GRDB
         }
 
         @Test
+        func manualModeRecognizesContiguousCAFAsOneLogicalRun() async throws {
+            let fixture = try makeFixture(name: "BatchManualLogicalRun", duration: 0.0125)
+            defer { fixture.removeFiles() }
+            try await createManualRecording(fixture: fixture, frameCounts: [80, 120])
+            let stateProbe = BatchProgressStateProbe()
+            let recognizer = ProgressSpeechRecognizer()
+            let coordinator = makeCoordinator(
+                fixture: fixture,
+                detector: ProgressLanguageDetector(detections: []),
+                recognizer: recognizer,
+                stateProbe: stateProbe
+            )
+
+            await coordinator.enqueue(sessionId: fixture.session.id)
+            try await waitUntil { await stateProbe.didComplete }
+
+            #expect(await recognizer.fileCallCount == 0)
+            #expect(await recognizer.sliceCounts == [2])
+            expectCompleteProgress(await stateProbe.reportedProgress(), totalFileCount: 2)
+            let transcript = try await fixture.database.dbQueue.read { db in
+                try TranscriptSegmentRecord
+                    .filter(Column("sessionId") == fixture.session.id)
+                    .fetchOne(db)
+            }
+            #expect(transcript?.startTime == fixture.now.addingTimeInterval(0.001))
+            #expect(transcript?.speakerLabel == RecordingAudioSource.microphone.speakerLabel)
+        }
+
+        @Test
+        func manualModeCompletesProgressForCAFWithoutAudioFrames() async throws {
+            let fixture = try makeFixture(name: "BatchManualEmptyCAF", duration: 0.0125)
+            defer { fixture.removeFiles() }
+            try await createManualRecording(fixture: fixture, frameCounts: [])
+            let stateProbe = BatchProgressStateProbe()
+            let recognizer = ProgressSpeechRecognizer()
+            let coordinator = makeCoordinator(
+                fixture: fixture,
+                detector: ProgressLanguageDetector(detections: []),
+                recognizer: recognizer,
+                stateProbe: stateProbe
+            )
+
+            await coordinator.enqueue(sessionId: fixture.session.id)
+            try await waitUntil { await stateProbe.didComplete }
+
+            #expect(await recognizer.callCount == 0)
+            expectCompleteProgress(await stateProbe.reportedProgress(), totalFileCount: 1)
+        }
+
+        @Test
         func reportsEachManualMultiRangeCAFAsOneCompletedFile() async throws {
             let fixture = try makeFixture(name: "BatchManualMultiRangeProgress", duration: 0.015)
             defer { fixture.removeFiles() }
@@ -118,16 +168,24 @@ import GRDB
         }
 
         private func createSegmentedAutomaticRecording(fixture: BatchAudioTestFixture) async throws {
+            try await createManualRecording(fixture: fixture, frameCounts: [80, 120])
+            try await configureAutomaticLanguageDetection(fixture: fixture)
+        }
+
+        private func createManualRecording(
+            fixture: BatchAudioTestFixture,
+            frameCounts: [AVAudioFrameCount]
+        ) async throws {
             let recorder = try makeRecorder(fixture: fixture, targetSegmentDuration: .milliseconds(5))
             let writer = try await recorder.beginRange(
                 source: .microphone,
                 locale: Locale(identifier: "ja_JP"),
                 at: fixture.now
             )
-            try writer.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 80))
-            try writer.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: 120))
+            for frameCount in frameCounts {
+                try writer.appendBuffer(makeBuffer(format: recorder.targetFormat, frameCount: frameCount))
+            }
             try await recorder.finish()
-            try await configureAutomaticLanguageDetection(fixture: fixture)
         }
 
         private func createSeparateAutomaticRecordingFiles(
@@ -358,10 +416,29 @@ import GRDB
     }
 
     private actor ProgressSpeechRecognizer: BatchSpeechRecognizing {
-        private(set) var callCount = 0
+        private(set) var fileCallCount = 0
+        private(set) var sliceCounts: [Int] = []
+
+        var callCount: Int {
+            fileCallCount + sliceCounts.count
+        }
 
         func recognize(audioURL _: URL, locale _: Locale) -> [BatchSpeechRecognition] {
-            callCount += 1
+            fileCallCount += 1
+            return [
+                BatchSpeechRecognition(
+                    startSeconds: 0.001,
+                    endSeconds: 0.002,
+                    text: "recognized-\(callCount)"
+                ),
+            ]
+        }
+
+        func recognize(
+            audioSlices: [BatchSpeechAudioSlice],
+            locale _: Locale
+        ) -> [BatchSpeechRecognition] {
+            sliceCounts.append(audioSlices.count)
             return [
                 BatchSpeechRecognition(
                     startSeconds: 0.001,

--- a/Tests/DahliaTests/BatchTranscriptionProgressTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionProgressTests.swift
@@ -29,35 +29,6 @@ import GRDB
         }
 
         @Test
-        func manualModeRecognizesContiguousCAFAsOneLogicalRun() async throws {
-            let fixture = try makeFixture(name: "BatchManualLogicalRun", duration: 0.0125)
-            defer { fixture.removeFiles() }
-            try await createManualRecording(fixture: fixture, frameCounts: [80, 120])
-            let stateProbe = BatchProgressStateProbe()
-            let recognizer = ProgressSpeechRecognizer()
-            let coordinator = makeCoordinator(
-                fixture: fixture,
-                detector: ProgressLanguageDetector(detections: []),
-                recognizer: recognizer,
-                stateProbe: stateProbe
-            )
-
-            await coordinator.enqueue(sessionId: fixture.session.id)
-            try await waitUntil { await stateProbe.didComplete }
-
-            #expect(await recognizer.fileCallCount == 0)
-            #expect(await recognizer.sliceCounts == [2])
-            expectCompleteProgress(await stateProbe.reportedProgress(), totalFileCount: 2)
-            let transcript = try await fixture.database.dbQueue.read { db in
-                try TranscriptSegmentRecord
-                    .filter(Column("sessionId") == fixture.session.id)
-                    .fetchOne(db)
-            }
-            #expect(transcript?.startTime == fixture.now.addingTimeInterval(0.001))
-            #expect(transcript?.speakerLabel == RecordingAudioSource.microphone.speakerLabel)
-        }
-
-        @Test
         func manualModeCompletesProgressForCAFWithoutAudioFrames() async throws {
             let fixture = try makeFixture(name: "BatchManualEmptyCAF", duration: 0.0125)
             defer { fixture.removeFiles() }
@@ -335,6 +306,44 @@ import GRDB
         }
     }
 
+    extension BatchTranscriptionProgressTests {
+        @Test
+        func manualModeRecognizesContiguousCAFAsOneLogicalRun() async throws {
+            let fixture = try makeFixture(name: "BatchManualLogicalRun", duration: 0.0125)
+            defer { fixture.removeFiles() }
+            try await createManualRecording(fixture: fixture, frameCounts: [80, 120])
+            let stateProbe = BatchProgressStateProbe()
+            let recognizer = ProgressSpeechRecognizer(pauseAfterFirstSlice: true)
+            defer { Task { await recognizer.releaseFirstSlice() } }
+            let coordinator = makeCoordinator(
+                fixture: fixture,
+                detector: ProgressLanguageDetector(detections: []),
+                recognizer: recognizer,
+                stateProbe: stateProbe
+            )
+
+            await coordinator.enqueue(sessionId: fixture.session.id)
+            try await waitUntil { await recognizer.didConsumeFirstSlice }
+            try await waitUntil {
+                await stateProbe.reportedProgress().last?.completedFileCount == 1
+            }
+            #expect(!(await stateProbe.didComplete))
+            await recognizer.releaseFirstSlice()
+            try await waitUntil { await stateProbe.didComplete }
+
+            #expect(await recognizer.fileCallCount == 0)
+            #expect(await recognizer.sliceCounts == [2])
+            expectCompleteProgress(await stateProbe.reportedProgress(), totalFileCount: 2)
+            let transcript = try await fixture.database.dbQueue.read { db in
+                try TranscriptSegmentRecord
+                    .filter(Column("sessionId") == fixture.session.id)
+                    .fetchOne(db)
+            }
+            #expect(transcript?.startTime == fixture.now.addingTimeInterval(0.001))
+            #expect(transcript?.speakerLabel == RecordingAudioSource.microphone.speakerLabel)
+        }
+    }
+
     private enum BatchTranscriptionProgressTestError: Error {
         case timedOut
     }
@@ -416,8 +425,15 @@ import GRDB
     }
 
     private actor ProgressSpeechRecognizer: BatchSpeechRecognizing {
+        private let pauseAfterFirstSlice: Bool
+        private var firstSliceContinuation: CheckedContinuation<Void, Never>?
         private(set) var fileCallCount = 0
         private(set) var sliceCounts: [Int] = []
+        private(set) var didConsumeFirstSlice = false
+
+        init(pauseAfterFirstSlice: Bool = false) {
+            self.pauseAfterFirstSlice = pauseAfterFirstSlice
+        }
 
         var callCount: Int {
             fileCallCount + sliceCounts.count
@@ -446,6 +462,35 @@ import GRDB
                     text: "recognized-\(callCount)"
                 ),
             ]
+        }
+
+        func recognize(
+            audioSlices: [BatchSpeechAudioSlice],
+            locale _: Locale,
+            onSliceConsumed: @escaping @Sendable (Int) async -> Void
+        ) async -> [BatchSpeechRecognition] {
+            sliceCounts.append(audioSlices.count)
+            for sliceIndex in audioSlices.indices {
+                await onSliceConsumed(sliceIndex)
+                if sliceIndex == audioSlices.startIndex, pauseAfterFirstSlice {
+                    didConsumeFirstSlice = true
+                    await withCheckedContinuation { continuation in
+                        firstSliceContinuation = continuation
+                    }
+                }
+            }
+            return [
+                BatchSpeechRecognition(
+                    startSeconds: 0.001,
+                    endSeconds: 0.002,
+                    text: "recognized-\(callCount)"
+                ),
+            ]
+        }
+
+        func releaseFirstSlice() {
+            firstSliceContinuation?.resume()
+            firstSliceContinuation = nil
         }
     }
 #endif

--- a/docs/architecture/audio-transcription-data-flow.md
+++ b/docs/architecture/audio-transcription-data-flow.md
@@ -216,11 +216,15 @@ sequenceDiagram
 
     Batch->>Audio: ready segments の read plan
     Audio-->>Batch: verified immutable CAF + locale ranges
-    Batch->>Speech: source / range ごとの transcription
+    Batch->>Speech: source / locale ごとの transcription run
     Speech-->>Batch: complete segment set
     Batch->>DB: session の旧 transcript を置換し、batchCompletedAt と meeting status を更新
     DB-->>Batch: single transaction commit
 ```
+
+固定言語では、同一音源、同一形式、同一 locale で session time が連続する verified CAF range を一つの論理 run として
+同じ `SpeechAnalyzer` へ順次供給する。ready CAF 自体は結合または変更せず、入力は一 buffer ずつ遅延読出しする。
+自動判定は CAF ごとの言語判定と認識の overlap を維持するため、CAF 単位の transcription のままとする。
 
 認識途中の結果は正本へ部分反映しない。成功した全結果を `BatchTranscriptionPersistence.complete` が一つの transaction で
 反映する。再文字起こし中は以前の成功結果を利用でき、新しい一式が成功した時だけ置き換える。


### PR DESCRIPTION
## Summary

- Group contiguous verified CAF ranges into logical transcription runs in fixed-language mode.
- Stream immutable CAF slices lazily into one `SpeechAnalyzer` session without creating a merged temporary file.
- Split runs on source, locale, timeline gaps, or exact audio processing-format changes.
- Preserve the existing CAF-unit language detection and parallel recognition path in automatic mode.
- Keep physical-CAF progress accurate, including zero-frame CAFs.

## Why

Starting a separate speech session for every physical CAF loses recognition context at rollover boundaries. Fixed-language mode already knows the locale, so contiguous compatible ranges can safely share one analyzer session while retaining the immutable CAF files as the source of truth.

The review also identified and fixed two edge cases: incompatible PCM formats are now split before recognition, and zero-frame CAFs complete progress without invoking speech recognition.

## Impact

- Improves fixed-language batch recognition context across CAF boundaries.
- Adds no merged audio file, additional recording writer, database migration, or persistent storage.
- Leaves automatic language detection behavior and concurrency unchanged.

## Validation

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build`
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` — 187 suites, 1202 tests
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer CI=true ./scripts/lint.sh`
- `git diff --check`
