### PR TITLE
Prioritize attending events in the menu bar

### DIFF
--- a/Sources/Dahlia/Models/MenuBarCalendarAgenda.swift
+++ b/Sources/Dahlia/Models/MenuBarCalendarAgenda.swift
@@ -47,7 +47,8 @@ struct MenuBarCalendarAgenda: Equatable {
     }
 
     func labelText(showsTitle: Bool, showsCountdown: Bool, now: Date) -> String? {
-        guard let featuredEvent else { return nil }
+        guard showsTitle || showsCountdown else { return nil }
+        guard let featuredEvent else { return L10n.menuBarNoEvents }
 
         var components: [String] = []
         if showsTitle {
@@ -56,11 +57,11 @@ struct MenuBarCalendarAgenda: Equatable {
         if showsCountdown {
             components.append(countdownText(now: now))
         }
-        return components.isEmpty ? nil : components.joined(separator: " · ")
+        return components.joined(separator: " · ")
     }
 
     func accessibilityLabel(now: Date) -> String? {
-        guard let featuredEvent else { return nil }
+        guard let featuredEvent else { return L10n.menuBarNoEvents }
         let participation = featuredEvent.isAttending ? ", \(L10n.calendarAttending)" : ""
         return "\(featuredEvent.resolvedMeetingTitle), \(countdownText(now: now))\(participation)"
     }
@@ -117,6 +118,9 @@ struct MenuBarCalendarAgenda: Equatable {
     }
 
     private static func compareOngoingEvents(_ lhs: CalendarEvent, _ rhs: CalendarEvent) -> Bool {
+        if lhs.isAttending != rhs.isAttending {
+            return !lhs.isAttending
+        }
         if lhs.startDate != rhs.startDate {
             return lhs.startDate < rhs.startDate
         }

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -647,6 +647,7 @@
 "Show the time until the event starts or ends." = "Show the time until the event starts or ends.";
 "No more events today" = "No more events today";
 "There are no ongoing or upcoming events today." = "There are no ongoing or upcoming events today.";
+"No events" = "No events";
 "Open Calendar Settings" = "Open Calendar Settings";
 "In progress" = "In progress";
 "Starting soon" = "Starting soon";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -647,6 +647,7 @@
 "Show the time until the event starts or ends." = "予定が開始または終了するまでの時間を表示します。";
 "No more events today" = "今日の予定はもうありません";
 "There are no ongoing or upcoming events today." = "今日の進行中または今後の予定はありません。";
+"No events" = "予定なし";
 "Open Calendar Settings" = "カレンダー設定を開く";
 "In progress" = "進行中";
 "Starting soon" = "まもなく開始";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -2414,6 +2414,7 @@ enum L10n {
         localized: "There are no ongoing or upcoming events today.",
         bundle: bundle
     ) }
+    static var menuBarNoEvents: String { String(localized: "No events", bundle: bundle) }
     static var menuBarOpenCalendarSettings: String { String(localized: "Open Calendar Settings", bundle: bundle) }
     static var menuBarInProgress: String { String(localized: "In progress", bundle: bundle) }
     static var menuBarStartingSoon: String { String(localized: "Starting soon", bundle: bundle) }

--- a/Sources/Dahlia/ViewModels/MenuBarCalendarViewModel.swift
+++ b/Sources/Dahlia/ViewModels/MenuBarCalendarViewModel.swift
@@ -13,6 +13,14 @@ final class MenuBarCalendarViewModel {
     private let macCalendarStore: MacCalendarStore
     private var cancellables: Set<AnyCancellable> = []
 
+    var allEnabledSourcesAreLoaded: Bool {
+        Self.allEnabledSourcesAreLoaded(
+            settings.enabledCalendarSources,
+            googleIsLoaded: googleCalendarStore.state == .loaded,
+            macOSIsLoaded: macCalendarStore.state == .loaded
+        )
+    }
+
     init(
         settings: AppSettings = .shared,
         googleCalendarStore: GoogleCalendarStore = .shared,
@@ -30,6 +38,16 @@ final class MenuBarCalendarViewModel {
             now: now
         )
         observeCalendarInputs()
+    }
+
+    static func allEnabledSourcesAreLoaded(
+        _ enabledSources: Set<CalendarSource>,
+        googleIsLoaded: Bool,
+        macOSIsLoaded: Bool
+    ) -> Bool {
+        guard !enabledSources.isEmpty else { return false }
+        return (!enabledSources.contains(.google) || googleIsLoaded)
+            && (!enabledSources.contains(.macOS) || macOSIsLoaded)
     }
 
     func runRefreshLoop() async {

--- a/Sources/Dahlia/Views/MenuBarLabel.swift
+++ b/Sources/Dahlia/Views/MenuBarLabel.swift
@@ -25,22 +25,18 @@ struct MenuBarLabel: View {
 
         Group {
             if settings.menuBarCalendarEnabled,
-               let featuredEvent = agenda.featuredEvent,
                let calendarText {
                 Label {
                     Text(calendarText)
                 } icon: {
                     if isListening {
                         Image(systemName: "record.circle.fill")
-                    } else {
+                    } else if let featuredEvent = agenda.featuredEvent {
                         MenuBarCalendarParticipationIndicator(isAttending: featuredEvent.isAttending)
+                    } else {
+                        Image(systemName: "waveform")
                     }
                 }
-            } else if settings.menuBarCalendarEnabled {
-                Label(
-                    L10n.dahlia,
-                    systemImage: isListening ? "record.circle.fill" : "waveform"
-                )
             } else {
                 Label(
                     L10n.dahlia,

--- a/Sources/Dahlia/Views/MenuBarLabel.swift
+++ b/Sources/Dahlia/Views/MenuBarLabel.swift
@@ -10,6 +10,7 @@ struct MenuBarLabel: View {
     var body: some View {
         let agenda = calendarViewModel.agenda
         let calendarText = settings.menuBarCalendarEnabled
+            && (agenda.featuredEvent != nil || calendarViewModel.allEnabledSourcesAreLoaded)
             ? agenda.labelText(
                 showsTitle: settings.menuBarCalendarShowsEventTitle,
                 showsCountdown: settings.menuBarCalendarShowsCountdown,

--- a/Tests/DahliaTests/MenuBarCalendarAgendaTests.swift
+++ b/Tests/DahliaTests/MenuBarCalendarAgendaTests.swift
@@ -76,7 +76,18 @@ import Foundation
         }
 
         @Test
-        func prioritizesMostRecentlyStartedOngoingEventThenNextEvent() {
+        func prioritizesAttendingOngoingEventBeforeLaterUnconfirmedEvent() {
+            let attending = event(id: "attending", start: -1_800, end: 3_600, isAttending: true)
+            let laterUnconfirmed = event(id: "unconfirmed", start: -600, end: 1_800)
+
+            let agenda = agenda(googleEvents: [laterUnconfirmed, attending])
+
+            #expect(agenda.featuredEvent?.id == attending.id)
+            #expect(agenda.featuredEventIsOngoing)
+        }
+
+        @Test
+        func prioritizesMostRecentlyStartedOngoingEventWithSameParticipationThenNextEvent() {
             let earlierOngoing = event(id: "earlier", start: -1_800, end: 3_600)
             let laterOngoing = event(id: "later", start: -600, end: 1_800)
             let next = event(id: "next", start: 3_600, end: 7_200)
@@ -106,6 +117,41 @@ import Foundation
 
             #expect(agenda.events == [allDay])
             #expect(agenda.featuredEvent == nil)
+        }
+
+        @Test
+        func usesNoEventsLabelWhenNoTimedEventIsAvailable() {
+            let startOfDay = calendar.startOfDay(for: now)
+            let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)
+                ?? startOfDay.addingTimeInterval(86_400)
+            let allDay = event(
+                id: "all-day",
+                startDate: startOfDay,
+                endDate: endOfDay,
+                isAllDay: true
+            )
+            let declined = event(id: "declined", start: 3_600, end: 7_200, isDeclined: true)
+            let filteredAgenda = MenuBarCalendarAgenda(
+                googleEvents: [declined],
+                macEvents: [],
+                enabledSources: [.google],
+                filter: CalendarEventFilter(includesDeclinedEvents: false),
+                now: now,
+                calendar: calendar
+            )
+
+            for emptyAgenda in [agenda(googleEvents: []), agenda(googleEvents: [allDay]), filteredAgenda] {
+                #expect(emptyAgenda.labelText(showsTitle: true, showsCountdown: true, now: now) == L10n.menuBarNoEvents)
+                #expect(emptyAgenda.accessibilityLabel(now: now) == L10n.menuBarNoEvents)
+            }
+        }
+
+        @Test
+        func keepsDahliaFallbackWhenAllCalendarLabelDetailsAreDisabled() {
+            let upcoming = event(id: "upcoming", start: 3_600, end: 7_200)
+
+            #expect(agenda(googleEvents: [upcoming]).labelText(showsTitle: false, showsCountdown: false, now: now) == nil)
+            #expect(agenda(googleEvents: []).labelText(showsTitle: false, showsCountdown: false, now: now) == nil)
         }
 
         @Test
@@ -158,7 +204,8 @@ import Foundation
             start: TimeInterval,
             end: TimeInterval,
             isAllDay: Bool = false,
-            isDeclined: Bool = false
+            isDeclined: Bool = false,
+            isAttending: Bool = false
         ) -> CalendarEvent {
             event(
                 id: id,
@@ -168,7 +215,8 @@ import Foundation
                 startDate: now.addingTimeInterval(start),
                 endDate: now.addingTimeInterval(end),
                 isAllDay: isAllDay,
-                isDeclined: isDeclined
+                isDeclined: isDeclined,
+                isAttending: isAttending
             )
         }
 
@@ -180,7 +228,8 @@ import Foundation
             startDate: Date,
             endDate: Date,
             isAllDay: Bool = false,
-            isDeclined: Bool = false
+            isDeclined: Bool = false,
+            isAttending: Bool = false
         ) -> CalendarEvent {
             CalendarEvent(
                 id: id,
@@ -197,6 +246,7 @@ import Foundation
                 isAllDay: isAllDay,
                 hasOtherAttendees: true,
                 isDeclined: isDeclined,
+                isAttending: isAttending,
                 conferenceURI: URL(string: "https://meet.example.com/\(id)")
             )
         }

--- a/Tests/DahliaTests/MenuBarCalendarViewModelTests.swift
+++ b/Tests/DahliaTests/MenuBarCalendarViewModelTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct MenuBarCalendarViewModelTests {
+        @Test
+        func requiresAtLeastOneSourceAndEveryEnabledSourceToBeLoaded() {
+            #expect(!loadedSources([], google: true, macOS: true))
+            #expect(!loadedSources([.google], google: false, macOS: true))
+            #expect(loadedSources([.google], google: true, macOS: false))
+            #expect(!loadedSources([.google, .macOS], google: true, macOS: false))
+            #expect(loadedSources([.google, .macOS], google: true, macOS: true))
+        }
+
+        private func loadedSources(
+            _ enabledSources: Set<CalendarSource>,
+            google: Bool,
+            macOS: Bool
+        ) -> Bool {
+            MenuBarCalendarViewModel.allEnabledSourcesAreLoaded(
+                enabledSources,
+                googleIsLoaded: google,
+                macOSIsLoaded: macOS
+            )
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary

- prioritize attending ongoing calendar events before comparing their start times
- keep the most recently started event as the next priority
- show a localized "No events" menu bar label when no timed event is available
- preserve the Dahlia fallback when calendar label details are disabled
- add regression coverage for overlapping events and empty calendar states

## Why

The menu bar selection logic did not consider whether the user had accepted an overlapping event. It also fell back to the app name when there was no displayable event, which did not communicate the calendar state.

## Validation

- `swift test --enable-swift-testing --disable-xctest --filter MenuBarCalendarAgendaTests` — 11 tests passed
- `swift build`
- SwiftFormat lint for the changed production Swift files
- `plutil -lint` for the English and Japanese localization files
