### PR TITLE
録音パネルに音量インジケーターを追加

### DIFF
--- a/Sources/Dahlia/Audio/AudioFrameRouter.swift
+++ b/Sources/Dahlia/Audio/AudioFrameRouter.swift
@@ -11,11 +11,13 @@ final class AudioFrameRouter: Sendable {
     private struct Consumers {
         let batch: BatchConsumer?
         let liveWorker: LiveAudioFrameWorker?
+        let meteringWorker: AudioLevelMeteringWorker?
     }
 
     private struct State {
         var batchConsumer: BatchConsumer?
         var liveWorker: LiveAudioFrameWorker?
+        var meteringWorker: AudioLevelMeteringWorker?
         var liveFailureHandler: LiveFailureHandler?
         var liveGeneration: UInt64 = 0
         var inFlightRouteCount = 0
@@ -28,6 +30,15 @@ final class AudioFrameRouter: Sendable {
 
     func setBatchConsumer(_ consumer: BatchConsumer?) {
         state.withLock { $0.batchConsumer = consumer }
+    }
+
+    func setMeteringWorker(_ worker: AudioLevelMeteringWorker?) {
+        let previousWorker = state.withLock { state in
+            let previousWorker = state.meteringWorker
+            state.meteringWorker = worker
+            return previousWorker
+        }
+        previousWorker?.cancel()
     }
 
     func setLiveConsumer(
@@ -58,12 +69,18 @@ final class AudioFrameRouter: Sendable {
     }
 
     func removeAllConsumers() {
-        let workersToFinish = state.withLock { state -> [LiveAudioFrameWorker] in
+        let result = state.withLock { state -> (
+            liveWorkers: [LiveAudioFrameWorker],
+            meteringWorker: AudioLevelMeteringWorker?
+        ) in
             state.batchConsumer = nil
             state.liveGeneration &+= 1
-            return retireCurrentLiveWorker(state: &state)
+            let meteringWorker = state.meteringWorker
+            state.meteringWorker = nil
+            return (retireCurrentLiveWorker(state: &state), meteringWorker)
         }
-        workersToFinish.forEach { $0.finish() }
+        result.meteringWorker?.cancel()
+        result.liveWorkers.forEach { $0.finish() }
     }
 
     func removeLiveConsumerAndWait() async {
@@ -94,14 +111,21 @@ final class AudioFrameRouter: Sendable {
 
     func route(_ chunk: CapturedAudioChunk) {
         guard let consumers: Consumers = state.withLock({ state in
-            guard state.batchConsumer != nil || state.liveWorker != nil else { return nil }
+            guard state.batchConsumer != nil ||
+                state.liveWorker != nil ||
+                state.meteringWorker != nil else { return nil }
             state.inFlightRouteCount += 1
-            return Consumers(batch: state.batchConsumer, liveWorker: state.liveWorker)
+            return Consumers(
+                batch: state.batchConsumer,
+                liveWorker: state.liveWorker,
+                meteringWorker: state.meteringWorker
+            )
         }) else { return }
         defer { finishRoute() }
 
         consumers.batch?(chunk)
         consumers.liveWorker?.enqueue(chunk)
+        consumers.meteringWorker?.enqueue(chunk)
     }
 
     private func liveWorkerFailed(generation: UInt64) {

--- a/Sources/Dahlia/Audio/AudioLevelMeteringWorker.swift
+++ b/Sources/Dahlia/Audio/AudioLevelMeteringWorker.swift
@@ -1,0 +1,61 @@
+import CoreMedia
+import Foundation
+import os
+
+/// 録音クリティカル経路から分離して、表示用の最新音量だけを低頻度で計算する。
+final class AudioLevelMeteringWorker: Sendable {
+    typealias Handler = @Sendable (_ source: RecordingAudioSource, _ level: Double) async -> Void
+
+    private let continuation: AsyncStream<CapturedAudioChunk>.Continuation
+    private let workerTask: Task<Void, Never>
+    private let isAcceptingFrames = OSAllocatedUnfairLock(initialState: true)
+
+    init(
+        source: RecordingAudioSource,
+        updateInterval: TimeInterval = 0.1,
+        handler: @escaping Handler
+    ) {
+        let pair = AsyncStream.makeStream(
+            of: CapturedAudioChunk.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        continuation = pair.continuation
+        workerTask = Task.detached(priority: .utility) {
+            var lastUpdateTime: TimeInterval?
+            for await chunk in pair.stream {
+                guard !Task.isCancelled else { return }
+                let chunkTime = chunk.sessionRelativeStartTime.seconds
+                if let lastUpdateTime,
+                   chunkTime - lastUpdateTime < updateInterval {
+                    continue
+                }
+
+                let level = AudioLevelCalculator.normalizedLevel(in: chunk.buffer)
+                guard !Task.isCancelled else { return }
+                lastUpdateTime = chunkTime
+                await handler(source, level)
+            }
+        }
+    }
+
+    func enqueue(_ chunk: CapturedAudioChunk) {
+        guard isAcceptingFrames.withLock({ $0 }) else { return }
+        continuation.yield(chunk)
+    }
+
+    /// 表示用projectionなので停止drainを待たず、保留中の更新を破棄する。
+    func cancel() {
+        let shouldCancel = isAcceptingFrames.withLock { isAcceptingFrames in
+            guard isAcceptingFrames else { return false }
+            isAcceptingFrames = false
+            return true
+        }
+        guard shouldCancel else { return }
+        continuation.finish()
+        workerTask.cancel()
+    }
+
+    func waitUntilFinished() async {
+        await workerTask.value
+    }
+}

--- a/Sources/Dahlia/Models/RecordingAudioLevelStore.swift
+++ b/Sources/Dahlia/Models/RecordingAudioLevelStore.swift
@@ -1,0 +1,26 @@
+import Combine
+
+@MainActor
+final class RecordingAudioLevelStore: ObservableObject {
+    @Published private(set) var levels: [RecordingAudioSource: Double] = [:]
+
+    func level(for source: RecordingAudioSource) -> Double {
+        levels[source] ?? 0
+    }
+
+    func update(source: RecordingAudioSource, level: Double) {
+        levels[source] = min(1, max(0, level))
+    }
+
+    func reset(source: RecordingAudioSource) {
+        levels[source] = nil
+    }
+
+    func retain(sources: Set<RecordingAudioSource>) {
+        levels = levels.filter { sources.contains($0.key) }
+    }
+
+    func reset() {
+        levels.removeAll()
+    }
+}

--- a/Sources/Dahlia/Services/RecordingSessionController+Runtime.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController+Runtime.swift
@@ -1,6 +1,61 @@
 import Foundation
+import os
 
 extension RecordingSessionController {
+    func attachAudioLevelMeter(
+        to pipeline: AudioSourcePipeline,
+        runtimeID: UUID,
+        sessionId: UUID
+    ) {
+        let source = pipeline.source
+        audioLevelDeliveryGates[source]?.supersede()
+        let deliveryGate = RecordingAudioLevelDeliveryGate()
+        audioLevelDeliveryGates[source] = deliveryGate
+        let worker = AudioLevelMeteringWorker(source: source) { [weak self] source, level in
+            await self?.handleAudioLevel(
+                source: source,
+                level: level,
+                runtimeID: runtimeID,
+                sessionId: sessionId,
+                deliveryGate: deliveryGate
+            )
+        }
+        pipeline.router.setMeteringWorker(worker)
+    }
+
+    private func handleAudioLevel(
+        source: RecordingAudioSource,
+        level: Double,
+        runtimeID: UUID,
+        sessionId: UUID,
+        deliveryGate: RecordingAudioLevelDeliveryGate
+    ) async {
+        guard state.belongs(to: sessionId),
+              sourceRuntimeGenerations[source] == runtimeID,
+              sourceRuntimes[source]?.id == runtimeID,
+              audioLevelDeliveryGates[source] === deliveryGate,
+              let onAudioLevel else { return }
+        await deliveryGate.deliver(source: source, level: level, handler: onAudioLevel)
+    }
+
+    func invalidateAudioLevelDelivery(for source: RecordingAudioSource) {
+        audioLevelDeliveryGates[source]?.invalidate()
+    }
+
+    func invalidateAllAudioLevelDeliveries() {
+        audioLevelDeliveryGates.values.forEach { $0.invalidate() }
+        audioLevelDeliveryGates.removeAll()
+    }
+
+    func resetAudioLevelProjection(for source: RecordingAudioSource) {
+        guard let deliveryGate = audioLevelDeliveryGates[source],
+              let onAudioLevel else { return }
+        deliveryGate.invalidate()
+        Task { @MainActor in
+            deliveryGate.deliverReset(source: source, handler: onAudioLevel)
+        }
+    }
+
     func startRecognition(
         _ recognition: any ProgressiveRecognitionSession,
         source: RecordingAudioSource,
@@ -165,6 +220,7 @@ extension RecordingSessionController {
               sourceRuntimeGenerations[source] == runtimeID,
               sourceRuntimes[source]?.id == runtimeID else { return }
 
+        resetAudioLevelProjection(for: source)
         await stopSource(source, expectedRuntimeID: runtimeID, finalMode: snapshot.plan.finalMode)
         guard sourceRuntimeGenerations[source] == runtimeID,
               sourceRuntimes[source] == nil else { return }
@@ -185,6 +241,7 @@ extension RecordingSessionController {
     ) async {
         guard let runtime = sourceRuntimes[source],
               expectedRuntimeID == nil || runtime.id == expectedRuntimeID else { return }
+        invalidateAudioLevelDelivery(for: source)
         sourceRuntimes[source] = nil
         try? await runtime.capture.stop()
         runtime.pipeline.router.removeAllConsumers()
@@ -200,6 +257,7 @@ extension RecordingSessionController {
         cancelRecognition: Bool,
         deleteBatchRecording: Bool
     ) async {
+        invalidateAllAudioLevelDeliveries()
         for source in Self.sortedSources(sourceRuntimes.keys) {
             try? await sourceRuntimes[source]?.capture.stop()
         }
@@ -322,6 +380,7 @@ extension RecordingSessionController {
               snapshot.sessionId == sessionId else {
             throw RecordingSessionControllerError.sessionNotActive
         }
+        invalidateAudioLevelDelivery(for: source)
         let runtimeID = UUID.v7()
         sourceRuntimeGenerations[source] = runtimeID
         return runtimeID
@@ -373,6 +432,46 @@ extension RecordingSessionController {
         if let failureMessage = pending.failureMessage {
             throw RecordingSessionControllerError.recognitionFailed(failureMessage)
         }
+    }
+}
+
+final class RecordingAudioLevelDeliveryGate: Sendable {
+    private enum State: Equatable {
+        case active
+        case invalidated
+        case superseded
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State.active)
+
+    func invalidate() {
+        state.withLock { state in
+            guard state == .active else { return }
+            state = .invalidated
+        }
+    }
+
+    func supersede() {
+        state.withLock { $0 = .superseded }
+    }
+
+    @MainActor
+    func deliver(
+        source: RecordingAudioSource,
+        level: Double,
+        handler: RecordingSessionController.AudioLevelHandler
+    ) {
+        guard state.withLock({ $0 == .active }) else { return }
+        handler(source, level)
+    }
+
+    @MainActor
+    func deliverReset(
+        source: RecordingAudioSource,
+        handler: RecordingSessionController.AudioLevelHandler
+    ) {
+        guard state.withLock({ $0 == .invalidated }) else { return }
+        handler(source, 0)
     }
 }
 

--- a/Sources/Dahlia/Services/RecordingSessionController+SourceReconfiguration.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController+SourceReconfiguration.swift
@@ -151,6 +151,11 @@ extension RecordingSessionController {
                 recognition: attachment.recognition,
                 batchRangeOrigin: batchRangeOrigin
             )
+            attachAudioLevelMeter(
+                to: preparation.pipeline,
+                runtimeID: newRuntimeID,
+                sessionId: snapshot.sessionId
+            )
             try await newCapture.start()
             try requireCurrentSourceRuntime(
                 source: preparation.source,
@@ -364,6 +369,11 @@ extension RecordingSessionController {
                 recognition: attachment.recognition,
                 batchRangeOrigin: batchRangeOrigin
             )
+            attachAudioLevelMeter(
+                to: preparation.pipeline,
+                runtimeID: replacementRuntimeID,
+                sessionId: snapshot.sessionId
+            )
             try await replacementCapture.start()
             try requireCurrentSourceRuntime(
                 source: preparation.source,
@@ -402,6 +412,7 @@ extension RecordingSessionController {
     ) async throws {
         if let runtimeID,
            sourceRuntimes[preparation.source]?.id == runtimeID {
+            invalidateAudioLevelDelivery(for: preparation.source)
             sourceRuntimes[preparation.source] = nil
         } else if sourceRuntimes[preparation.source]?.id == previousRuntime.id {
             if didAttemptPreviousCaptureStop {
@@ -483,6 +494,7 @@ extension RecordingSessionController {
         guard sourceRuntimes[source]?.id == runtime.id else {
             throw RecordingSessionControllerError.sessionNotActive
         }
+        invalidateAudioLevelDelivery(for: source)
         sourceRuntimes[source] = nil
         var currentSnapshot = snapshot
         currentSnapshot.enabledSources = Set(sourceRuntimes.keys)
@@ -639,6 +651,11 @@ extension RecordingSessionController {
         var restoredRuntime = previousRuntime
         restoredRuntime.batchRangeOrigin = batchRangeOrigin
         sourceRuntimes[source] = restoredRuntime
+        attachAudioLevelMeter(
+            to: previousRuntime.pipeline,
+            runtimeID: previousRuntime.id,
+            sessionId: sessionId
+        )
         do {
             try await previousRuntime.capture.start()
             try requireCurrentSourceRuntime(

--- a/Sources/Dahlia/Services/RecordingSessionController+Startup.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController+Startup.swift
@@ -63,6 +63,11 @@ extension RecordingSessionController {
             recognition: recognition,
             batchRangeOrigin: batchRangeOrigin
         )
+        attachAudioLevelMeter(
+            to: pipeline,
+            runtimeID: runtimeID,
+            sessionId: snapshot.sessionId
+        )
         try await capture.start()
         try requireCurrentSourceRuntime(
             source: configuration.source,

--- a/Sources/Dahlia/Services/RecordingSessionController.swift
+++ b/Sources/Dahlia/Services/RecordingSessionController.swift
@@ -12,6 +12,10 @@ actor RecordingSessionController {
         _ message: String,
         _ isFatal: Bool
     ) -> Void
+    typealias AudioLevelHandler = @MainActor @Sendable (
+        _ source: RecordingAudioSource,
+        _ level: Double
+    ) -> Void
 
     struct SourceConfiguration: Equatable {
         let source: RecordingAudioSource
@@ -131,12 +135,14 @@ actor RecordingSessionController {
     private var preparation: Preparation?
     var sourceRuntimes: [RecordingAudioSource: SourceRuntime] = [:]
     var sourceRuntimeGenerations: [RecordingAudioSource: UUID] = [:]
+    var audioLevelDeliveryGates: [RecordingAudioSource: RecordingAudioLevelDeliveryGate] = [:]
     var pendingRecognitionStarts: [UUID: PendingRecognitionStart] = [:]
     var batchRecording: (any BatchRecordingSession)?
     var batchEventTask: Task<Void, Never>?
     private var batchScheduler: (any BatchTranscriptionScheduling)?
     var onEvent: EventHandler?
     var onRuntimeFailure: RuntimeFailureHandler?
+    var onAudioLevel: AudioLevelHandler?
     var currentLocale: Locale?
     var batchRuntimeFailureMessage: String?
 
@@ -154,7 +160,8 @@ actor RecordingSessionController {
     func prepare(
         _ request: PreparationRequest,
         onEvent: @escaping EventHandler,
-        onRuntimeFailure: @escaping RuntimeFailureHandler
+        onRuntimeFailure: @escaping RuntimeFailureHandler,
+        onAudioLevel: @escaping AudioLevelHandler = { _, _ in }
     ) async throws {
         guard case .idle = state else {
             throw RecordingSessionControllerError.sessionAlreadyActive
@@ -243,6 +250,7 @@ actor RecordingSessionController {
             batchScheduler = request.batchScheduler
             self.onEvent = onEvent
             self.onRuntimeFailure = onRuntimeFailure
+            self.onAudioLevel = onAudioLevel
             currentLocale = request.locale
             state = .prepared(snapshot)
             startBatchEventMonitoring()
@@ -295,6 +303,7 @@ actor RecordingSessionController {
             throw RecordingSessionControllerError.sessionNotActive
         }
         state = .stopping(snapshot)
+        invalidateAllAudioLevelDeliveries()
 
         let firstCaptureFailure = await stopCaptures()
         await drainRouters()
@@ -429,6 +438,7 @@ actor RecordingSessionController {
     }
 
     private func resetState() {
+        invalidateAllAudioLevelDeliveries()
         batchEventTask?.cancel()
         batchEventTask = nil
         preparation = nil
@@ -439,6 +449,7 @@ actor RecordingSessionController {
         batchScheduler = nil
         onEvent = nil
         onRuntimeFailure = nil
+        onAudioLevel = nil
         currentLocale = nil
         batchRuntimeFailureMessage = nil
         state = .idle

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -143,6 +143,9 @@ final class CaptionViewModel: ObservableObject {
         didSet { updateCanBeginRecording() }
     }
 
+    @Published private(set) var activeControllerSources: Set<RecordingAudioSource> = []
+    let recordingAudioLevelStore = RecordingAudioLevelStore()
+
     @Published var selectedLocale: String = AppSettings.shared.transcriptionLocale {
         didSet {
             guard selectedLocale != oldValue else { return }
@@ -380,7 +383,7 @@ final class CaptionViewModel: ObservableObject {
                     isEnabled,
                     translateSegment: self.translationHandler(for: locale)
                 )
-                self.activeControllerSources = snapshot.enabledSources
+                self.setActiveControllerSources(snapshot.enabledSources)
             } catch {
                 guard self.activeTranscriptionPlan?.liveChatEnabled == isEnabled else { return }
                 self.errorMessage = error.localizedDescription
@@ -462,6 +465,10 @@ final class CaptionViewModel: ObservableObject {
         recordingContext?.store ?? store
     }
 
+    func isRecordingAudioSourceActive(_ source: RecordingAudioSource) -> Bool {
+        activeControllerSources.contains(source)
+    }
+
     // MARK: - Private
 
     private var currentDbQueue: DatabaseQueue?
@@ -477,7 +484,6 @@ final class CaptionViewModel: ObservableObject {
     private let recordingSessionController = RecordingSessionController()
     private var activeTranscriptionPlan: TranscriptionSessionPlan?
     private var activeRecordingSessionId: UUID?
-    private var activeControllerSources: Set<RecordingAudioSource> = []
     private var recordingLifecycle: RecordingLifecycle = .idle {
         didSet { updateCanBeginRecording() }
     }
@@ -1833,6 +1839,7 @@ final class CaptionViewModel: ObservableObject {
         recordingSessionId: UUID
     ) async -> Bool {
         guard recordingLifecycle == .recording(recordingSessionId) else { return false }
+        resetAudioLevels(for: reason)
         do {
             let snapshot: RecordingSessionController.Snapshot
             switch reason {
@@ -1851,7 +1858,8 @@ final class CaptionViewModel: ObservableObject {
                 )
             }
             guard snapshot.sessionId == recordingSessionId else { return false }
-            activeControllerSources = snapshot.enabledSources
+            resetAudioLevels(for: reason)
+            setActiveControllerSources(snapshot.enabledSources)
             errorMessage = nil
             return true
         } catch {
@@ -1859,7 +1867,8 @@ final class CaptionViewModel: ObservableObject {
                   recordingLifecycle == .recording(recordingSessionId) else { return false }
             if let snapshot = await recordingSessionController.snapshot(),
                snapshot.sessionId == recordingSessionId {
-                activeControllerSources = snapshot.enabledSources
+                resetAudioLevels(for: reason)
+                setActiveControllerSources(snapshot.enabledSources)
             }
             setPipelineRebuildError(error, reason: reason)
             return false
@@ -1893,6 +1902,17 @@ final class CaptionViewModel: ObservableObject {
             errorMessage = L10n.languageChangeFailed(error.localizedDescription)
         case .audioSourceChange:
             errorMessage = error.localizedDescription
+        }
+    }
+
+    private func resetAudioLevels(for reason: PipelineRebuildReason) {
+        switch reason {
+        case .localeChange:
+            for source in activeControllerSources {
+                recordingAudioLevelStore.reset(source: source)
+            }
+        case let .audioSourceChange(source):
+            recordingAudioLevelStore.reset(source: source)
         }
     }
 
@@ -1945,9 +1965,15 @@ final class CaptionViewModel: ObservableObject {
                 isFatal: isFatal,
                 recordingSessionId: request.sessionId
             )
+        } onAudioLevel: { [weak self] source, level in
+            self?.handleControllerAudioLevel(
+                source: source,
+                level: level,
+                recordingSessionId: request.sessionId
+            )
         }
         let snapshot = try await recordingSessionController.startPrepared()
-        activeControllerSources = snapshot.enabledSources
+        setActiveControllerSources(snapshot.enabledSources)
         if request.plan.recordsBatchAudio {
             batchTranscriptionState = .recording(sessionId: request.sessionId)
         }
@@ -2115,7 +2141,7 @@ final class CaptionViewModel: ObservableObject {
         activeTranscriptionMode = nil
         activeTranscriptionPlan = nil
         activeRecordingSessionId = nil
-        activeControllerSources.removeAll()
+        setActiveControllerSources([])
         pendingRealtimeRecognitionFailure = nil
         pendingLiveSubtitleWarning = nil
         startingMicrophoneSelection = nil
@@ -2214,6 +2240,7 @@ final class CaptionViewModel: ObservableObject {
         activeTranscriptionMode = transcriptionMode
         activeTranscriptionPlan = transcriptionPlan
         activeRecordingSessionId = recordingSessionId
+        setActiveControllerSources([])
         if transcriptionPlan.liveSubtitlesEnabled {
             liveCaptionStore.start(sessionId: recordingSessionId)
         } else {
@@ -2300,6 +2327,7 @@ final class CaptionViewModel: ObservableObject {
               !isFinalizingRecording else { return }
 
         recordingLifecycle = .stopping(activeSessionId)
+        recordingAudioLevelStore.reset()
         finalizingMeetingId = recordingMeetingId
         isFinalizingRecording = true
         let automaticScreenshotStopTask = stopAutomaticScreenshotCapture()
@@ -2384,7 +2412,7 @@ final class CaptionViewModel: ObservableObject {
         activeTranscriptionMode = nil
         activeTranscriptionPlan = nil
         activeRecordingSessionId = nil
-        activeControllerSources.removeAll()
+        setActiveControllerSources([])
         pendingRealtimeRecognitionFailure = nil
         pendingLiveSubtitleWarning = nil
         startingMicrophoneSelection = nil
@@ -3612,12 +3640,28 @@ final class CaptionViewModel: ObservableObject {
                   self.activeRecordingSessionId == recordingSessionId else { return }
             if let snapshot = await self.recordingSessionController.snapshot(),
                snapshot.sessionId == recordingSessionId {
-                self.activeControllerSources = snapshot.enabledSources
+                self.setActiveControllerSources(snapshot.enabledSources)
             }
             if isFatal {
                 self.stopListening()
             }
         }
+    }
+
+    private func handleControllerAudioLevel(
+        source: RecordingAudioSource,
+        level: Double,
+        recordingSessionId: UUID
+    ) {
+        guard activeRecordingSessionId == recordingSessionId,
+              recordingLifecycle == .starting(recordingSessionId) ||
+              recordingLifecycle == .recording(recordingSessionId) else { return }
+        recordingAudioLevelStore.update(source: source, level: level)
+    }
+
+    private func setActiveControllerSources(_ sources: Set<RecordingAudioSource>) {
+        activeControllerSources = sources
+        recordingAudioLevelStore.retain(sources: sources)
     }
 
     private func handleLiveSubtitleSettingChange(isEnabled: Bool) {
@@ -3663,7 +3707,7 @@ final class CaptionViewModel: ObservableObject {
                     isEnabled,
                     translateSegment: self.translationHandler(for: locale)
                 )
-                self.activeControllerSources = snapshot.enabledSources
+                self.setActiveControllerSources(snapshot.enabledSources)
             } catch {
                 self.errorMessage = error.localizedDescription
                 self.restoreLiveSubtitleSetting(
@@ -3727,7 +3771,7 @@ final class CaptionViewModel: ObservableObject {
                     latestPlan.liveSubtitlesEnabled,
                     translateSegment: translationHandler(for: locale)
                 )
-                activeControllerSources = snapshot.enabledSources
+                setActiveControllerSources(snapshot.enabledSources)
                 appliedPlan = snapshot.plan
             }
             if appliedPlan.liveChatEnabled != latestPlan.liveChatEnabled {
@@ -3736,7 +3780,7 @@ final class CaptionViewModel: ObservableObject {
                     latestPlan.liveChatEnabled,
                     translateSegment: translationHandler(for: locale)
                 )
-                activeControllerSources = snapshot.enabledSources
+                setActiveControllerSources(snapshot.enabledSources)
                 appliedPlan = snapshot.plan
             }
             guard activeTranscriptionPlan?.liveSubtitlesEnabled == latestPlan.liveSubtitlesEnabled,

--- a/Sources/Dahlia/Views/MeetingListSidebarView.swift
+++ b/Sources/Dahlia/Views/MeetingListSidebarView.swift
@@ -355,6 +355,9 @@ private struct RecordingStatusBar: View {
             title: L10n.mic,
             displayValue: selectedMicrophoneDisplayName,
             systemImage: "mic.fill",
+            audioLevelStore: viewModel.recordingAudioLevelStore,
+            inputSource: .microphone,
+            isInputActive: viewModel.isRecordingAudioSourceActive(.microphone),
             selection: $viewModel.microphoneSelection,
             items: microphoneMenuItems
         ) { oldValue, newValue in
@@ -388,6 +391,9 @@ private struct RecordingStatusBar: View {
             title: L10n.system,
             displayValue: viewModel.isSystemAudioEnabled ? L10n.record : L10n.none,
             systemImage: "speaker.wave.2.fill",
+            audioLevelStore: viewModel.recordingAudioLevelStore,
+            inputSource: .system,
+            isInputActive: viewModel.isRecordingAudioSourceActive(.system),
             selection: $viewModel.isSystemAudioEnabled,
             items: [
                 .option(title: L10n.noComputerAudio, value: false),
@@ -523,6 +529,9 @@ private struct RecordingSourceMenu<Value: Hashable>: View {
     let title: String
     let displayValue: String
     let systemImage: String
+    var audioLevelStore: RecordingAudioLevelStore?
+    var inputSource: RecordingAudioSource?
+    var isInputActive = false
     @Binding var selection: Value
     let items: [RecordingSourceMenuItem<Value>]
     var onSelectionChange: (Value, Value) -> Void = { _, _ in }
@@ -531,7 +540,10 @@ private struct RecordingSourceMenu<Value: Hashable>: View {
         RecordingSourceControlLabel(
             title: title,
             value: displayValue,
-            systemImage: systemImage
+            systemImage: systemImage,
+            audioLevelStore: audioLevelStore,
+            inputSource: inputSource,
+            isInputActive: isInputActive
         )
         .overlay {
             RecordingSourcePopupButton(
@@ -623,6 +635,9 @@ private struct RecordingSourceControlLabel: View {
     let title: String
     let value: String
     let systemImage: String
+    let audioLevelStore: RecordingAudioLevelStore?
+    let inputSource: RecordingAudioSource?
+    let isInputActive: Bool
 
     var body: some View {
         HStack(spacing: 6) {
@@ -644,6 +659,14 @@ private struct RecordingSourceControlLabel: View {
                 .truncationMode(.middle)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
+            if let audioLevelStore, let inputSource {
+                RecordingInputLevelMeter(
+                    store: audioLevelStore,
+                    source: inputSource,
+                    isActive: isInputActive
+                )
+            }
+
             Image(systemName: "chevron.down")
                 .font(.caption2.weight(.semibold))
                 .foregroundStyle(.tertiary)
@@ -656,6 +679,38 @@ private struct RecordingSourceControlLabel: View {
                 .fill(Color.primary.opacity(0.06))
         )
         .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct RecordingInputLevelMeter: View {
+    private static let segmentHeights: [CGFloat] = [4, 6, 8, 10, 12]
+
+    @ObservedObject var store: RecordingAudioLevelStore
+    let source: RecordingAudioSource
+    let isActive: Bool
+
+    private var level: Double {
+        store.level(for: source)
+    }
+
+    private var activeSegmentCount: Int {
+        guard isActive, level > 0 else { return 0 }
+        return min(Self.segmentHeights.count, max(1, Int(ceil(level * Double(Self.segmentHeights.count)))))
+    }
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 2) {
+            ForEach(Array(Self.segmentHeights.enumerated()), id: \.offset) { index, height in
+                Capsule()
+                    .fill(index < activeSegmentCount ? Color.green : Color.secondary.opacity(0.2))
+                    .frame(width: 3, height: height)
+            }
+        }
+        .frame(width: 23, height: 12, alignment: .bottom)
+        .opacity(isActive ? 1 : 0.45)
+        .animation(.linear(duration: 0.12), value: activeSegmentCount)
+        .accessibilityLabel(L10n.inputLevel)
+        .accessibilityValue(Text(level, format: .percent.precision(.fractionLength(0))))
     }
 }
 

--- a/Tests/DahliaTests/AudioFrameRouterTests.swift
+++ b/Tests/DahliaTests/AudioFrameRouterTests.swift
@@ -8,6 +8,38 @@ import os
 
     struct AudioFrameRouterTests {
         @Test
+        func routesToMeteringWithoutRecordingOrRecognitionConsumers() async throws {
+            let format = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: 48000,
+                channels: 1,
+                interleaved: false
+            ))
+            let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 32))
+            buffer.frameLength = 32
+            let samples = try #require(buffer.floatChannelData?[0])
+            for frame in 0 ..< Int(buffer.frameLength) {
+                samples[frame] = 0.1
+            }
+            let events = AsyncStream.makeStream(of: Double.self, bufferingPolicy: .bufferingNewest(1))
+            let worker = AudioLevelMeteringWorker(source: .system) { _, level in
+                events.continuation.yield(level)
+            }
+            let router = AudioFrameRouter()
+            let pipeline = AudioSourcePipeline(source: .system, router: router, captureFormat: format)
+            router.setMeteringWorker(worker)
+            var iterator = events.stream.makeAsyncIterator()
+
+            router.route(pipeline.capture(buffer))
+
+            #expect(try #require(await iterator.next()) > 0)
+            router.removeAllConsumers()
+            await router.waitUntilIdle()
+            await worker.waitUntilFinished()
+            events.continuation.finish()
+        }
+
+        @Test
         func routesOneCapturedBufferToBatchAndLiveConsumers() async throws {
             let format = try #require(AVAudioFormat(
                 commonFormat: .pcmFormatInt16,

--- a/Tests/DahliaTests/AudioLevelMeteringWorkerTests.swift
+++ b/Tests/DahliaTests/AudioLevelMeteringWorkerTests.swift
@@ -1,0 +1,109 @@
+#if canImport(Testing)
+    @preconcurrency import AVFoundation
+    import CoreMedia
+    import Testing
+    @testable import Dahlia
+
+    struct AudioLevelMeteringWorkerTests {
+        @Test
+        func reportsSourceLevelAndCoalescesRapidFrames() async throws {
+            let events = AsyncStream.makeStream(
+                of: (RecordingAudioSource, Double).self,
+                bufferingPolicy: .unbounded
+            )
+            let worker = AudioLevelMeteringWorker(source: .microphone) { source, level in
+                events.continuation.yield((source, level))
+            }
+            var iterator = events.stream.makeAsyncIterator()
+
+            try worker.enqueue(makeChunk(sample: 0.1, time: 0))
+            let first = try #require(await iterator.next())
+            #expect(first.0 == .microphone)
+            #expect(first.1 > 0)
+
+            try worker.enqueue(makeChunk(sample: 0.2, time: 0.02))
+            try worker.enqueue(makeChunk(sample: 0.4, time: 0.1))
+            let second = try #require(await iterator.next())
+            #expect(second.1 > first.1)
+
+            worker.cancel()
+            await worker.waitUntilFinished()
+            events.continuation.finish()
+        }
+
+        @Test
+        func silenceReportsZero() async throws {
+            let events = AsyncStream.makeStream(of: Double.self, bufferingPolicy: .bufferingNewest(1))
+            let worker = AudioLevelMeteringWorker(source: .system) { _, level in
+                events.continuation.yield(level)
+            }
+            var iterator = events.stream.makeAsyncIterator()
+
+            try worker.enqueue(makeChunk(sample: 0, time: 0))
+
+            #expect(try #require(await iterator.next()) == 0)
+            worker.cancel()
+            await worker.waitUntilFinished()
+            events.continuation.finish()
+        }
+
+        @Test
+        func slowHandlerRetainsOnlyLatestPendingFrame() async throws {
+            let events = AsyncStream.makeStream(of: Double.self, bufferingPolicy: .unbounded)
+            let gate = MeteringHandlerGate()
+            let worker = AudioLevelMeteringWorker(source: .microphone) { _, level in
+                events.continuation.yield(level)
+                await gate.waitIfBlocked()
+            }
+            var iterator = events.stream.makeAsyncIterator()
+
+            try worker.enqueue(makeChunk(sample: 0.1, time: 0))
+            _ = try #require(await iterator.next())
+            try worker.enqueue(makeChunk(sample: 0.2, time: 0.1))
+            try worker.enqueue(makeChunk(sample: 0.3, time: 0.2))
+            try worker.enqueue(makeChunk(sample: 0.4, time: 0.3))
+            await gate.release()
+
+            let latestLevel = try #require(await iterator.next())
+            #expect(try latestLevel == AudioLevelCalculator.normalizedLevel(
+                in: makeChunk(sample: 0.4, time: 0).buffer
+            ))
+            worker.cancel()
+            await worker.waitUntilFinished()
+            events.continuation.finish()
+        }
+
+        private func makeChunk(sample: Float, time: TimeInterval) throws -> CapturedAudioChunk {
+            let format = try #require(AVAudioFormat(standardFormatWithSampleRate: 48000, channels: 1))
+            let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 128))
+            buffer.frameLength = 128
+            let samples = try #require(buffer.floatChannelData?[0])
+            for frame in 0 ..< Int(buffer.frameLength) {
+                samples[frame] = sample
+            }
+            return CapturedAudioChunk(
+                source: .microphone,
+                buffer: buffer,
+                sessionRelativeStartTime: CMTime(seconds: time, preferredTimescale: 48000)
+            )
+        }
+    }
+
+    private actor MeteringHandlerGate {
+        private var isBlocked = true
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func waitIfBlocked() async {
+            guard isBlocked else { return }
+            await withCheckedContinuation { continuation in
+                waiters.append(continuation)
+            }
+        }
+
+        func release() {
+            isBlocked = false
+            waiters.forEach { $0.resume() }
+            waiters.removeAll()
+        }
+    }
+#endif

--- a/Tests/DahliaTests/RecordingAudioLevelStoreTests.swift
+++ b/Tests/DahliaTests/RecordingAudioLevelStoreTests.swift
@@ -1,0 +1,38 @@
+#if canImport(Testing)
+    import Testing
+    @testable import Dahlia
+
+    @MainActor
+    struct RecordingAudioLevelStoreTests {
+        @Test
+        func clampsLevelsAndRemovesInactiveSources() {
+            let store = RecordingAudioLevelStore()
+            store.update(source: .microphone, level: 2)
+            store.update(source: .system, level: -1)
+
+            #expect(store.level(for: .microphone) == 1)
+            #expect(store.level(for: .system) == 0)
+
+            store.retain(sources: [.system])
+
+            #expect(store.level(for: .microphone) == 0)
+            #expect(store.level(for: .system) == 0)
+        }
+
+        @Test
+        func resetClearsEverySource() {
+            let store = RecordingAudioLevelStore()
+            store.update(source: .microphone, level: 0.5)
+            store.update(source: .system, level: 0.25)
+
+            store.reset(source: .microphone)
+
+            #expect(store.level(for: .microphone) == 0)
+            #expect(store.level(for: .system) == 0.25)
+            store.reset()
+
+            #expect(store.level(for: .microphone) == 0)
+            #expect(store.level(for: .system) == 0)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/RecordingSessionAudioLevelTests.swift
+++ b/Tests/DahliaTests/RecordingSessionAudioLevelTests.swift
@@ -1,0 +1,331 @@
+#if canImport(Testing)
+    @preconcurrency import AVFoundation
+    import CoreMedia
+    import Dispatch
+    import GRDB
+    import os
+    import Testing
+    @testable import Dahlia
+
+    struct RecordingSessionAudioLevelTests {
+        @Test
+        func invalidatedGateDropsDeliveryQueuedBehindMainActor() async throws {
+            let deliveryGate = RecordingAudioLevelDeliveryGate()
+            let levelRecorder = MeteringLevelRecorder()
+            let mainActorEntered = DispatchSemaphore(value: 0)
+            let releaseMainActor = DispatchSemaphore(value: 0)
+            let blocker = Task { @MainActor in
+                blockMainActor(entered: mainActorEntered, release: releaseMainActor)
+            }
+            try await wait(for: mainActorEntered)
+            let delivery = Task {
+                await deliveryGate.deliver(source: .microphone, level: 1) { source, level in
+                    levelRecorder.append(source: source, level: level)
+                }
+            }
+
+            deliveryGate.invalidate()
+            releaseMainActor.signal()
+            await blocker.value
+            await delivery.value
+
+            #expect(await levelRecorder.entries.isEmpty)
+        }
+
+        @Test
+        func replacementPublishesCurrentPipelineLevelAndRejectsRetiredPipeline() async throws {
+            let pipelineStore = MeteringPipelineStore()
+            let levelRecorder = MeteringLevelRecorder()
+            let controller = RecordingSessionController(
+                captureFactory: MeteringCaptureFactory(pipelineStore: pipelineStore),
+                recognitionFactory: MeteringRecognitionFactory(),
+                batchRecordingFactory: UnusedMeteringBatchFactory()
+            )
+            let sessionID = UUID.v7()
+            try await controller.prepare(
+                .init(
+                    sessionId: sessionID,
+                    startedAt: .now,
+                    plan: .init(finalMode: .realtime, liveSubtitlesEnabled: false, retainBatchAudio: false),
+                    locale: Locale(identifier: "ja_JP"),
+                    sources: [.init(source: .microphone)]
+                ),
+                onEvent: { _ in },
+                onRuntimeFailure: { _, _, _ in },
+                onAudioLevel: { source, level in
+                    levelRecorder.append(source: source, level: level)
+                }
+            )
+            _ = try await controller.startPrepared()
+            let retiredPipeline = try #require(pipelineStore.pipelines(for: .microphone).first)
+            let retiredDeliveryGate = try #require(await controller.audioLevelDeliveryGates[.microphone])
+            try retiredPipeline.router.route(makeChunk(sample: 0.1, time: 0))
+            try await levelRecorder.waitUntilCount(1)
+
+            _ = try await controller.setSource(
+                .init(source: .microphone, forcesEchoCancellationForExternalMicrophone: true),
+                enabled: true,
+                translateSegment: nil
+            )
+            let currentPipeline = try #require(pipelineStore.pipelines(for: .microphone).last)
+            #expect(currentPipeline !== retiredPipeline)
+
+            await retiredDeliveryGate.deliver(source: .microphone, level: 1) { source, level in
+                levelRecorder.append(source: source, level: level)
+            }
+            try retiredPipeline.router.route(makeChunk(sample: 0.9, time: 1))
+            try currentPipeline.router.route(makeChunk(sample: 0.3, time: 0))
+            try await levelRecorder.waitUntilCount(2)
+            let entries = await levelRecorder.entries
+
+            #expect(entries.count == 2)
+            #expect(entries.allSatisfy { $0.source == .microphone })
+            #expect(try entries[1].level < AudioLevelCalculator.normalizedLevel(
+                in: makeChunk(sample: 0.9, time: 0).buffer
+            ))
+
+            _ = try await controller.stop()
+            await controller.completeStop()
+        }
+
+        @Test
+        func unexpectedCaptureStopResetsLevelBeforeRecognitionFinishes() async throws {
+            let pipelineStore = MeteringPipelineStore()
+            let levelRecorder = MeteringLevelRecorder()
+            let recognitionFinishGate = MeteringRecognitionFinishGate()
+            let controller = RecordingSessionController(
+                captureFactory: MeteringCaptureFactory(pipelineStore: pipelineStore),
+                recognitionFactory: MeteringRecognitionFactory(finishGate: recognitionFinishGate),
+                batchRecordingFactory: UnusedMeteringBatchFactory()
+            )
+            let sessionID = UUID.v7()
+            try await controller.prepare(
+                .init(
+                    sessionId: sessionID,
+                    startedAt: .now,
+                    plan: .init(finalMode: .realtime, liveSubtitlesEnabled: false, retainBatchAudio: false),
+                    locale: Locale(identifier: "ja_JP"),
+                    sources: [.init(source: .microphone)]
+                ),
+                onEvent: { _ in },
+                onRuntimeFailure: { _, _, _ in },
+                onAudioLevel: { source, level in
+                    levelRecorder.append(source: source, level: level)
+                }
+            )
+            _ = try await controller.startPrepared()
+            let pipeline = try #require(pipelineStore.pipelines(for: .microphone).first)
+            let runtimeID = try #require(await controller.sourceRuntimes[.microphone]?.id)
+            try pipeline.router.route(makeChunk(sample: 0.3, time: 0))
+            try await levelRecorder.waitUntilCount(1)
+
+            let unexpectedStop = Task {
+                await controller.handleUnexpectedCaptureStop(
+                    source: .microphone,
+                    runtimeID: runtimeID,
+                    sessionId: sessionID,
+                    message: "capture stopped"
+                )
+            }
+            try await recognitionFinishGate.waitUntilWaiting()
+            try await levelRecorder.waitUntilCount(2)
+            let entriesBeforeRecognitionFinished = await levelRecorder.entries
+
+            #expect(entriesBeforeRecognitionFinished.last?.level == 0)
+            await recognitionFinishGate.release()
+            await unexpectedStop.value
+            await controller.abort()
+        }
+
+        private func wait(
+            for semaphore: DispatchSemaphore,
+            timeout: DispatchTimeInterval = .seconds(5)
+        ) async throws {
+            try await withCheckedThrowingContinuation { continuation in
+                DispatchQueue.global().async {
+                    if semaphore.wait(timeout: .now() + timeout) == .success {
+                        continuation.resume()
+                    } else {
+                        continuation.resume(throwing: MeteringTestError.timedOutWaitingForMainActor)
+                    }
+                }
+            }
+        }
+
+        @MainActor
+        private func blockMainActor(
+            entered: DispatchSemaphore,
+            release: DispatchSemaphore
+        ) {
+            entered.signal()
+            release.wait()
+        }
+
+        private func makeChunk(sample: Float, time: TimeInterval) throws -> CapturedAudioChunk {
+            let format = try #require(AVAudioFormat(standardFormatWithSampleRate: 16000, channels: 1))
+            let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 128))
+            buffer.frameLength = 128
+            let samples = try #require(buffer.floatChannelData?[0])
+            for frame in 0 ..< Int(buffer.frameLength) {
+                samples[frame] = sample
+            }
+            return CapturedAudioChunk(
+                source: .microphone,
+                buffer: buffer,
+                sessionRelativeStartTime: CMTime(seconds: time, preferredTimescale: 16000)
+            )
+        }
+    }
+
+    @MainActor
+    private final class MeteringLevelRecorder {
+        struct Entry {
+            let source: RecordingAudioSource
+            let level: Double
+        }
+
+        private(set) var entries: [Entry] = []
+
+        func append(source: RecordingAudioSource, level: Double) {
+            entries.append(.init(source: source, level: level))
+        }
+
+        func waitUntilCount(_ count: Int, timeout: Duration = .seconds(5)) async throws {
+            let deadline = ContinuousClock.now + timeout
+            while entries.count < count {
+                guard ContinuousClock.now < deadline else {
+                    throw MeteringTestError.timedOutWaitingForLevel
+                }
+                await Task.yield()
+            }
+        }
+    }
+
+    private final class MeteringPipelineStore: Sendable {
+        private let storage = OSAllocatedUnfairLock(initialState: [RecordingAudioSource: [AudioSourcePipeline]]())
+
+        func append(_ pipeline: AudioSourcePipeline) {
+            storage.withLock { $0[pipeline.source, default: []].append(pipeline) }
+        }
+
+        func pipelines(for source: RecordingAudioSource) -> [AudioSourcePipeline] {
+            storage.withLock { $0[source] ?? [] }
+        }
+    }
+
+    private struct MeteringCaptureFactory: AudioCaptureSessionFactory {
+        let pipelineStore: MeteringPipelineStore
+
+        func requestPermission(for _: RecordingAudioSource) async throws {}
+
+        func makeSession(
+            for pipeline: AudioSourcePipeline,
+            onWarning _: @escaping AudioCaptureWarningHandler,
+            onUnexpectedStop _: @escaping AudioCaptureUnexpectedStopHandler
+        ) -> any AudioCaptureSession {
+            pipelineStore.append(pipeline)
+            return MeteringCaptureSession()
+        }
+    }
+
+    private actor MeteringCaptureSession: AudioCaptureSession {
+        func start() async throws {}
+        func stop() async throws {}
+    }
+
+    private struct MeteringRecognitionFactory: ProgressiveRecognitionSessionFactory {
+        let finishGate: MeteringRecognitionFinishGate?
+
+        init(finishGate: MeteringRecognitionFinishGate? = nil) {
+            self.finishGate = finishGate
+        }
+
+        func prepareModel(locale _: Locale) async throws {}
+
+        func prepareSession(
+            locale _: Locale,
+            source _: RecordingAudioSource,
+            sourceFormat _: AVAudioFormat?,
+            bufferingMode _: AudioBufferBridge.BufferingMode,
+            translateSegment _: ProgressiveSegmentTranslationHandler?
+        ) async throws -> PreparedProgressiveRecognitionSession {
+            let format = try #require(AVAudioFormat(standardFormatWithSampleRate: 16000, channels: 1))
+            return PreparedProgressiveRecognitionSession(
+                analyzerFormat: format,
+                session: MeteringRecognitionSession(finishGate: finishGate)
+            )
+        }
+    }
+
+    private actor MeteringRecognitionSession: ProgressiveRecognitionSession {
+        nonisolated let pipelineID = UUID.v7()
+        nonisolated let liveConsumer: AudioFrameRouter.LiveConsumer = { _ in true }
+        private let finishGate: MeteringRecognitionFinishGate?
+
+        init(finishGate: MeteringRecognitionFinishGate?) {
+            self.finishGate = finishGate
+        }
+
+        func start(
+            recordingStartTime _: Date,
+            recordingSessionId _: UUID,
+            onEvent _: @escaping ProgressiveTranscriptionEventHandler
+        ) async throws {}
+
+        func finish() async throws {
+            await finishGate?.wait()
+        }
+
+        func cancel() async {}
+    }
+
+    private actor MeteringRecognitionFinishGate {
+        private var isWaiting = false
+        private var isReleased = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func wait() async {
+            isWaiting = true
+            guard !isReleased else { return }
+            await withCheckedContinuation { continuation in
+                waiters.append(continuation)
+            }
+        }
+
+        func waitUntilWaiting(timeout: Duration = .seconds(5)) async throws {
+            let deadline = ContinuousClock.now + timeout
+            while !isWaiting {
+                guard ContinuousClock.now < deadline else {
+                    throw MeteringTestError.timedOutWaitingForRecognitionFinish
+                }
+                await Task.yield()
+            }
+        }
+
+        func release() {
+            isReleased = true
+            waiters.forEach { $0.resume() }
+            waiters.removeAll()
+        }
+    }
+
+    private struct UnusedMeteringBatchFactory: BatchRecordingSessionFactory {
+        func makeSession(
+            dbQueue _: DatabaseQueue,
+            managedRootURL _: URL,
+            meetingId _: UUID,
+            recordingSessionId _: UUID,
+            recordingStartTime _: Date,
+            sampleRate _: Double
+        ) throws -> any BatchRecordingSession {
+            throw MeteringTestError.unexpectedBatchRecording
+        }
+    }
+
+    private enum MeteringTestError: Error {
+        case unexpectedBatchRecording
+        case timedOutWaitingForLevel
+        case timedOutWaitingForMainActor
+        case timedOutWaitingForRecognitionFinish
+    }
+#endif

--- a/docs/architecture/audio-transcription-data-flow.md
+++ b/docs/architecture/audio-transcription-data-flow.md
@@ -84,6 +84,9 @@ flowchart LR
     LiveWorker --> Recognizer["AudioBufferBridge<br/>SpeechTranscriberService"]
     Recognizer --> Events["TranscriptionEventPipeline"]
 
+    Router -.->|"latest-wins / 約10 Hz"| Meter["AudioLevelMeteringWorker<br/>rebuildable UI projection"]
+    Meter -.-> LevelUI["録音パネル<br/>音源別レベルメーター"]
+
     Events --> Caption["bounded UI projection<br/>LiveCaptionStore / TranscriptStore"]
     Events --> Chat["live transcript relay"]
     Events -->|"realtime policy"| StreamWriter["TranscriptPersistenceWriter"]
@@ -162,6 +165,8 @@ capture callback ごとに `AudioSourcePipeline.capture` が frame count から 
 
 - batch consumer は `SegmentedAudioSourceWriter.appendBuffer` へ同期投入する。
 - live consumer は `LiveAudioFrameWorker` へ投入し、format conversion と Speech recognition を callback 外で行う。
+- 音量メーターは最新1フレームだけを保持する表示専用workerへ渡し、約10 Hzで音源別レベルを更新する。
+  このprojectionは中間値を破棄でき、MainActorや表示処理を録音の保存・認識・停止drainから分離する。
 - writer queue が満杯の場合は、その後の受付を閉じて `writeQueueOverflow` を録音失敗として表面化する。
 - batch mode の live lane は低遅延の bounded queue であり、正本音声の writer lane とは独立して縮退できる。
 - realtime mode は再処理可能な batch 音声を持たないため、live recognition input を lossless に扱う。


### PR DESCRIPTION
## 概要

録音パネルに、マイクとシステム音声の入力レベルを個別に確認できる5段階メーターを追加します。

## 変更内容

- 録音後段のPCMを既存の音量計算処理へ渡し、約100ms間隔でUIへ反映
- 最新フレームだけを保持する独立ワーカーにより、保存・文字起こし・停止時のdrainからメータリングを分離
- セッションと音源runtime世代を検証し、音源切替後の古い通知を破棄
- 停止、開始失敗、音源無効化、予期しないcapture停止時に音量をリセット
- マイク／システム音声の設定行へ5段階メーターとVoiceOver向けの入力レベル値を追加
- メータリングが破棄可能なUI projectionであることを音声データフロー文書へ追記

## 影響

録音中に各音源が実際にcaptureされているかを視覚的に確認できます。メータリングの遅延や破棄は録音データの保存成功、文字起こし、正常停止を妨げません。

## 検証

- `swift test` — 192 suites / 1225 tests passed
- `swift test --filter RecordingSessionAudioLevelTests` — 3 tests passed
- `swift test --filter AudioFrameRouterTests` — 7 tests passed
- `swift test --filter AudioLevelMeteringWorkerTests` — 3 tests passed
- `swift test --filter RecordingSessionControllerTests` — 18 tests passed
- `CI=true ./scripts/lint.sh` — SwiftFormat clean（SwiftLintは既存のファイル長・関数長警告のみ）
- `git diff --check`
