### PR TITLE
Add transcript audio feature persistence

### DIFF
--- a/Sources/Dahlia/Audio/AudioLevelCalculator.swift
+++ b/Sources/Dahlia/Audio/AudioLevelCalculator.swift
@@ -1,6 +1,11 @@
 @preconcurrency import AVFoundation
 
 enum AudioLevelCalculator {
+    static func rmsDecibels(rootMeanSquare: Double, floorDecibels: Double = -100) -> Double {
+        guard rootMeanSquare.isFinite, rootMeanSquare > 0 else { return floorDecibels }
+        return min(0, max(floorDecibels, 20 * log10(rootMeanSquare)))
+    }
+
     static func normalizedLevel(in buffer: AVAudioPCMBuffer) -> Double {
         normalizedLevels(in: buffer).max() ?? 0
     }
@@ -44,8 +49,7 @@ enum AudioLevelCalculator {
             }
 
             let rootMeanSquare = sqrt(sumOfSquares / Double(frameCount))
-            guard rootMeanSquare > 0 else { return 0 }
-            let decibels = 20 * log10(rootMeanSquare)
+            let decibels = rmsDecibels(rootMeanSquare: rootMeanSquare, floorDecibels: -60)
             return min(1, max(0, (decibels + 60) / 60))
         }
     }

--- a/Sources/Dahlia/Database/AppDatabaseManager.swift
+++ b/Sources/Dahlia/Database/AppDatabaseManager.swift
@@ -170,6 +170,10 @@ final class AppDatabaseManager: Sendable {
             try MeetingConversationMetricsMigration.migrate(in: db)
         }
 
+        migrator.registerMigration("v32_transcriptAudioFeatures") { db in
+            try addTranscriptAudioFeatureColumnsIfNeeded(in: db)
+        }
+
         return migrator
     }()
 
@@ -684,6 +688,14 @@ final class AppDatabaseManager: Sendable {
 
     private static func addTranscriptSegmentTranslatedTextColumnIfNeeded(in db: Database) throws {
         try addColumnIfNeeded(in: db, table: "transcript_segments", column: "translatedText", type: .text)
+    }
+
+    private static func addTranscriptAudioFeatureColumnsIfNeeded(in db: Database) throws {
+        try addColumnIfNeeded(in: db, table: "transcript_segments", column: "audioFeatureVersion", type: .integer)
+        try addColumnIfNeeded(in: db, table: "transcript_segments", column: "audioActiveRmsDecibels", type: .double)
+        try addColumnIfNeeded(in: db, table: "transcript_segments", column: "audioMedianPitchHertz", type: .double)
+        try addColumnIfNeeded(in: db, table: "transcript_segments", column: "audioVoicedFrameRatio", type: .double)
+        try addColumnIfNeeded(in: db, table: "transcript_segments", column: "audioPitchSpreadHertz", type: .double)
     }
 
     private static func addRecordingSessionSchemaIfNeeded(in db: Database) throws {

--- a/Sources/Dahlia/Database/TranscriptSegmentRecord.swift
+++ b/Sources/Dahlia/Database/TranscriptSegmentRecord.swift
@@ -14,6 +14,11 @@ struct TranscriptSegmentRecord: Codable, FetchableRecord, PersistableRecord {
     var translatedText: String?
     var isConfirmed: Bool
     var speakerLabel: String?
+    var audioFeatureVersion: Int? = nil
+    var audioActiveRmsDecibels: Double? = nil
+    var audioMedianPitchHertz: Double? = nil
+    var audioVoicedFrameRatio: Double? = nil
+    var audioPitchSpreadHertz: Double? = nil
 }
 
 extension TranscriptSegmentRecord {
@@ -28,6 +33,23 @@ extension TranscriptSegmentRecord {
         self.translatedText = segment.translatedText
         self.isConfirmed = segment.isConfirmed
         self.speakerLabel = segment.speakerLabel
+        self.audioFeatureVersion = segment.audioFeatures?.version
+        self.audioActiveRmsDecibels = segment.audioFeatures?.activeRmsDecibels
+        self.audioMedianPitchHertz = segment.audioFeatures?.medianPitchHertz
+        self.audioVoicedFrameRatio = segment.audioFeatures?.voicedFrameRatio
+        self.audioPitchSpreadHertz = segment.audioFeatures?.pitchSpreadHertz
+    }
+
+    var audioFeatures: TranscriptAudioFeatures? {
+        guard let audioFeatureVersion,
+              let audioVoicedFrameRatio else { return nil }
+        return TranscriptAudioFeatures(
+            version: audioFeatureVersion,
+            activeRmsDecibels: audioActiveRmsDecibels,
+            medianPitchHertz: audioMedianPitchHertz,
+            voicedFrameRatio: audioVoicedFrameRatio,
+            pitchSpreadHertz: audioPitchSpreadHertz
+        )
     }
 
     static func updateTranslatedText(

--- a/Sources/Dahlia/Models/TranscriptAudioFeatures.swift
+++ b/Sources/Dahlia/Models/TranscriptAudioFeatures.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// A compact, best-effort summary of the audio associated with one transcript segment.
+struct TranscriptAudioFeatures: Equatable, Sendable {
+    static let currentVersion = 1
+
+    let version: Int
+    let activeRmsDecibels: Double?
+    let medianPitchHertz: Double?
+    let voicedFrameRatio: Double
+    let pitchSpreadHertz: Double?
+
+    init(
+        version: Int = currentVersion,
+        activeRmsDecibels: Double?,
+        medianPitchHertz: Double?,
+        voicedFrameRatio: Double,
+        pitchSpreadHertz: Double?
+    ) {
+        self.version = version
+        self.activeRmsDecibels = activeRmsDecibels
+        self.medianPitchHertz = medianPitchHertz
+        self.voicedFrameRatio = voicedFrameRatio
+        self.pitchSpreadHertz = pitchSpreadHertz
+    }
+}

--- a/Sources/Dahlia/Models/TranscriptAudioFeatures.swift
+++ b/Sources/Dahlia/Models/TranscriptAudioFeatures.swift
@@ -7,6 +7,7 @@ struct TranscriptAudioFeatures: Equatable, Sendable {
     let version: Int
     let activeRmsDecibels: Double?
     let medianPitchHertz: Double?
+    /// Fraction of analysis frames whose RMS passed the version 1 activity gate.
     let voicedFrameRatio: Double
     let pitchSpreadHertz: Double?
 

--- a/Sources/Dahlia/Models/TranscriptSegment.swift
+++ b/Sources/Dahlia/Models/TranscriptSegment.swift
@@ -69,6 +69,7 @@ struct TranscriptSegment: Identifiable, Equatable {
     var translatedText: String?
     var isConfirmed: Bool
     var speakerLabel: String?
+    var audioFeatures: TranscriptAudioFeatures?
 
     /// 表示用テキスト。
     var displayText: String { text }
@@ -96,7 +97,8 @@ struct TranscriptSegment: Identifiable, Equatable {
         text: String,
         translatedText: String? = nil,
         isConfirmed: Bool = false,
-        speakerLabel: String? = nil
+        speakerLabel: String? = nil,
+        audioFeatures: TranscriptAudioFeatures? = nil
     ) {
         self.id = id
         self.sessionId = sessionId
@@ -106,6 +108,7 @@ struct TranscriptSegment: Identifiable, Equatable {
         self.translatedText = translatedText
         self.isConfirmed = isConfirmed
         self.speakerLabel = speakerLabel
+        self.audioFeatures = audioFeatures
     }
 
     /// TranscriptSegmentRecord からの変換イニシャライザ。
@@ -118,5 +121,6 @@ struct TranscriptSegment: Identifiable, Equatable {
         self.translatedText = record.translatedText
         self.isConfirmed = record.isConfirmed
         self.speakerLabel = record.speakerLabel
+        self.audioFeatures = record.audioFeatures
     }
 }

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -55,6 +55,7 @@ actor BatchTranscriptionCoordinator {
     private let translationService = TranscriptTranslationService()
     private let languageDetector: any BatchLanguageDetecting
     private let speechRecognizer: any BatchSpeechRecognizing
+    private let audioFeatureAnalyzer: any BatchTranscriptAudioFeatureAnalyzing
     private let supportedLocalesProvider: @Sendable () async -> [Locale]
     let languageFallbackReporter: LanguageFallbackReporter
     let onStateChange: StateHandler
@@ -70,6 +71,7 @@ actor BatchTranscriptionCoordinator {
         managedRootURL: URL = BatchAudioStorage.managedRootURL,
         languageDetector: any BatchLanguageDetecting = WhisperKitBatchLanguageDetector(),
         speechRecognizer: any BatchSpeechRecognizing = AppleBatchSpeechRecognizer(),
+        audioFeatureAnalyzer: any BatchTranscriptAudioFeatureAnalyzing = BatchTranscriptAudioFeatureAnalyzer(),
         supportedLocalesProvider: @escaping @Sendable () async -> [Locale] = {
             await SpeechTranscriber.supportedLocales
         },
@@ -83,6 +85,7 @@ actor BatchTranscriptionCoordinator {
         )
         self.languageDetector = SerializedBatchLanguageDetector(detector: languageDetector)
         self.speechRecognizer = AdaptiveBatchSpeechRecognizer(recognizer: speechRecognizer)
+        self.audioFeatureAnalyzer = audioFeatureAnalyzer
         self.supportedLocalesProvider = supportedLocalesProvider
         self.languageFallbackReporter = languageFallbackReporter ?? { fallbacks, candidates in
             ErrorReportingService.capture(
@@ -397,6 +400,7 @@ actor BatchTranscriptionCoordinator {
                 request,
                 languageDetector: languageDetector,
                 speechRecognizer: speechRecognizer,
+                audioFeatureAnalyzer: audioFeatureAnalyzer,
                 onLanguageFallback: { fallback in
                     await fallbackCollector.record(fallback)
                 }
@@ -408,6 +412,7 @@ actor BatchTranscriptionCoordinator {
             result = try await BatchManualSpeechTranscriberService.transcribe(
                 run,
                 speechRecognizer: speechRecognizer,
+                audioFeatureAnalyzer: audioFeatureAnalyzer,
                 onFileConsumed: onFileConsumed
             )
         case let .noAudio(localeIdentifier):

--- a/Sources/Dahlia/Speech/BatchManualSpeechTranscriberService.swift
+++ b/Sources/Dahlia/Speech/BatchManualSpeechTranscriberService.swift
@@ -4,6 +4,7 @@ enum BatchManualSpeechTranscriberService {
     static func transcribe(
         _ run: BatchManualTranscriptionRun,
         speechRecognizer: any BatchSpeechRecognizing,
+        audioFeatureAnalyzer: any BatchTranscriptAudioFeatureAnalyzing = BatchTranscriptAudioFeatureAnalyzer(),
         onFileConsumed: @escaping @Sendable (Int) async -> Void = { _ in }
     ) async throws -> BatchSpeechTranscriptionResult {
         guard !run.slices.isEmpty,
@@ -24,8 +25,15 @@ enum BatchManualSpeechTranscriberService {
                 await onFileConsumed(fileIndex)
             }
         )
+        let audioFeatures = try await BatchTranscriptAudioFeatureExtraction.bestEffort(
+            recognitions: recognitions,
+            audioSlices: run.slices,
+            source: run.source,
+            analyzer: audioFeatureAnalyzer
+        )
         let segments = BatchSpeechTranscriberService.transcriptSegments(
             from: recognitions,
+            audioFeatures: audioFeatures,
             recordingSessionId: run.recordingSessionId,
             recordingStartTime: run.recordingStartTime,
             sessionOffsetSeconds: run.sessionOffsetSeconds,

--- a/Sources/Dahlia/Speech/BatchPitchEstimator.swift
+++ b/Sources/Dahlia/Speech/BatchPitchEstimator.swift
@@ -1,0 +1,138 @@
+import Accelerate
+import Foundation
+
+enum BatchPitchEstimator {
+    private static let lowPassCutoffHertz = 800.0
+    private static let lowPassStageCount = 4
+    private static let minimumFilteredPowerRatio = 0.01
+
+    static func estimate(in samples: [Float], sampleRate: Double) -> Double? {
+        guard sampleRate > 0, !samples.isEmpty else { return nil }
+        let inputMeanSquare = meanSquare(of: samples)
+        guard inputMeanSquare > 0 else { return nil }
+        let filtered = lowPass(samples, sampleRate: sampleRate)
+        guard meanSquare(of: filtered) >= inputMeanSquare * minimumFilteredPowerRatio else {
+            return nil
+        }
+        let downsampleFactor = sampleRate >= 12000 ? 2 : 1
+        let downsampled = stride(from: 0, to: filtered.count, by: downsampleFactor).map {
+            filtered[$0]
+        }
+        guard downsampled.count >= 3 else { return nil }
+        let analysisSampleRate = sampleRate / Double(downsampleFactor)
+        let mean = downsampled.reduce(0, +) / Float(downsampled.count)
+        let centered = downsampled.map { $0 - mean }
+        let minimumLag = max(1, Int(floor(
+            analysisSampleRate / BatchTranscriptAudioFeatureAnalyzer.maximumPitchHertz
+        )))
+        let maximumLag = min(
+            centered.count - 2,
+            Int(ceil(analysisSampleRate / BatchTranscriptAudioFeatureAnalyzer.minimumPitchHertz))
+        )
+        guard minimumLag < maximumLag else { return nil }
+
+        let correlations = normalizedCorrelations(
+            in: centered,
+            minimumLag: minimumLag,
+            maximumLag: maximumLag
+        )
+        guard let strongestCorrelation = correlations.max(),
+              Double(strongestCorrelation) >= BatchTranscriptAudioFeatureAnalyzer.minimumPitchCorrelation,
+              let lag = refinedLag(
+                  correlations: correlations,
+                  minimumLag: minimumLag,
+                  strongestCorrelation: strongestCorrelation
+              ) else {
+            return nil
+        }
+        let pitch = analysisSampleRate / lag
+        guard pitch >= BatchTranscriptAudioFeatureAnalyzer.minimumPitchHertz,
+              pitch <= BatchTranscriptAudioFeatureAnalyzer.maximumPitchHertz else { return nil }
+        return pitch
+    }
+
+    private static func lowPass(_ samples: [Float], sampleRate: Double) -> [Float] {
+        let alpha = Float(1 - exp(-2 * Double.pi * lowPassCutoffHertz / sampleRate))
+        var filtered = samples
+        for _ in 0 ..< lowPassStageCount {
+            var previous: Float = 0
+            for index in filtered.indices {
+                previous += alpha * (filtered[index] - previous)
+                filtered[index] = previous
+            }
+        }
+        return filtered
+    }
+
+    private static func meanSquare(of samples: [Float]) -> Double {
+        samples.reduce(0.0) {
+            $0 + (Double($1) * Double($1))
+        } / Double(samples.count)
+    }
+
+    private static func normalizedCorrelations(
+        in centered: [Float],
+        minimumLag: Int,
+        maximumLag: Int
+    ) -> [Float] {
+        var prefixEnergy = Array(repeating: Float.zero, count: centered.count + 1)
+        for index in centered.indices {
+            prefixEnergy[index + 1] = prefixEnergy[index] + (centered[index] * centered[index])
+        }
+        var correlations = Array(repeating: Float.zero, count: maximumLag - minimumLag + 1)
+        centered.withUnsafeBufferPointer { buffer in
+            guard let baseAddress = buffer.baseAddress else { return }
+            for lag in minimumLag ... maximumLag {
+                let count = centered.count - lag
+                var dotProduct: Float = 0
+                vDSP_dotpr(
+                    baseAddress,
+                    1,
+                    baseAddress.advanced(by: lag),
+                    1,
+                    &dotProduct,
+                    vDSP_Length(count)
+                )
+                let firstEnergy = prefixEnergy[count]
+                let secondEnergy = prefixEnergy[centered.count] - prefixEnergy[lag]
+                let denominator = sqrt(firstEnergy * secondEnergy)
+                if denominator > 0 {
+                    correlations[lag - minimumLag] = dotProduct / denominator
+                }
+            }
+        }
+        return correlations
+    }
+
+    private static func refinedLag(
+        correlations: [Float],
+        minimumLag: Int,
+        strongestCorrelation: Float
+    ) -> Double? {
+        let acceptableCorrelation = max(
+            Float(BatchTranscriptAudioFeatureAnalyzer.minimumPitchCorrelation),
+            strongestCorrelation - 0.02
+        )
+        let peakOffset = correlations.indices.first { index in
+            correlations[index] >= acceptableCorrelation
+                && (index == correlations.startIndex || correlations[index] >= correlations[index - 1])
+                && (index == correlations.index(before: correlations.endIndex)
+                    || correlations[index] >= correlations[index + 1])
+        } ?? correlations.indices.max(by: { correlations[$0] < correlations[$1] })
+        guard let peakOffset else { return nil }
+
+        var lag = Double(peakOffset + minimumLag)
+        if peakOffset > correlations.startIndex,
+           peakOffset < correlations.index(before: correlations.endIndex) {
+            let previous = Double(correlations[peakOffset - 1])
+            let current = Double(correlations[peakOffset])
+            let next = Double(correlations[peakOffset + 1])
+            let denominator = previous - (2 * current) + next
+            if abs(denominator) > .ulpOfOne {
+                lag += 0.5 * (previous - next) / denominator
+            }
+        }
+        guard lag > 0 else { return nil }
+        return lag
+    }
+}

--- a/Sources/Dahlia/Speech/BatchSpeechTranscriberService.swift
+++ b/Sources/Dahlia/Speech/BatchSpeechTranscriberService.swift
@@ -12,6 +12,7 @@ enum BatchSpeechTranscriberService {
         _ request: BatchSpeechTranscriptionRequest,
         languageDetector: (any BatchLanguageDetecting)? = nil,
         speechRecognizer: any BatchSpeechRecognizing = AppleBatchSpeechRecognizer(),
+        audioFeatureAnalyzer: any BatchTranscriptAudioFeatureAnalyzing = BatchTranscriptAudioFeatureAnalyzer(),
         onLanguageFallback: @escaping @Sendable (BatchLanguageFallback) async -> Void = { _ in }
     ) async throws -> BatchSpeechTranscriptionResult {
         guard request.startFrame >= 0, request.frameCount > 0 else {
@@ -49,8 +50,15 @@ enum BatchSpeechTranscriberService {
             await onLanguageFallback(fallback)
         }
         let recognitions = try await speechRecognizer.recognize(audioURL: preparedAudio.url, locale: resolution.locale)
+        let audioFeatures = try await BatchTranscriptAudioFeatureExtraction.bestEffort(
+            recognitions: recognitions,
+            audioURL: preparedAudio.url,
+            source: request.source,
+            analyzer: audioFeatureAnalyzer
+        )
         let segments = transcriptSegments(
             from: recognitions,
+            audioFeatures: audioFeatures,
             recordingSessionId: request.recordingSessionId,
             recordingStartTime: request.recordingStartTime,
             sessionOffsetSeconds: request.sessionOffsetSeconds,
@@ -65,12 +73,13 @@ enum BatchSpeechTranscriberService {
 
     static func transcriptSegments(
         from recognitions: [BatchSpeechRecognition],
+        audioFeatures: [TranscriptAudioFeatures?] = [],
         recordingSessionId: UUID,
         recordingStartTime: Date,
         sessionOffsetSeconds: TimeInterval,
         source: RecordingAudioSource
     ) -> [TranscriptSegment] {
-        recognitions.compactMap { recognition -> TranscriptSegment? in
+        recognitions.enumerated().compactMap { index, recognition -> TranscriptSegment? in
             guard let text = SpeechTranscriberService.normalizedTranscriptText(recognition.text) else { return nil }
             let absoluteStart = recordingStartTime.addingTimeInterval(
                 sessionOffsetSeconds + (recognition.startSeconds.isFinite ? recognition.startSeconds : 0)
@@ -84,7 +93,8 @@ enum BatchSpeechTranscriberService {
                 endTime: absoluteEnd,
                 text: text,
                 isConfirmed: true,
-                speakerLabel: source.speakerLabel
+                speakerLabel: source.speakerLabel,
+                audioFeatures: audioFeatures.indices.contains(index) ? audioFeatures[index] : nil
             )
         }
     }

--- a/Sources/Dahlia/Speech/BatchTranscriptAudioFeatureAnalyzer.swift
+++ b/Sources/Dahlia/Speech/BatchTranscriptAudioFeatureAnalyzer.swift
@@ -1,0 +1,413 @@
+@preconcurrency import AVFoundation
+import Foundation
+
+struct BatchTranscriptAudioFeatureAnalysis: Sendable {
+    let features: [TranscriptAudioFeatures?]
+    let invalidRecognitionCount: Int
+}
+
+protocol BatchTranscriptAudioFeatureAnalyzing: Sendable {
+    func analyze(
+        recognitions: [BatchSpeechRecognition],
+        audioURL: URL
+    ) throws -> BatchTranscriptAudioFeatureAnalysis
+
+    func analyze(
+        recognitions: [BatchSpeechRecognition],
+        audioSlices: [BatchSpeechAudioSlice]
+    ) throws -> BatchTranscriptAudioFeatureAnalysis
+}
+
+enum BatchTranscriptAudioFeatureAnalyzerError: LocalizedError {
+    case audioFormatUnavailable
+    case extractionFailed
+    case invalidAudioRange
+    case invalidRecognitionRanges(count: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .audioFormatUnavailable:
+            "Audio format is unavailable for transcript feature analysis."
+        case .extractionFailed:
+            "Transcript audio feature analysis failed."
+        case .invalidAudioRange:
+            "Audio range is invalid for transcript feature analysis."
+        case let .invalidRecognitionRanges(count):
+            "\(count) transcript ranges could not be matched for audio feature analysis."
+        }
+    }
+}
+
+enum BatchTranscriptAudioFeatureExtraction {
+    static func bestEffort(
+        recognitions: [BatchSpeechRecognition],
+        audioURL: URL,
+        source: RecordingAudioSource,
+        analyzer: any BatchTranscriptAudioFeatureAnalyzing
+    ) async throws -> [TranscriptAudioFeatures?] {
+        try await bestEffort(
+            recognitionCount: recognitions.count,
+            source: source
+        ) {
+            try analyzer.analyze(recognitions: recognitions, audioURL: audioURL)
+        }
+    }
+
+    static func bestEffort(
+        recognitions: [BatchSpeechRecognition],
+        audioSlices: [BatchSpeechAudioSlice],
+        source: RecordingAudioSource,
+        analyzer: any BatchTranscriptAudioFeatureAnalyzing
+    ) async throws -> [TranscriptAudioFeatures?] {
+        try await bestEffort(
+            recognitionCount: recognitions.count,
+            source: source
+        ) {
+            try analyzer.analyze(recognitions: recognitions, audioSlices: audioSlices)
+        }
+    }
+
+    private static func bestEffort(
+        recognitionCount: Int,
+        source: RecordingAudioSource,
+        operation: @escaping @Sendable () throws -> BatchTranscriptAudioFeatureAnalysis
+    ) async throws -> [TranscriptAudioFeatures?] {
+        guard recognitionCount > 0 else { return [] }
+        let task = Task.detached(priority: .utility, operation: operation)
+        do {
+            let analysis = try await withTaskCancellationHandler {
+                try await task.value
+            } onCancel: {
+                task.cancel()
+            }
+            if analysis.invalidRecognitionCount > 0 {
+                ErrorReportingService.capture(
+                    BatchTranscriptAudioFeatureAnalyzerError.invalidRecognitionRanges(
+                        count: analysis.invalidRecognitionCount
+                    ),
+                    context: [
+                        "source": "batchTranscriptAudioFeatures",
+                        "audioSource": source.rawValue,
+                    ]
+                )
+            }
+            return analysis.features
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            ErrorReportingService.capture(
+                BatchTranscriptAudioFeatureAnalyzerError.extractionFailed,
+                context: [
+                    "source": "batchTranscriptAudioFeatures",
+                    "audioSource": source.rawValue,
+                ]
+            )
+            return Array(repeating: nil, count: recognitionCount)
+        }
+    }
+}
+
+struct BatchTranscriptAudioFeatureAnalyzer: BatchTranscriptAudioFeatureAnalyzing {
+    static let windowDuration: TimeInterval = 0.04
+    static let hopDuration: TimeInterval = 0.02
+    static let activeGateDecibels = -50.0
+    static let minimumPitchHertz = 60.0
+    static let maximumPitchHertz = 500.0
+    static let minimumPitchCorrelation = 0.6
+
+    private static let readCapacity: AVAudioFrameCount = 4096
+
+    func analyze(
+        recognitions: [BatchSpeechRecognition],
+        audioURL: URL
+    ) throws -> BatchTranscriptAudioFeatureAnalysis {
+        let audioFile = try AVAudioFile(forReading: audioURL)
+        return try analyze(
+            recognitions: recognitions,
+            audioSlices: [
+                BatchSpeechAudioSlice(
+                    audioURL: audioURL,
+                    startFrame: 0,
+                    frameCount: audioFile.length
+                ),
+            ]
+        )
+    }
+
+    func analyze(
+        recognitions: [BatchSpeechRecognition],
+        audioSlices: [BatchSpeechAudioSlice]
+    ) throws -> BatchTranscriptAudioFeatureAnalysis {
+        guard !audioSlices.isEmpty else {
+            return BatchTranscriptAudioFeatureAnalysis(
+                features: Array(repeating: nil, count: recognitions.count),
+                invalidRecognitionCount: recognitions.count
+            )
+        }
+
+        var processor: FeatureWindowProcessor?
+        for slice in audioSlices {
+            try Task.checkCancellation()
+            let audioFile = try AVAudioFile(forReading: slice.audioURL)
+            let format = audioFile.processingFormat
+            guard format.sampleRate > 0, format.channelCount == 1 else {
+                throw BatchTranscriptAudioFeatureAnalyzerError.audioFormatUnavailable
+            }
+            guard slice.startFrame >= 0,
+                  slice.frameCount > 0,
+                  slice.startFrame <= audioFile.length - slice.frameCount else {
+                throw BatchTranscriptAudioFeatureAnalyzerError.invalidAudioRange
+            }
+
+            if processor == nil {
+                processor = FeatureWindowProcessor(
+                    recognitions: recognitions,
+                    sampleRate: format.sampleRate
+                )
+            } else if processor?.sampleRate != format.sampleRate {
+                throw BatchTranscriptAudioFeatureAnalyzerError.audioFormatUnavailable
+            }
+
+            audioFile.framePosition = slice.startFrame
+            var remainingFrameCount = slice.frameCount
+            guard let buffer = AVAudioPCMBuffer(
+                pcmFormat: format,
+                frameCapacity: Self.readCapacity
+            ) else {
+                throw BatchTranscriptAudioFeatureAnalyzerError.audioFormatUnavailable
+            }
+            while remainingFrameCount > 0 {
+                try Task.checkCancellation()
+                let requestedFrameCount = AVAudioFrameCount(
+                    min(Int64(Self.readCapacity), remainingFrameCount)
+                )
+                try audioFile.read(into: buffer, frameCount: requestedFrameCount)
+                guard buffer.frameLength > 0 else {
+                    throw BatchTranscriptAudioFeatureAnalyzerError.invalidAudioRange
+                }
+                try processor?.consume(Self.samples(from: buffer))
+                remainingFrameCount -= Int64(buffer.frameLength)
+            }
+        }
+
+        guard var processor else {
+            throw BatchTranscriptAudioFeatureAnalyzerError.audioFormatUnavailable
+        }
+        return processor.finish()
+    }
+
+    private static func samples(from buffer: AVAudioPCMBuffer) throws -> [Float] {
+        let frameCount = Int(buffer.frameLength)
+        switch buffer.format.commonFormat {
+        case .pcmFormatFloat32:
+            guard let channel = buffer.floatChannelData?[0] else {
+                throw BatchTranscriptAudioFeatureAnalyzerError.audioFormatUnavailable
+            }
+            return Array(UnsafeBufferPointer(start: channel, count: frameCount))
+        case .pcmFormatInt16:
+            guard let channel = buffer.int16ChannelData?[0] else {
+                throw BatchTranscriptAudioFeatureAnalyzerError.audioFormatUnavailable
+            }
+            return UnsafeBufferPointer(start: channel, count: frameCount).map {
+                Float($0) / Float(Int16.max)
+            }
+        default:
+            throw BatchTranscriptAudioFeatureAnalyzerError.audioFormatUnavailable
+        }
+    }
+}
+
+private struct FeatureWindowProcessor {
+    struct Interval {
+        let recognitionIndex: Int
+        let startFrame: Int64
+        let endFrame: Int64
+    }
+
+    struct Accumulator {
+        var analysisFrameCount = 0
+        var activeFrameCount = 0
+        var activeMeanSquareSum = 0.0
+        var pitches: [Double] = []
+
+        func features() -> TranscriptAudioFeatures {
+            let voicedFrameRatio = analysisFrameCount > 0
+                ? Double(activeFrameCount) / Double(analysisFrameCount)
+                : 0
+            let activeRmsDecibels = activeFrameCount > 0
+                ? AudioLevelCalculator.rmsDecibels(
+                    rootMeanSquare: sqrt(activeMeanSquareSum / Double(activeFrameCount))
+                )
+                : nil
+            let sortedPitches = pitches.sorted()
+            let medianPitchHertz = Self.quantile(0.5, values: sortedPitches)
+            let pitchSpreadHertz: Double? = if sortedPitches.count >= 4,
+                                               let lower = Self.quantile(0.25, values: sortedPitches),
+                                               let upper = Self.quantile(0.75, values: sortedPitches) {
+                upper - lower
+            } else {
+                nil
+            }
+            return TranscriptAudioFeatures(
+                activeRmsDecibels: activeRmsDecibels,
+                medianPitchHertz: medianPitchHertz,
+                voicedFrameRatio: voicedFrameRatio,
+                pitchSpreadHertz: pitchSpreadHertz
+            )
+        }
+
+        private static func quantile(_ probability: Double, values: [Double]) -> Double? {
+            guard !values.isEmpty else { return nil }
+            let position = probability * Double(values.count - 1)
+            let lowerIndex = Int(floor(position))
+            let upperIndex = Int(ceil(position))
+            guard lowerIndex != upperIndex else { return values[lowerIndex] }
+            let fraction = position - Double(lowerIndex)
+            return values[lowerIndex] + ((values[upperIndex] - values[lowerIndex]) * fraction)
+        }
+    }
+
+    let sampleRate: Double
+    private let windowSize: Int
+    private let hopSize: Int
+    private let intervals: [Interval]
+    private let initiallyInvalidRecognitionIndices: Set<Int>
+    private var accumulators: [Accumulator]
+    private var pendingSamples: [Float] = []
+    private var pendingStartIndex = 0
+    private var nextWindowStartFrame: Int64 = 0
+    private var receivedFrameCount: Int64 = 0
+    private var nextIntervalIndex = 0
+    private var activeIntervals: [Interval] = []
+
+    init(recognitions: [BatchSpeechRecognition], sampleRate: Double) {
+        self.sampleRate = sampleRate
+        windowSize = max(1, Int((sampleRate * BatchTranscriptAudioFeatureAnalyzer.windowDuration).rounded()))
+        hopSize = max(1, Int((sampleRate * BatchTranscriptAudioFeatureAnalyzer.hopDuration).rounded()))
+        accumulators = Array(repeating: Accumulator(), count: recognitions.count)
+
+        var intervals: [Interval] = []
+        var invalidIndices: Set<Int> = []
+        for (index, recognition) in recognitions.enumerated() {
+            guard recognition.startSeconds.isFinite,
+                  recognition.endSeconds.isFinite,
+                  recognition.startSeconds >= 0,
+                  recognition.endSeconds > recognition.startSeconds,
+                  let startFrame = Int64(exactly: floor(recognition.startSeconds * sampleRate)),
+                  let endFrame = Int64(exactly: ceil(recognition.endSeconds * sampleRate)) else {
+                invalidIndices.insert(index)
+                continue
+            }
+            intervals.append(Interval(
+                recognitionIndex: index,
+                startFrame: startFrame,
+                endFrame: endFrame
+            ))
+        }
+        self.intervals = intervals.sorted {
+            if $0.startFrame == $1.startFrame {
+                return $0.endFrame < $1.endFrame
+            }
+            return $0.startFrame < $1.startFrame
+        }
+        initiallyInvalidRecognitionIndices = invalidIndices
+    }
+
+    mutating func consume(_ samples: [Float]) throws {
+        try Task.checkCancellation()
+        guard !samples.isEmpty else { return }
+        pendingSamples.append(contentsOf: samples)
+        receivedFrameCount += Int64(samples.count)
+
+        while pendingSamples.count - pendingStartIndex >= windowSize {
+            let window = Array(
+                pendingSamples[pendingStartIndex ..< pendingStartIndex + windowSize]
+            )
+            process(window: window, actualSampleCount: windowSize)
+            pendingStartIndex += hopSize
+            nextWindowStartFrame += Int64(hopSize)
+        }
+
+        if pendingStartIndex >= 16384 {
+            pendingSamples.removeFirst(pendingStartIndex)
+            pendingStartIndex = 0
+        }
+    }
+
+    mutating func finish() -> BatchTranscriptAudioFeatureAnalysis {
+        let remainingSampleCount = pendingSamples.count - pendingStartIndex
+        if remainingSampleCount > 0, nextWindowStartFrame < receivedFrameCount {
+            var window = Array(pendingSamples[pendingStartIndex...])
+            let actualSampleCount = window.count
+            if window.count < windowSize {
+                window.append(contentsOf: repeatElement(0, count: windowSize - window.count))
+            }
+            process(window: window, actualSampleCount: actualSampleCount)
+        }
+
+        var invalidRecognitionIndices = initiallyInvalidRecognitionIndices
+        for interval in intervals where interval.endFrame > receivedFrameCount + 1 {
+            invalidRecognitionIndices.insert(interval.recognitionIndex)
+        }
+        let features = accumulators.indices.map { index -> TranscriptAudioFeatures? in
+            guard !invalidRecognitionIndices.contains(index) else { return nil }
+            return accumulators[index].features()
+        }
+        return BatchTranscriptAudioFeatureAnalysis(
+            features: features,
+            invalidRecognitionCount: invalidRecognitionIndices.count
+        )
+    }
+
+    private mutating func process(window: [Float], actualSampleCount: Int) {
+        guard actualSampleCount > 0 else { return }
+        let windowStartFrame = nextWindowStartFrame
+        let windowEndFrame = windowStartFrame + Int64(actualSampleCount)
+        activeIntervals.removeAll { $0.endFrame <= windowStartFrame }
+        while nextIntervalIndex < intervals.count,
+              intervals[nextIntervalIndex].startFrame < windowEndFrame {
+            let interval = intervals[nextIntervalIndex]
+            nextIntervalIndex += 1
+            if interval.endFrame > windowStartFrame {
+                activeIntervals.append(interval)
+            }
+        }
+        guard !activeIntervals.isEmpty else { return }
+
+        var didEstimateFullWindowPitch = false
+        var fullWindowPitch: Double?
+        for interval in activeIntervals {
+            let overlapStartFrame = max(windowStartFrame, interval.startFrame)
+            let overlapEndFrame = min(windowEndFrame, interval.endFrame)
+            let overlapStartIndex = Int(overlapStartFrame - windowStartFrame)
+            let overlapEndIndex = Int(overlapEndFrame - windowStartFrame)
+            guard overlapStartIndex < overlapEndIndex else { continue }
+            let overlapSamples = window[overlapStartIndex ..< overlapEndIndex]
+            let meanSquare = overlapSamples.reduce(0.0) {
+                $0 + (Double($1) * Double($1))
+            } / Double(overlapSamples.count)
+            let decibels = AudioLevelCalculator.rmsDecibels(
+                rootMeanSquare: sqrt(meanSquare)
+            )
+            let isActive = decibels >= BatchTranscriptAudioFeatureAnalyzer.activeGateDecibels
+
+            accumulators[interval.recognitionIndex].analysisFrameCount += 1
+            if isActive {
+                accumulators[interval.recognitionIndex].activeFrameCount += 1
+                accumulators[interval.recognitionIndex].activeMeanSquareSum += meanSquare
+            }
+            if isActive, overlapSamples.count == windowSize {
+                if !didEstimateFullWindowPitch {
+                    fullWindowPitch = BatchPitchEstimator.estimate(
+                        in: window,
+                        sampleRate: sampleRate
+                    )
+                    didEstimateFullWindowPitch = true
+                }
+                if let fullWindowPitch {
+                    accumulators[interval.recognitionIndex].pitches.append(fullWindowPitch)
+                }
+            }
+        }
+    }
+}

--- a/Sources/Dahlia/Speech/BatchTranscriptAudioFeatureAnalyzer.swift
+++ b/Sources/Dahlia/Speech/BatchTranscriptAudioFeatureAnalyzer.swift
@@ -92,8 +92,8 @@ enum BatchTranscriptAudioFeatureExtraction {
                 )
             }
             return analysis.features
-        } catch is CancellationError {
-            throw CancellationError()
+        } catch let error as CancellationError {
+            throw error
         } catch {
             ErrorReportingService.capture(
                 BatchTranscriptAudioFeatureAnalyzerError.extractionFailed,
@@ -346,7 +346,7 @@ private struct FeatureWindowProcessor {
         }
 
         var invalidRecognitionIndices = initiallyInvalidRecognitionIndices
-        for interval in intervals where interval.endFrame > receivedFrameCount + 1 {
+        for interval in intervals where interval.endFrame > receivedFrameCount {
             invalidRecognitionIndices.insert(interval.recognitionIndex)
         }
         let features = accumulators.indices.map { index -> TranscriptAudioFeatures? in

--- a/Tests/DahliaTests/BatchTranscriptAudioFeatureAnalyzerTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptAudioFeatureAnalyzerTests.swift
@@ -1,0 +1,369 @@
+@preconcurrency import AVFoundation
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct BatchTranscriptAudioFeatureAnalyzerTests {
+        private let analyzer = BatchTranscriptAudioFeatureAnalyzer()
+
+        @Test
+        func extractsActiveRmsPitchVoicedRatioAndPitchSpread() throws {
+            let audioURL = try makeAudioFile([
+                Tone(duration: 2, frequency: 220, amplitude: 0.25),
+            ])
+            defer { try? FileManager.default.removeItem(at: audioURL) }
+
+            let analysis = try analyzer.analyze(
+                recognitions: [recognition(start: 0, end: 2)],
+                audioURL: audioURL
+            )
+            let features = try firstFeatures(in: analysis)
+
+            #expect(try abs(#require(features.activeRmsDecibels) - -15.05) < 0.5)
+            #expect(try abs(#require(features.medianPitchHertz) - 220) < 3)
+            #expect(features.voicedFrameRatio > 0.99)
+            #expect(try #require(features.pitchSpreadHertz) < 1)
+        }
+
+        @Test
+        func silenceChangesVoicedRatioWithoutDilutingActiveRms() throws {
+            let continuousURL = try makeAudioFile([
+                Tone(duration: 2, frequency: 220, amplitude: 0.25),
+            ])
+            let pausedURL = try makeAudioFile([
+                Tone(duration: 1, frequency: 220, amplitude: 0.25),
+                Tone(duration: 1, frequency: nil, amplitude: 0),
+                Tone(duration: 1, frequency: 220, amplitude: 0.25),
+            ])
+            defer {
+                try? FileManager.default.removeItem(at: continuousURL)
+                try? FileManager.default.removeItem(at: pausedURL)
+            }
+
+            let continuous = try firstFeatures(
+                in: analyzer.analyze(
+                    recognitions: [recognition(start: 0, end: 2)],
+                    audioURL: continuousURL
+                )
+            )
+            let paused = try firstFeatures(
+                in: analyzer.analyze(
+                    recognitions: [recognition(start: 0, end: 3)],
+                    audioURL: pausedURL
+                )
+            )
+
+            #expect(try abs(
+                #require(continuous.activeRmsDecibels)
+                    - (try #require(paused.activeRmsDecibels))
+            ) < 0.5)
+            #expect(continuous.voicedFrameRatio > 0.99)
+            #expect(paused.voicedFrameRatio > 0.6)
+            #expect(paused.voicedFrameRatio < 0.72)
+        }
+
+        @Test
+        func pitchSpreadCapturesVariation() throws {
+            let audioURL = try makeAudioFile([
+                Tone(duration: 1, frequency: 180, amplitude: 0.25),
+                Tone(duration: 1, frequency: 300, amplitude: 0.25),
+            ])
+            defer { try? FileManager.default.removeItem(at: audioURL) }
+
+            let analysis = try analyzer.analyze(
+                recognitions: [recognition(start: 0, end: 2)],
+                audioURL: audioURL
+            )
+            let features = try firstFeatures(in: analysis)
+
+            #expect(try #require(features.pitchSpreadHertz) > 100)
+        }
+
+        @Test
+        func highFrequencySignalDoesNotAliasIntoPitchRange() throws {
+            let audioURL = try makeAudioFile([
+                Tone(duration: 2, frequency: 7800, amplitude: 0.25),
+            ])
+            defer { try? FileManager.default.removeItem(at: audioURL) }
+
+            let features = try firstFeatures(
+                in: analyzer.analyze(
+                    recognitions: [recognition(start: 0, end: 2)],
+                    audioURL: audioURL
+                )
+            )
+
+            #expect(features.activeRmsDecibels != nil)
+            #expect(features.medianPitchHertz == nil)
+            #expect(features.pitchSpreadHertz == nil)
+        }
+
+        @Test(arguments: [60.0, 500.0])
+        func pitchRangeBoundariesRemainDetectable(frequency: Double) throws {
+            let audioURL = try makeAudioFile([
+                Tone(duration: 2, frequency: frequency, amplitude: 0.25),
+            ])
+            defer { try? FileManager.default.removeItem(at: audioURL) }
+
+            let features = try firstFeatures(
+                in: analyzer.analyze(
+                    recognitions: [recognition(start: 0, end: 2)],
+                    audioURL: audioURL
+                )
+            )
+
+            #expect(try abs(#require(features.medianPitchHertz) - frequency) < 3)
+        }
+
+        @Test
+        func segmentFeaturesExcludeAdjacentAudio() throws {
+            let audioURL = try makeAudioFile([
+                Tone(duration: 1, frequency: 220, amplitude: 0.25),
+                Tone(duration: 1, frequency: nil, amplitude: 0),
+            ])
+            defer { try? FileManager.default.removeItem(at: audioURL) }
+
+            let features = try firstFeatures(
+                in: analyzer.analyze(
+                    recognitions: [recognition(start: 1, end: 1.01)],
+                    audioURL: audioURL
+                )
+            )
+
+            #expect(features.activeRmsDecibels == nil)
+            #expect(features.medianPitchHertz == nil)
+            #expect(features.voicedFrameRatio == 0)
+            #expect(features.pitchSpreadHertz == nil)
+        }
+
+        @Test
+        func silenceAndShortAudioUseDefinedMissingValues() throws {
+            let silenceURL = try makeAudioFile([
+                Tone(duration: 1, frequency: nil, amplitude: 0),
+            ])
+            let shortURL = try makeAudioFile([
+                Tone(duration: 0.01, frequency: 220, amplitude: 0.25),
+            ])
+            defer {
+                try? FileManager.default.removeItem(at: silenceURL)
+                try? FileManager.default.removeItem(at: shortURL)
+            }
+
+            let silence = try firstFeatures(
+                in: analyzer.analyze(
+                    recognitions: [recognition(start: 0, end: 1)],
+                    audioURL: silenceURL
+                )
+            )
+            let short = try firstFeatures(
+                in: analyzer.analyze(
+                    recognitions: [recognition(start: 0, end: 0.01)],
+                    audioURL: shortURL
+                )
+            )
+
+            #expect(silence.activeRmsDecibels == nil)
+            #expect(silence.medianPitchHertz == nil)
+            #expect(silence.voicedFrameRatio == 0)
+            #expect(silence.pitchSpreadHertz == nil)
+            #expect(short.activeRmsDecibels != nil)
+            #expect(short.medianPitchHertz == nil)
+            #expect(short.voicedFrameRatio == 1)
+            #expect(short.pitchSpreadHertz == nil)
+        }
+
+        @Test
+        func manualSlicesFormOneLogicalAudioTimeline() async throws {
+            let firstURL = try makeAudioFile([
+                Tone(duration: 1, frequency: 220, amplitude: 0.25),
+            ])
+            let secondURL = try makeAudioFile([
+                Tone(duration: 1, frequency: 220, amplitude: 0.25),
+            ])
+            defer {
+                try? FileManager.default.removeItem(at: firstURL)
+                try? FileManager.default.removeItem(at: secondURL)
+            }
+            let slices = [
+                BatchSpeechAudioSlice(audioURL: firstURL, startFrame: 0, frameCount: 16000),
+                BatchSpeechAudioSlice(audioURL: secondURL, startFrame: 0, frameCount: 16000),
+            ]
+            let run = BatchManualTranscriptionRun(
+                slices: slices,
+                sliceFileIndices: [0, 1],
+                localeIdentifier: "en_US",
+                source: .microphone,
+                recordingSessionId: .v7(),
+                recordingStartTime: Date(timeIntervalSince1970: 1_776_384_000),
+                sessionOffsetSeconds: 0,
+                fileIndices: [0, 1]
+            )
+            let recognizer = SliceSpeechRecognizer(
+                recognitions: [recognition(start: 0.8, end: 1.2)]
+            )
+
+            let result = try await BatchManualSpeechTranscriberService.transcribe(
+                run,
+                speechRecognizer: recognizer
+            )
+            let features = try #require(result.segments.first?.audioFeatures)
+
+            #expect(try abs(#require(features.medianPitchHertz) - 220) < 3)
+            #expect(features.voicedFrameRatio > 0.99)
+        }
+
+        @Test
+        func extractionFailureDoesNotFailAutomaticTranscription() async throws {
+            let audioURL = try makeAudioFile([
+                Tone(duration: 1, frequency: 220, amplitude: 0.25),
+            ])
+            defer { try? FileManager.default.removeItem(at: audioURL) }
+            let request = BatchSpeechTranscriptionRequest(
+                audioURL: audioURL,
+                startFrame: 0,
+                frameCount: 16000,
+                recordedLocaleIdentifiers: ["en_US"],
+                languageDetectionMode: .manual,
+                supportedLocales: [],
+                source: .microphone,
+                recordingSessionId: .v7(),
+                recordingStartTime: .now,
+                sessionOffsetSeconds: 0
+            )
+
+            let result = try await BatchSpeechTranscriberService.transcribe(
+                request,
+                speechRecognizer: FileSpeechRecognizer(
+                    recognitions: [recognition(start: 0.2, end: 0.8)]
+                ),
+                audioFeatureAnalyzer: FailingAudioFeatureAnalyzer()
+            )
+
+            #expect(result.segments.map(\.text) == ["speech"])
+            #expect(result.segments.first?.audioFeatures == nil)
+        }
+
+        @Test
+        func invalidRecognitionOnlyOmitsThatSegmentsFeatures() throws {
+            let audioURL = try makeAudioFile([
+                Tone(duration: 1, frequency: 220, amplitude: 0.25),
+            ])
+            defer { try? FileManager.default.removeItem(at: audioURL) }
+
+            let analysis = try analyzer.analyze(
+                recognitions: [
+                    recognition(start: 0.1, end: 0.5),
+                    recognition(start: 2, end: 3),
+                    recognition(start: 0.1, end: .greatestFiniteMagnitude),
+                ],
+                audioURL: audioURL
+            )
+
+            #expect(analysis.features[0] != nil)
+            #expect(analysis.features[1] == nil)
+            #expect(analysis.features[2] == nil)
+            #expect(analysis.invalidRecognitionCount == 2)
+        }
+
+        private func recognition(start: TimeInterval, end: TimeInterval) -> BatchSpeechRecognition {
+            BatchSpeechRecognition(startSeconds: start, endSeconds: end, text: "speech")
+        }
+
+        private func firstFeatures(
+            in analysis: BatchTranscriptAudioFeatureAnalysis
+        ) throws -> TranscriptAudioFeatures {
+            let first = try #require(analysis.features.first)
+            return try #require(first)
+        }
+
+        private func makeAudioFile(_ tones: [Tone]) throws -> URL {
+            let sampleRate = 16000.0
+            let format = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: sampleRate,
+                channels: 1,
+                interleaved: false
+            ))
+            let url = FileManager.default.temporaryDirectory
+                .appending(path: "dahlia-audio-features-\(UUID.v7().uuidString).caf")
+            let audioFile = try AVAudioFile(
+                forWriting: url,
+                settings: format.settings,
+                commonFormat: .pcmFormatFloat32,
+                interleaved: false
+            )
+            let frameCount = tones.reduce(0) {
+                $0 + Int(($1.duration * sampleRate).rounded())
+            }
+            let buffer = try #require(AVAudioPCMBuffer(
+                pcmFormat: format,
+                frameCapacity: AVAudioFrameCount(frameCount)
+            ))
+            buffer.frameLength = AVAudioFrameCount(frameCount)
+            let samples = try #require(buffer.floatChannelData?[0])
+            var frame = 0
+            for tone in tones {
+                let toneFrameCount = Int((tone.duration * sampleRate).rounded())
+                for toneFrame in 0 ..< toneFrameCount {
+                    if let frequency = tone.frequency {
+                        samples[frame] = tone.amplitude * sin(
+                            2 * .pi * Float(frequency) * Float(toneFrame) / Float(sampleRate)
+                        )
+                    } else {
+                        samples[frame] = 0
+                    }
+                    frame += 1
+                }
+            }
+            try audioFile.write(from: buffer)
+            return url
+        }
+    }
+
+    private struct Tone {
+        let duration: TimeInterval
+        let frequency: Double?
+        let amplitude: Float
+    }
+
+    private struct FileSpeechRecognizer: BatchSpeechRecognizing {
+        let recognitions: [BatchSpeechRecognition]
+
+        func recognize(audioURL _: URL, locale _: Locale) -> [BatchSpeechRecognition] {
+            recognitions
+        }
+    }
+
+    private struct SliceSpeechRecognizer: BatchSpeechRecognizing {
+        let recognitions: [BatchSpeechRecognition]
+
+        func recognize(audioURL _: URL, locale _: Locale) -> [BatchSpeechRecognition] {
+            []
+        }
+
+        func recognize(
+            audioSlices _: [BatchSpeechAudioSlice],
+            locale _: Locale
+        ) -> [BatchSpeechRecognition] {
+            recognitions
+        }
+    }
+
+    private struct FailingAudioFeatureAnalyzer: BatchTranscriptAudioFeatureAnalyzing {
+        func analyze(
+            recognitions _: [BatchSpeechRecognition],
+            audioURL _: URL
+        ) throws -> BatchTranscriptAudioFeatureAnalysis {
+            throw CocoaError(.fileReadUnknown)
+        }
+
+        func analyze(
+            recognitions _: [BatchSpeechRecognition],
+            audioSlices _: [BatchSpeechAudioSlice]
+        ) throws -> BatchTranscriptAudioFeatureAnalysis {
+            throw CocoaError(.fileReadUnknown)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/BatchTranscriptAudioFeatureAnalyzerTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptAudioFeatureAnalyzerTests.swift
@@ -96,6 +96,7 @@ import Foundation
             )
 
             #expect(features.activeRmsDecibels != nil)
+            #expect(features.voicedFrameRatio > 0.99)
             #expect(features.medianPitchHertz == nil)
             #expect(features.pitchSpreadHertz == nil)
         }
@@ -255,6 +256,7 @@ import Foundation
             let analysis = try analyzer.analyze(
                 recognitions: [
                     recognition(start: 0.1, end: 0.5),
+                    recognition(start: 0.1, end: 1.000_062_5),
                     recognition(start: 2, end: 3),
                     recognition(start: 0.1, end: .greatestFiniteMagnitude),
                 ],
@@ -264,7 +266,8 @@ import Foundation
             #expect(analysis.features[0] != nil)
             #expect(analysis.features[1] == nil)
             #expect(analysis.features[2] == nil)
-            #expect(analysis.invalidRecognitionCount == 2)
+            #expect(analysis.features[3] == nil)
+            #expect(analysis.invalidRecognitionCount == 3)
         }
 
         private func recognition(start: TimeInterval, end: TimeInterval) -> BatchSpeechRecognition {

--- a/Tests/DahliaTests/BatchTranscriptionPersistenceTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionPersistenceTests.swift
@@ -61,18 +61,42 @@ import GRDB
                 text: "final",
                 now: now
             )
+            let expectedAudioFeatures = sampleAudioFeatures
             try BatchTranscriptionPersistence.complete(
                 sessionId: fixture.session.id,
                 meetingId: fixture.meeting.id,
-                records: [finalRecord],
+                records: [record(finalRecord, with: expectedAudioFeatures)],
                 completedAt: completedAt,
                 dbQueue: fixture.database.dbQueue
             )
 
             let completed = try fetchState(fixture)
             #expect(completed.records.map(\.text) == ["final"])
+            #expect(completed.records.first?.audioFeatures == expectedAudioFeatures)
             #expect(completed.session.batchCompletedAt == completedAt)
             #expect(completed.meeting.status == .ready)
+        }
+
+        private var sampleAudioFeatures: TranscriptAudioFeatures {
+            TranscriptAudioFeatures(
+                activeRmsDecibels: -16,
+                medianPitchHertz: 210,
+                voicedFrameRatio: 0.8,
+                pitchSpreadHertz: 35
+            )
+        }
+
+        private func record(
+            _ record: TranscriptSegmentRecord,
+            with audioFeatures: TranscriptAudioFeatures
+        ) -> TranscriptSegmentRecord {
+            var record = record
+            record.audioFeatureVersion = audioFeatures.version
+            record.audioActiveRmsDecibels = audioFeatures.activeRmsDecibels
+            record.audioMedianPitchHertz = audioFeatures.medianPitchHertz
+            record.audioVoicedFrameRatio = audioFeatures.voicedFrameRatio
+            record.audioPitchSpreadHertz = audioFeatures.pitchSpreadHertz
+            return record
         }
 
         private func fetchState(_ fixture: BatchAudioTestFixture) throws -> PersistenceState {

--- a/Tests/DahliaTests/MeetingConversationMetricsMigrationTests.swift
+++ b/Tests/DahliaTests/MeetingConversationMetricsMigrationTests.swift
@@ -26,20 +26,27 @@ import GRDB
                 createdAt: now,
                 updatedAt: now
             )
-            let segment = TranscriptSegmentRecord(
-                id: UUID(),
-                meetingId: meeting.id,
-                startTime: now,
-                endTime: now.addingTimeInterval(1),
-                text: "Preserved",
-                translatedText: nil,
-                isConfirmed: true,
-                speakerLabel: RecordingAudioSource.microphone.speakerLabel
-            )
+            let segmentID = UUID()
             try queue.write { db in
                 try vault.insert(db)
                 try meeting.insert(db)
-                try segment.insert(db)
+                try db.execute(
+                    sql: """
+                    INSERT INTO transcript_segments (
+                        id, meetingId, startTime, endTime, text,
+                        translatedText, isConfirmed, speakerLabel
+                    )
+                    VALUES (?, ?, ?, ?, ?, NULL, 1, ?)
+                    """,
+                    arguments: [
+                        segmentID,
+                        meeting.id,
+                        now,
+                        now.addingTimeInterval(1),
+                        "Preserved",
+                        RecordingAudioSource.microphone.speakerLabel,
+                    ]
+                )
             }
 
             try AppDatabaseManager.migrator.migrate(queue)
@@ -47,7 +54,7 @@ import GRDB
             let result = try queue.read { db in
                 (
                     try MeetingRecord.fetchOne(db, key: meeting.id),
-                    try TranscriptSegmentRecord.fetchOne(db, key: segment.id),
+                    try TranscriptSegmentRecord.fetchOne(db, key: segmentID),
                     try db.tableExists(MeetingConversationMetricsRecord.databaseTableName),
                     try db.tableExists(MeetingConversationSourceMetricsRecord.databaseTableName)
                 )

--- a/Tests/DahliaTests/TranscriptAudioFeaturesMigrationTests.swift
+++ b/Tests/DahliaTests/TranscriptAudioFeaturesMigrationTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct TranscriptAudioFeaturesMigrationTests {
+        @Test
+        func migrationFromV31PreservesTranscriptAndAddsNullableFeatureColumns() throws {
+            let (queue, segmentID) = try makeV31Database()
+
+            try AppDatabaseManager.migrator.migrate(queue)
+
+            let result = try queue.read { db in
+                try (
+                    TranscriptSegmentRecord.fetchOne(db, key: segmentID),
+                    String.fetchAll(
+                        db,
+                        sql: """
+                        SELECT name
+                        FROM pragma_table_info('transcript_segments')
+                        WHERE name LIKE 'audio%'
+                        ORDER BY cid
+                        """
+                    )
+                )
+            }
+
+            #expect(result.0?.text == "Preserved")
+            #expect(result.0?.audioFeatures == nil)
+            #expect(result.1 == [
+                "audioFeatureVersion",
+                "audioActiveRmsDecibels",
+                "audioMedianPitchHertz",
+                "audioVoicedFrameRatio",
+                "audioPitchSpreadHertz",
+            ])
+        }
+
+        private func makeV31Database() throws -> (DatabaseQueue, UUID) {
+            let queue = try DatabaseQueue()
+            try AppDatabaseManager.migrator.migrate(queue, upTo: "v31_meetingConversationMetrics")
+            let now = Date(timeIntervalSince1970: 1_776_384_000)
+            let vault = VaultRecord(
+                id: .v7(),
+                path: "/tmp/transcript-audio-features-migration",
+                name: "Vault",
+                createdAt: now,
+                lastOpenedAt: now
+            )
+            let meeting = MeetingRecord(
+                id: .v7(),
+                vaultId: vault.id,
+                projectId: nil,
+                name: "Preserved",
+                createdAt: now,
+                updatedAt: now
+            )
+            let segmentID = UUID.v7()
+            try queue.write { db in
+                try vault.insert(db)
+                try meeting.insert(db)
+                try db.execute(
+                    sql: """
+                    INSERT INTO transcript_segments (
+                        id, meetingId, startTime, endTime, text,
+                        translatedText, isConfirmed, speakerLabel
+                    )
+                    VALUES (?, ?, ?, ?, ?, NULL, 1, ?)
+                    """,
+                    arguments: [
+                        segmentID,
+                        meeting.id,
+                        now,
+                        now.addingTimeInterval(1),
+                        "Preserved",
+                        RecordingAudioSource.microphone.speakerLabel,
+                    ]
+                )
+            }
+            return (queue, segmentID)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/TranscriptSegmentTests.swift
+++ b/Tests/DahliaTests/TranscriptSegmentTests.swift
@@ -189,14 +189,21 @@ struct TranscriptSegmentTests {
     }
 
     @Test
-    func transcriptSegmentRecordRoundTripsTranslatedText() {
+    func transcriptSegmentRecordRoundTripsTranslationAndAudioFeatures() {
         let meetingID = UUID.v7()
+        let audioFeatures = TranscriptAudioFeatures(
+            activeRmsDecibels: -18.5,
+            medianPitchHertz: 220,
+            voicedFrameRatio: 0.75,
+            pitchSpreadHertz: 42
+        )
         let segment = TranscriptSegment(
             startTime: Date(timeIntervalSince1970: 1_776_384_000),
             text: "Hello world",
             translatedText: "こんにちは、世界",
             isConfirmed: true,
-            speakerLabel: "mic"
+            speakerLabel: "mic",
+            audioFeatures: audioFeatures
         )
 
         let record = TranscriptSegmentRecord(from: segment, meetingId: meetingID)
@@ -204,6 +211,8 @@ struct TranscriptSegmentTests {
 
         #expect(record.translatedText == "こんにちは、世界")
         #expect(roundTripped.translatedText == "こんにちは、世界")
+        #expect(record.audioFeatureVersion == TranscriptAudioFeatures.currentVersion)
+        #expect(roundTripped.audioFeatures == audioFeatures)
     }
 
     @Test

--- a/docs/architecture/audio-transcription-data-flow.md
+++ b/docs/architecture/audio-transcription-data-flow.md
@@ -123,7 +123,7 @@ flowchart LR
 | preview／preview translation | event pipeline と UI store memory | 現在の表示候補を更新した | durable にしない | 後続イベントまたは正本から置換 |
 | realtime finalized event | event pipeline／persistence writer memory | UI より先に persistence lane へ受理した | `transcript_segments` の SQLite transaction が commit した時点 | batch 音声がなければ元音声からは再生成不能 |
 | batch recognition result | `BatchTranscriptionCoordinator` memory | ready CAF から一式を生成した | transcript rows と batch 完了状態の transaction が commit した時点 | ready CAF が残る間は再生成可能 |
-| transcript audio features | batch recognition work item memory | 認識に使った音声から発話区間の RMS、pitch、voiced ratio、pitch spread を best effort で集約した | 対応する `transcript_segments` row と batch 完了状態の transaction が commit した時点 | ready CAF が残る間だけ再生成可能 |
+| transcript audio features | batch recognition work item memory | 認識に使った音声から発話区間の RMS、pitch、activity-gate ratio、pitch spread を best effort で集約した | 対応する `transcript_segments` row と batch 完了状態の transaction が commit した時点 | ready CAF が残る間だけ再生成可能 |
 | transcript source of truth | SQLite `transcript_segments` | realtime の差分 insert または batch の一式置換 | SQLite commit 完了時 | UI projection を再構築できる |
 | recording metadata | SQLite `recording_sessions` ほか | mode、開始／終了、batch 状態、audio progress を更新 | 各 SQLite commit 完了時 | ファイルだけから完全には再生成しない |
 
@@ -241,6 +241,7 @@ sequenceDiagram
 各 recognition work item は、認識直後かつ一時的な prepared audio または logical CAF slices が有効な間に、
 確定区間ごとの軽量な音声特徴量を一回の走査で集約する。特徴量は補助データであり、抽出失敗は文字起こし完了、
 既存の retry policy、音声 purge を妨げず、その区間または work item の値を `NULL` として保存する。
+version 1 の `audioVoicedFrameRatio` は pitch 検出率ではなく、全分析 frame に占める activity gate 通過 frame の比率を表す。
 音量は RMS dBFS の相対値であり、OS の処理や音源ごとの gain が異なるため microphone と system の間では比較せず、
 同一 recording session・同一音源内の参考値として扱う。リアルタイム文字起こしでは音声特徴量を生成しない。
 

--- a/docs/architecture/audio-transcription-data-flow.md
+++ b/docs/architecture/audio-transcription-data-flow.md
@@ -123,6 +123,7 @@ flowchart LR
 | preview／preview translation | event pipeline と UI store memory | 現在の表示候補を更新した | durable にしない | 後続イベントまたは正本から置換 |
 | realtime finalized event | event pipeline／persistence writer memory | UI より先に persistence lane へ受理した | `transcript_segments` の SQLite transaction が commit した時点 | batch 音声がなければ元音声からは再生成不能 |
 | batch recognition result | `BatchTranscriptionCoordinator` memory | ready CAF から一式を生成した | transcript rows と batch 完了状態の transaction が commit した時点 | ready CAF が残る間は再生成可能 |
+| transcript audio features | batch recognition work item memory | 認識に使った音声から発話区間の RMS、pitch、voiced ratio、pitch spread を best effort で集約した | 対応する `transcript_segments` row と batch 完了状態の transaction が commit した時点 | ready CAF が残る間だけ再生成可能 |
 | transcript source of truth | SQLite `transcript_segments` | realtime の差分 insert または batch の一式置換 | SQLite commit 完了時 | UI projection を再構築できる |
 | recording metadata | SQLite `recording_sessions` ほか | mode、開始／終了、batch 状態、audio progress を更新 | 各 SQLite commit 完了時 | ファイルだけから完全には再生成しない |
 
@@ -217,12 +218,15 @@ sequenceDiagram
     participant Audio as RecordingAudioStore
     participant Batch as BatchTranscriptionCoordinator
     participant Speech as Batch speech recognizer
+    participant Features as Audio feature analyzer
     participant DB as SQLite
 
     Batch->>Audio: ready segments の read plan
     Audio-->>Batch: verified immutable CAF + locale ranges
     Batch->>Speech: source / locale ごとの transcription run
     Speech-->>Batch: complete segment set
+    Batch->>Features: recognition range + prepared audio / logical slices
+    Features-->>Batch: optional per-segment numeric features
     Batch->>DB: session の旧 transcript を置換し、batchCompletedAt と meeting status を更新
     DB-->>Batch: single transaction commit
 ```
@@ -233,6 +237,12 @@ sequenceDiagram
 
 認識途中の結果は正本へ部分反映しない。成功した全結果を `BatchTranscriptionPersistence.complete` が一つの transaction で
 反映する。再文字起こし中は以前の成功結果を利用でき、新しい一式が成功した時だけ置き換える。
+
+各 recognition work item は、認識直後かつ一時的な prepared audio または logical CAF slices が有効な間に、
+確定区間ごとの軽量な音声特徴量を一回の走査で集約する。特徴量は補助データであり、抽出失敗は文字起こし完了、
+既存の retry policy、音声 purge を妨げず、その区間または work item の値を `NULL` として保存する。
+音量は RMS dBFS の相対値であり、OS の処理や音源ごとの gain が異なるため microphone と system の間では比較せず、
+同一 recording session・同一音源内の参考値として扱う。リアルタイム文字起こしでは音声特徴量を生成しない。
 
 ### 正常停止
 
@@ -271,6 +281,7 @@ sequenceDiagram
 | live recognition failure in batch | audio writer が健全なら正本音声を継続 | 字幕／chat を縮退し、停止後 batch を維持 |
 | realtime SQLite failure | pending event と順序を writer actor 内で保持 | exponential backoff。停止時にも flush failure を返す |
 | batch recognition failure | 旧成功 transcript と ready audio を保持 | failure state を保存し、再試行可能 |
+| batch audio feature extraction failure | 認識済み transcript と通常の purge policy を維持 | sanitized error を報告し、該当 feature columns を `NULL` にする |
 | crash 中の partial／finalizing CAF | 既存 ready segment を変更しない | startup reconciler が DB state と file を照合 |
 | ready CAF の missing／mismatch | 自動再作成、上書き、削除をしない | `failed` と reconciliation issue を記録 |
 


### PR DESCRIPTION
## Summary

- extract active RMS dBFS, median pitch, voiced-frame ratio, and pitch IQR for batch transcript segments before recorded audio is purged
- support automatic prepared-audio work items and manual logical slice runs with best-effort failure handling
- persist the optional values through the v32 additive migration and the existing atomic batch completion transaction
- document that the metrics are reference values intended for comparisons within the same session and audio source

## Implementation notes

- uses bounded 40 ms windows with 20 ms hops and segment-local overlap accounting
- band-limits pitch input before decimation to prevent high-frequency aliasing
- treats invalid segment ranges and extraction failures as nullable feature data without changing transcription completion, retry, or purge behavior
- reports only sanitized diagnostics without audio, transcript text, or file paths

## Validation

- `swift build`
- relevant audio feature, transcription, persistence, and migration suites: 31 tests passed
- full test suite: 1,247 tests in 197 suites passed
- `CI=true ./scripts/lint.sh` (SwiftFormat clean; repository-existing SwiftLint violations remain non-blocking)
- post-review analyzer regression suite: 10 tests passed
