### PR TITLE
Support shared organization domains

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -93,8 +93,8 @@ Meeting creation / recording-start coordinator
        └─ recordings: only after capture starts successfully
             ├─ Vault-scoped Contact
             ├─ Meeting participant
-            ├─ domain → Organization
-            └─ Organization membership
+            ├─ domain → one or more root Organizations
+            └─ unambiguous, setting-enabled Organization membership
 
 SQLite typed records
     ├─ Organization / unit / domain / membership

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>37</string>
+    <string>38</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.7.2</string>
+    <string>0.8.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/Database/AppDatabaseManager.swift
+++ b/Sources/Dahlia/Database/AppDatabaseManager.swift
@@ -174,6 +174,13 @@ final class AppDatabaseManager: Sendable {
             try addTranscriptAudioFeatureColumnsIfNeeded(in: db)
         }
 
+        migrator.registerMigration(
+            "v33_sharedOrganizationDomains",
+            foreignKeyChecks: .deferred
+        ) { db in
+            try SharedOrganizationDomainsMigration.migrate(in: db)
+        }
+
         return migrator
     }()
 

--- a/Sources/Dahlia/Database/CustomerIntelligencePersistence.swift
+++ b/Sources/Dahlia/Database/CustomerIntelligencePersistence.swift
@@ -79,29 +79,36 @@ enum CustomerIntelligencePersistence {
         return contact
     }
 
-    static func organization(
+    static func organizations(
         forDomain rawDomainName: String,
         vaultId: UUID,
         observedAt: Date,
         automaticallyCreate: Bool,
         in db: Database
-    ) throws -> OrganizationRecord? {
+    ) throws -> [OrganizationRecord] {
         guard let domainName = CustomerIdentityNormalizer.domainName(rawDomainName) else {
             throw CustomerIntelligenceError.invalidDomain
         }
-        if var domain = try OrganizationDomainRecord
+        let domains = try OrganizationDomainRecord
             .filter(Column("vaultId") == vaultId && Column("domainName") == domainName)
-            .fetchOne(db) {
-            let firstObservedAt = min(domain.firstObservedAt, observedAt)
-            let lastObservedAt = max(domain.lastObservedAt, observedAt)
-            if firstObservedAt != domain.firstObservedAt || lastObservedAt != domain.lastObservedAt {
+            .fetchAll(db)
+        if !domains.isEmpty {
+            for var domain in domains {
+                let firstObservedAt = min(domain.firstObservedAt, observedAt)
+                let lastObservedAt = max(domain.lastObservedAt, observedAt)
+                guard firstObservedAt != domain.firstObservedAt || lastObservedAt != domain.lastObservedAt else {
+                    continue
+                }
                 domain.firstObservedAt = firstObservedAt
                 domain.lastObservedAt = lastObservedAt
                 try domain.update(db)
             }
-            return try OrganizationRecord.fetchOne(db, key: domain.organizationId)
+            let organizationIDs = domains.map(\.organizationId)
+            return try OrganizationRecord
+                .filter(organizationIDs.contains(Column("id")))
+                .fetchAll(db)
         }
-        guard automaticallyCreate else { return nil }
+        guard automaticallyCreate else { return [] }
 
         let organization = OrganizationRecord(
             id: .v7(),
@@ -122,7 +129,7 @@ enum CustomerIntelligencePersistence {
             firstObservedAt: observedAt,
             lastObservedAt: observedAt
         ).insert(db)
-        return organization
+        return [organization]
     }
 
     static func addMembership(
@@ -150,6 +157,7 @@ enum CustomerIntelligencePersistence {
         meetingId: UUID,
         vaultId: UUID,
         observedAt: Date,
+        automaticallyLinkMemberships: Bool,
         in db: Database
     ) throws -> CustomerIntelligenceIngestionMetrics {
         let selection = canonicalParticipants(participants)
@@ -177,17 +185,19 @@ enum CustomerIntelligencePersistence {
             )
 
             guard let domainName = CustomerIdentityNormalizer.domainName(fromEmail: email),
-                  CustomerIdentityNormalizer.isAutomaticOrganizationDomain(domainName),
-                  let organization = try organization(
-                      forDomain: domainName,
-                      vaultId: vaultId,
-                      observedAt: observedAt,
-                      automaticallyCreate: true,
-                      in: db
-                  )
+                  CustomerIdentityNormalizer.isAutomaticOrganizationDomain(domainName)
             else {
                 continue
             }
+            let matchingOrganizations = try organizations(
+                forDomain: domainName,
+                vaultId: vaultId,
+                observedAt: observedAt,
+                automaticallyCreate: true,
+                in: db
+            )
+            guard automaticallyLinkMemberships, matchingOrganizations.count == 1,
+                  let organization = matchingOrganizations.first else { continue }
             try addMembership(
                 organizationId: organization.id,
                 contactId: contact.id,

--- a/Sources/Dahlia/Database/CustomerIntelligenceWorkspaceRecords.swift
+++ b/Sources/Dahlia/Database/CustomerIntelligenceWorkspaceRecords.swift
@@ -68,6 +68,7 @@ struct OrganizationMergePreview: Equatable, Sendable {
 enum OrganizationDomainAssignmentPlan: Equatable, Sendable {
     case unassigned
     case alreadyAssigned
+    case shared
     case merge(OrganizationMergePreview)
 }
 

--- a/Sources/Dahlia/Database/MeetingRepository+CustomerIntelligence.swift
+++ b/Sources/Dahlia/Database/MeetingRepository+CustomerIntelligence.swift
@@ -335,14 +335,29 @@ extension MeetingRepository {
             guard target.isRootOrganization else {
                 throw CustomerIntelligenceError.invalidOrganizationMerge
             }
-            guard let domain = try OrganizationDomainRecord
+            let domains = try OrganizationDomainRecord
                 .filter(Column("vaultId") == vaultId && Column("domainName") == domainName)
-                .fetchOne(db)
-            else {
+                .fetchAll(db)
+            guard !domains.isEmpty else {
                 return .unassigned
             }
-            guard domain.organizationId != targetOrganizationId else {
+            guard !domains.contains(where: { $0.organizationId == targetOrganizationId }) else {
                 return .alreadyAssigned
+            }
+            guard domains.count == 1, let domain = domains.first else {
+                let ownerIDs = domains.map(\.organizationId)
+                let rootOwnerCount = try OrganizationRecord
+                    .filter(
+                        ownerIDs.contains(Column("id"))
+                            && Column("vaultId") == vaultId
+                            && Column("nodeKind") == OrganizationNodeKind.organization
+                            && Column("parentOrganizationId") == nil
+                    )
+                    .fetchCount(db)
+                guard rootOwnerCount == ownerIDs.count else {
+                    throw CustomerIntelligenceError.invalidOrganizationMerge
+                }
+                return .shared
             }
             guard let source = try OrganizationRecord
                 .filter(Column("id") == domain.organizationId && Column("vaultId") == vaultId)
@@ -376,7 +391,7 @@ extension MeetingRepository {
             guard let organization = try OrganizationRecord
                 .filter(Column("id") == organizationId && Column("vaultId") == vaultId)
                 .fetchOne(db),
-                organization.nodeKind == .organization
+                organization.isRootOrganization
             else {
                 throw CustomerIntelligenceError.organizationNotFound
             }
@@ -384,11 +399,12 @@ extension MeetingRepository {
                 throw CustomerIntelligenceError.revisionConflict
             }
             if var existing = try OrganizationDomainRecord
-                .filter(Column("vaultId") == vaultId && Column("domainName") == domainName)
+                .filter(
+                    Column("vaultId") == vaultId
+                        && Column("domainName") == domainName
+                        && Column("organizationId") == organizationId
+                )
                 .fetchOne(db) {
-                guard existing.organizationId == organizationId else {
-                    throw CustomerIntelligenceError.domainAlreadyAssigned
-                }
                 let firstObservedAt = min(existing.firstObservedAt, observedAt)
                 let lastObservedAt = max(existing.lastObservedAt, observedAt)
                 if firstObservedAt != existing.firstObservedAt || lastObservedAt != existing.lastObservedAt {
@@ -408,7 +424,11 @@ extension MeetingRepository {
             )
             try domain.insert(db)
             domain = try OrganizationDomainRecord
-                .filter(Column("vaultId") == vaultId && Column("domainName") == domainName)
+                .filter(
+                    Column("vaultId") == vaultId
+                        && Column("domainName") == domainName
+                        && Column("organizationId") == organizationId
+                )
                 .fetchOne(db) ?? domain
             return domain
         }
@@ -444,13 +464,21 @@ extension MeetingRepository {
         }
     }
 
-    nonisolated func removeOrganizationDomain(vaultId: UUID, domainName rawDomainName: String) throws {
+    nonisolated func removeOrganizationDomain(
+        organizationId: UUID,
+        vaultId: UUID,
+        domainName rawDomainName: String
+    ) throws {
         guard let domainName = CustomerIdentityNormalizer.domainName(rawDomainName) else {
             throw CustomerIntelligenceError.invalidDomain
         }
         try dbQueue.write { db in
             _ = try OrganizationDomainRecord
-                .filter(Column("vaultId") == vaultId && Column("domainName") == domainName)
+                .filter(
+                    Column("vaultId") == vaultId
+                        && Column("domainName") == domainName
+                        && Column("organizationId") == organizationId
+                )
                 .deleteAll(db)
         }
     }
@@ -538,14 +566,28 @@ extension MeetingRepository {
                 .filter(Column("organizationId") == sourceOrganizationId)
                 .deleteAll(db)
             for domain in domainsToMove {
-                try OrganizationDomainRecord(
-                    vaultId: domain.vaultId,
-                    domainName: domain.domainName,
-                    organizationId: targetOrganizationId,
-                    isPrimary: !targetHasPrimaryDomain && domain.isPrimary,
-                    firstObservedAt: domain.firstObservedAt,
-                    lastObservedAt: domain.lastObservedAt
-                ).insert(db)
+                let shouldBePrimary = !targetHasPrimaryDomain && domain.isPrimary
+                if var existing = try OrganizationDomainRecord
+                    .filter(
+                        Column("vaultId") == domain.vaultId
+                            && Column("domainName") == domain.domainName
+                            && Column("organizationId") == targetOrganizationId
+                    )
+                    .fetchOne(db) {
+                    existing.firstObservedAt = min(existing.firstObservedAt, domain.firstObservedAt)
+                    existing.lastObservedAt = max(existing.lastObservedAt, domain.lastObservedAt)
+                    existing.isPrimary = existing.isPrimary || shouldBePrimary
+                    try existing.update(db)
+                } else {
+                    try OrganizationDomainRecord(
+                        vaultId: domain.vaultId,
+                        domainName: domain.domainName,
+                        organizationId: targetOrganizationId,
+                        isPrimary: shouldBePrimary,
+                        firstObservedAt: domain.firstObservedAt,
+                        lastObservedAt: domain.lastObservedAt
+                    ).insert(db)
+                }
             }
 
             try db.execute(

--- a/Sources/Dahlia/Database/SharedOrganizationDomainsMigration.swift
+++ b/Sources/Dahlia/Database/SharedOrganizationDomainsMigration.swift
@@ -1,0 +1,115 @@
+import GRDB
+
+enum SharedOrganizationDomainsMigration {
+    // swiftlint:disable:next function_body_length
+    static func migrate(in db: Database) throws {
+        try db.execute(sql: """
+        ALTER TABLE organization_domains RENAME TO organization_domains_v31;
+
+        CREATE TABLE organization_domains (
+            vaultId BLOB NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+            domainName TEXT NOT NULL,
+            organizationId BLOB NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+            isPrimary BOOLEAN NOT NULL DEFAULT 0 CHECK (isPrimary IN (0, 1)),
+            firstObservedAt DATETIME NOT NULL,
+            lastObservedAt DATETIME NOT NULL,
+            PRIMARY KEY (vaultId, domainName, organizationId),
+            CHECK (LENGTH(domainName) > 0),
+            CHECK (lastObservedAt >= firstObservedAt)
+        );
+
+        INSERT INTO organization_domains (
+            vaultId,
+            domainName,
+            organizationId,
+            isPrimary,
+            firstObservedAt,
+            lastObservedAt
+        )
+        SELECT
+            vaultId,
+            domainName,
+            organizationId,
+            isPrimary,
+            firstObservedAt,
+            lastObservedAt
+        FROM organization_domains_v31;
+
+        DROP TABLE organization_domains_v31;
+
+        CREATE INDEX organization_domains_on_organizationId_domainName
+            ON organization_domains(organizationId, domainName);
+        CREATE UNIQUE INDEX organization_domains_one_primary
+            ON organization_domains(organizationId)
+            WHERE isPrimary = 1;
+
+        CREATE TRIGGER organization_domains_validate_insert
+        BEFORE INSERT ON organization_domains
+        BEGIN
+            SELECT RAISE(ABORT, 'organization domain owner must be an organization in the same vault')
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM organizations
+                WHERE id = NEW.organizationId
+                  AND vaultId = NEW.vaultId
+                  AND nodeKind = 'organization'
+            );
+        END;
+
+        CREATE TRIGGER organization_domains_validate_update
+        BEFORE UPDATE OF vaultId, domainName, organizationId ON organization_domains
+        BEGIN
+            SELECT RAISE(ABORT, 'organization domain identity is immutable')
+            WHERE NEW.vaultId <> OLD.vaultId
+               OR NEW.domainName <> OLD.domainName
+               OR NEW.organizationId <> OLD.organizationId;
+        END;
+
+        CREATE TRIGGER organization_domains_assign_first_primary
+        AFTER INSERT ON organization_domains
+        WHEN NOT EXISTS (
+            SELECT 1
+            FROM organization_domains
+            WHERE organizationId = NEW.organizationId AND isPrimary = 1
+        )
+        BEGIN
+            UPDATE organization_domains
+            SET isPrimary = 1
+            WHERE vaultId = NEW.vaultId
+              AND domainName = NEW.domainName
+              AND organizationId = NEW.organizationId;
+        END;
+
+        CREATE TRIGGER organization_domains_promote_after_primary_delete
+        AFTER DELETE ON organization_domains
+        WHEN OLD.isPrimary = 1
+        BEGIN
+            UPDATE organization_domains
+            SET isPrimary = 1
+            WHERE rowid = (
+                SELECT rowid
+                FROM organization_domains
+                WHERE organizationId = OLD.organizationId
+                ORDER BY firstObservedAt ASC, domainName ASC
+                LIMIT 1
+            );
+        END;
+
+        CREATE TRIGGER organization_domains_revision_insert
+        AFTER INSERT ON organization_domains
+        BEGIN
+            UPDATE organizations SET revision = revision + 1 WHERE id = NEW.organizationId;
+        END;
+        CREATE TRIGGER organization_domains_revision_update
+        AFTER UPDATE ON organization_domains
+        BEGIN
+            UPDATE organizations SET revision = revision + 1 WHERE id = NEW.organizationId;
+        END;
+        CREATE TRIGGER organization_domains_revision_delete
+        AFTER DELETE ON organization_domains
+        BEGIN
+            UPDATE organizations SET revision = revision + 1 WHERE id = OLD.organizationId;
+        END;
+        """)
+    }
+}

--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -100,6 +100,7 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     nonisolated static let transcriptionLanguageScopeUserDefaultsKey = "transcriptionLanguageScope"
     nonisolated static let customerIntelligenceBetaEnabledUserDefaultsKey = "customerIntelligenceBetaEnabled"
     nonisolated static let conversationAnalyticsBetaEnabledUserDefaultsKey = "conversationAnalyticsBetaEnabled"
+    nonisolated static let automaticOrganizationMembershipEnabledUserDefaultsKey = "automaticOrganizationMembershipEnabled"
     nonisolated static let customerIntelligenceSectionUserDefaultsKey = "customerIntelligenceSection"
     nonisolated static let customerIntelligenceScopeUserDefaultsKey = "customerIntelligenceScope"
     nonisolated static let customerIntelligenceTableDensityUserDefaultsKey = "customerIntelligenceTableDensity"
@@ -392,6 +393,8 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     @AppStorage("menuBarCalendarEnabled") var menuBarCalendarEnabled = true
     @AppStorage("menuBarCalendarShowsEventTitle") var menuBarCalendarShowsEventTitle = true
     @AppStorage("menuBarCalendarShowsCountdown") var menuBarCalendarShowsCountdown = true
+    @AppStorage(AppSettings.automaticOrganizationMembershipEnabledUserDefaultsKey)
+    var isAutomaticOrganizationMembershipEnabled = true
     nonisolated static let googleOAuthClientIDOverrideUserDefaultsKey = "googleOAuthClientIDOverride"
     nonisolated static let googleOAuthClientSecretOverrideKey = "googleOAuthClientSecretOverride"
     @AppStorage(AppSettings.googleOAuthClientIDOverrideUserDefaultsKey) var googleOAuthClientIDOverride = ""

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -1055,6 +1055,11 @@
 "Related Resources" = "Related Resources";
 "Danger Zone" = "Danger Zone";
 "Merge" = "Merge";
+"This email domain is already used by “%@”" = "This email domain is already used by “%@”";
+"Add as Shared Domain" = "Add as Shared Domain";
+"Merge Organizations" = "Merge Organizations";
+"Automatically link participants to organizations" = "Automatically link participants to organizations";
+"Organizations are still created for new domains when this is off. Shared domains never link participants automatically." = "Organizations are still created for new domains when this is off. Shared domains never link participants automatically.";
 "Merge with Existing Contact?" = "Merge with Existing Contact?";
 "Accept" = "Accept";
 "Accepted" = "Accepted";
@@ -1137,7 +1142,6 @@
 "The organization parent is invalid." = "The organization parent is invalid.";
 "The organization hierarchy cannot contain a cycle." = "The organization hierarchy cannot contain a cycle.";
 "The organization hierarchy exceeds the maximum depth." = "The organization hierarchy exceeds the maximum depth.";
-"The domain is already assigned to another organization." = "The domain is already assigned to another organization.";
 "Projects can reference only organizations and contacts." = "Projects can reference only organizations and contacts.";
 "The conversation topic was not found." = "The conversation topic was not found.";
 "The record changed after it was read." = "The record changed after it was read.";
@@ -1148,9 +1152,8 @@
 "Email Domains" = "Email Domains";
 "Email Domain" = "Email Domain";
 "Add Email Domain" = "Add Email Domain";
-"If this domain belongs to another organization, you can review a complete merge before anything changes." = "If this domain belongs to another organization, you can review a complete merge before anything changes.";
+"If another organization uses this domain, you can add it as shared or review a complete merge." = "If another organization uses this domain, you can add it as shared or review a complete merge.";
 "Primary" = "Primary";
-"Merge “%@”?" = "Merge “%@”?";
 "%lld domain" = "%lld domain";
 "%lld domains" = "%lld domains";
 "%lld membership" = "%lld membership";
@@ -1162,7 +1165,7 @@
 "%lld Topics" = "%lld Topics";
 "%lld insight" = "%lld insight";
 "%lld insights" = "%lld insights";
-"The domain “%@” belongs to another organization. The source contains %@, %@, %@, %@, %@, and %@. Merging into “%@” combines them and deletes the source organization. Matching relationships keep the target organization’s metadata." = "The domain “%@” belongs to another organization. The source contains %@, %@, %@, %@, %@, and %@. Merging into “%@” combines them and deletes the source organization. Matching relationships keep the target organization’s metadata.";
+"The domain “%@” belongs to another organization. Adding it as shared keeps both organizations separate. The source contains %@, %@, %@, %@, %@, and %@. Merging into “%@” combines them and deletes the source organization. Matching relationships keep the target organization’s metadata." = "The domain “%@” belongs to another organization. Adding it as shared keeps both organizations separate. The source contains %@, %@, %@, %@, %@, and %@. Merging into “%@” combines them and deletes the source organization. Matching relationships keep the target organization’s metadata.";
 "Conversation Analytics" = "Conversation Analytics";
 "BETA" = "BETA";
 "Analysis is waiting for transcription" = "Analysis is waiting for transcription";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -1055,6 +1055,11 @@
 "Related Resources" = "関係先";
 "Danger Zone" = "危険な操作";
 "Merge" = "統合";
+"This email domain is already used by “%@”" = "このメールドメインは「%@」でも使用されています";
+"Add as Shared Domain" = "共有ドメインとして追加";
+"Merge Organizations" = "組織を統合";
+"Automatically link participants to organizations" = "参加者を組織へ自動で紐付ける";
+"Organizations are still created for new domains when this is off. Shared domains never link participants automatically." = "オフでも初出ドメインの組織は自動登録されます。ドメインが複数組織に登録されている場合は自動で紐付けません。";
 "Merge with Existing Contact?" = "既存の人物と統合しますか？";
 "Accept" = "承認";
 "Accepted" = "承認済み";
@@ -1137,7 +1142,6 @@
 "The organization parent is invalid." = "親組織が正しくありません。";
 "The organization hierarchy cannot contain a cycle." = "組織階層を循環させることはできません。";
 "The organization hierarchy exceeds the maximum depth." = "組織階層が最大の深さを超えています。";
-"The domain is already assigned to another organization." = "このドメインは別の組織に割り当てられています。";
 "Projects can reference only organizations and contacts." = "Projects から参照できるのは組織と人物だけです。";
 "The conversation topic was not found." = "トピックが見つかりませんでした。";
 "The record changed after it was read." = "表示後にデータが変更されました。再読み込みしてください。";
@@ -1148,9 +1152,8 @@
 "Email Domains" = "メールドメイン";
 "Email Domain" = "メールドメイン";
 "Add Email Domain" = "メールドメインを追加";
-"If this domain belongs to another organization, you can review a complete merge before anything changes." = "別の組織に属するドメインの場合、変更前に完全統合の内容を確認できます。";
+"If another organization uses this domain, you can add it as shared or review a complete merge." = "別の組織でも使われているドメインは、共有として追加するか、完全統合の内容を確認できます。";
 "Primary" = "主ドメイン";
-"Merge “%@”?" = "「%@」を統合しますか？";
 "%lld domain" = "ドメイン%lld件";
 "%lld domains" = "ドメイン%lld件";
 "%lld membership" = "所属%lld件";
@@ -1162,7 +1165,7 @@
 "%lld Topics" = "トピック%lld件";
 "%lld insight" = "インサイト%lld件";
 "%lld insights" = "インサイト%lld件";
-"The domain “%@” belongs to another organization. The source contains %@, %@, %@, %@, %@, and %@. Merging into “%@” combines them and deletes the source organization. Matching relationships keep the target organization’s metadata." = "ドメイン「%@」は別の組織に属しています。元の組織には、%@、%@、%@、%@、%@、%@があります。これらを「%@」へ統合して元の組織を削除します。重複する関連では統合先の情報を維持します。";
+"The domain “%@” belongs to another organization. Adding it as shared keeps both organizations separate. The source contains %@, %@, %@, %@, %@, and %@. Merging into “%@” combines them and deletes the source organization. Matching relationships keep the target organization’s metadata." = "ドメイン「%@」は別の組織に属しています。共有ドメインとして追加すると両方の組織を分けたまま維持します。元の組織には、%@、%@、%@、%@、%@、%@があります。「%@」へ統合するとこれらを移し、元の組織を削除します。重複する関連では統合先の情報を維持します。";
 "Conversation Analytics" = "会話分析";
 "BETA" = "BETA";
 "Analysis is waiting for transcription" = "文字起こしの完了を待っています";

--- a/Sources/Dahlia/Services/CustomerIntelligenceError.swift
+++ b/Sources/Dahlia/Services/CustomerIntelligenceError.swift
@@ -13,7 +13,6 @@ enum CustomerIntelligenceError: LocalizedError, Equatable {
     case invalidOrganizationParent
     case organizationCycle
     case organizationHierarchyTooDeep
-    case domainAlreadyAssigned
     case invalidOrganizationMerge
     case unsupportedProjectResource
     case topicNotFound
@@ -48,8 +47,6 @@ enum CustomerIntelligenceError: LocalizedError, Equatable {
             "The organization hierarchy cannot contain a cycle."
         case .organizationHierarchyTooDeep:
             "The organization hierarchy exceeds the maximum depth."
-        case .domainAlreadyAssigned:
-            "The domain is already assigned to another organization."
         case .invalidOrganizationMerge:
             "Only two different root organizations can be merged."
         case .unsupportedProjectResource:

--- a/Sources/Dahlia/Services/CustomerIntelligenceIngestionService.swift
+++ b/Sources/Dahlia/Services/CustomerIntelligenceIngestionService.swift
@@ -29,9 +29,11 @@ enum CustomerIntelligenceIngestionService {
         meetingId: UUID,
         vaultId: UUID,
         observedAt: Date,
-        dbQueue: DatabaseQueue
+        dbQueue: DatabaseQueue,
+        defaults: UserDefaults = .standard
     ) -> Task<Void, Never> {
         let participants = calendarEvent.participants
+        let automaticallyLinkMemberships = automaticallyLinkMemberships(defaults: defaults)
         return Task(priority: .utility) {
             do {
                 _ = try await ingest(
@@ -39,7 +41,8 @@ enum CustomerIntelligenceIngestionService {
                     meetingId: meetingId,
                     vaultId: vaultId,
                     observedAt: observedAt,
-                    dbQueue: dbQueue
+                    dbQueue: dbQueue,
+                    automaticallyLinkMemberships: automaticallyLinkMemberships
                 )
             } catch {
                 ErrorReportingService.captureSanitized(.customerIntelligenceIngestion)
@@ -55,13 +58,37 @@ enum CustomerIntelligenceIngestionService {
         observedAt: Date,
         dbQueue: DatabaseQueue
     ) async throws -> CustomerIntelligenceIngestionMetrics {
-        try await ingest(
+        let automaticallyLinkMemberships = automaticallyLinkMemberships(defaults: .standard)
+        return try await ingest(
             participants: calendarEvent.participants,
             meetingId: meetingId,
             vaultId: vaultId,
             observedAt: observedAt,
-            dbQueue: dbQueue
+            dbQueue: dbQueue,
+            automaticallyLinkMemberships: automaticallyLinkMemberships
         )
+    }
+
+    static func ingest(
+        calendarEvent: CalendarEvent,
+        meetingId: UUID,
+        vaultId: UUID,
+        observedAt: Date,
+        dbQueue: DatabaseQueue,
+        defaults: UserDefaults
+    ) -> Task<CustomerIntelligenceIngestionMetrics, Error> {
+        let participants = calendarEvent.participants
+        let automaticallyLinkMemberships = automaticallyLinkMemberships(defaults: defaults)
+        return Task {
+            try await ingest(
+                participants: participants,
+                meetingId: meetingId,
+                vaultId: vaultId,
+                observedAt: observedAt,
+                dbQueue: dbQueue,
+                automaticallyLinkMemberships: automaticallyLinkMemberships
+            )
+        }
     }
 
     private static func ingest(
@@ -69,7 +96,8 @@ enum CustomerIntelligenceIngestionService {
         meetingId: UUID,
         vaultId: UUID,
         observedAt: Date,
-        dbQueue: DatabaseQueue
+        dbQueue: DatabaseQueue,
+        automaticallyLinkMemberships: Bool
     ) async throws -> CustomerIntelligenceIngestionMetrics {
         guard !participants.isEmpty else {
             log(.empty)
@@ -81,11 +109,17 @@ enum CustomerIntelligenceIngestionService {
                 meetingId: meetingId,
                 vaultId: vaultId,
                 observedAt: observedAt,
+                automaticallyLinkMemberships: automaticallyLinkMemberships,
                 in: db
             )
         }
         log(metrics)
         return metrics
+    }
+
+    private static func automaticallyLinkMemberships(defaults: UserDefaults) -> Bool {
+        let key = AppSettings.automaticOrganizationMembershipEnabledUserDefaultsKey
+        return defaults.object(forKey: key) == nil ? true : defaults.bool(forKey: key)
     }
 
     private static func log(_ metrics: CustomerIntelligenceIngestionMetrics) {

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -517,23 +517,40 @@ enum L10n {
     static var organizationDomains: String { String(localized: "Email Domains", bundle: bundle) }
     static var organizationDomain: String { String(localized: "Email Domain", bundle: bundle) }
     static var addOrganizationDomain: String { String(localized: "Add Email Domain", bundle: bundle) }
+    static func organizationDomainAlreadyUsed(by organizationName: String) -> String {
+        String(
+            format: String(localized: "This email domain is already used by “%@”", bundle: bundle),
+            locale: .current,
+            organizationName
+        )
+    }
+
+    static var addAsSharedOrganizationDomain: String {
+        String(localized: "Add as Shared Domain", bundle: bundle)
+    }
+
+    static var mergeOrganizations: String { String(localized: "Merge Organizations", bundle: bundle) }
+
+    static var automaticOrganizationMembership: String {
+        String(localized: "Automatically link participants to organizations", bundle: bundle)
+    }
+
+    static var automaticOrganizationMembershipDescription: String {
+        String(
+            localized: "Organizations are still created for new domains when this is off. Shared domains never link participants automatically.",
+            bundle: bundle
+        )
+    }
+
     static var organizationDomainHelp: String {
         String(
-            localized: "If this domain belongs to another organization, you can review a complete merge before anything changes.",
+            localized: "If another organization uses this domain, you can add it as shared or review a complete merge.",
             bundle: bundle
         )
     }
 
     static var primary: String { String(localized: "Primary", bundle: bundle) }
     static var merge: String { String(localized: "Merge", bundle: bundle) }
-
-    static func mergeOrganization(named name: String) -> String {
-        String(
-            format: String(localized: "Merge “%@”?", bundle: bundle),
-            locale: .current,
-            name
-        )
-    }
 
     static func organizationMergeImpact(
         domainName: String,
@@ -553,7 +570,7 @@ enum L10n {
         return String(
             format: String(
                 // swiftlint:disable:next line_length
-                localized: "The domain “%@” belongs to another organization. The source contains %@, %@, %@, %@, %@, and %@. Merging into “%@” combines them and deletes the source organization. Matching relationships keep the target organization’s metadata.",
+                localized: "The domain “%@” belongs to another organization. Adding it as shared keeps both organizations separate. The source contains %@, %@, %@, %@, %@, and %@. Merging into “%@” combines them and deletes the source organization. Matching relationships keep the target organization’s metadata.",
                 bundle: bundle
             ),
             locale: .current,

--- a/Sources/Dahlia/ViewModels/OrganizationWorkspaceViewModel.swift
+++ b/Sources/Dahlia/ViewModels/OrganizationWorkspaceViewModel.swift
@@ -391,7 +391,7 @@ final class OrganizationWorkspaceViewModel {
             }
             guard self.vaultID == vaultID else { return false }
             switch plan {
-            case .unassigned:
+            case .unassigned, .shared:
                 return await mutate(vaultID: vaultID) {
                     try $0.addOrganizationDomain(
                         organizationId: target.id,
@@ -425,6 +425,20 @@ final class OrganizationWorkspaceViewModel {
                 expectedSourceRevision: preview.source.revision,
                 expectedTargetRevision: preview.target.revision,
                 expectedImpact: preview.impact
+            )
+        }
+    }
+
+    func confirmSharedDomain(_ pending: PendingOrganizationMerge) async {
+        pendingMerge = nil
+        let preview = pending.preview
+        guard let vaultID else { return }
+        await mutate(vaultID: vaultID) {
+            try $0.addOrganizationDomain(
+                organizationId: preview.target.id,
+                vaultId: vaultID,
+                domainName: preview.domainName,
+                expectedOrganizationRevision: preview.target.revision
             )
         }
     }

--- a/Sources/Dahlia/Views/OrganizationWorkspaceView.swift
+++ b/Sources/Dahlia/Views/OrganizationWorkspaceView.swift
@@ -106,7 +106,28 @@ struct OrganizationHierarchyView: View {
                     await model.addDomain($0, to: target)
                 }
             }
-            .alert(item: $model.pendingMerge, content: mergeAlert)
+            .confirmationDialog(
+                L10n.organizationDomainAlreadyUsed(by: model.pendingMerge?.preview.source.name ?? ""),
+                isPresented: Binding(
+                    get: { model.pendingMerge != nil },
+                    set: { if !$0 { model.pendingMerge = nil } }
+                ),
+                presenting: model.pendingMerge
+            ) { pending in
+                Button(L10n.addAsSharedOrganizationDomain) {
+                    Task { await model.confirmSharedDomain(pending) }
+                }
+                Button(L10n.mergeOrganizations, role: .destructive) {
+                    Task { await model.confirmMerge(pending) }
+                }
+                Button(L10n.cancel, role: .cancel) {}
+            } message: { pending in
+                Text(L10n.organizationMergeImpact(
+                    domainName: pending.preview.domainName,
+                    targetName: pending.preview.target.name,
+                    impact: pending.preview.impact
+                ))
+            }
             .customerIntelligenceErrorAlert(
                 title: L10n.organizationWorkspaceError,
                 message: $model.errorMessage
@@ -119,21 +140,6 @@ struct OrganizationHierarchyView: View {
             message: Text(L10n.organizationDeletionImpact(pending.impact)),
             primaryButton: .destructive(Text(L10n.delete)) {
                 Task { await model.confirmDeletion(pending) }
-            },
-            secondaryButton: .cancel()
-        )
-    }
-
-    private func mergeAlert(_ pending: OrganizationWorkspaceViewModel.PendingOrganizationMerge) -> Alert {
-        Alert(
-            title: Text(L10n.mergeOrganization(named: pending.preview.source.name)),
-            message: Text(L10n.organizationMergeImpact(
-                domainName: pending.preview.domainName,
-                targetName: pending.preview.target.name,
-                impact: pending.preview.impact
-            )),
-            primaryButton: .destructive(Text(L10n.merge)) {
-                Task { await model.confirmMerge(pending) }
             },
             secondaryButton: .cancel()
         )

--- a/Sources/Dahlia/Views/Settings/CalendarSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/CalendarSettingsView.swift
@@ -37,6 +37,14 @@ struct CalendarSettingsView: View {
             CalendarEventFilterSettingsView(settings: settings)
 
             Section {
+                Toggle(isOn: $settings.isAutomaticOrganizationMembershipEnabled) {
+                    Text(L10n.automaticOrganizationMembership)
+                    Text(L10n.automaticOrganizationMembershipDescription)
+                }
+                .toggleStyle(.switch)
+            }
+
+            Section {
                 ForEach(displayedCalendarSources) { source in
                     Toggle(isOn: calendarSourceBinding(for: source)) {
                         Text(source.displayName)

--- a/Sources/DahliaMeetingAccess/CustomerIntelligenceAccessStore.swift
+++ b/Sources/DahliaMeetingAccess/CustomerIntelligenceAccessStore.swift
@@ -458,7 +458,7 @@ extension MeetingAccessStore {
         guard try Bool.fetchOne(
             db,
             sql: "SELECT EXISTS(SELECT 1 FROM grdb_migrations WHERE identifier = ?)",
-            arguments: ["v30_organizationDescription"]
+            arguments: ["v33_sharedOrganizationDomains"]
         ) == true else {
             throw MeetingAccessError.databaseUpgradeRequired
         }

--- a/Sources/DahliaMeetingAccess/CustomerIntelligenceWorkspaceAccessModels.swift
+++ b/Sources/DahliaMeetingAccess/CustomerIntelligenceWorkspaceAccessModels.swift
@@ -128,6 +128,7 @@ public struct CustomerIntelligenceRecordDeletionResult: Codable, Sendable, Equat
 }
 
 public enum CustomerIntelligenceRelationshipKind: String, Codable, Sendable, Equatable {
+    case organizationDomain = "organization_domain"
     case contactOrganizationMembership = "contact_organization_membership"
     case projectResourceReference = "project_resource_reference"
     case conversationTopicResourceReference = "conversation_topic_resource_reference"

--- a/Sources/DahliaMeetingAccess/CustomerIntelligenceWriteStore.swift
+++ b/Sources/DahliaMeetingAccess/CustomerIntelligenceWriteStore.swift
@@ -697,6 +697,159 @@ public extension MeetingAccessStore {
         )
     }
 
+    // swiftlint:disable:next function_body_length
+    func setOrganizationDomain(
+        organizationID: UUID,
+        expectedOrganizationRevision: Int,
+        domainName rawDomainName: String,
+        isPrimary: Bool
+    ) throws -> CustomerIntelligenceRelationshipMutationResult {
+        try requireCustomerIntelligenceWriteAccess()
+        guard let domainName = CustomerIdentityNormalizer.domainName(rawDomainName) else {
+            throw MeetingAccessError.invalidCustomerIntelligenceMutation
+        }
+        let vault = try database.read(fetchCustomerIntelligenceVault(in:))
+        let result = try database.write { db -> (Int, Bool) in
+            let revision = try validatedRootOrganizationRevision(
+                id: organizationID,
+                expected: expectedOrganizationRevision,
+                in: db
+            )
+            let existing = try Row.fetchOne(
+                db,
+                sql: """
+                SELECT isPrimary
+                FROM organization_domains
+                WHERE vaultId = ? AND organizationId = ? AND domainName = ?
+                """,
+                arguments: [vaultID, organizationID, domainName]
+            )
+
+            if let existing {
+                let currentlyPrimary: Bool = existing["isPrimary"]
+                guard currentlyPrimary != isPrimary else { return (revision, false) }
+                if isPrimary {
+                    try db.execute(
+                        sql: """
+                        UPDATE organization_domains SET isPrimary = 0
+                        WHERE organizationId = ? AND isPrimary = 1
+                        """,
+                        arguments: [organizationID]
+                    )
+                    try db.execute(
+                        sql: """
+                        UPDATE organization_domains SET isPrimary = 1
+                        WHERE vaultId = ? AND organizationId = ? AND domainName = ?
+                        """,
+                        arguments: [vaultID, organizationID, domainName]
+                    )
+                } else {
+                    guard let replacement = try String.fetchOne(
+                        db,
+                        sql: """
+                        SELECT domainName
+                        FROM organization_domains
+                        WHERE organizationId = ? AND domainName <> ?
+                        ORDER BY firstObservedAt ASC, domainName ASC
+                        LIMIT 1
+                        """,
+                        arguments: [organizationID, domainName]
+                    ) else {
+                        return (revision, false)
+                    }
+                    try db.execute(
+                        sql: """
+                        UPDATE organization_domains SET isPrimary = 0
+                        WHERE vaultId = ? AND organizationId = ? AND domainName = ?
+                        """,
+                        arguments: [vaultID, organizationID, domainName]
+                    )
+                    try db.execute(
+                        sql: """
+                        UPDATE organization_domains SET isPrimary = 1
+                        WHERE vaultId = ? AND organizationId = ? AND domainName = ?
+                        """,
+                        arguments: [vaultID, organizationID, replacement]
+                    )
+                }
+            } else {
+                if isPrimary {
+                    try db.execute(
+                        sql: """
+                        UPDATE organization_domains SET isPrimary = 0
+                        WHERE organizationId = ? AND isPrimary = 1
+                        """,
+                        arguments: [organizationID]
+                    )
+                }
+                try db.execute(
+                    sql: """
+                    INSERT INTO organization_domains (
+                        vaultId, domainName, organizationId, isPrimary, firstObservedAt, lastObservedAt
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    arguments: [vaultID, domainName, organizationID, isPrimary, Date.now, Date.now]
+                )
+            }
+            return try (currentRevision(table: "organizations", id: organizationID, in: db), true)
+        }
+        if result.1 { postCustomerIntelligenceChange() }
+        return CustomerIntelligenceRelationshipMutationResult(
+            vault: vault,
+            relationship: .organizationDomain,
+            sourceID: organizationID,
+            targetID: nil,
+            revision: result.0,
+            changed: result.1
+        )
+    }
+
+    func removeOrganizationDomain(
+        organizationID: UUID,
+        expectedOrganizationRevision: Int,
+        domainName rawDomainName: String
+    ) throws -> CustomerIntelligenceRelationshipMutationResult {
+        try requireCustomerIntelligenceWriteAccess()
+        guard let domainName = CustomerIdentityNormalizer.domainName(rawDomainName) else {
+            throw MeetingAccessError.invalidCustomerIntelligenceMutation
+        }
+        let vault = try database.read(fetchCustomerIntelligenceVault(in:))
+        let result = try database.write { db -> (Int, Bool) in
+            let revision = try validatedRootOrganizationRevision(
+                id: organizationID,
+                expected: expectedOrganizationRevision,
+                in: db
+            )
+            let exists = try Int.fetchOne(
+                db,
+                sql: """
+                SELECT 1 FROM organization_domains
+                WHERE vaultId = ? AND organizationId = ? AND domainName = ?
+                """,
+                arguments: [vaultID, organizationID, domainName]
+            ) != nil
+            guard exists else { return (revision, false) }
+            try db.execute(
+                sql: """
+                DELETE FROM organization_domains
+                WHERE vaultId = ? AND organizationId = ? AND domainName = ?
+                """,
+                arguments: [vaultID, organizationID, domainName]
+            )
+            return try (currentRevision(table: "organizations", id: organizationID, in: db), true)
+        }
+        if result.1 { postCustomerIntelligenceChange() }
+        return CustomerIntelligenceRelationshipMutationResult(
+            vault: vault,
+            relationship: .organizationDomain,
+            sourceID: organizationID,
+            targetID: nil,
+            revision: result.0,
+            changed: result.1
+        )
+    }
+
     func setProjectResourceReference(
         projectID: UUID,
         expectedProjectRevision: Int,
@@ -1287,6 +1440,34 @@ private extension MeetingAccessStore {
         }
         guard revision == expected else {
             throw MeetingAccessError.customerIntelligenceRevisionConflict
+        }
+        return revision
+    }
+
+    func validatedRootOrganizationRevision(
+        id: UUID,
+        expected: Int,
+        in db: Database
+    ) throws -> Int {
+        guard let row = try Row.fetchOne(
+            db,
+            sql: """
+            SELECT nodeKind, parentOrganizationId, revision
+            FROM organizations
+            WHERE id = ? AND vaultId = ?
+            """,
+            arguments: [id, vaultID]
+        ) else {
+            throw MeetingAccessError.organizationNotFound
+        }
+        let revision: Int = row["revision"]
+        guard revision == expected else {
+            throw MeetingAccessError.customerIntelligenceRevisionConflict
+        }
+        let nodeKind: String = row["nodeKind"]
+        let parentID: UUID? = row["parentOrganizationId"]
+        guard nodeKind == OrganizationAccessNodeKind.organization.rawValue, parentID == nil else {
+            throw MeetingAccessError.invalidCustomerIntelligenceMutation
         }
         return revision
     }

--- a/Sources/DahliaMeetingAccess/DahliaMCPServer.swift
+++ b/Sources/DahliaMeetingAccess/DahliaMCPServer.swift
@@ -69,6 +69,8 @@ public final class DahliaMCPServer {
             + "change exactly one canonical record or relationship per call. Continue with independent records after one "
             + "call fails, and query a conflicted record again before retrying. Record updates require revision. "
             + "Relationship tools use set for create-or-update and remove for unlinking without deleting either endpoint. "
+            + "A domain may be shared by multiple root Organizations. For Contacts using a shared domain, use Meeting "
+            + "transcripts or other evidence and set_contact_organization_membership to assign membership explicitly. "
             + "Deletes require revision. Delete Organizations from the leaves upward after removing Contact memberships; "
             + "a Contact must have no memberships, Meeting participation, or typed resource references before deletion. "
             : ""
@@ -418,6 +420,34 @@ public final class DahliaMCPServer {
                 organizationID: requiredUUID(arguments, key: "organization_id"),
                 expectedOrganizationRevision: requiredRevision(arguments, key: "organization_revision"),
                 roleLabel: nullableString(arguments, key: "role_label")
+            ))
+        case "set_organization_domain":
+            try validate(arguments, allowedKeys: [
+                "organization_id", "expected_organization_revision", "domain_name", "is_primary",
+            ])
+            guard let isPrimary = try boolean(arguments, key: "is_primary") else {
+                throw ParameterError("is_primary is required")
+            }
+            return try toolResult(store.setOrganizationDomain(
+                organizationID: requiredUUID(arguments, key: "organization_id"),
+                expectedOrganizationRevision: requiredRevision(
+                    arguments,
+                    key: "expected_organization_revision"
+                ),
+                domainName: requiredString(arguments, key: "domain_name"),
+                isPrimary: isPrimary
+            ))
+        case "remove_organization_domain":
+            try validate(arguments, allowedKeys: [
+                "organization_id", "expected_organization_revision", "domain_name",
+            ])
+            return try toolResult(store.removeOrganizationDomain(
+                organizationID: requiredUUID(arguments, key: "organization_id"),
+                expectedOrganizationRevision: requiredRevision(
+                    arguments,
+                    key: "expected_organization_revision"
+                ),
+                domainName: requiredString(arguments, key: "domain_name")
             ))
         case "remove_contact_organization_membership":
             try validate(arguments, allowedKeys: [
@@ -1366,6 +1396,7 @@ private extension DahliaMCPServer {
                     "type": "string",
                     "enum": [
                         "contact_organization_membership",
+                        "organization_domain",
                         "project_resource_reference",
                         "conversation_topic_resource_reference",
                         "insight_resource_reference",
@@ -1833,6 +1864,11 @@ private extension DahliaMCPServer {
             "minLength": 1,
             "maxLength": CustomerIntelligenceWriteLimits.shortText,
         ]
+        let domainName: [String: Any] = [
+            "type": "string",
+            "minLength": 1,
+            "maxLength": CustomerIdentityNormalizer.maximumDomainNameLength,
+        ]
         let nullableText: [String: Any] = [
             "type": ["string", "null"],
             "maxLength": CustomerIntelligenceWriteLimits.shortText,
@@ -2018,6 +2054,35 @@ private extension DahliaMCPServer {
                 "Delete insight",
                 "Delete one Insight and its typed references without deleting referenced records.",
                 idKey: "insight_id"
+            ),
+            relationshipWriteTool(
+                "set_organization_domain",
+                "Set organization domain",
+                "Create or update one root Organization's domain link. A domain may be shared by multiple root "
+                    + "Organizations; this changes only this Organization's link. The first domain becomes primary even "
+                    + "when is_primary is false.",
+                [
+                    "organization_id": uuid,
+                    "expected_organization_revision": revision,
+                    "domain_name": domainName,
+                    "is_primary": ["type": "boolean"],
+                ],
+                required: [
+                    "organization_id", "expected_organization_revision", "domain_name", "is_primary",
+                ],
+                destructive: true
+            ),
+            relationshipWriteTool(
+                "remove_organization_domain",
+                "Remove organization domain",
+                "Remove one domain link from one root Organization without changing links from other Organizations.",
+                [
+                    "organization_id": uuid,
+                    "expected_organization_revision": revision,
+                    "domain_name": domainName,
+                ],
+                required: ["organization_id", "expected_organization_revision", "domain_name"],
+                destructive: true
             ),
             relationshipWriteTool(
                 "set_contact_organization_membership",

--- a/Sources/DahliaRuntimeSupport/CustomerIdentityNormalizer.swift
+++ b/Sources/DahliaRuntimeSupport/CustomerIdentityNormalizer.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 public enum CustomerIdentityNormalizer {
+    public static let maximumDomainNameLength = 253
+
     public static func email(_ rawValue: String) -> String? {
         let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty,
@@ -36,7 +38,7 @@ public enum CustomerIdentityNormalizer {
             value.removeLast()
         }
         guard !value.isEmpty,
-              value.utf8.count <= 253,
+              value.utf8.count <= maximumDomainNameLength,
               value.unicodeScalars.allSatisfy(\.isPrintableASCII),
               !value.contains("@"),
               !value.contains("/"),

--- a/Tests/DahliaTests/CustomerIntelligenceIngestionTests.swift
+++ b/Tests/DahliaTests/CustomerIntelligenceIngestionTests.swift
@@ -6,6 +6,7 @@ import GRDB
     import Testing
 
     @MainActor
+    // swiftlint:disable:next type_body_length
     struct CustomerIntelligenceIngestionTests {
         @Test
         // swiftlint:disable:next function_body_length
@@ -165,7 +166,7 @@ import GRDB
                 conferenceURI: nil
             )
 
-            try await CustomerIntelligenceIngestionService.ingest(
+            _ = try await CustomerIntelligenceIngestionService.ingest(
                 calendarEvent: event,
                 meetingId: meeting.id,
                 vaultId: fixture.vault.id,
@@ -213,7 +214,7 @@ import GRDB
                 )
             }
 
-            try await CustomerIntelligenceIngestionService.ingest(
+            _ = try await CustomerIntelligenceIngestionService.ingest(
                 calendarEvent: event(displayName: nil, role: .unknown),
                 meetingId: meeting.id,
                 vaultId: fixture.vault.id,
@@ -233,7 +234,7 @@ import GRDB
             let firstOrganization = try #require(first.1)
             #expect(firstContact.displayName == "person")
 
-            try await CustomerIntelligenceIngestionService.ingest(
+            _ = try await CustomerIntelligenceIngestionService.ingest(
                 calendarEvent: event(displayName: "Person", role: .required),
                 meetingId: meeting.id,
                 vaultId: fixture.vault.id,
@@ -250,6 +251,199 @@ import GRDB
             #expect(secondContact.displayName == "person")
             #expect(secondContact.revision == firstContact.revision + 1)
             #expect(secondOrganization.revision == firstOrganization.revision + 1)
+        }
+
+        @Test
+        func missingAutomaticMembershipSettingKeepsLegacyBehavior() async throws {
+            let fixture = try CustomerIntelligenceFixture()
+            let meeting = try fixture.insertMeeting()
+            let suiteName = "CustomerIntelligenceIngestionTests.missing.\(UUID.v7())"
+            let defaults = try #require(UserDefaults(suiteName: suiteName))
+            defaults.removePersistentDomain(forName: suiteName)
+            defer { UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName) }
+
+            _ = try await CustomerIntelligenceIngestionService.ingest(
+                calendarEvent: event(participants: [participant(email: "person@legacy.example")]),
+                meetingId: meeting.id,
+                vaultId: fixture.vault.id,
+                observedAt: .now,
+                dbQueue: fixture.manager.dbQueue,
+                defaults: defaults
+            ).value
+
+            let counts = try await fixture.manager.dbQueue.read { db in
+                (
+                    organizations: try OrganizationRecord.fetchCount(db),
+                    memberships: try OrganizationMembershipRecord.fetchCount(db)
+                )
+            }
+            #expect(counts.organizations == 1)
+            #expect(counts.memberships == 1)
+        }
+
+        @Test
+        func disabledAutomaticMembershipStillCreatesOrganizationAndContact() async throws {
+            let fixture = try CustomerIntelligenceFixture()
+            let meeting = try fixture.insertMeeting()
+            let suiteName = "CustomerIntelligenceIngestionTests.disabled.\(UUID.v7())"
+            let defaults = try #require(UserDefaults(suiteName: suiteName))
+            defaults.set(false, forKey: AppSettings.automaticOrganizationMembershipEnabledUserDefaultsKey)
+            defer { UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName) }
+
+            _ = try await CustomerIntelligenceIngestionService.ingest(
+                calendarEvent: event(participants: [participant(email: "person@disabled.example")]),
+                meetingId: meeting.id,
+                vaultId: fixture.vault.id,
+                observedAt: .now,
+                dbQueue: fixture.manager.dbQueue,
+                defaults: defaults
+            ).value
+
+            let counts = try await fixture.manager.dbQueue.read { db in
+                (
+                    contacts: try ContactRecord.fetchCount(db),
+                    organizations: try OrganizationRecord.fetchCount(db),
+                    participants: try MeetingParticipantRecord.fetchCount(db),
+                    memberships: try OrganizationMembershipRecord.fetchCount(db)
+                )
+            }
+            #expect(counts.contacts == 1)
+            #expect(counts.organizations == 1)
+            #expect(counts.participants == 1)
+            #expect(counts.memberships == 0)
+
+            defaults.set(true, forKey: AppSettings.automaticOrganizationMembershipEnabledUserDefaultsKey)
+            _ = try await CustomerIntelligenceIngestionService.ingest(
+                calendarEvent: event(participants: [participant(email: "linked@disabled.example")]),
+                meetingId: meeting.id,
+                vaultId: fixture.vault.id,
+                observedAt: .now,
+                dbQueue: fixture.manager.dbQueue,
+                defaults: defaults
+            ).value
+            let enabledCounts = try await fixture.manager.dbQueue.read { db in
+                (
+                    organizations: try OrganizationRecord.fetchCount(db),
+                    memberships: try OrganizationMembershipRecord.fetchCount(db)
+                )
+            }
+            #expect(enabledCounts.organizations == 1)
+            #expect(enabledCounts.memberships == 1)
+        }
+
+        @Test
+        func sharedDomainNeverCreatesAutomaticMembershipOrAnotherOrganization() async throws {
+            let fixture = try CustomerIntelligenceFixture()
+            let meeting = try fixture.insertMeeting()
+            let first = try fixture.repository.createOrganization(
+                vaultId: fixture.vault.id,
+                parentOrganizationId: nil,
+                nodeKind: .organization,
+                name: "First"
+            )
+            let second = try fixture.repository.createOrganization(
+                vaultId: fixture.vault.id,
+                parentOrganizationId: nil,
+                nodeKind: .organization,
+                name: "Second"
+            )
+            _ = try fixture.repository.addOrganizationDomain(
+                organizationId: first.id,
+                vaultId: fixture.vault.id,
+                domainName: "shared.example"
+            )
+            _ = try fixture.repository.addOrganizationDomain(
+                organizationId: second.id,
+                vaultId: fixture.vault.id,
+                domainName: "shared.example"
+            )
+            let suiteName = "CustomerIntelligenceIngestionTests.shared.\(UUID.v7())"
+            let defaults = try #require(UserDefaults(suiteName: suiteName))
+            defaults.set(true, forKey: AppSettings.automaticOrganizationMembershipEnabledUserDefaultsKey)
+            defer { UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName) }
+
+            _ = try await CustomerIntelligenceIngestionService.ingest(
+                calendarEvent: event(participants: [participant(email: "person@shared.example")]),
+                meetingId: meeting.id,
+                vaultId: fixture.vault.id,
+                observedAt: .now,
+                dbQueue: fixture.manager.dbQueue,
+                defaults: defaults
+            ).value
+
+            let counts = try await fixture.manager.dbQueue.read { db in
+                (
+                    organizations: try OrganizationRecord.fetchCount(db),
+                    memberships: try OrganizationMembershipRecord.fetchCount(db)
+                )
+            }
+            #expect(counts.organizations == 2)
+            #expect(counts.memberships == 0)
+        }
+
+        @Test
+        func olderObservationUpdatesEverySharedDomainAssignment() async throws {
+            let fixture = try CustomerIntelligenceFixture()
+            let meeting = try fixture.insertMeeting()
+            let recent = Date(timeIntervalSince1970: 1_800_000_000)
+            let older = recent.addingTimeInterval(-3600)
+            for name in ["First", "Second"] {
+                let organization = try fixture.repository.createOrganization(
+                    vaultId: fixture.vault.id,
+                    parentOrganizationId: nil,
+                    nodeKind: .organization,
+                    name: name
+                )
+                _ = try fixture.repository.addOrganizationDomain(
+                    organizationId: organization.id,
+                    vaultId: fixture.vault.id,
+                    domainName: "observed.example",
+                    observedAt: recent
+                )
+            }
+            let suiteName = "CustomerIntelligenceIngestionTests.observation.\(UUID.v7())"
+            let defaults = try #require(UserDefaults(suiteName: suiteName))
+            defaults.set(false, forKey: AppSettings.automaticOrganizationMembershipEnabledUserDefaultsKey)
+            defer { UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName) }
+
+            _ = try await CustomerIntelligenceIngestionService.ingest(
+                calendarEvent: event(participants: [participant(email: "person@observed.example")]),
+                meetingId: meeting.id,
+                vaultId: fixture.vault.id,
+                observedAt: older,
+                dbQueue: fixture.manager.dbQueue,
+                defaults: defaults
+            ).value
+
+            let domains = try await fixture.manager.dbQueue.read { db in
+                try OrganizationDomainRecord
+                    .filter(Column("domainName") == "observed.example")
+                    .fetchAll(db)
+            }
+            #expect(domains.count == 2)
+            #expect(domains.allSatisfy { $0.firstObservedAt == older })
+            #expect(domains.allSatisfy { $0.lastObservedAt == recent })
+        }
+
+        private func event(
+            participants: [CalendarParticipant],
+            observedAt: Date = .now
+        ) -> CalendarEvent {
+            CalendarEvent(
+                id: "event-\(UUID.v7())",
+                calendarID: "calendar",
+                calendarName: "Work",
+                calendarColorHex: nil,
+                platformId: "event-\(UUID.v7())",
+                title: "Customer sync",
+                description: "",
+                icalUid: "event-\(UUID.v7())@example.com",
+                startDate: observedAt,
+                endDate: observedAt.addingTimeInterval(1800),
+                isAllDay: false,
+                participants: participants,
+                conferenceURI: nil
+            )
         }
 
         private func participant(email: String) -> CalendarParticipant {

--- a/Tests/DahliaTests/CustomerIntelligenceTests.swift
+++ b/Tests/DahliaTests/CustomerIntelligenceTests.swift
@@ -210,6 +210,7 @@ import GRDB
                 domainName: secondDomain.domainName
             )
             try fixture.repository.removeOrganizationDomain(
+                organizationId: organization.id,
                 vaultId: fixture.vault.id,
                 domainName: secondDomain.domainName
             )

--- a/Tests/DahliaTests/MeetingAccessStoreTests.swift
+++ b/Tests/DahliaTests/MeetingAccessStoreTests.swift
@@ -1047,6 +1047,235 @@ import ImageIO
 
         @Test
         // swiftlint:disable:next function_body_length
+        func organizationDomainWriteToolsPreserveSharingRootAndPrimaryContracts() throws {
+            let fixture = try Fixture()
+            let store = try fixture.store(vaultID: fixture.primaryVaultID, allowsWrites: true)
+            let first = try store.createOrganization(
+                name: "First",
+                nodeKind: .organization,
+                parentOrganizationID: nil
+            )
+            let second = try store.createOrganization(
+                name: "Second",
+                nodeKind: .organization,
+                parentOrganizationID: nil
+            )
+
+            let firstDomain = try store.setOrganizationDomain(
+                organizationID: first.resourceID,
+                expectedOrganizationRevision: first.revision,
+                domainName: " Shared.Example. ",
+                isPrimary: false
+            )
+            #expect(firstDomain.changed)
+            #expect(try store.organization(id: first.resourceID).domains.first?.domainName == "shared.example")
+            #expect(try store.organization(id: first.resourceID).domains.first?.isPrimary == true)
+
+            let onlyPrimaryNoOp = try store.setOrganizationDomain(
+                organizationID: first.resourceID,
+                expectedOrganizationRevision: try #require(firstDomain.revision),
+                domainName: "shared.example",
+                isPrimary: false
+            )
+            #expect(!onlyPrimaryNoOp.changed)
+
+            let secondDomain = try store.setOrganizationDomain(
+                organizationID: first.resourceID,
+                expectedOrganizationRevision: try #require(onlyPrimaryNoOp.revision),
+                domainName: "second.example",
+                isPrimary: false
+            )
+            _ = try store.setOrganizationDomain(
+                organizationID: first.resourceID,
+                expectedOrganizationRevision: try #require(secondDomain.revision),
+                domainName: "alpha.example",
+                isPrimary: false
+            )
+            try fixture.manager.dbQueue.write { db in
+                try db.execute(
+                    sql: """
+                    UPDATE organization_domains SET firstObservedAt = ?
+                    WHERE organizationId = ? AND domainName IN ('alpha.example', 'second.example')
+                    """,
+                    arguments: [Date(timeIntervalSince1970: 1_700_000_000), first.resourceID]
+                )
+            }
+            let revisionAfterObservationUpdate = try store.organization(id: first.resourceID).organization.revision
+            let promotedReplacement = try store.setOrganizationDomain(
+                organizationID: first.resourceID,
+                expectedOrganizationRevision: revisionAfterObservationUpdate,
+                domainName: "shared.example",
+                isPrimary: false
+            )
+            #expect(promotedReplacement.changed)
+            let firstDomains = try store.organization(id: first.resourceID).domains
+            #expect(firstDomains.count(where: \.isPrimary) == 1)
+            #expect(firstDomains.first(where: \.isPrimary)?.domainName == "alpha.example")
+
+            let shared = try store.setOrganizationDomain(
+                organizationID: second.resourceID,
+                expectedOrganizationRevision: second.revision,
+                domainName: "shared.example",
+                isPrimary: false
+            )
+            #expect(shared.changed)
+            #expect(try store.organization(id: second.resourceID).domains.map(\.domainName) == ["shared.example"])
+
+            #expect(throws: MeetingAccessError.customerIntelligenceRevisionConflict) {
+                try store.setOrganizationDomain(
+                    organizationID: second.resourceID,
+                    expectedOrganizationRevision: second.revision,
+                    domainName: "stale.example",
+                    isPrimary: false
+                )
+            }
+            #expect(throws: MeetingAccessError.invalidCustomerIntelligenceMutation) {
+                try store.setOrganizationDomain(
+                    organizationID: second.resourceID,
+                    expectedOrganizationRevision: try #require(shared.revision),
+                    domainName: "not a domain",
+                    isPrimary: false
+                )
+            }
+
+            let unit = try store.createOrganization(
+                name: "Unit",
+                nodeKind: .unit,
+                parentOrganizationID: first.resourceID
+            )
+            #expect(throws: MeetingAccessError.invalidCustomerIntelligenceMutation) {
+                try store.setOrganizationDomain(
+                    organizationID: unit.resourceID,
+                    expectedOrganizationRevision: unit.revision,
+                    domainName: "unit.example",
+                    isPrimary: false
+                )
+            }
+            let nestedOrganization = try store.createOrganization(
+                name: "Nested organization",
+                nodeKind: .organization,
+                parentOrganizationID: first.resourceID
+            )
+            #expect(throws: MeetingAccessError.invalidCustomerIntelligenceMutation) {
+                try store.setOrganizationDomain(
+                    organizationID: nestedOrganization.resourceID,
+                    expectedOrganizationRevision: nestedOrganization.revision,
+                    domainName: "nested.example",
+                    isPrimary: false
+                )
+            }
+
+            let removed = try store.removeOrganizationDomain(
+                organizationID: second.resourceID,
+                expectedOrganizationRevision: try #require(shared.revision),
+                domainName: "shared.example"
+            )
+            #expect(removed.changed)
+            let removeNoOp = try store.removeOrganizationDomain(
+                organizationID: second.resourceID,
+                expectedOrganizationRevision: try #require(removed.revision),
+                domainName: "shared.example"
+            )
+            #expect(!removeNoOp.changed)
+        }
+
+        @Test
+        // swiftlint:disable:next function_body_length
+        func organizationDomainMCPToolsDeclareDispatchAndEnforceWriteAccess() throws {
+            let fixture = try Fixture()
+            let store = try fixture.store(vaultID: fixture.primaryVaultID, allowsWrites: true)
+            let organization = try store.createOrganization(
+                name: "Domain MCP",
+                nodeKind: .organization,
+                parentOrganizationID: nil
+            )
+            let server = DahliaMCPServer(store: store)
+            let initialized = try Self.json(server.handleLine(
+                #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#
+            ))
+            let instructions = try #require(
+                (initialized["result"] as? [String: Any])?["instructions"] as? String
+            )
+            #expect(instructions.contains("domain may be shared"))
+            #expect(instructions.contains("set_contact_organization_membership"))
+            _ = server.handleLine(#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#)
+
+            let tools = try Self.json(server.handleLine(#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#))
+            let definitions = ((tools["result"] as? [String: Any])?["tools"] as? [[String: Any]]) ?? []
+            let setDefinition = try #require(
+                definitions.first { $0["name"] as? String == "set_organization_domain" }
+            )
+            let setSchema = try #require(setDefinition["inputSchema"] as? [String: Any])
+            #expect(Set(setSchema["required"] as? [String] ?? []) == [
+                "organization_id", "expected_organization_revision", "domain_name", "is_primary",
+            ])
+            let setProperties = try #require(setSchema["properties"] as? [String: Any])
+            let setDomainSchema = try #require(setProperties["domain_name"] as? [String: Any])
+            #expect(
+                setDomainSchema["maxLength"] as? Int
+                    == CustomerIdentityNormalizer.maximumDomainNameLength
+            )
+            let removeDefinition = try #require(
+                definitions.first { $0["name"] as? String == "remove_organization_domain" }
+            )
+            let removeSchema = try #require(removeDefinition["inputSchema"] as? [String: Any])
+            #expect(Set(removeSchema["required"] as? [String] ?? []) == [
+                "organization_id", "expected_organization_revision", "domain_name",
+            ])
+            let removeProperties = try #require(removeSchema["properties"] as? [String: Any])
+            let removeDomainSchema = try #require(removeProperties["domain_name"] as? [String: Any])
+            #expect(
+                removeDomainSchema["maxLength"] as? Int
+                    == CustomerIdentityNormalizer.maximumDomainNameLength
+            )
+
+            let setCall = try Self.json(server.handleLine("""
+            {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"set_organization_domain","arguments":{\
+            "organization_id":"\(organization.resourceID.uuidString)",\
+            "expected_organization_revision":\(organization.revision),\
+            "domain_name":"mcp.example","is_primary":false}}}
+            """))
+            let setContent = try #require(
+                (setCall["result"] as? [String: Any])?["structuredContent"] as? [String: Any]
+            )
+            #expect(setContent["changed"] as? Bool == true)
+            let revision = try #require(setContent["revision"] as? Int)
+
+            let removeCall = try Self.json(server.handleLine("""
+            {"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"remove_organization_domain","arguments":{\
+            "organization_id":"\(organization.resourceID.uuidString)",\
+            "expected_organization_revision":\(revision),\
+            "domain_name":"mcp.example"}}}
+            """))
+            let removeContent = try #require(
+                (removeCall["result"] as? [String: Any])?["structuredContent"] as? [String: Any]
+            )
+            #expect(removeContent["changed"] as? Bool == true)
+
+            let readOnlyServer = try DahliaMCPServer(
+                store: fixture.store(vaultID: fixture.primaryVaultID)
+            )
+            _ = try Self.json(readOnlyServer.handleLine(
+                #"{"jsonrpc":"2.0","id":5,"method":"initialize","params":{}}"#
+            ))
+            _ = readOnlyServer.handleLine(#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#)
+            let readOnlyTools = try Self.json(
+                readOnlyServer.handleLine(#"{"jsonrpc":"2.0","id":6,"method":"tools/list"}"#)
+            )
+            let readOnlyDefinitions =
+                ((readOnlyTools["result"] as? [String: Any])?["tools"] as? [[String: Any]]) ?? []
+            #expect(!readOnlyDefinitions.contains { $0["name"] as? String == "set_organization_domain" })
+            let denied = try Self.json(readOnlyServer.handleLine("""
+            {"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"set_organization_domain","arguments":{\
+            "organization_id":"\(organization.resourceID.uuidString)",\
+            "expected_organization_revision":1,\
+            "domain_name":"denied.example","is_primary":false}}}
+            """))
+            #expect((denied["result"] as? [String: Any])?["isError"] as? Bool == true)
+        }
+
+        @Test
+        // swiftlint:disable:next function_body_length
         func writeMCPPublishesSimpleCrudToolsOnlyWhenEnabled() throws {
             let fixture = try Fixture()
             let readOnlyServer = try DahliaMCPServer(store: fixture.store(vaultID: fixture.primaryVaultID))
@@ -1080,6 +1309,7 @@ import ImageIO
                 "create_contact", "update_contact", "delete_contact", "resolve_contact",
                 "create_conversation_topic", "update_conversation_topic", "delete_conversation_topic",
                 "create_insight", "update_insight", "delete_insight",
+                "set_organization_domain", "remove_organization_domain",
                 "set_contact_organization_membership", "remove_contact_organization_membership",
                 "set_project_resource_reference", "remove_project_resource_reference",
                 "set_conversation_topic_resource_reference",

--- a/Tests/DahliaTests/OrganizationDomainMergeTests.swift
+++ b/Tests/DahliaTests/OrganizationDomainMergeTests.swift
@@ -7,6 +7,7 @@ import GRDB
     import Testing
 
     @MainActor
+    // swiftlint:disable:next type_body_length
     struct OrganizationDomainMergeTests {
         @Test
         // swiftlint:disable:next function_body_length
@@ -203,14 +204,14 @@ import GRDB
                 #expect(insightReferences.count == 2)
                 #expect(insightReferences.allSatisfy { $0.resourceId == target.id })
 
-                let resolved = try CustomerIntelligencePersistence.organization(
+                let resolved = try CustomerIntelligencePersistence.organizations(
                     forDomain: "example.co.jp",
                     vaultId: fixture.vault.id,
                     observedAt: .now,
                     automaticallyCreate: true,
                     in: db
                 )
-                #expect(resolved?.id == target.id)
+                #expect(resolved.map(\.id) == [target.id])
             }
         }
 
@@ -291,6 +292,7 @@ import GRDB
                 domainName: "moved.example"
             )
             try fixture.repository.removeOrganizationDomain(
+                organizationId: formerOwner.id,
                 vaultId: fixture.vault.id,
                 domainName: "moved.example"
             )
@@ -398,6 +400,111 @@ import GRDB
         }
 
         @Test
+        func mergeCoalescesDomainAlreadySharedWithTarget() throws {
+            let fixture = try CustomerIntelligenceFixture()
+            let target = try fixture.repository.createOrganization(
+                vaultId: fixture.vault.id,
+                parentOrganizationId: nil,
+                nodeKind: .organization,
+                name: "Target"
+            )
+            let source = try fixture.repository.createOrganization(
+                vaultId: fixture.vault.id,
+                parentOrganizationId: nil,
+                nodeKind: .organization,
+                name: "Source"
+            )
+            let older = Date.now.addingTimeInterval(-1000)
+            let newer = Date.now
+            _ = try fixture.repository.addOrganizationDomain(
+                organizationId: target.id,
+                vaultId: fixture.vault.id,
+                domainName: "shared.example",
+                observedAt: newer
+            )
+            _ = try fixture.repository.addOrganizationDomain(
+                organizationId: source.id,
+                vaultId: fixture.vault.id,
+                domainName: "shared.example",
+                observedAt: older
+            )
+            _ = try fixture.repository.addOrganizationDomain(
+                organizationId: source.id,
+                vaultId: fixture.vault.id,
+                domainName: "source.example"
+            )
+            let preview = try mergePreview(
+                repository: fixture.repository,
+                targetOrganizationId: target.id,
+                vaultId: fixture.vault.id,
+                domainName: "source.example"
+            )
+
+            _ = try fixture.repository.mergeOrganization(
+                sourceOrganizationId: source.id,
+                targetOrganizationId: target.id,
+                vaultId: fixture.vault.id,
+                expectedSourceDomainName: preview.domainName,
+                expectedSourceRevision: preview.source.revision,
+                expectedTargetRevision: preview.target.revision,
+                expectedImpact: preview.impact
+            )
+
+            let domains = try fixture.repository.fetchOrganizationDomains(
+                organizationId: target.id,
+                vaultId: fixture.vault.id
+            )
+            #expect(domains.map(\.domainName).sorted() == ["shared.example", "source.example"])
+            let shared = try #require(domains.first { $0.domainName == "shared.example" })
+            #expect(abs(shared.firstObservedAt.timeIntervalSince(older)) < 0.001)
+            #expect(abs(shared.lastObservedAt.timeIntervalSince(newer)) < 0.001)
+            #expect(domains.count(where: \.isPrimary) == 1)
+        }
+
+        @Test
+        func domainSharedByMultipleOwnersIsAddedWithoutOfferingMerge() throws {
+            let fixture = try CustomerIntelligenceFixture()
+            let organizations = try ["First", "Second", "Target"].map { name in
+                try fixture.repository.createOrganization(
+                    vaultId: fixture.vault.id,
+                    parentOrganizationId: nil,
+                    nodeKind: .organization,
+                    name: name
+                )
+            }
+            for organization in organizations.prefix(2) {
+                _ = try fixture.repository.addOrganizationDomain(
+                    organizationId: organization.id,
+                    vaultId: fixture.vault.id,
+                    domainName: "shared.example"
+                )
+            }
+            let target = organizations[2]
+            let currentTarget = try #require(
+                try fixture.repository.fetchOrganization(id: target.id, vaultId: fixture.vault.id)
+            )
+            let plan = try fixture.repository.organizationDomainAssignmentPlan(
+                targetOrganizationId: target.id,
+                vaultId: fixture.vault.id,
+                domainName: "shared.example",
+                expectedTargetRevision: currentTarget.revision
+            )
+            #expect(plan == .shared)
+            _ = try fixture.repository.addOrganizationDomain(
+                organizationId: target.id,
+                vaultId: fixture.vault.id,
+                domainName: "shared.example",
+                expectedOrganizationRevision: currentTarget.revision
+            )
+            let assignments = try fixture.manager.dbQueue.read { db in
+                try OrganizationDomainRecord
+                    .filter(Column("domainName") == "shared.example")
+                    .fetchCount(db)
+            }
+            #expect(assignments == 3)
+        }
+
+        @Test
         func viewModelAddsANewDomainAndPreparesAnExistingOwnerForMerge() async throws {
             let fixture = try CustomerIntelligenceFixture()
             let target = try fixture.repository.createOrganization(
@@ -479,6 +586,7 @@ import GRDB
 
         @Test
         func mergeImpactUsesSingularLabels() {
+            let title = L10n.organizationDomainAlreadyUsed(by: "Source")
             let message = L10n.organizationMergeImpact(
                 domainName: "source.example",
                 targetName: "Target",
@@ -492,6 +600,7 @@ import GRDB
                 )
             )
 
+            #expect(title.contains("Source"))
             #expect(message.contains("Target"))
             #expect(!message.contains("1 domains"))
             #expect(!message.contains("1 memberships"))

--- a/Tests/DahliaTests/SharedOrganizationDomainsMigrationTests.swift
+++ b/Tests/DahliaTests/SharedOrganizationDomainsMigrationTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct SharedOrganizationDomainsMigrationTests {
+        @Test
+        // swiftlint:disable:next function_body_length
+        func preservesExistingRowsAndAllowsSharedDomains() throws {
+            let queue = try DatabaseQueue()
+            try AppDatabaseManager.migrator.migrate(queue, upTo: "v32_transcriptAudioFeatures")
+            let vault = VaultRecord(
+                id: .v7(),
+                path: "/tmp/shared-organization-domains-vault",
+                name: "Vault",
+                createdAt: .now,
+                lastOpenedAt: .now
+            )
+            let firstOrganizationID = UUID.v7()
+            let secondOrganizationID = UUID.v7()
+            let firstObservedAt = Date(timeIntervalSince1970: 1_700_000_000)
+            let lastObservedAt = firstObservedAt.addingTimeInterval(600)
+            try queue.write { db in
+                try vault.insert(db)
+                try insertRootOrganization(firstOrganizationID, vaultID: vault.id, in: db)
+                try insertRootOrganization(secondOrganizationID, vaultID: vault.id, in: db)
+                try db.execute(
+                    sql: """
+                    INSERT INTO organization_domains (
+                        vaultId, domainName, organizationId, isPrimary, firstObservedAt, lastObservedAt
+                    )
+                    VALUES (?, 'alpha.example', ?, 1, ?, ?),
+                           (?, 'shared.example', ?, 0, ?, ?)
+                    """,
+                    arguments: [
+                        vault.id, firstOrganizationID, firstObservedAt, lastObservedAt,
+                        vault.id, firstOrganizationID, firstObservedAt, lastObservedAt,
+                    ]
+                )
+            }
+
+            try AppDatabaseManager.migrator.migrate(queue)
+
+            try queue.write { db in
+                let preservedRecord = try OrganizationDomainRecord
+                    .filter(
+                        Column("vaultId") == vault.id
+                            && Column("domainName") == "shared.example"
+                            && Column("organizationId") == firstOrganizationID
+                    )
+                    .fetchOne(db)
+                let preserved = try #require(preservedRecord)
+                #expect(preserved.isPrimary == false)
+                #expect(preserved.firstObservedAt == firstObservedAt)
+                #expect(preserved.lastObservedAt == lastObservedAt)
+
+                try db.execute(
+                    sql: """
+                    INSERT INTO organization_domains (
+                        vaultId, domainName, organizationId, isPrimary, firstObservedAt, lastObservedAt
+                    )
+                    VALUES (?, 'shared.example', ?, 0, ?, ?)
+                    """,
+                    arguments: [vault.id, secondOrganizationID, firstObservedAt, lastObservedAt]
+                )
+
+                let shared = try OrganizationDomainRecord
+                    .filter(Column("vaultId") == vault.id && Column("domainName") == "shared.example")
+                    .fetchAll(db)
+                #expect(shared.count == 2)
+                #expect(shared.first { $0.organizationId == firstOrganizationID }?.isPrimary == false)
+                #expect(shared.first { $0.organizationId == secondOrganizationID }?.isPrimary == true)
+
+                #expect(throws: DatabaseError.self) {
+                    try db.execute(
+                        sql: """
+                        INSERT INTO organization_domains (
+                            vaultId, domainName, organizationId, isPrimary, firstObservedAt, lastObservedAt
+                        )
+                        VALUES (?, 'shared.example', ?, 0, ?, ?)
+                        """,
+                        arguments: [vault.id, secondOrganizationID, firstObservedAt, lastObservedAt]
+                    )
+                }
+                #expect(throws: DatabaseError.self) {
+                    try db.execute(
+                        sql: """
+                        INSERT INTO organization_domains (
+                            vaultId, domainName, organizationId, isPrimary, firstObservedAt, lastObservedAt
+                        )
+                        VALUES (?, 'second.example', ?, 1, ?, ?)
+                        """,
+                        arguments: [vault.id, secondOrganizationID, firstObservedAt, lastObservedAt]
+                    )
+                }
+            }
+        }
+
+        @Test
+        func appliesAllMigrationsToEmptyDatabase() throws {
+            let queue = try DatabaseQueue()
+            try AppDatabaseManager.migrator.migrate(queue)
+            let applied = try queue.read { db in
+                try String.fetchOne(
+                    db,
+                    sql: "SELECT identifier FROM grdb_migrations ORDER BY rowid DESC LIMIT 1"
+                )
+            }
+            #expect(applied == "v33_sharedOrganizationDomains")
+        }
+
+        private func insertRootOrganization(
+            _ id: UUID,
+            vaultID: UUID,
+            in db: Database
+        ) throws {
+            try db.execute(
+                sql: """
+                INSERT INTO organizations (
+                    id, vaultId, parentOrganizationId, nodeKind, name, description, revision, createdAt, updatedAt
+                )
+                VALUES (?, ?, NULL, 'organization', ?, '', 1, ?, ?)
+                """,
+                arguments: [id, vaultID, id.uuidString, Date.now, Date.now]
+            )
+        }
+    }
+#endif

--- a/docs/adr/0016-shared-organization-domains.md
+++ b/docs/adr/0016-shared-organization-domains.md
@@ -1,0 +1,38 @@
+# ADR 0016: Organization domains can be shared
+
+- Status: Accepted
+- Date: 2026-07-31
+- Amends: [ADR 0011](0011-vault-scoped-customer-intelligence.md),
+  [ADR 0014](0014-domain-driven-organization-merge.md)
+
+## Context
+
+Independent top-level companies can use the same email domain. Treating `(vaultId, domainName)` as unique forced those
+companies into one Organization and made calendar ingestion assign Contacts to a company without enough evidence.
+Domain-driven merge remains useful when two records represent one company, but it must not be the only way to add an
+already-observed domain.
+
+## Decision
+
+- `organization_domains` uses `(vaultId, domainName, organizationId)` as its primary key. The v33 migration rebuilds the
+  table and copies existing rows without transforming them.
+- Only root Organizations can receive domains through supported Repository and MCP writes. One Organization still has
+  exactly one primary domain whenever it has domains.
+- Calendar ingestion creates an Organization only for the first observation of a non-public domain. Later observations
+  update `firstObservedAt` and `lastObservedAt` on every Organization sharing that domain.
+- Automatic Contact membership is controlled by a setting that defaults to enabled for compatibility. It is always
+  suppressed when a domain has multiple Organization owners. Contact creation, Meeting participation, and first-domain
+  Organization creation continue when the setting is disabled.
+- When one other root owns a domain, the UI offers either a non-destructive shared assignment or the existing destructive
+  Organization merge. When multiple roots already share it, the UI adds another shared assignment without offering merge.
+- Merge coalesces a domain already present on the target by taking the earliest first observation and latest last
+  observation while preserving the established primary-domain rule.
+- Write-enabled MCP sessions expose `set_organization_domain` and `remove_organization_domain`. Agents use explicit
+  Contact membership tools and Meeting evidence to classify Contacts on shared domains. The common customer-intelligence
+  schema gate advances to `v33_sharedOrganizationDomains`; this is an intentional compatibility change.
+
+## Consequences
+
+Shared corporate email infrastructure no longer requires a false Organization merge. Automatic ingestion remains useful
+for unambiguous domains, while ambiguous membership requires user or evidence-based agent action. Existing database rows
+and observation timestamps retain their meaning.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,3 +24,4 @@ Codex は全 ADR を順番に読まず、最初にこの一覧から現在の作
 | [0013](0013-expand-codex-stdout-burst-buffer.md) | AI runtime | Codex stdout の burst buffer を拡張し、消費済み payload を即時解放する | Accepted; amends 0003 |
 | [0014](0014-domain-driven-organization-merge.md) | Customer intelligence / Identity | メールドメイン追加を入口にルート組織を完全統合する | Accepted; amends 0011 and 0012 |
 | [0015](0015-preset-projects-optimizer-skill.md) | AI runtime / Project workspace | Projects Optimizer skill をアプリ内チャットへプリセットする | Accepted; amends 0003, builds on 0010 |
+| [0016](0016-shared-organization-domains.md) | Customer intelligence / Identity | 同じメールドメインを複数のルート組織で共有可能にする | Accepted; amends 0011 and 0014 |

--- a/docs/customer-intelligence-workspace.md
+++ b/docs/customer-intelligence-workspace.md
@@ -20,9 +20,10 @@ Dahlia の「顧客インテリジェンス」画面は、選択中の Vault に
   確認受信箱で、確認済みへの変更を明示的に行います。
 - Project の名称、親、種別、説明はこの画面で編集できます。Meeting の移動、Project 階層の削除、
   要約ファイル処理は「Projectsで管理」から従来の管理ウインドウを開きます。
-- ルート Organization のインスペクタには、参加者の分類に使うメールドメインを表示します。未割当の
-  ドメインはそのまま追加し、別のルート Organization に割り当て済みの場合は、影響件数を確認してから
-  ドメイン、人物、部署、Project、Topic、Insight の参照を選択中の Organization へ一括統合します。
+- ルート Organization のインスペクタには、参加者の分類に使うメールドメインを表示します。同じドメインを
+  複数のルート Organization で共有できます。別の1組織に割り当て済みの場合は、非破壊の共有追加または
+  ドメイン、人物、部署、Project、Topic、Insight の参照を選択中の Organization へ移す統合を選びます。
+  すでに複数組織で共有されている場合は共有追加だけを行います。
   統合先の名称と主ドメインを維持し、重複する所属や参照では統合先の情報を優先して、元の Organization
   を削除します。統合先に主ドメインがない場合は、元の Organization の主ドメインを引き継ぎます。
 - Organization と部門には説明を保存でき、作成・編集・詳細表示と組織検索で利用できます。
@@ -46,7 +47,9 @@ Dahlia の「顧客インテリジェンス」画面は、選択中の Vault に
 ## AI で整理
 
 「AIで整理」は既定90日の期間、組織 UUID、任意の Project UUID を含む依頼をチャット入力欄に準備します。
-自動送信しません。AI は保存済み要約を先に読み、必要な場合だけ transcript を確認します。
+自動送信しません。AI は保存済み要約を先に読み、必要な場合だけ transcript を確認します。共有ドメインの
+人物はドメインだけで所属を決めず、議事録などの証拠に基づいて `set_contact_organization_membership` で
+明示的に所属させます。
 
 AI は書き込み前に `query_*` または `get_*` で現在値と revision を取得し、次の単純なツールを順番に呼びます。
 
@@ -82,6 +85,7 @@ Insight の参照がすべて解除されている場合だけ削除できます
 - `create_contact` / `update_contact` / `delete_contact` / `resolve_contact`
 - `create_conversation_topic` / `update_conversation_topic` / `delete_conversation_topic`
 - `create_insight` / `update_insight` / `delete_insight`
+- `set_organization_domain` / `remove_organization_domain`
 - `set_contact_organization_membership` / `remove_contact_organization_membership`
 - `set_project_resource_reference` / `remove_project_resource_reference`
 - `set_conversation_topic_resource_reference` / `remove_conversation_topic_resource_reference`
@@ -96,5 +100,10 @@ Topic と Insight の削除は所有する参照だけを削除し、参照先�
 
 開発途中の旧スキーマを適用済みの QA データベースは、Dahlia 起動時の
 `v29_customerIntelligenceDirectCRUD` で現在の Insight 列と cleanup trigger へ前方修復されます。
-続く `v30_organizationDescription` は既存 Organization を保持したまま説明列を追加します。MCP は v30
+続く `v30_organizationDescription` は既存 Organization を保持したまま説明列を追加します。
+`v33_sharedOrganizationDomains` は既存ドメイン行を無変換で保ちながら共有を可能にします。MCP は v33
 完了前のデータベースを開かず、Dahlia を一度起動してアップグレードするよう案内します。
+
+設定の「カレンダー」にある「参加者を組織へ自動で紐付ける」は既定でオンです。オフでも Contact、
+Meeting participant、初出ドメインの Organization は作成されます。設定にかかわらず、複数組織で共有する
+ドメインからは Membership を自動作成しません。


### PR DESCRIPTION
## Summary

- add the `v33_sharedOrganizationDomains` migration, changing organization-domain identity to `(vaultId, domainName, organizationId)` while preserving existing rows
- keep automatic Organization and Contact discovery, but suppress automatic membership for shared domains and add a default-on Calendar setting for automatic membership
- let users choose between a non-destructive shared-domain assignment and a destructive Organization merge
- add `set_organization_domain` and `remove_organization_domain` to write-enabled Dahlia MCP sessions, including root/revision/primary-domain validation
- update architecture documentation, ADR 0016, localization, and regression coverage
- prepare release version `0.8.0` with build number `38`

## Why

Independent top-level companies can share the same corporate email domain. The previous `(vaultId, domainName)` key forced one domain to one Organization, and calendar ingestion then assigned every Contact from that domain to that Organization without enough evidence.

## User and developer impact

Existing domain rows and observation timestamps are copied without reinterpretation. Automatic membership remains enabled by default for compatibility, but ambiguous shared domains now require an explicit user or evidence-based MCP assignment. The customer-intelligence MCP schema gate advances to v33.

The existing table rebuild changes a data contract, so this PR applies the repository's compatibility-version policy and advances the release from `0.7.2` to `0.8.0` (`CFBundleVersion` 38).

## Validation

- `swift build`
- targeted migration, ingestion, merge, and MeetingAccessStore/MCP tests
- `swift test`: 198 suites, 1260 tests passed
- `CI=true ./scripts/lint.sh`: SwiftFormat clean; existing SwiftLint violations remain non-blocking per the script
- `plutil -lint Resources/Info.plist`
- `git diff --check`

## Manual follow-up

The signed app flow (`./scripts/run-dev.sh`) and live `dahlia-mcp --write` interaction were not run as part of the automated verification.