### PR TITLE
Reduce per-event work when dragging the floating chat

### DIFF
--- a/Sources/Dahlia/ViewModels/CodexChatFloatingLayoutModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatFloatingLayoutModel.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+/// フローティングチャットの位置とサイズを保持する。
+///
+/// ドラッグ中のマウスイベントごとに更新されるため、状態を `CodexChatFloatingView` の `@State` ではなく
+/// この Observable に置き、再評価をジオメトリを読む小さなコンテナビューだけに限定する。
+@MainActor
+@Observable
+final class CodexChatFloatingLayoutModel {
+    var layout: CodexChatFloatingLayout
+    var dragTranslation = CGSize.zero
+
+    init(dockSide: CodexChatDockSide) {
+        layout = CodexChatFloatingLayout(dockSide: dockSide)
+    }
+
+    func updateDragging(_ translation: CGSize) {
+        withoutAnimation { dragTranslation = translation }
+    }
+
+    /// ドラッグを確定し、ウィンドウ中心に近い側へドックさせる。
+    func finishDragging(_ translation: CGSize, availableSize: CGSize, animated: Bool) {
+        let origin = layout.origin(in: availableSize, dragTranslation: translation)
+        let horizontalCenter = origin.x + layout.size.width / 2
+        guard animated else {
+            snap(horizontalCenter: horizontalCenter, availableWidth: availableSize.width)
+            return
+        }
+        withAnimation(.snappy(duration: 0.28)) {
+            snap(horizontalCenter: horizontalCenter, availableWidth: availableSize.width)
+        }
+    }
+
+    func resize(
+        from edge: CodexChatResizeEdge,
+        start: CodexChatFloatingLayout,
+        translation: CGSize,
+        availableSize: CGSize
+    ) {
+        var resized = start
+        resized.resize(from: edge, translation: translation, availableSize: availableSize)
+        withoutAnimation { layout = resized }
+    }
+
+    func clamp(to availableSize: CGSize) {
+        layout.clamp(to: availableSize)
+    }
+
+    private func snap(horizontalCenter: CGFloat, availableWidth: CGFloat) {
+        layout.snap(horizontalCenter: horizontalCenter, availableWidth: availableWidth)
+        dragTranslation = .zero
+    }
+
+    private func withoutAnimation(_ body: () -> Void) {
+        var transaction = Transaction()
+        transaction.animation = nil
+        withTransaction(transaction, body)
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatActionButton.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatActionButton.swift
@@ -7,14 +7,16 @@ struct CodexChatActionButton: View {
     let action: () -> Void
 
     var body: some View {
-        Button(label, systemImage: systemImage, action: action)
-            .labelStyle(.iconOnly)
-            .buttonStyle(.plain)
-            .foregroundStyle(.white)
-            .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
-            .background(.primary.opacity(isEnabled ? 0.85 : 0.32), in: Circle())
-            .contentShape(Circle())
-            .disabled(!isEnabled)
-            .help(label)
+        Button(action: action) {
+            Label(label, systemImage: systemImage)
+                .labelStyle(.iconOnly)
+                .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.white)
+        .background(.primary.opacity(isEnabled ? 0.85 : 0.32), in: Circle())
+        .disabled(!isEnabled)
+        .help(label)
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
@@ -19,31 +19,33 @@ struct CodexChatComposerInputRow: View {
 
     var body: some View {
         HStack(alignment: .bottom, spacing: 10) {
-            Button(L10n.addToChat, systemImage: "plus", action: onToggleAddPanel)
-                .labelStyle(.iconOnly)
-                .buttonStyle(.plain)
-                .foregroundStyle(.secondary)
-                .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
-                .background(.quaternary, in: Circle())
-                .contentShape(Circle())
-                .help(L10n.addToChat)
-                .overlay(alignment: .bottomLeading) {
-                    if showsAddPanel {
-                        CodexChatAddPanel(
-                            showsMeetingPicker: showsMeetingPicker,
-                            meetingReferences: suggestions,
-                            highlightedMeetingID: highlightedMeetingID,
-                            onAttachImages: onShowImageImporter,
-                            onAddMeetingReference: onShowMeetingPicker,
-                            onSelectMeeting: onSelectMeeting
-                        )
-                        .codexChatDismissOnOutsideClick(perform: onExitCommand)
-                        .offset(y: -(CodexChatDesign.controlSize + 8))
-                        .zIndex(1)
-                    }
+            Button(action: onToggleAddPanel) {
+                Label(L10n.addToChat, systemImage: "plus")
+                    .labelStyle(.iconOnly)
+                    .frame(width: CodexChatDesign.controlSize, height: CodexChatDesign.controlSize)
+                    .contentShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .background(.quaternary, in: Circle())
+            .help(L10n.addToChat)
+            .overlay(alignment: .bottomLeading) {
+                if showsAddPanel {
+                    CodexChatAddPanel(
+                        showsMeetingPicker: showsMeetingPicker,
+                        meetingReferences: suggestions,
+                        highlightedMeetingID: highlightedMeetingID,
+                        onAttachImages: onShowImageImporter,
+                        onAddMeetingReference: onShowMeetingPicker,
+                        onSelectMeeting: onSelectMeeting
+                    )
+                    .codexChatDismissOnOutsideClick(perform: onExitCommand)
+                    .offset(y: -(CodexChatDesign.controlSize + 8))
+                    .zIndex(1)
                 }
-                .onExitCommand(perform: onExitCommand)
-                .zIndex(showsAddPanel ? 1 : 0)
+            }
+            .onExitCommand(perform: onExitCommand)
+            .zIndex(showsAddPanel ? 1 : 0)
 
             CodexChatComposerTextEditor(
                 text: $session.draft,

--- a/Sources/Dahlia/Views/CodexChat/CodexChatCopyButton.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatCopyButton.swift
@@ -4,14 +4,16 @@ struct CodexChatCopyButton: View {
     let text: String
 
     var body: some View {
-        Button(L10n.copyChatMessage, systemImage: "square.on.square", action: copyMessage)
-            .labelStyle(.iconOnly)
-            .buttonStyle(.plain)
-            .font(.caption)
-            .foregroundStyle(.tertiary)
-            .frame(width: 24, height: 24)
-            .contentShape(Rectangle())
-            .help(L10n.copyChatMessage)
+        Button(action: copyMessage) {
+            Label(L10n.copyChatMessage, systemImage: "square.on.square")
+                .labelStyle(.iconOnly)
+                .frame(width: 24, height: 24)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .font(.caption)
+        .foregroundStyle(.tertiary)
+        .help(L10n.copyChatMessage)
     }
 
     private func copyMessage() {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatFloatingView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatFloatingView.swift
@@ -7,8 +7,7 @@ struct CodexChatFloatingView: View {
     let onOpenDetachedSession: (CodexChatSessionID) -> Void
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var layout: CodexChatFloatingLayout
-    @State private var dragTranslation = CGSize.zero
+    @State private var layoutModel: CodexChatFloatingLayoutModel
 
     init(
         coordinator: CodexChatCoordinator,
@@ -20,16 +19,19 @@ struct CodexChatFloatingView: View {
         self.sidebarViewModel = sidebarViewModel
         self.onPopOut = onPopOut
         self.onOpenDetachedSession = onOpenDetachedSession
-        _layout = State(initialValue: CodexChatFloatingLayout(dockSide: AppSettings.shared.codexChatDockSide))
+        _layoutModel = State(
+            initialValue: CodexChatFloatingLayoutModel(dockSide: AppSettings.shared.codexChatDockSide)
+        )
     }
 
+    // ドラッグ中に更新されるジオメトリは `CodexChatFloatingContainer` だけが読む。
+    // ここでレイアウトを読むとマウスイベントごとにチャット本体まで再評価される。
     var body: some View {
         GeometryReader { geometry in
-            let origin = layout.origin(in: geometry.size, dragTranslation: dragTranslation)
-            let restingOrigin = layout.origin(in: geometry.size)
-            let interactionSize = CodexChatResizeHandles.interactionSize(for: layout.size)
-            ZStack {
-                CodexChatView(
+            CodexChatFloatingContainer(
+                layoutModel: layoutModel,
+                availableSize: geometry.size,
+                content: CodexChatView(
                     session: coordinator.floatingSession,
                     coordinator: coordinator,
                     meetingReferences: sidebarViewModel.meetingReferences,
@@ -40,28 +42,12 @@ struct CodexChatFloatingView: View {
                     onPopOut: popOut,
                     onHide: coordinator.hideFloating,
                     onOpenHistory: openHistory,
-                    onHeaderDragChanged: updateDragging,
+                    onHeaderDragChanged: layoutModel.updateDragging,
                     onHeaderDragEnded: { finishDragging($0, availableSize: geometry.size) }
                 )
-                .frame(width: layout.size.width, height: layout.size.height)
-                .clipShape(.rect(cornerRadius: 24))
-                .contentShape(.interaction, .rect(cornerRadius: 24))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 24)
-                        .stroke(.separator.opacity(0.6), lineWidth: 1)
-                }
-                .shadow(color: .black.opacity(0.18), radius: 22, y: 8)
-
-                CodexChatResizeHandles(layout: $layout, availableSize: geometry.size)
-            }
-            .frame(width: interactionSize.width, height: interactionSize.height)
-            .position(
-                x: restingOrigin.x + layout.size.width / 2,
-                y: restingOrigin.y + layout.size.height / 2
             )
-            .offset(x: origin.x - restingOrigin.x)
             .onChange(of: geometry.size) {
-                layout.clamp(to: geometry.size)
+                layoutModel.clamp(to: geometry.size)
             }
             .task(id: sidebarViewModel.currentVault?.id) {
                 sidebarViewModel.loadMeetingReferencesIfNeeded()
@@ -69,26 +55,9 @@ struct CodexChatFloatingView: View {
         }
     }
 
-    private func updateDragging(_ translation: CGSize) {
-        var transaction = Transaction()
-        transaction.animation = nil
-        withTransaction(transaction) {
-            dragTranslation = translation
-        }
-    }
-
     private func finishDragging(_ translation: CGSize, availableSize: CGSize) {
-        let origin = layout.origin(in: availableSize, dragTranslation: translation)
-        let snap = {
-            layout.snap(horizontalCenter: origin.x + layout.size.width / 2, availableWidth: availableSize.width)
-            dragTranslation = .zero
-        }
-        if reduceMotion {
-            snap()
-        } else {
-            withAnimation(.snappy(duration: 0.28), snap)
-        }
-        AppSettings.shared.codexChatDockSide = layout.dockSide
+        layoutModel.finishDragging(translation, availableSize: availableSize, animated: !reduceMotion)
+        AppSettings.shared.codexChatDockSide = layoutModel.layout.dockSide
     }
 
     private func popOut() {
@@ -102,5 +71,46 @@ struct CodexChatFloatingView: View {
                 onOpenDetachedSession(id)
             }
         }
+    }
+}
+
+/// ドラッグ中の位置とサイズだけを反映する薄いコンテナ。
+///
+/// `content` は組み立て済みのビュー値として受け取るため、ここが再評価されてもチャット本体の body は再評価されない。
+private struct CodexChatFloatingContainer<Content: View>: View {
+    let layoutModel: CodexChatFloatingLayoutModel
+    let availableSize: CGSize
+    let content: Content
+
+    var body: some View {
+        let layout = layoutModel.layout
+        let origin = layout.origin(in: availableSize, dragTranslation: layoutModel.dragTranslation)
+        let restingOrigin = layout.origin(in: availableSize)
+        let interactionSize = CodexChatResizeHandles.interactionSize(for: layout.size)
+        ZStack {
+            content
+                .frame(width: layout.size.width, height: layout.size.height)
+                .clipShape(.rect(cornerRadius: 24))
+                .contentShape(.interaction, .rect(cornerRadius: 24))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 24)
+                        .stroke(.separator.opacity(0.6), lineWidth: 1)
+                }
+                // 影はチャット本体ではなく同じ形の背景シェイプに掛ける。
+                // 本体に掛けるとリサイズのたびにチャット全体をオフスクリーンにラスタライズし直すことになる。
+                .background {
+                    RoundedRectangle(cornerRadius: 24)
+                        .fill(.background)
+                        .shadow(color: .black.opacity(0.18), radius: 22, y: 8)
+                }
+
+            CodexChatResizeHandles(layoutModel: layoutModel, availableSize: availableSize)
+        }
+        .frame(width: interactionSize.width, height: interactionSize.height)
+        .position(
+            x: restingOrigin.x + layout.size.width / 2,
+            y: restingOrigin.y + layout.size.height / 2
+        )
+        .offset(x: origin.x - restingOrigin.x)
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatFloatingView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatFloatingView.swift
@@ -24,8 +24,8 @@ struct CodexChatFloatingView: View {
         )
     }
 
-    // ドラッグ中に更新されるジオメトリは `CodexChatFloatingContainer` だけが読む。
-    // ここでレイアウトを読むとマウスイベントごとにチャット本体まで再評価される。
+    /// ドラッグ中に更新されるジオメトリは `CodexChatFloatingContainer` だけが読む。
+    /// ここでレイアウトを読むとマウスイベントごとにチャット本体まで再評価される。
     var body: some View {
         GeometryReader { geometry in
             CodexChatFloatingContainer(

--- a/Sources/Dahlia/Views/CodexChat/CodexChatIconButton.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatIconButton.swift
@@ -9,16 +9,20 @@ struct CodexChatIconButton: View {
     @State private var isHovering = false
 
     var body: some View {
-        Button(label, systemImage: systemImage, action: action)
-            .labelStyle(.iconOnly)
-            .buttonStyle(.plain)
-            .frame(width: size, height: size)
-            .background(
-                isHovering ? AnyShapeStyle(.quaternary) : AnyShapeStyle(.clear),
-                in: RoundedRectangle(cornerRadius: 8)
-            )
-            .contentShape(Rectangle())
-            .onHover { isHovering = $0 }
-            .help(label)
+        Button(action: action) {
+            // クリック判定はラベルの形で決まる。frame と contentShape をボタンの外に置くと
+            // グリフの矩形しか反応せず、minus のように背の低い記号はほとんど押せなくなる。
+            Label(label, systemImage: systemImage)
+                .labelStyle(.iconOnly)
+                .frame(width: size, height: size)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .background(
+            isHovering ? AnyShapeStyle(.quaternary) : AnyShapeStyle(.clear),
+            in: RoundedRectangle(cornerRadius: 8)
+        )
+        .onHover { isHovering = $0 }
+        .help(label)
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownTextView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownTextView.swift
@@ -5,18 +5,7 @@ struct CodexChatMarkdownTextView: NSViewRepresentable {
     let blocks: [CodexChatMarkdownRenderedBlock]
 
     func makeNSView(context _: Context) -> CodexChatSelectableTextView {
-        let textView = CodexChatSelectableTextView()
-        textView.isEditable = false
-        textView.isSelectable = true
-        textView.isRichText = true
-        textView.drawsBackground = false
-        textView.textColor = .labelColor
-        textView.textContainerInset = .zero
-        textView.textContainer?.lineFragmentPadding = 0
-        textView.textContainer?.widthTracksTextView = true
-        textView.isHorizontallyResizable = false
-        textView.isVerticallyResizable = false
-        return textView
+        CodexChatSelectableTextView.makeConfigured()
     }
 
     func updateNSView(_ textView: CodexChatSelectableTextView, context _: Context) {
@@ -41,6 +30,9 @@ struct CodexChatMarkdownTextView: NSViewRepresentable {
 
 final class CodexChatSelectableTextView: NSTextView {
     private static let layoutBatchCharacterCount = 4096
+    /// リサイズドラッグのように幅が連続で変わる間、レイアウトのやり直しを 1 表示フレームぶん待って合流させる。
+    private static let settleInterval = Duration.milliseconds(16)
+    private static let batchInterval = Duration.milliseconds(1)
 
     private var renderedBlocks: [CodexChatMarkdownRenderedBlock] = []
     private var blockOffsets: [Int] = []
@@ -50,6 +42,21 @@ final class CodexChatSelectableTextView: NSTextView {
     private var needsImmediateLayout = true
     private var layoutGeneration = 0
     private var layoutTask: Task<Void, Never>?
+
+    static func makeConfigured() -> Self {
+        let textView = Self()
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.isRichText = true
+        textView.drawsBackground = false
+        textView.textColor = .labelColor
+        textView.textContainerInset = .zero
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainer?.widthTracksTextView = true
+        textView.isHorizontallyResizable = false
+        textView.isVerticallyResizable = false
+        return textView
+    }
 
     func setBlocks(_ blocks: [CodexChatMarkdownRenderedBlock]) {
         let reusableBlockCount = zip(renderedBlocks, blocks)
@@ -115,9 +122,16 @@ final class CodexChatSelectableTextView: NSTextView {
         guard let textContainer, layoutManager != nil else { return nil }
 
         if measuredWidth != width {
+            let previousWidth = measuredWidth
             measuredWidth = width
             textContainer.containerSize = CGSize(width: width, height: .greatestFiniteMagnitude)
             resetLayout(from: 0)
+            // 実測済みの高さがあるなら、同期レイアウトをやり直さず面積を保つ近似値を返し、
+            // 正確な高さは段階レイアウトの収束に任せる。
+            if let previousWidth, measuredDocumentHeight > 0 {
+                measuredDocumentHeight = ceil(measuredDocumentHeight * previousWidth / width)
+                needsImmediateLayout = false
+            }
         }
         if needsImmediateLayout {
             needsImmediateLayout = false
@@ -194,16 +208,21 @@ final class CodexChatSelectableTextView: NSTextView {
         layoutTask = Task { @MainActor [weak self] in
             guard let self else { return }
 
+            var interval = Self.settleInterval
             while !Task.isCancelled, layoutGeneration == generation {
                 do {
-                    try await Task.sleep(for: .milliseconds(1))
+                    try await Task.sleep(for: interval)
                 } catch {
                     break
                 }
                 guard !Task.isCancelled, layoutGeneration == generation else { break }
+                interval = Self.batchInterval
 
+                let previousHeight = measuredDocumentHeight
                 layoutNextBatch()
-                invalidateIntrinsicContentSize()
+                if measuredDocumentHeight != previousHeight {
+                    invalidateIntrinsicContentSize()
+                }
                 if nextLayoutCharacterIndex >= attributedString().length {
                     break
                 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatResizeHandle.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatResizeHandle.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct CodexChatResizeHandle: View {
-    @Binding var layout: CodexChatFloatingLayout
+    let layoutModel: CodexChatFloatingLayoutModel
     let availableSize: CGSize
     let edge: CodexChatResizeEdge
 
@@ -22,16 +22,16 @@ struct CodexChatResizeHandle: View {
 
     private func resize(_ value: DragGesture.Value) {
         if resizeStart == nil {
-            resizeStart = layout
+            resizeStart = layoutModel.layout
             edge.cursor.set()
         }
-        guard var resized = resizeStart else { return }
-        resized.resize(from: edge, translation: value.translation, availableSize: availableSize)
-        var transaction = Transaction()
-        transaction.animation = nil
-        withTransaction(transaction) {
-            layout = resized
-        }
+        guard let resizeStart else { return }
+        layoutModel.resize(
+            from: edge,
+            start: resizeStart,
+            translation: value.translation,
+            availableSize: availableSize
+        )
     }
 
     private func endResize(_: DragGesture.Value) {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatResizeHandles.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatResizeHandles.swift
@@ -1,16 +1,17 @@
 import SwiftUI
 
 struct CodexChatResizeHandles: View {
-    @Binding var layout: CodexChatFloatingLayout
+    let layoutModel: CodexChatFloatingLayoutModel
     let availableSize: CGSize
 
     var body: some View {
-        let interactionSize = Self.interactionSize(for: layout.size)
+        let size = layoutModel.layout.size
+        let interactionSize = Self.interactionSize(for: size)
 
         ZStack(alignment: .topLeading) {
             ForEach(CodexChatResizeEdge.allCases, id: \.self) { edge in
-                let frame = Self.frame(for: edge, in: layout.size)
-                CodexChatResizeHandle(layout: $layout, availableSize: availableSize, edge: edge)
+                let frame = Self.frame(for: edge, in: size)
+                CodexChatResizeHandle(layoutModel: layoutModel, availableSize: availableSize, edge: edge)
                     .frame(width: frame.width, height: frame.height)
                     .position(x: frame.midX, y: frame.midY)
                     .accessibilityHidden(edge != .top)
@@ -85,18 +86,19 @@ struct CodexChatResizeHandles: View {
             return
         }
         let step = CodexChatDesign.resizeAccessibilityStep * multiplier
+        let layout = layoutModel.layout
         let edge: CodexChatResizeEdge = layout.dockSide == .left ? .topRight : .topLeft
         let horizontalTranslation = layout.dockSide == .left ? step : -step
-        var resized = layout
-        resized.resize(
+        layoutModel.resize(
             from: edge,
+            start: layout,
             translation: CGSize(width: horizontalTranslation, height: -step),
             availableSize: availableSize
         )
-        layout = resized
     }
 
     private var accessibilityValue: String {
-        "\(Int(layout.size.width.rounded())) × \(Int(layout.size.height.rounded()))"
+        let size = layoutModel.layout.size
+        return "\(Int(size.width.rounded())) × \(Int(size.height.rounded()))"
     }
 }

--- a/Tests/DahliaTests/CodexChatFloatingLayoutModelTests.swift
+++ b/Tests/DahliaTests/CodexChatFloatingLayoutModelTests.swift
@@ -1,0 +1,90 @@
+import CoreGraphics
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct CodexChatFloatingLayoutModelTests {
+        private let available = CGSize(width: 1000, height: 800)
+
+        @Test
+        func draggingMovesTheOriginWithoutChangingTheLayout() {
+            let model = CodexChatFloatingLayoutModel(dockSide: .right)
+            let resting = model.layout
+
+            model.updateDragging(CGSize(width: -300, height: 0))
+
+            #expect(model.dragTranslation == CGSize(width: -300, height: 0))
+            #expect(model.layout == resting)
+            #expect(
+                model.layout.origin(in: available, dragTranslation: model.dragTranslation).x
+                    < resting.origin(in: available).x
+            )
+        }
+
+        @Test
+        func finishingADragDocksToTheNearestSideAndClearsTheTranslation() {
+            let model = CodexChatFloatingLayoutModel(dockSide: .right)
+            model.updateDragging(CGSize(width: -600, height: 0))
+
+            model.finishDragging(CGSize(width: -600, height: 0), availableSize: available, animated: false)
+
+            #expect(model.layout.dockSide == .left)
+            #expect(model.dragTranslation == .zero)
+        }
+
+        @Test
+        func finishingAShortDragKeepsTheCurrentSide() {
+            let model = CodexChatFloatingLayoutModel(dockSide: .right)
+            model.updateDragging(CGSize(width: -20, height: 0))
+
+            model.finishDragging(CGSize(width: -20, height: 0), availableSize: available, animated: false)
+
+            #expect(model.layout.dockSide == .right)
+            #expect(model.dragTranslation == .zero)
+        }
+
+        @Test
+        func resizeAppliesEachTranslationToTheDragStartLayout() {
+            let model = CodexChatFloatingLayoutModel(dockSide: .right)
+            let start = model.layout
+            var expected = start
+            expected.resize(
+                from: .topLeft,
+                translation: CGSize(width: -80, height: -60),
+                availableSize: available
+            )
+
+            // ドラッグ中の中間イベントは開始時のレイアウトを基準に適用し、積み上げない。
+            model.resize(
+                from: .topLeft,
+                start: start,
+                translation: CGSize(width: -40, height: -30),
+                availableSize: available
+            )
+            model.resize(
+                from: .topLeft,
+                start: start,
+                translation: CGSize(width: -80, height: -60),
+                availableSize: available
+            )
+
+            #expect(model.layout == expected)
+        }
+
+        @Test
+        func clampFitsTheLayoutIntoASmallerContainer() {
+            let model = CodexChatFloatingLayoutModel(dockSide: .right)
+            let smaller = CGSize(width: 420, height: 400)
+            var expected = model.layout
+            expected.clamp(to: smaller)
+
+            model.clamp(to: smaller)
+
+            #expect(model.layout == expected)
+            #expect(model.layout.size.width <= smaller.width)
+            #expect(model.layout.size.height <= smaller.height)
+        }
+    }
+#endif

--- a/Tests/DahliaTests/CodexChatMarkdownTextViewTests.swift
+++ b/Tests/DahliaTests/CodexChatMarkdownTextViewTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct CodexChatMarkdownTextViewTests {
+        @Test
+        func firstMeasurementIsExactWithoutWaiting() throws {
+            let reference = try #require(Self.makeTextView().measuredHeight(constrainedTo: 400))
+            let textView = Self.makeTextView()
+
+            #expect(reference > 0)
+            #expect(textView.measuredHeight(constrainedTo: 400) == reference)
+        }
+
+        @Test
+        func widthChangeReturnsAnAreaPreservingEstimate() throws {
+            let textView = Self.makeTextView()
+            let wideHeight = try #require(textView.measuredHeight(constrainedTo: 400))
+
+            let estimate = try #require(textView.measuredHeight(constrainedTo: 200))
+
+            // 同期レイアウトをやり直さず、幅の比で高さを見積もって即座に返す。
+            #expect(estimate == (wideHeight * 400 / 200).rounded(.up))
+        }
+
+        @Test
+        func widthChangeConvergesToTheExactHeight() async throws {
+            let exact = try #require(Self.makeTextView().measuredHeight(constrainedTo: 200))
+            let textView = Self.makeTextView()
+            _ = textView.measuredHeight(constrainedTo: 400)
+            _ = textView.measuredHeight(constrainedTo: 200)
+
+            let settled = try await Self.settledHeight(of: textView, width: 200, expecting: exact)
+
+            #expect(settled == exact)
+        }
+
+        @Test
+        func burstOfWidthChangesConvergesToTheFinalWidth() async throws {
+            let exact = try #require(Self.makeTextView().measuredHeight(constrainedTo: 240))
+            let textView = Self.makeTextView()
+
+            // リサイズドラッグのように 1 フレーム未満の間隔で幅が変わり続ける状況。
+            let widths: [CGFloat] = [400, 360, 320, 280, 240]
+            for width in widths {
+                _ = textView.measuredHeight(constrainedTo: width)
+            }
+
+            let settled = try await Self.settledHeight(of: textView, width: 240, expecting: exact)
+
+            #expect(settled == exact)
+        }
+
+        private static func makeTextView() -> CodexChatSelectableTextView {
+            let textView = CodexChatSelectableTextView.makeConfigured()
+            let blocks = (0 ..< 20).map { index in
+                CodexChatMarkdownRenderedBlock.paragraph(AttributedString(
+                    "Paragraph \(index): " + String(repeating: "measurement sample text ", count: 5)
+                ))
+            }
+            textView.setBlocks(blocks)
+            return textView
+        }
+
+        private static func settledHeight(
+            of textView: CodexChatSelectableTextView,
+            width: CGFloat,
+            expecting expected: CGFloat
+        ) async throws -> CGFloat {
+            for _ in 0 ..< 200 {
+                let height = try #require(textView.measuredHeight(constrainedTo: width))
+                if height == expected {
+                    return height
+                }
+                try await Task.sleep(for: .milliseconds(5))
+            }
+            return try #require(textView.measuredHeight(constrainedTo: width))
+        }
+    }
+#endif


### PR DESCRIPTION
The AI chat floating window is a SwiftUI overlay inside the main window,
so every pointer event runs a full body evaluation, layout pass and
TextKit relayout on the main actor. That cost exceeded a display frame,
making move and resize trail the pointer.

- Move the drag geometry into an observable model and read it only from a
  thin container that wraps the already-built chat view, so a drag no
  longer re-evaluates the header, composer and conversation bodies.
- Return an area-preserving height estimate when a markdown text view is
  re-measured at a new width, and let the incremental layout converge
  after the drag settles instead of relaying out every document
  synchronously on each event. The first measurement and streaming
  updates keep their synchronous exact layout.
- Pace the incremental layout loop by one display frame after a reset and
  only invalidate the intrinsic content size when the height changed.
- Cast the panel shadow from a rounded rectangle background instead of
  the chat content, so resizing no longer rasterizes the whole chat
  offscreen every frame.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011TNGmm1NWk9vbbzrMuhjhL