### PR TITLE
Link .claude/skills to .agents/skills as a directory

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.claude/skills/swiftui-pro
+++ b/.claude/skills/swiftui-pro
@@ -1,1 +1,0 @@
-../../.agents/skills/swiftui-pro


### PR DESCRIPTION
Replace the per-skill symlink for swiftui-pro with a single
directory-level symlink so every skill under .agents/skills is
available to Claude Code, and new skills are picked up without
adding another link.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014JR43LPWj55hiPsFsVzxRa