### PR TITLE
Fix CI unit test failures from a stdout drain crash and wall-clock races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Show toolchain
+        id: toolchain
+        run: |
+          toolchain="$(xcodebuild -version; swift --version)"
+          echo "$toolchain"
+          toolchain_hash="$(printf '%s' "$toolchain" | shasum -a 256 | awk '{ print $1 }')"
+          echo "hash=$toolchain_hash" >> "$GITHUB_OUTPUT"
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: .build
+          key: spm-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.hash }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
+          restore-keys: |
+            spm-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.hash }}-${{ hashFiles('Package.resolved') }}-
+
       - name: Run unit tests
         run: |
           set -o pipefail

--- a/Sources/Dahlia/Services/CodexAppServerProcessTransport.swift
+++ b/Sources/Dahlia/Services/CodexAppServerProcessTransport.swift
@@ -4,14 +4,20 @@ import Foundation
 
 /// Process stdio adapter. All potentially blocking pipe operations stay outside Swift's cooperative executor.
 actor CodexAppServerProcessTransport: CodexAppServerTransport {
+    private enum OutputEvent: Sendable {
+        case chunk(Data)
+        case end(Int32)
+    }
+
     private let process: Process
     private let inputChannel: DispatchIO
-    private let outputHandle: FileHandle
+    private let outputChannel: DispatchIO
     private let errorChannel: DispatchIO
     private let ioQueue = DispatchQueue(label: "app.dahlia.codex-app-server-stdio")
-    private var outputDrainTask: Task<Void, Never>?
+    private var isOutputDrainStarted = false
     private var isErrorDrainStarted = false
     private var isErrorDrainFinished = false
+    private var stdoutPending = Data()
     private var outputLines: [Data] = []
     private var outputLineReadIndex = 0
     private var outputWaiter: (id: UUID, continuation: CheckedContinuation<Data?, any Error>)?
@@ -58,24 +64,37 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
             process.terminate()
             throw CodexAppServerError.launchFailed(String(cString: strerror(errno)))
         }
+        let outputHandle = standardOutput.fileHandleForReading
+        let duplicatedOutput = Darwin.dup(outputHandle.fileDescriptor)
+        guard duplicatedOutput >= 0 else {
+            Darwin.close(duplicatedInput)
+            process.terminate()
+            throw CodexAppServerError.launchFailed(String(cString: strerror(errno)))
+        }
         let errorHandle = standardError.fileHandleForReading
         let duplicatedError = Darwin.dup(errorHandle.fileDescriptor)
         guard duplicatedError >= 0 else {
+            Darwin.close(duplicatedOutput)
             Darwin.close(duplicatedInput)
             process.terminate()
             throw CodexAppServerError.launchFailed(String(cString: strerror(errno)))
         }
         try? inputHandle.close()
+        try? outputHandle.close()
         try? errorHandle.close()
 
         self.process = process
-        outputHandle = standardOutput.fileHandleForReading
         inputChannel = DispatchIO(type: .stream, fileDescriptor: duplicatedInput, queue: ioQueue) { _ in
             Darwin.close(duplicatedInput)
+        }
+        outputChannel = DispatchIO(type: .stream, fileDescriptor: duplicatedOutput, queue: ioQueue) { _ in
+            Darwin.close(duplicatedOutput)
         }
         errorChannel = DispatchIO(type: .stream, fileDescriptor: duplicatedError, queue: ioQueue) { _ in
             Darwin.close(duplicatedError)
         }
+        // A JSON-RPC line must reach the reader as soon as the child writes it.
+        outputChannel.setLimit(lowWater: 1)
         errorChannel.setLimit(highWater: 4096)
     }
 
@@ -154,10 +173,8 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
             await waitForExit(for: .seconds(1))
         }
 
-        try? outputHandle.close()
+        outputChannel.close(flags: .stop)
         errorChannel.close(flags: .stop)
-        outputDrainTask?.cancel()
-        outputDrainTask = nil
         outputWaiter?.continuation.resume(returning: nil)
         outputWaiter = nil
     }
@@ -202,25 +219,36 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
     }
 
     private func startDrainsIfNeeded() {
+        // A closed transport has already released its channels. Restarting a drain here would
+        // read from a torn-down descriptor instead of reporting the closure to the caller.
+        guard !isClosed else { return }
         startOutputDrainIfNeeded()
         startErrorDrainIfNeeded()
     }
 
     private func startOutputDrainIfNeeded() {
-        guard outputDrainTask == nil else { return }
-        let outputHandle = outputHandle
-        // Keep the long-lived iterator off the transport actor so waiting for the next pipe byte
-        // cannot prevent a later sendLine or receiveLine call from entering the actor.
-        outputDrainTask = Task.detached(priority: .utility) { [weak self] in
-            do {
-                for try await line in outputHandle.bytes.lines where !line.isEmpty {
-                    await self?.enqueueOutputLine(Data(line.utf8))
+        guard !isOutputDrainStarted else { return }
+        isOutputDrainStarted = true
+        let (events, continuation) = AsyncStream<OutputEvent>.makeStream()
+        // DispatchIO keeps the blocking pipe read on ioQueue. The stream carries chunks into the
+        // actor in arrival order, which one unstructured task per chunk would not guarantee.
+        outputChannel.read(offset: 0, length: Int.max, queue: ioQueue) { done, data, errorCode in
+            if let data, !data.isEmpty {
+                continuation.yield(.chunk(Data(data)))
+            }
+            if done {
+                continuation.yield(.end(errorCode))
+                continuation.finish()
+            }
+        }
+        Task { [weak self] in
+            for await event in events {
+                switch event {
+                case let .chunk(data):
+                    await self?.consumeStdout(data)
+                case let .end(errorCode):
+                    await self?.finishOutputDrain(errorCode: errorCode)
                 }
-                await self?.finishOutput()
-            } catch is CancellationError {
-                await self?.finishOutput()
-            } catch {
-                await self?.finishOutput(throwing: error)
             }
         }
     }
@@ -234,6 +262,34 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
                 await self?.consumeStderr(chunk, done: done)
             }
         }
+    }
+
+    private func consumeStdout(_ data: Data) {
+        stdoutPending.append(data)
+        guard stdoutPending.contains(0x0A) else { return }
+        var lines = stdoutPending.split(separator: 0x0A, omittingEmptySubsequences: false)
+        stdoutPending = Data(lines.removeLast())
+        for line in lines where !line.isEmpty {
+            enqueueOutputLine(Data(line))
+        }
+    }
+
+    private func finishOutputDrain(errorCode: Int32) async {
+        // The child may exit after a final line that carries no trailing newline.
+        if !stdoutPending.isEmpty {
+            let trailing = stdoutPending
+            stdoutPending.removeAll()
+            enqueueOutputLine(trailing)
+        }
+        guard errorCode != 0 else {
+            await finishOutput()
+            return
+        }
+        await finishOutput(throwing: NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(errorCode),
+            userInfo: [NSLocalizedDescriptionKey: String(cString: strerror(errorCode))]
+        ))
     }
 
     private func consumeStderr(_ data: Data, done: Bool) {

--- a/Sources/Dahlia/Services/CodexAppServerProcessTransport.swift
+++ b/Sources/Dahlia/Services/CodexAppServerProcessTransport.swift
@@ -6,8 +6,15 @@ import Foundation
 actor CodexAppServerProcessTransport: CodexAppServerTransport {
     private enum OutputEvent: Sendable {
         case chunk(Data)
+        case overflow
         case end(Int32)
     }
+
+    // DispatchIO reads as fast as the child writes, so the bytes waiting to reach the actor need
+    // their own ceiling. Without one the documented maximumBufferedOutputLines policy only applies
+    // after parsing, which leaves memory growth unbounded ahead of it.
+    private static let maximumBufferedOutputChunks = 64
+    private static let maximumOutputChunkBytes = 64 * 1024
 
     private let process: Process
     private let inputChannel: DispatchIO
@@ -93,8 +100,10 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
         errorChannel = DispatchIO(type: .stream, fileDescriptor: duplicatedError, queue: ioQueue) { _ in
             Darwin.close(duplicatedError)
         }
-        // A JSON-RPC line must reach the reader as soon as the child writes it.
+        // A JSON-RPC line must reach the reader as soon as the child writes it, and one delivery
+        // must stay small enough that the handoff ceiling below is expressed in bytes, not chunks.
         outputChannel.setLimit(lowWater: 1)
+        outputChannel.setLimit(highWater: Self.maximumOutputChunkBytes)
         errorChannel.setLimit(highWater: 4096)
     }
 
@@ -229,12 +238,20 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
     private func startOutputDrainIfNeeded() {
         guard !isOutputDrainStarted else { return }
         isOutputDrainStarted = true
-        let (events, continuation) = AsyncStream<OutputEvent>.makeStream()
+        let (events, continuation) = AsyncStream<OutputEvent>.makeStream(
+            bufferingPolicy: .bufferingOldest(Self.maximumBufferedOutputChunks)
+        )
         // DispatchIO keeps the blocking pipe read on ioQueue. The stream carries chunks into the
         // actor in arrival order, which one unstructured task per chunk would not guarantee.
         outputChannel.read(offset: 0, length: Int.max, queue: ioQueue) { done, data, errorCode in
             if let data, !data.isEmpty {
-                continuation.yield(.chunk(Data(data)))
+                // Losing even one chunk splices unrelated bytes into the next line, so a full
+                // buffer becomes the documented overflow rather than a silent discard.
+                if case .dropped = continuation.yield(.chunk(Data(data))) {
+                    continuation.yield(.overflow)
+                    continuation.finish()
+                    return
+                }
             }
             if done {
                 continuation.yield(.end(errorCode))
@@ -246,6 +263,8 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
                 switch event {
                 case let .chunk(data):
                     await self?.consumeStdout(data)
+                case .overflow:
+                    await self?.failOutputDrainWithOverflow()
                 case let .end(errorCode):
                     await self?.finishOutputDrain(errorCode: errorCode)
                 }
@@ -272,6 +291,28 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
         for line in lines where !line.isEmpty {
             enqueueOutputLine(Data(line))
         }
+    }
+
+    private func failOutputDrainWithOverflow() {
+        // Continuing to read only discards more bytes, and the buffered prefix can no longer be
+        // parsed into whole lines.
+        outputChannel.close(flags: .stop)
+        stdoutPending.removeAll()
+        latchOutputBufferOverflow()
+        guard let waiter = outputWaiter else { return }
+        outputWaiter = nil
+        waiter.continuation.resume(throwing: CodexAppServerError.outputBufferOverflow)
+    }
+
+    private func latchOutputBufferOverflow() {
+        outputLines.removeAll(keepingCapacity: false)
+        outputLineReadIndex = 0
+        outputError = CodexAppServerError.outputBufferOverflow
+        #if DEBUG
+            let waiters = outputBufferOverflowWaiters
+            outputBufferOverflowWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        #endif
     }
 
     private func finishOutputDrain(errorCode: Int32) async {
@@ -308,14 +349,7 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
         } else {
             guard outputError == nil else { return }
             if outputLines.count - outputLineReadIndex >= maximumBufferedOutputLines {
-                outputLines.removeAll(keepingCapacity: false)
-                outputLineReadIndex = 0
-                outputError = CodexAppServerError.outputBufferOverflow
-                #if DEBUG
-                    let waiters = outputBufferOverflowWaiters
-                    outputBufferOverflowWaiters.removeAll()
-                    waiters.forEach { $0.resume() }
-                #endif
+                latchOutputBufferOverflow()
                 return
             }
             outputLines.append(line)

--- a/Sources/Dahlia/Services/CodexAppServerProcessTransport.swift
+++ b/Sources/Dahlia/Services/CodexAppServerProcessTransport.swift
@@ -1,11 +1,11 @@
 import Darwin
 import Dispatch
 import Foundation
+import os
 
 /// Process stdio adapter. All potentially blocking pipe operations stay outside Swift's cooperative executor.
 actor CodexAppServerProcessTransport: CodexAppServerTransport {
-    private enum OutputEvent: Sendable {
-        case chunk(Data)
+    private enum OutputTermination: Sendable {
         case overflow
         case end(Int32)
     }
@@ -238,36 +238,44 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
     private func startOutputDrainIfNeeded() {
         guard !isOutputDrainStarted else { return }
         isOutputDrainStarted = true
-        let (events, continuation) = AsyncStream<OutputEvent>.makeStream(
+        let (chunks, continuation) = AsyncStream<Data>.makeStream(
             bufferingPolicy: .bufferingOldest(Self.maximumBufferedOutputChunks)
         )
+        // The terminal outcome must not compete with chunks for stream capacity. Yielding it into a
+        // full buffer would drop it, ending the consumer without ever reporting EOF or overflow and
+        // leaving the reader suspended in receiveLine. First writer wins, so a later callback on the
+        // stopped channel cannot relabel an overflow as a clean exit.
+        let termination = OSAllocatedUnfairLock<OutputTermination?>(initialState: nil)
         // DispatchIO keeps the blocking pipe read on ioQueue. The stream carries chunks into the
         // actor in arrival order, which one unstructured task per chunk would not guarantee.
         outputChannel.read(offset: 0, length: Int.max, queue: ioQueue) { done, data, errorCode in
             if let data, !data.isEmpty {
                 // Losing even one chunk splices unrelated bytes into the next line, so a full
                 // buffer becomes the documented overflow rather than a silent discard.
-                if case .dropped = continuation.yield(.chunk(Data(data))) {
-                    continuation.yield(.overflow)
+                if case .dropped = continuation.yield(Data(data)) {
+                    termination.withLock { $0 = $0 ?? .overflow }
                     continuation.finish()
                     return
                 }
             }
             if done {
-                continuation.yield(.end(errorCode))
+                termination.withLock { $0 = $0 ?? .end(errorCode) }
                 continuation.finish()
             }
         }
         Task { [weak self] in
-            for await event in events {
-                switch event {
-                case let .chunk(data):
-                    await self?.consumeStdout(data)
-                case .overflow:
-                    await self?.failOutputDrainWithOverflow()
-                case let .end(errorCode):
-                    await self?.finishOutputDrain(errorCode: errorCode)
-                }
+            for await chunk in chunks {
+                await self?.consumeStdout(chunk)
+            }
+            // Runs after every buffered chunk has been parsed, so a trailing partial line is still
+            // whole by the time the terminal outcome is applied.
+            switch termination.withLock({ $0 }) {
+            case .overflow:
+                await self?.failOutputDrainWithOverflow()
+            case let .end(errorCode):
+                await self?.finishOutputDrain(errorCode: errorCode)
+            case nil:
+                break
             }
         }
     }

--- a/Tests/DahliaTests/BatchAudioRecordingSessionTests.swift
+++ b/Tests/DahliaTests/BatchAudioRecordingSessionTests.swift
@@ -31,14 +31,10 @@ import GRDB
             }
         }
 
-        func waitUntilWaiting(timeout: Duration = .seconds(30)) async throws {
-            let deadline = ContinuousClock.now.advanced(by: timeout)
-            while !isWaiting {
-                guard ContinuousClock.now < deadline else {
-                    isOpen = true
-                    throw AudioConsumptionGateError.timedOut
-                }
-                try await Task.sleep(for: .milliseconds(10))
+        func waitUntilWaiting(timeout: Duration = testPollTimeout) async throws {
+            guard await pollUntil(timeout: timeout, { isWaiting }) else {
+                isOpen = true
+                throw AudioConsumptionGateError.timedOut
             }
         }
 
@@ -342,14 +338,8 @@ import GRDB
             #expect(delayed.pendingByteCount == 320)
             #expect(delayed.oldestFinalizationStartedAt != nil)
 
-            let clock = ContinuousClock()
-            let deadline = clock.now + .seconds(2)
-            var recovered = await writer.backlogSnapshot()
-            while recovered.segmentCount > 0, clock.now < deadline {
-                try await Task.sleep(for: .milliseconds(10))
-                recovered = await writer.backlogSnapshot()
-            }
-            #expect(recovered.segmentCount == 0)
+            let backlogRecovered = await pollUntil { await writer.backlogSnapshot().segmentCount == 0 }
+            #expect(backlogRecovered)
             try writer.appendBuffer(makeBuffer(
                 format: recorder.targetFormat,
                 frameCount: 80,

--- a/Tests/DahliaTests/BatchSpeechTranscriberServiceTests.swift
+++ b/Tests/DahliaTests/BatchSpeechTranscriberServiceTests.swift
@@ -258,15 +258,11 @@ import Foundation
         }
 
         private func waitUntil(
-            timeout: Duration = .seconds(5),
+            timeout: Duration = testPollTimeout,
             condition: @escaping @Sendable () async -> Bool
         ) async throws {
-            let deadline = ContinuousClock.now.advanced(by: timeout)
-            while await !condition() {
-                guard ContinuousClock.now < deadline else {
-                    throw BatchSpeechTranscriberServiceTestError.timedOut
-                }
-                try await Task.sleep(for: .milliseconds(10))
+            guard await pollUntil(timeout: timeout, condition) else {
+                throw BatchSpeechTranscriberServiceTestError.timedOut
             }
         }
     }

--- a/Tests/DahliaTests/BatchTranscriptionConcurrencyTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionConcurrencyTests.swift
@@ -210,15 +210,11 @@ import Speech
         }
 
         private func waitUntil(
-            timeout: Duration = .seconds(5),
+            timeout: Duration = testPollTimeout,
             condition: @escaping @Sendable () async -> Bool
         ) async throws {
-            let deadline = ContinuousClock.now.advanced(by: timeout)
-            while await !condition() {
-                guard ContinuousClock.now < deadline else {
-                    throw ConcurrencyTestError.timedOut
-                }
-                try await Task.sleep(for: .milliseconds(10))
+            guard await pollUntil(timeout: timeout, condition) else {
+                throw ConcurrencyTestError.timedOut
             }
         }
     }

--- a/Tests/DahliaTests/BatchTranscriptionCoordinatorLanguageDetectionTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionCoordinatorLanguageDetectionTests.swift
@@ -377,15 +377,11 @@ import GRDB
         }
 
         private func waitUntil(
-            timeout: Duration = .seconds(5),
+            timeout: Duration = testPollTimeout,
             condition: @escaping @Sendable () async -> Bool
         ) async throws {
-            let deadline = ContinuousClock.now.advanced(by: timeout)
-            while await !condition() {
-                guard ContinuousClock.now < deadline else {
-                    throw CoordinatorLanguageDetectionTestError.timedOut
-                }
-                try await Task.sleep(for: .milliseconds(10))
+            guard await pollUntil(timeout: timeout, condition) else {
+                throw CoordinatorLanguageDetectionTestError.timedOut
             }
         }
     }

--- a/Tests/DahliaTests/BatchTranscriptionProgressTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionProgressTests.swift
@@ -293,15 +293,11 @@ import GRDB
         }
 
         private func waitUntil(
-            timeout: Duration = .seconds(5),
+            timeout: Duration = testPollTimeout,
             condition: @escaping @Sendable () async -> Bool
         ) async throws {
-            let deadline = ContinuousClock.now.advanced(by: timeout)
-            while await !condition() {
-                guard ContinuousClock.now < deadline else {
-                    throw BatchTranscriptionProgressTestError.timedOut
-                }
-                try await Task.sleep(for: .milliseconds(10))
+            guard await pollUntil(timeout: timeout, condition) else {
+                throw BatchTranscriptionProgressTestError.timedOut
             }
         }
     }

--- a/Tests/DahliaTests/CaptionViewModelBatchRetryTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelBatchRetryTests.swift
@@ -116,16 +116,10 @@ import GRDB
         }
 
         private func waitUntil(
-            timeout: Duration = .seconds(15),
+            timeout: Duration = testPollTimeout,
             condition: () -> Bool
         ) async -> Bool {
-            let clock = ContinuousClock()
-            let deadline = clock.now + timeout
-            while clock.now < deadline {
-                if condition() { return true }
-                try? await Task.sleep(for: .milliseconds(10))
-            }
-            return condition()
+            await pollUntil(timeout: timeout) { condition() }
         }
     }
 #endif

--- a/Tests/DahliaTests/CaptionViewModelBatchUpdateTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelBatchUpdateTests.swift
@@ -278,20 +278,10 @@ import GRDB
         }
 
         private func waitUntil(
-            timeout: Duration = .seconds(15),
+            timeout: Duration = testPollTimeout,
             condition: () -> Bool
         ) async -> Bool {
-            let clock = ContinuousClock()
-            let deadline = clock.now + timeout
-
-            while clock.now < deadline {
-                if condition() {
-                    return true
-                }
-                try? await Task.sleep(for: .milliseconds(10))
-            }
-
-            return condition()
+            await pollUntil(timeout: timeout) { condition() }
         }
     }
 

--- a/Tests/DahliaTests/CodexAccountControllerTests.swift
+++ b/Tests/DahliaTests/CodexAccountControllerTests.swift
@@ -9,7 +9,7 @@ import Foundation
         @Test
         func explicitSignInOpensBrowserAndRefreshesAccount() async {
             let transport = TestCodexAppServerTransport(mode: .loginCompletes)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             let urlOpener = TestCodexLoginURLOpener()
             let controller = CodexAccountController(service: service, urlOpener: urlOpener)
 
@@ -24,7 +24,7 @@ import Foundation
         @Test
         func browserOpenFailureCancelsLoginAndShowsRetryableError() async {
             let transport = TestCodexAppServerTransport(mode: .loginBlocks)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             let urlOpener = TestCodexLoginURLOpener(result: false)
             let controller = CodexAccountController(service: service, urlOpener: urlOpener)
 
@@ -75,7 +75,7 @@ import Foundation
             let configURL = try locator.homeURL().appending(path: "config.toml")
             try Data("model_provider = \"Databricks\"\n".utf8).write(to: configURL)
             let transport = TestCodexAppServerTransport(mode: .blockInitialize)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             let configurationStore = TestCodexAccountConfigurationStore(
                 configuredProvider: .databricks,
                 configuredDatabricksProfile: "DEFAULT"

--- a/Tests/DahliaTests/CodexAppServerConcurrencyTests.swift
+++ b/Tests/DahliaTests/CodexAppServerConcurrencyTests.swift
@@ -8,7 +8,7 @@ import Foundation
         @Test
         func cancellingOneConcurrentGenerationDoesNotInterruptTheOther() async throws {
             let transport = TestCodexAppServerTransport(mode: .generationBlocks)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             let first = Task { try await service.generate(request) }
             let second = Task { try await service.generate(request) }
 
@@ -40,7 +40,7 @@ import Foundation
         @Test
         func concurrentGenerationsCompleteOutOfOrderIndependently() async throws {
             let transport = TestCodexAppServerTransport(mode: .generationBlocks)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             let first = Task { try await service.generate(request) }
             let second = Task { try await service.generate(request) }
 
@@ -63,7 +63,7 @@ import Foundation
         @Test
         func failedConcurrentGenerationDoesNotInterruptTheOther() async throws {
             let transport = TestCodexAppServerTransport(mode: .generationBlocks)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             let first = Task { try await service.generate(request) }
             let second = Task { try await service.generate(request) }
 
@@ -89,7 +89,7 @@ import Foundation
             let timeout = Duration.seconds(270)
             let clock = SummaryTimeoutTestClock(summaryTimeout: timeout)
             let transport = TestCodexAppServerTransport(mode: .generationBlocks)
-            let service = CodexAppServerService(
+            let service = makeTestCodexAppServerService(
                 transportFactory: { transport },
                 clock: clock,
                 summaryTimeout: timeout

--- a/Tests/DahliaTests/CodexAppServerInfrastructureTests.swift
+++ b/Tests/DahliaTests/CodexAppServerInfrastructureTests.swift
@@ -132,7 +132,7 @@ import Foundation
         @Test
         func invalidJSONClosesConnection() async {
             let transport = TestCodexAppServerTransport(mode: .invalidInitializeResponse)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
 
             await #expect(throws: CodexAppServerError.self) {
                 try await service.start()
@@ -143,7 +143,7 @@ import Foundation
         @Test
         func modelSelectionPrefersSavedThenDefault() async {
             let transport = TestCodexAppServerTransport(mode: .models)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             let catalog = CodexModelCatalog(service: service)
 
             await catalog.load()
@@ -173,7 +173,7 @@ import Foundation
         @Test
         func cancelledInitialCatalogLoadCanBeRetried() async {
             let transport = TestCodexAppServerTransport(mode: .blockFirstModelList)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             let catalog = CodexModelCatalog(service: service)
             let load = Task { await catalog.load(forceRefresh: true) }
 

--- a/Tests/DahliaTests/CodexAppServerProcessTransportXCTests.swift
+++ b/Tests/DahliaTests/CodexAppServerProcessTransportXCTests.swift
@@ -147,5 +147,35 @@ import Foundation
             #expect(state.retainedByteCount == 768 * line.count)
             await transport.close()
         }
+
+        @Test
+        func receiveLineAfterCloseReportsClosureInsteadOfReadingATornDownDescriptor() async throws {
+            let transport = try CodexAppServerProcessTransport(
+                executableURL: URL(fileURLWithPath: "/bin/cat"),
+                arguments: []
+            )
+
+            try await transport.sendLine(Data("first".utf8))
+            #expect(try await transport.receiveLine() == Data("first".utf8))
+            await transport.close()
+
+            // The shared service reader loop can re-enter receiveLine after a concurrent shutdown.
+            #expect(try await transport.receiveLine() == nil)
+            #expect(try await transport.receiveLine() == nil)
+        }
+
+        @Test
+        func closeImmediatelyAfterStartingTheDrainDoesNotTearDownAnActiveRead() async throws {
+            let transport = try CodexAppServerProcessTransport(
+                executableURL: URL(fileURLWithPath: "/bin/cat"),
+                arguments: []
+            )
+
+            // Starts the stdout drain, then closes before the drain has observed any output.
+            let pending = Task { try await transport.receiveLine() }
+            await transport.close()
+
+            #expect(try await pending.value == nil)
+        }
     }
 #endif

--- a/Tests/DahliaTests/CodexAppServerServiceTests.swift
+++ b/Tests/DahliaTests/CodexAppServerServiceTests.swift
@@ -13,7 +13,7 @@ import Foundation
         @Test
         func connectionIsInitializedOnceAndReused() async throws {
             let transport = TestCodexAppServerTransport(mode: .models)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
 
             let first = try await service.models()
             let second = try await service.models(forceRefresh: true)
@@ -30,7 +30,7 @@ import Foundation
         @Test
         func bootstrapChecksAccountWithoutRefreshingToken() async throws {
             let transport = TestCodexAppServerTransport(mode: .models)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
 
             try await service.start()
 
@@ -44,7 +44,7 @@ import Foundation
         @Test
         func browserLoginUsesSupportedParametersAndBuffersImmediateCompletion() async throws {
             let transport = TestCodexAppServerTransport(mode: .loginCompletes)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
 
             let initialStatus = try await service.accountStatus(forceRefresh: false)
             #expect(!initialStatus.isAuthenticated)
@@ -70,7 +70,7 @@ import Foundation
         @Test
         func cancellingBrowserLoginSendsCancelWithoutClosingSharedProcess() async throws {
             let transport = TestCodexAppServerTransport(mode: .loginBlocks)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             let session = try await service.startChatGPTLogin()
             let completion = Task {
                 try await service.waitForLoginCompletion(loginID: session.id)
@@ -91,7 +91,7 @@ import Foundation
         @Test
         func logoutUsesNullParamsAndClearsCachedAccount() async throws {
             let transport = TestCodexAppServerTransport(mode: .models)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             #expect(try await service.accountStatus(forceRefresh: false).isAuthenticated)
 
             try await service.logout()
@@ -107,7 +107,7 @@ import Foundation
         @Test
         func signedOutGenerationFailsBeforeStartingThread() async {
             let transport = TestCodexAppServerTransport(mode: .signedOut)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
 
             await #expect(throws: CodexAppServerError.notLoggedIn) {
                 _ = try await service.generate(.init(
@@ -125,7 +125,7 @@ import Foundation
         @Test
         func cancelledModelRequestDoesNotCloseHealthySharedProcess() async throws {
             let transport = TestCodexAppServerTransport(mode: .blockFirstModelList)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             let firstRequest = Task { try await service.models(forceRefresh: true) }
 
             await transport.waitUntilSent("model/list")
@@ -144,7 +144,7 @@ import Foundation
         @Test
         func requestTimeoutKeepsHealthySharedTransport() async throws {
             let transport = TestCodexAppServerTransport(mode: .models)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
 
             await #expect(throws: CodexAppServerError.requestTimedOut("test/blocked")) {
                 _ = try await service.request(method: "test/blocked", timeout: .milliseconds(20))
@@ -160,7 +160,7 @@ import Foundation
         @Test
         func lightweightRequestTimeoutDoesNotInterruptActiveSummary() async throws {
             let transport = TestCodexAppServerTransport(mode: .generationBlocks)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             let generation = Task {
                 try await service.generate(.init(
                     model: nil,
@@ -209,7 +209,7 @@ import Foundation
             let second = TestCodexAppServerTransport(mode: .models)
             let transports = Mutex([first, second])
             let launchCount = Mutex(0)
-            let service = CodexAppServerService(transportFactory: {
+            let service = makeTestCodexAppServerService(transportFactory: {
                 launchCount.withLock { $0 += 1 }
                 return transports.withLock { $0.removeFirst() }
             })
@@ -261,7 +261,7 @@ import Foundation
         @Test
         func modelListRequiresCurrentAccountConfigurationUnlessBypassed() async throws {
             let transport = TestCodexAppServerTransport(mode: .models)
-            let service = CodexAppServerService(
+            let service = makeTestCodexAppServerService(
                 transportFactory: { transport },
                 configurationReadiness: { false }
             )
@@ -288,7 +288,7 @@ import Foundation
         func shutdownWaitsForCloseAndPermanentlyPreventsRestart() async throws {
             let blocked = TestCodexAppServerTransport(mode: .blockClose)
             let launchCount = Mutex(0)
-            let service = CodexAppServerService(transportFactory: {
+            let service = makeTestCodexAppServerService(transportFactory: {
                 launchCount.withLock { $0 += 1 }
                 return blocked
             })
@@ -315,7 +315,7 @@ import Foundation
             let second = TestCodexAppServerTransport(mode: .models)
             let transports = Mutex([first, second])
             let launchCount = Mutex(0)
-            let service = CodexAppServerService(transportFactory: {
+            let service = makeTestCodexAppServerService(transportFactory: {
                 launchCount.withLock { $0 += 1 }
                 return transports.withLock { $0.removeFirst() }
             })
@@ -335,7 +335,7 @@ import Foundation
             let blocked = TestCodexAppServerTransport(mode: .blockInitialize)
             let replacement = TestCodexAppServerTransport(mode: .models)
             let transports = Mutex([blocked, replacement])
-            let service = CodexAppServerService(transportFactory: {
+            let service = makeTestCodexAppServerService(transportFactory: {
                 transports.withLock { available in available.removeFirst() }
             })
             let startup = Task { try await service.start() }
@@ -355,7 +355,7 @@ import Foundation
         @Test
         func responsesAreMatchedByIDWhenTheyArriveOutOfOrder() async throws {
             let transport = TestCodexAppServerTransport(mode: .outOfOrder)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             let first = Task { try await service.request(method: "test/first") }
 
             await transport.waitUntilSent("test/first")
@@ -370,7 +370,7 @@ import Foundation
         @Test
         func approvalRequestsAreDeclinedAndUnknownRequestsReturnMethodNotFound() async throws {
             let transport = TestCodexAppServerTransport(mode: .serverRequests)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
 
             try await service.start()
             await transport.waitUntilResponded(to: "approval-1")
@@ -393,7 +393,7 @@ import Foundation
         @Test
         func turnNotificationSubscriptionReceivesMessagesAndFinishes() async throws {
             let transport = TestCodexAppServerTransport(mode: .models)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             try await service.start()
             let notifications = await service.notifications(threadID: "thread-1", turnID: "turn-1")
             let collected = Task {
@@ -429,7 +429,7 @@ import Foundation
             let crashed = TestCodexAppServerTransport(mode: .blockRequests)
             let replacement = TestCodexAppServerTransport(mode: .models)
             let transports = Mutex([crashed, replacement])
-            let service = CodexAppServerService(transportFactory: {
+            let service = makeTestCodexAppServerService(transportFactory: {
                 transports.withLock { available in available.removeFirst() }
             })
             let first = Task { try await service.request(method: "test/one") }
@@ -449,7 +449,7 @@ import Foundation
         @Test
         func generationUsesEphemeralThreadAndStructuredOutput() async throws {
             let transport = TestCodexAppServerTransport(mode: .generationCompletes)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
 
             let response = try await service.generate(.init(
                 model: "default-model",
@@ -551,7 +551,7 @@ import Foundation
         @Test
         func generationScopesDahliaMCPToConfiguredMeetings() async throws {
             let transport = TestCodexAppServerTransport(mode: .generationCompletes)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             let vaultID = try #require(UUID(uuidString: "019E61FD-B5D6-7A04-AC25-4B820FE951E6"))
             let firstMeetingID = try #require(UUID(uuidString: "019E61FD-B5D6-7A04-AC25-4B820FE951E7"))
             let secondMeetingID = try #require(UUID(uuidString: "019E61FD-B5D6-7A04-AC25-4B820FE951E8"))
@@ -598,7 +598,7 @@ import Foundation
         @Test
         func unavailableSavedModelFallsBackToServerDefault() async throws {
             let transport = TestCodexAppServerTransport(mode: .generationCompletes)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
 
             _ = try await service.generate(.init(
                 model: "retired-model",
@@ -617,7 +617,7 @@ import Foundation
         @Test
         func defaultTextOnlyModelDropsImagesAndStillGenerates() async throws {
             let transport = TestCodexAppServerTransport(mode: .textOnlyGenerationCompletes)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
 
             let response = try await service.generate(.init(
                 model: nil,
@@ -643,7 +643,7 @@ import Foundation
         @Test
         func structuredUnauthorizedTurnFailureRequiresLogin() async {
             let transport = TestCodexAppServerTransport(mode: .generationFailsUnauthorized)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
 
             await #expect(throws: CodexAppServerError.notLoggedIn) {
                 _ = try await service.generate(.init(
@@ -659,7 +659,7 @@ import Foundation
         @Test
         func expectedProviderAuthenticationFailurePreservesDetailWithoutReporting() async {
             let transport = TestCodexAppServerTransport(mode: .generationFailsExpectedProviderAuthentication)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             let detail = """
             unexpected status 401 Unauthorized: {"error_code":401,"message":"Credential was not sent or was of an unsupported type for this API."}
             """
@@ -683,7 +683,7 @@ import Foundation
         @Test
         func unrelatedHTTPUnauthorizedTurnFailureRemainsReportable() async {
             let transport = TestCodexAppServerTransport(mode: .generationFailsOtherHTTPUnauthorized)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             let detail = """
             unexpected status 401 Unauthorized: {"error":"An upstream tool rejected its credentials."}
             """
@@ -704,7 +704,7 @@ import Foundation
         @Test
         func unrelatedUnauthorizedTextRemainsTurnFailure() async {
             let transport = TestCodexAppServerTransport(mode: .generationFailsMessageOnlyUnauthorized)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
 
             await #expect(throws: CodexAppServerError.turnFailed("unauthorized while generating")) {
                 _ = try await service.generate(.init(
@@ -720,7 +720,7 @@ import Foundation
         @Test
         func structuredAuthenticationRPCErrorRequiresLogin() async {
             let transport = TestCodexAppServerTransport(mode: .models)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
 
             await #expect(throws: CodexAppServerError.notLoggedIn) {
                 _ = try await service.request(method: "test/auth")
@@ -744,7 +744,7 @@ import Foundation
         @Test
         func generationReusesAccountAndConfigReads() async throws {
             let transport = TestCodexAppServerTransport(mode: .generationCompletes)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             let request = CodexAppServerRequest(
                 model: nil,
                 developerInstructions: "Summarize.",
@@ -764,7 +764,7 @@ import Foundation
         @Test
         func loginCompletionInvalidatesCachedModels() async throws {
             let transport = TestCodexAppServerTransport(mode: .models)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             _ = try await service.models()
 
             await transport.sendFromServer(.object([
@@ -785,7 +785,7 @@ import Foundation
         @Test
         func generationCancellationInterruptsAndUnsubscribesWithoutKillingProcess() async {
             let transport = TestCodexAppServerTransport(mode: .generationBlocks)
-            let service = CodexAppServerService(transportFactory: { transport })
+            let service = makeTestCodexAppServerService(transportFactory: { transport })
             let generation = Task {
                 try await service.generate(.init(
                     model: nil,
@@ -815,7 +815,7 @@ import Foundation
             let replacement = TestCodexAppServerTransport(mode: .models)
             let transports = Mutex([crashed, replacement])
             let launchCount = Mutex(0)
-            let service = CodexAppServerService(transportFactory: {
+            let service = makeTestCodexAppServerService(transportFactory: {
                 launchCount.withLock { $0 += 1 }
                 return transports.withLock { $0.removeFirst() }
             })

--- a/Tests/DahliaTests/CodexChatServiceTests.swift
+++ b/Tests/DahliaTests/CodexChatServiceTests.swift
@@ -9,7 +9,7 @@ import Foundation
         @Test
         func persistentChatOmitsOutputSchemaAndReplaysEarlyDeltas() async throws {
             let transport = TestCodexChatAppServerTransport()
-            let appServer = CodexAppServerService(transportFactory: { transport })
+            let appServer = makeTestCodexAppServerService(transportFactory: { transport })
             let workspace = URL(filePath: "/tmp/dahlia-chat-tests", directoryHint: .isDirectory)
             let service = CodexChatService(
                 appServer: appServer,
@@ -75,7 +75,7 @@ import Foundation
         @Test
         func threadNameUsesPlainUserText() async throws {
             let transport = TestCodexChatAppServerTransport()
-            let appServer = CodexAppServerService(transportFactory: { transport })
+            let appServer = makeTestCodexAppServerService(transportFactory: { transport })
             let service = CodexChatService(
                 appServer: appServer,
                 workspaceLocator: TestCodexChatWorkspaceLocator(url: URL(filePath: "/tmp/dahlia-chat-tests"))
@@ -94,7 +94,7 @@ import Foundation
         @Test
         func steeringAddsTextBlocksToTheExpectedActiveTurn() async throws {
             let transport = TestCodexChatAppServerTransport()
-            let appServer = CodexAppServerService(transportFactory: { transport })
+            let appServer = makeTestCodexAppServerService(transportFactory: { transport })
             let service = CodexChatService(
                 appServer: appServer,
                 workspaceLocator: TestCodexChatWorkspaceLocator(url: URL(filePath: "/tmp/dahlia-chat-tests"))
@@ -128,7 +128,7 @@ import Foundation
         @Test
         func imageInputsAreSentAndRestoredFromHistory() async throws {
             let transport = TestCodexChatAppServerTransport()
-            let appServer = CodexAppServerService(transportFactory: { transport })
+            let appServer = makeTestCodexAppServerService(transportFactory: { transport })
             let service = CodexChatService(
                 appServer: appServer,
                 workspaceLocator: TestCodexChatWorkspaceLocator(url: URL(filePath: "/tmp/dahlia-chat-images"))
@@ -175,7 +175,7 @@ import Foundation
         @Test
         func connectionLossFailsTheTurnStream() async throws {
             let transport = TestCodexChatAppServerTransport(turnOutcome: .disconnected)
-            let appServer = CodexAppServerService(transportFactory: { transport })
+            let appServer = makeTestCodexAppServerService(transportFactory: { transport })
             let service = CodexChatService(
                 appServer: appServer,
                 workspaceLocator: TestCodexChatWorkspaceLocator(
@@ -202,7 +202,7 @@ import Foundation
         @Test
         func historyUsesExactWorkspaceAndBundledCodexSourceAndRestoresMessages() async throws {
             let transport = TestCodexChatAppServerTransport()
-            let appServer = CodexAppServerService(transportFactory: { transport })
+            let appServer = makeTestCodexAppServerService(transportFactory: { transport })
             let workspace = URL(filePath: "/tmp/dahlia-chat-history", directoryHint: .isDirectory)
             let service = CodexChatService(
                 appServer: appServer,
@@ -250,7 +250,7 @@ import Foundation
             for outcome: TestCodexChatAppServerTransport.TurnOutcome
         ) async throws -> [CodexChatTurnEvent] {
             let transport = TestCodexChatAppServerTransport(turnOutcome: outcome)
-            let appServer = CodexAppServerService(transportFactory: { transport })
+            let appServer = makeTestCodexAppServerService(transportFactory: { transport })
             let service = CodexChatService(
                 appServer: appServer,
                 workspaceLocator: TestCodexChatWorkspaceLocator(

--- a/Tests/DahliaTests/CodexChatStreamingSessionTests.swift
+++ b/Tests/DahliaTests/CodexChatStreamingSessionTests.swift
@@ -5,7 +5,7 @@ import Foundation
     import Testing
 
     @MainActor
-    @Suite(.timeLimit(.minutes(1)))
+    @Suite(.timeLimit(.minutes(3)))
     struct CodexChatStreamingSessionTests {
         @Test
         func trailingUpdateAppearsWhileStreamIsStillWaiting() async {
@@ -80,19 +80,10 @@ import Foundation
         }
 
         private func waitUntil(
-            timeout: Duration = .seconds(30),
+            timeout: Duration = testPollTimeout,
             _ predicate: @MainActor () -> Bool
         ) async -> Bool {
-            let clock = ContinuousClock()
-            let deadline = clock.now + timeout
-
-            while clock.now < deadline, !Task.isCancelled {
-                if predicate() {
-                    return true
-                }
-                try? await Task.sleep(for: .milliseconds(10))
-            }
-            return predicate()
+            await pollUntil(timeout: timeout) { predicate() }
         }
     }
 #endif

--- a/Tests/DahliaTests/MCPWorkspaceNotificationTests.swift
+++ b/Tests/DahliaTests/MCPWorkspaceNotificationTests.swift
@@ -9,7 +9,7 @@ import Foundation
     @MainActor
     @Suite(.serialized)
     struct MCPWorkspaceNotificationTests {
-        @Test(.timeLimit(.minutes(1)))
+        @Test(.timeLimit(.minutes(3)))
         func projectMutationNotifiesTheRunningApplication() async throws {
             let fixture = try Fixture()
             let store = try fixture.store(vaultID: fixture.primaryVaultID, allowsWrites: true)
@@ -36,7 +36,7 @@ import Foundation
             #expect(await iterator.next() != nil)
         }
 
-        @Test(.timeLimit(.minutes(1)))
+        @Test(.timeLimit(.minutes(3)))
         func projectMutationRefreshesTheRunningSidebar() async throws {
             let fixture = try Fixture()
             let vault = VaultRecord(
@@ -68,17 +68,10 @@ import Foundation
         }
 
         private func waitUntil(
-            timeout: Duration = .seconds(5),
+            timeout: Duration = testPollTimeout,
             _ predicate: @MainActor () -> Bool
         ) async -> Bool {
-            let clock = ContinuousClock()
-            let deadline = clock.now + timeout
-
-            while clock.now < deadline, !Task.isCancelled {
-                if predicate() { return true }
-                try? await Task.sleep(for: .milliseconds(10))
-            }
-            return predicate()
+            await pollUntil(timeout: timeout) { predicate() }
         }
     }
 #endif

--- a/Tests/DahliaTests/MeetingPersistenceServiceTests.swift
+++ b/Tests/DahliaTests/MeetingPersistenceServiceTests.swift
@@ -113,12 +113,7 @@ import os
                 factoryState.withLock { $0.finished = true }
                 return service
             }
-            let factoryStartDeadline = ContinuousClock.now + .seconds(10)
-            while !factoryState.withLock({ $0.started }),
-                  ContinuousClock.now < factoryStartDeadline {
-                try await Task.sleep(for: .milliseconds(10))
-            }
-            let didStartFactory = factoryState.withLock(\.started)
+            let didStartFactory = await pollUntil { factoryState.withLock(\.started) }
             #expect(didStartFactory)
 
             let mainActorResponded = await Task { @MainActor in true }.value
@@ -1166,17 +1161,11 @@ private func waitForAppendPersistence(
     database: AppDatabaseManager,
     meetingId: UUID,
     segmentId: UUID,
-    timeout: Duration = .seconds(5)
+    timeout: Duration = testPollTimeout
 ) async throws -> PersistedAppendState {
-    let clock = ContinuousClock()
-    let deadline = clock.now + timeout
-
-    while clock.now < deadline {
-        let state = try fetchAppendPersistence(database: database, meetingId: meetingId, segmentId: segmentId)
-        if state.segment != nil, state.meeting != nil {
-            return state
-        }
-        try? await Task.sleep(for: .milliseconds(20))
+    _ = await pollUntil(timeout: timeout, interval: .milliseconds(20)) {
+        let state = try? fetchAppendPersistence(database: database, meetingId: meetingId, segmentId: segmentId)
+        return state?.segment != nil && state?.meeting != nil
     }
 
     return try fetchAppendPersistence(database: database, meetingId: meetingId, segmentId: segmentId)
@@ -1224,14 +1213,7 @@ private final class SynchronousDatabaseGate: @unchecked Sendable {
     }
 
     func waitUntilStarted() async -> Bool {
-        let deadline = ContinuousClock.now + .seconds(10)
-        while ContinuousClock.now < deadline {
-            if hasStarted.withLock(\.self) {
-                return true
-            }
-            try? await Task.sleep(for: .milliseconds(10))
-        }
-        return false
+        await pollUntil { hasStarted.withLock(\.self) }
     }
 }
 

--- a/Tests/DahliaTests/OrganizationWorkspaceDeletionTests.swift
+++ b/Tests/DahliaTests/OrganizationWorkspaceDeletionTests.swift
@@ -51,7 +51,7 @@
             #expect(deletedOrganization == nil)
         }
 
-        @Test(.timeLimit(.minutes(1)))
+        @Test(.timeLimit(.minutes(3)))
         func workspaceChangeDuringDeletionPreparationStillPresentsConfirmation() async throws {
             let (fixture, organization, model) = try await makeDeletionFixture()
 
@@ -82,9 +82,10 @@
             }
 
             let preparation = Task { await model.prepareOrganizationDeletion() }
-            while !model.isPreparingDeletion {
-                await Task.yield()
-            }
+            // Spinning on Task.yield() here starves every other MainActor test while the
+            // database lock below is held.
+            let didStartPreparing = await pollUntil { model.isPreparingDeletion }
+            #expect(didStartPreparing)
             let reloadWasDeferred = await withTaskCancellationHandler {
                 await model.handleWorkspaceChange()
             } onCancel: {

--- a/Tests/DahliaTests/PreviewTranslationCoordinatorTests.swift
+++ b/Tests/DahliaTests/PreviewTranslationCoordinatorTests.swift
@@ -410,18 +410,8 @@ private actor AsyncCompletionState {
 }
 
 private func waitUntil(
-    timeout: Duration = .seconds(1),
+    timeout: Duration = testPollTimeout,
     condition: @escaping @Sendable () async -> Bool
 ) async -> Bool {
-    let clock = ContinuousClock()
-    let deadline = clock.now + timeout
-
-    while clock.now < deadline {
-        if await condition() {
-            return true
-        }
-        try? await Task.sleep(for: .milliseconds(10))
-    }
-
-    return await condition()
+    await pollUntil(timeout: timeout, condition)
 }

--- a/Tests/DahliaTests/RecordingSessionAudioLevelTests.swift
+++ b/Tests/DahliaTests/RecordingSessionAudioLevelTests.swift
@@ -17,6 +17,10 @@
             let blocker = Task { @MainActor in
                 blockMainActor(entered: mainActorEntered, release: releaseMainActor)
             }
+            // blockMainActor holds the MainActor until it is signalled. Leaving this scope without
+            // signalling — the wait below can time out — wedges the MainActor for every remaining
+            // test in the process, not just this one.
+            defer { releaseMainActor.signal() }
             try await wait(for: mainActorEntered)
             let delivery = Task {
                 await deliveryGate.deliver(source: .microphone, level: 1) { source, level in
@@ -139,7 +143,9 @@
 
         private func wait(
             for semaphore: DispatchSemaphore,
-            timeout: DispatchTimeInterval = .seconds(5)
+            // Matches testPollTimeout: the MainActor task this waits on competes with every other
+            // MainActor test, so a short bound here reports contention as a failure.
+            timeout: DispatchTimeInterval = .seconds(120)
         ) async throws {
             try await withCheckedThrowingContinuation { continuation in
                 DispatchQueue.global().async {

--- a/Tests/DahliaTests/RecordingSessionAudioLevelTests.swift
+++ b/Tests/DahliaTests/RecordingSessionAudioLevelTests.swift
@@ -190,13 +190,9 @@
             entries.append(.init(source: source, level: level))
         }
 
-        func waitUntilCount(_ count: Int, timeout: Duration = .seconds(5)) async throws {
-            let deadline = ContinuousClock.now + timeout
-            while entries.count < count {
-                guard ContinuousClock.now < deadline else {
-                    throw MeteringTestError.timedOutWaitingForLevel
-                }
-                await Task.yield()
+        func waitUntilCount(_ count: Int, timeout: Duration = testPollTimeout) async throws {
+            guard await pollUntil(timeout: timeout, { entries.count >= count }) else {
+                throw MeteringTestError.timedOutWaitingForLevel
             }
         }
     }
@@ -292,13 +288,9 @@
             }
         }
 
-        func waitUntilWaiting(timeout: Duration = .seconds(5)) async throws {
-            let deadline = ContinuousClock.now + timeout
-            while !isWaiting {
-                guard ContinuousClock.now < deadline else {
-                    throw MeteringTestError.timedOutWaitingForRecognitionFinish
-                }
-                await Task.yield()
+        func waitUntilWaiting(timeout: Duration = testPollTimeout) async throws {
+            guard await pollUntil(timeout: timeout, { isWaiting }) else {
+                throw MeteringTestError.timedOutWaitingForRecognitionFinish
             }
         }
 

--- a/Tests/DahliaTests/SidebarViewModelMeetingListTests.swift
+++ b/Tests/DahliaTests/SidebarViewModelMeetingListTests.swift
@@ -7,7 +7,7 @@ import GRDB
 
     @MainActor
     struct SidebarViewModelMeetingListTests {
-        @Test(.timeLimit(.minutes(1)))
+        @Test(.timeLimit(.minutes(3)))
         func loadsMeetingsInFiftyItemBatches() async throws {
             let fixture = try SidebarViewModelMeetingListFixture()
             defer {
@@ -44,7 +44,7 @@ import GRDB
             #expect(!viewModel.hasMoreMeetings)
         }
 
-        @Test(.timeLimit(.minutes(1)))
+        @Test(.timeLimit(.minutes(3)))
         func refreshesMeetingRowsLoadedAfterInitialPage() async throws {
             let fixture = try SidebarViewModelMeetingListFixture()
             defer {
@@ -98,7 +98,7 @@ import GRDB
             })
         }
 
-        @Test(.timeLimit(.minutes(1)))
+        @Test(.timeLimit(.minutes(3)))
         func debouncesSearchAndKeepsTranscriptTextOutOfResults() async throws {
             let fixture = try SidebarViewModelMeetingListFixture()
             defer {
@@ -152,7 +152,7 @@ import GRDB
             #expect(viewModel.displayedMeetingItems.count == 2)
         }
 
-        @Test(.timeLimit(.minutes(1)))
+        @Test(.timeLimit(.minutes(3)))
         func searchesBeyondInitialPageAndPaginatesMatches() async throws {
             let fixture = try SidebarViewModelMeetingListFixture()
             defer {
@@ -200,7 +200,7 @@ import GRDB
             #expect(!viewModel.hasMoreMeetingSearchResults)
         }
 
-        @Test(.timeLimit(.minutes(1)))
+        @Test(.timeLimit(.minutes(3)))
         func rapidSearchChangePublishesOnlyLatestQuery() async throws {
             let fixture = try SidebarViewModelMeetingListFixture()
             defer {
@@ -226,7 +226,7 @@ import GRDB
             #expect(viewModel.meetingSearchQuery == "Beta")
         }
 
-        @Test(.timeLimit(.minutes(1)))
+        @Test(.timeLimit(.minutes(3)))
         func selectedMeetingOutsideInitialPageStaysAvailableAndObservesChanges() async throws {
             let fixture = try SidebarViewModelMeetingListFixture()
             defer {
@@ -275,7 +275,7 @@ import GRDB
             #expect(viewModel.selectedMeetingDetail == nil)
         }
 
-        @Test(.timeLimit(.minutes(1)))
+        @Test(.timeLimit(.minutes(3)))
         func capsMaterializedMeetingListAndDefersChatCatalog() async throws {
             let fixture = try SidebarViewModelMeetingListFixture()
             defer {
@@ -316,23 +316,16 @@ import GRDB
         }
 
         private func waitUntil(
-            timeout: Duration = .seconds(5),
+            timeout: Duration = testPollTimeout,
             _ predicate: @MainActor () -> Bool
         ) async -> Bool {
-            let clock = ContinuousClock()
-            let deadline = clock.now + timeout
-
-            while clock.now < deadline, !Task.isCancelled {
-                if predicate() { return true }
-                try? await Task.sleep(for: .milliseconds(10))
-            }
-            return predicate()
+            await pollUntil(timeout: timeout) { predicate() }
         }
     }
 
     @MainActor
     struct SidebarViewModelMeetingSearchTests {
-        @Test(.timeLimit(.minutes(1)))
+        @Test(.timeLimit(.minutes(3)))
         func searchesWithFiltersWithoutFreeTextAndClearsThemTogether() async throws {
             let fixture = try SidebarViewModelMeetingListFixture()
             defer {
@@ -378,17 +371,10 @@ import GRDB
         }
 
         private func waitUntil(
-            timeout: Duration = .seconds(5),
+            timeout: Duration = testPollTimeout,
             _ predicate: @MainActor () -> Bool
         ) async -> Bool {
-            let clock = ContinuousClock()
-            let deadline = clock.now + timeout
-
-            while clock.now < deadline, !Task.isCancelled {
-                if predicate() { return true }
-                try? await Task.sleep(for: .milliseconds(10))
-            }
-            return predicate()
+            await pollUntil(timeout: timeout) { predicate() }
         }
     }
 

--- a/Tests/DahliaTests/SystemAudioCaptureLifecycleTests.swift
+++ b/Tests/DahliaTests/SystemAudioCaptureLifecycleTests.swift
@@ -144,14 +144,7 @@
         }
 
         func waitUntilStarted() async -> Bool {
-            let deadline = ContinuousClock.now + .seconds(10)
-            while ContinuousClock.now < deadline {
-                if hasStarted.withLock(\.self) {
-                    return true
-                }
-                try? await Task.sleep(for: .milliseconds(10))
-            }
-            return false
+            await pollUntil { hasStarted.withLock(\.self) }
         }
     }
 #endif

--- a/Tests/DahliaTests/TestCodexAppServerService.swift
+++ b/Tests/DahliaTests/TestCodexAppServerService.swift
@@ -1,0 +1,24 @@
+import Foundation
+@testable import Dahlia
+
+/// Builds a `CodexAppServerService` for tests that exercise protocol ordering, cancellation, and
+/// failure handling rather than the transport deadline itself.
+///
+/// Production uses `transportTimeout: .seconds(15)`. Swift Testing starts every test at once, so a
+/// loaded runner can delay a stubbed exchange past that deadline and report `.requestTimedOut` in
+/// place of the behavior under test. Tests that do assert timeout behavior pass an explicit
+/// per-request `timeout:` or inject a clock, so the long default here does not weaken them.
+func makeTestCodexAppServerService(
+    transportFactory: @escaping CodexAppServerService.TransportFactory,
+    clock: any CodexAppServerClock = ContinuousCodexAppServerClock(),
+    summaryTimeout: Duration = .seconds(270),
+    configurationReadiness: @escaping CodexAppServerService.ConfigurationReadiness = { true }
+) -> CodexAppServerService {
+    CodexAppServerService(
+        transportFactory: transportFactory,
+        clock: clock,
+        transportTimeout: .seconds(600),
+        summaryTimeout: summaryTimeout,
+        configurationReadiness: configurationReadiness
+    )
+}

--- a/Tests/DahliaTests/TestWait.swift
+++ b/Tests/DahliaTests/TestWait.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Deadline shared by the polling waits in this test target.
+///
+/// Swift Testing starts every test at once, so the whole suite competes for a small number of
+/// cores. A wait that resolves in milliseconds on a developer machine has been observed taking
+/// tens of seconds on CI purely from scheduling delay. This deadline therefore sits far above the
+/// time any of these waits actually needs: it exists to describe a genuine hang, not a busy
+/// machine. A suite that uses it must not carry a shorter `.timeLimit` trait, because the trait
+/// would fail the test before the wait reports anything useful.
+let testPollTimeout = Duration.seconds(120)
+
+/// Polls `condition` until it holds or `timeout` elapses, and reports whether it held.
+///
+/// Prefer this over a hand-rolled deadline loop, and never over `Task.yield()` spinning, which
+/// keeps the caller's executor busy for the whole wait. Inheriting `#isolation` lets `@MainActor`
+/// suites and non-isolated suites share one implementation.
+func pollUntil(
+    timeout: Duration = testPollTimeout,
+    interval: Duration = .milliseconds(10),
+    isolation: isolated (any Actor)? = #isolation,
+    _ condition: () async -> Bool
+) async -> Bool {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline, !Task.isCancelled {
+        if await condition() { return true }
+        try? await Task.sleep(for: interval)
+    }
+    return await condition()
+}

--- a/Tests/DahliaTests/TranscriptPersistenceRetryTests.swift
+++ b/Tests/DahliaTests/TranscriptPersistenceRetryTests.swift
@@ -6,7 +6,7 @@
     @testable import Dahlia
 
     @MainActor
-    @Suite(.timeLimit(.minutes(1)))
+    @Suite(.timeLimit(.minutes(3)))
     struct TranscriptPersistenceRetryTests {
         @Test
         func stopRetriesEventsRetainedAfterATemporaryDatabaseFailure() async throws {
@@ -245,17 +245,10 @@
     }
 
     private func waitUntil(
-        timeout: Duration = .seconds(10),
+        timeout: Duration = testPollTimeout,
         condition: @escaping @Sendable () async -> Bool
     ) async -> Bool {
-        let deadline = ContinuousClock.now + timeout
-        while ContinuousClock.now < deadline {
-            if await condition() {
-                return true
-            }
-            try? await Task.sleep(for: .milliseconds(10))
-        }
-        return false
+        await pollUntil(timeout: timeout, condition)
     }
 
     private final class PersistenceDatabaseGate: @unchecked Sendable {
@@ -272,14 +265,7 @@
         }
 
         func waitUntilStarted() async -> Bool {
-            let deadline = ContinuousClock.now + .seconds(10)
-            while ContinuousClock.now < deadline {
-                if hasStarted.withLock(\.self) {
-                    return true
-                }
-                try? await Task.sleep(for: .milliseconds(10))
-            }
-            return false
+            await pollUntil { hasStarted.withLock(\.self) }
         }
     }
 #endif

--- a/Tests/DahliaTests/TranscriptionEventPipelineTests.swift
+++ b/Tests/DahliaTests/TranscriptionEventPipelineTests.swift
@@ -898,14 +898,7 @@
         }
 
         func waitUntilStarted() async -> Bool {
-            let deadline = ContinuousClock.now + .seconds(30)
-            while ContinuousClock.now < deadline, !Task.isCancelled {
-                if state.withLock(\.hasStarted) {
-                    return true
-                }
-                try? await Task.sleep(for: .milliseconds(10))
-            }
-            return false
+            await pollUntil { state.withLock(\.hasStarted) }
         }
     }
 #endif


### PR DESCRIPTION
## 背景

`Unit Tests` ジョブが継続的に失敗していた（直近 30 run はすべて failure / cancelled）。ローカルでは再現しない。GitHub Actions のログを解析したところ、原因は独立した 2 つに分かれていた。

### 原因 1: `swift test` プロセスが ObjC 例外で abort する

```
*** Terminating app due to uncaught exception 'NSFileHandleOperationException',
    reason: '*** -[NSConcreteFileHandle fileDescriptor]: unknown error'
5   Foundation           AsyncLineSequence.makeAsyncIterator
6   DahliaPackageTests   CodexAppServerProcessTransport.startOutputDrainIfNeeded
libc++abi: terminating due to uncaught exception of type NSException
```

`outputHandle.bytes.lines` が close 済みの `FileHandle` に対してイテレータを生成すると ObjC 例外を投げる。Swift では catch できず、テスト結果と無関係にプロセス全体が落ちる。到達経路は 2 つ。

1. `receiveLine()` が `close()` 後にドレインを再開していた。`CodexAppServerService.readLoop` は `while let line = try await transport.receiveLine()` のループで、`stopConnection` は `readerTask?.cancel()` の後に `close()` を呼ぶ。キャンセルは協調的なので、シャットダウン中にループが `receiveLine()` へ再突入する窓がある。
2. `Task.detached(priority: .utility)` のドレイン本体が走る前に `close()` がハンドルを閉じうる。コアの少ないランナーでは utility 優先度の起動が遅れ、この窓が広がる。

テスト専用ではなく、アプリのシャットダウン経路でも起こりうる実バグ。

### 原因 2: 並列実行の過負荷で実時間デッドラインが誤発火する

失敗した run のテスト所要時間を集計すると分布が二峰性になる。

| 所要時間 | テスト数 |
| --- | --- |
| ~2 秒 | 509 |
| 3〜40 秒 | 62 |
| 41〜44 秒 | 769 |

Swift Testing は既定で全テストを同時に開始するため、1260 テストがコアの少ないランナーに一斉投入され、個々のテストの実時間レイテンシが膨らむ。失敗箇所はすべて実時間依存だった。

- `CodexAppServerServiceTests` / `CodexAppServerInfrastructureTests` — 既定の `transportTimeout: .seconds(15)` が先に発火し、キャンセル検証テストが `CancellationError` ではなく `.requestTimedOut(...)` を観測する
- `CodexChatStreamingSessionTests` — ローカル `waitUntil` の 30 秒デッドラインを超過
- `CaptionViewModelBatchUpdateTests` / `CaptionViewModelBatchRetryTests` — 同 15 秒を超過

## 変更内容

**`CodexAppServerProcessTransport` の stdout ドレインを DispatchIO に置換**
同ファイルが stdin / stderr で既に使っている形に揃えた。DispatchIO は close 済みチャネルをエラーコードで報告するため、ObjC 例外の発生面自体が消える。チャンクは `AsyncStream` 経由でアクタへ渡し到着順を保証する（チャンクごとに非構造化タスクを作る形では保証されない）。`startDrainsIfNeeded()` は close 後に起動しないようガードを追加。回帰テストとして「close 後の `receiveLine()`」と「ドレイン開始直後の close」を追加した。

**Codex サービステストの 15 秒タイムアウト依存を除去**
スタブトランスポートを使うテストを、長い `transportTimeout` を持つ生成ヘルパー経由に変更。タイムアウト自体を検証するテストはリクエスト単位の `timeout:` かクロック注入を使っているため影響を受けない。実バイナリを起動する `DAHLIA_CODEX_INTEGRATION_TEST` 用テストは本番既定のまま。

**実時間待機を共通ヘルパーへ集約**
各ファイルに散っていた 22 箇所のデッドラインループを `pollUntil` に統一し、観測された CI のスケジューリング遅延より十分大きいデッドラインを設定。先に発火してしまう `.timeLimit` トレイトを引き上げた。`Task.yield()` でスピンしていた 2 箇所は sleep に変更したので、待機中ずっと MainActor を占有しなくなる。

**`Unit Tests` ジョブに `.build` キャッシュを追加**
`Run unit tests` ステップ 5 分 57 秒のうち、テスト実行は約 60 秒で残りはコンパイルだった。

並列度（`--no-parallel` など）は変更していない。swift-testing に同時実行数の上限設定は存在せず、実時間依存を取り除く方針を選んだ。

## 検証

作業環境が Linux コンテナで Swift ツールチェーンがないため、`swift build` / `swift test` / `scripts/lint.sh` はローカルで実行できていない。**この PR の CI が唯一の検証手段**であり、現時点でどの検査も通ったとは言えない。

確認予定:

- [ ] `Lint` が通る（SwiftFormat / SwiftLint）
- [ ] `Unit Tests` のログに `Test run with N tests in M suites passed` が出る
- [ ] `Verify tests executed` と `Build executable` が skipped でなく実行される
- [ ] `NSFileHandleOperationException` と `waitUntil` / `requestTimedOut` 由来の issue が 0 件
- [ ] 複数回 re-run してすべて緑（1 回の成功では断続的失敗の修正を証明できない）

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyaqDYcf7DqSg4rSYZ8eXc)_