### PR TITLE
Fix Codex stdout backpressure

### DIFF
--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -844,7 +844,7 @@
 "Codex app-server exited unexpectedly: %@" = "Codex app-server exited unexpectedly: %@";
 "Codex did not respond in time (%@). Try again." = "Codex did not respond in time (%@). Try again.";
 "Codex returned an invalid response." = "Codex returned an invalid response.";
-"Codex produced output faster than Dahlia could process it." = "Codex produced output faster than Dahlia could process it.";
+"Codex returned an output line larger than Dahlia's 4 MiB safety limit." = "Codex returned an output line larger than Dahlia's 4 MiB safety limit.";
 "Codex request failed: %@" = "Codex request failed: %@";
 "Codex could not complete the request." = "Codex could not complete the request.";
 "Codex generation was interrupted." = "Codex generation was interrupted.";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -844,7 +844,7 @@
 "Codex app-server exited unexpectedly: %@" = "Codex app-server が予期せず終了しました: %@";
 "Codex did not respond in time (%@). Try again." = "Codex から時間内に応答がありませんでした（%@）。再試行してください。";
 "Codex returned an invalid response." = "Codex から不正な応答が返されました。";
-"Codex produced output faster than Dahlia could process it." = "Codex の出力速度が Dahlia の処理速度を超えました。";
+"Codex returned an output line larger than Dahlia's 4 MiB safety limit." = "Codex から Dahlia の安全上限（4 MiB）を超える1行の出力が返されました。";
 "Codex request failed: %@" = "Codex リクエストに失敗しました: %@";
 "Codex could not complete the request." = "Codex がリクエストを完了できませんでした。";
 "Codex generation was interrupted." = "Codex の生成が中断されました。";

--- a/Sources/Dahlia/Services/CodexAppServerError.swift
+++ b/Sources/Dahlia/Services/CodexAppServerError.swift
@@ -9,7 +9,7 @@ enum CodexAppServerError: LocalizedError, Equatable {
     case processExited(String?)
     case requestTimedOut(String)
     case invalidProtocolResponse
-    case outputBufferOverflow
+    case outputLineTooLarge
     case rpcError(code: Int?, message: String)
     case providerAuthenticationFailed(String?)
     case turnFailed(String?)
@@ -27,7 +27,7 @@ enum CodexAppServerError: LocalizedError, Equatable {
             detail.map(L10n.codexProcessExitedWithDetail) ?? L10n.codexProcessExited
         case let .requestTimedOut(operation): L10n.codexRequestTimedOut(operation)
         case .invalidProtocolResponse: L10n.codexInvalidResponse
-        case .outputBufferOverflow: L10n.codexOutputBufferOverflow
+        case .outputLineTooLarge: L10n.codexOutputLineTooLarge
         case let .rpcError(_, message): L10n.codexRequestFailed(message)
         case let .providerAuthenticationFailed(detail):
             detail.map(L10n.codexRequestFailed) ?? L10n.codexTurnFailed

--- a/Sources/Dahlia/Services/CodexAppServerOutputReadRelay.swift
+++ b/Sources/Dahlia/Services/CodexAppServerOutputReadRelay.swift
@@ -1,0 +1,165 @@
+import Foundation
+import os
+
+struct CodexOutputReadSnapshot: Sendable {
+    let data: Data
+    let terminalErrorCode: Int32?
+    let totalByteCount: Int
+}
+
+/// A byte-bounded handoff for one DispatchIO read window.
+///
+/// DispatchIO may deliver a 64 KiB read in many small callbacks. The relay keeps one consumer
+/// suspended between callbacks instead of creating a task or applying a count limit per callback.
+final class CodexOutputReadRelay: Sendable {
+    private struct State {
+        var data = Data()
+        var totalByteCount = 0
+        var terminalErrorCode: Int32?
+        var waiter: CheckedContinuation<CodexOutputReadSnapshot, Never>?
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    func append(_ data: Data, done: Bool, errorCode: Int32) {
+        let delivery = state.withLock { state -> (
+            CheckedContinuation<CodexOutputReadSnapshot, Never>,
+            CodexOutputReadSnapshot
+        )? in
+            state.data.append(data)
+            state.totalByteCount += data.count
+            if done {
+                state.terminalErrorCode = errorCode
+            }
+            guard let waiter = state.waiter else { return nil }
+            state.waiter = nil
+            return (waiter, Self.takeSnapshot(from: &state))
+        }
+        if let delivery {
+            delivery.0.resume(returning: delivery.1)
+        }
+    }
+
+    func next() async -> CodexOutputReadSnapshot {
+        await withCheckedContinuation { continuation in
+            let snapshot = state.withLock { state -> CodexOutputReadSnapshot? in
+                if !state.data.isEmpty || state.terminalErrorCode != nil {
+                    return Self.takeSnapshot(from: &state)
+                }
+                precondition(state.waiter == nil)
+                state.waiter = continuation
+                return nil
+            }
+            if let snapshot {
+                continuation.resume(returning: snapshot)
+            }
+        }
+    }
+
+    #if DEBUG
+        func retainedByteCount() -> Int {
+            state.withLock { $0.data.count }
+        }
+    #endif
+
+    private static func takeSnapshot(from state: inout State) -> CodexOutputReadSnapshot {
+        let snapshot = CodexOutputReadSnapshot(
+            data: state.data,
+            terminalErrorCode: state.terminalErrorCode,
+            totalByteCount: state.totalByteCount
+        )
+        state.data = Data()
+        state.terminalErrorCode = nil
+        return snapshot
+    }
+}
+
+#if DEBUG
+    /// Suspends the actor-side drain so tests can observe a completely filled read window.
+    final class CodexAppServerOutputReadTestGate: Sendable {
+        private struct State {
+            var isReleased = false
+            var didStartRead = false
+            var finishedReadByteCount: Int?
+            var drainWaiter: CheckedContinuation<Void, Never>?
+            var readStartWaiter: CheckedContinuation<Void, Never>?
+            var readFinishedWaiter: CheckedContinuation<Int, Never>?
+        }
+
+        private let state = OSAllocatedUnfairLock(initialState: State())
+
+        func waitBeforeDraining() async {
+            await withCheckedContinuation { continuation in
+                let shouldResume = state.withLock { state in
+                    if state.isReleased { return true }
+                    precondition(state.drainWaiter == nil)
+                    state.drainWaiter = continuation
+                    return false
+                }
+                if shouldResume {
+                    continuation.resume()
+                }
+            }
+        }
+
+        func recordReadFinished(retainedByteCount: Int) {
+            let waiter = state.withLock { state -> CheckedContinuation<Int, Never>? in
+                state.finishedReadByteCount = retainedByteCount
+                let waiter = state.readFinishedWaiter
+                state.readFinishedWaiter = nil
+                return waiter
+            }
+            waiter?.resume(returning: retainedByteCount)
+        }
+
+        func recordReadStarted() {
+            let waiter = state.withLock { state -> CheckedContinuation<Void, Never>? in
+                state.didStartRead = true
+                let waiter = state.readStartWaiter
+                state.readStartWaiter = nil
+                return waiter
+            }
+            waiter?.resume()
+        }
+
+        func waitUntilReadStarted() async {
+            await withCheckedContinuation { continuation in
+                let shouldResume = state.withLock { state in
+                    if state.didStartRead { return true }
+                    precondition(state.readStartWaiter == nil)
+                    state.readStartWaiter = continuation
+                    return false
+                }
+                if shouldResume {
+                    continuation.resume()
+                }
+            }
+        }
+
+        func waitUntilReadFinished() async -> Int {
+            await withCheckedContinuation { continuation in
+                let retainedByteCount = state.withLock { state -> Int? in
+                    if let retainedByteCount = state.finishedReadByteCount {
+                        return retainedByteCount
+                    }
+                    precondition(state.readFinishedWaiter == nil)
+                    state.readFinishedWaiter = continuation
+                    return nil
+                }
+                if let retainedByteCount {
+                    continuation.resume(returning: retainedByteCount)
+                }
+            }
+        }
+
+        func resumeDraining() {
+            let waiter = state.withLock { state -> CheckedContinuation<Void, Never>? in
+                state.isReleased = true
+                let waiter = state.drainWaiter
+                state.drainWaiter = nil
+                return waiter
+            }
+            waiter?.resume()
+        }
+    }
+#endif

--- a/Sources/Dahlia/Services/CodexAppServerProcessTransport.swift
+++ b/Sources/Dahlia/Services/CodexAppServerProcessTransport.swift
@@ -1,27 +1,18 @@
 import Darwin
 import Dispatch
 import Foundation
-import os
 
 /// Process stdio adapter. All potentially blocking pipe operations stay outside Swift's cooperative executor.
 actor CodexAppServerProcessTransport: CodexAppServerTransport {
-    private enum OutputTermination: Sendable {
-        case overflow
-        case end(Int32)
-    }
-
-    // DispatchIO reads as fast as the child writes, so the bytes waiting to reach the actor need
-    // their own ceiling. Without one the documented maximumBufferedOutputLines policy only applies
-    // after parsing, which leaves memory growth unbounded ahead of it.
-    private static let maximumBufferedOutputChunks = 64
-    private static let maximumOutputChunkBytes = 64 * 1024
+    private static let maximumOutputReadBytes = 64 * 1024
+    private static let maximumOutputLineBytes = 4 * 1024 * 1024
 
     private let process: Process
     private let inputChannel: DispatchIO
     private let outputChannel: DispatchIO
     private let errorChannel: DispatchIO
     private let ioQueue = DispatchQueue(label: "app.dahlia.codex-app-server-stdio")
-    private var isOutputDrainStarted = false
+    private var activeOutputReadID: UUID?
     private var isErrorDrainStarted = false
     private var isErrorDrainFinished = false
     private var stdoutPending = Data()
@@ -33,10 +24,9 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
     private var pendingWrites: [UUID: CheckedContinuation<Void, any Error>] = [:]
     private var isClosed = false
     private var stderrTail = Data()
-    private let maximumBufferedOutputLines = 1024
     private let minimumConsumedOutputLinesBeforeCompaction = 256
     #if DEBUG
-        private var outputBufferOverflowWaiters: [CheckedContinuation<Void, Never>] = []
+        private var outputReadTestGate: CodexAppServerOutputReadTestGate?
     #endif
 
     init(
@@ -100,16 +90,15 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
         errorChannel = DispatchIO(type: .stream, fileDescriptor: duplicatedError, queue: ioQueue) { _ in
             Darwin.close(duplicatedError)
         }
-        // A JSON-RPC line must reach the reader as soon as the child writes it, and one delivery
-        // must stay small enough that the handoff ceiling below is expressed in bytes, not chunks.
+        // Deliver short JSON-RPC lines promptly while keeping each read window byte-bounded.
         outputChannel.setLimit(lowWater: 1)
-        outputChannel.setLimit(highWater: Self.maximumOutputChunkBytes)
+        outputChannel.setLimit(highWater: Self.maximumOutputReadBytes)
         errorChannel.setLimit(highWater: 4096)
     }
 
     func sendLine(_ data: Data) async throws {
         guard !isClosed else { throw CodexAppServerError.processExited(stderrDescription) }
-        startDrainsIfNeeded()
+        startErrorDrainIfNeeded()
         var line = data
         line.append(0x0A)
         let writeID = UUID()
@@ -138,7 +127,7 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
     }
 
     func receiveLine() async throws -> Data? {
-        startDrainsIfNeeded()
+        startErrorDrainIfNeeded()
         if let line = dequeueOutputLine() {
             return line
         }
@@ -154,6 +143,7 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
                     continuation.resume(throwing: CodexAppServerError.invalidProtocolResponse)
                 } else {
                     outputWaiter = (waiterID, continuation)
+                    startOutputReadIfNeeded()
                 }
             }
         } onCancel: {
@@ -193,25 +183,8 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
             process.processIdentifier
         }
 
-        func waitUntilOutputBufferOverflowForTesting() async {
-            startDrainsIfNeeded()
-            if outputError as? CodexAppServerError == .outputBufferOverflow { return }
-            await withCheckedContinuation { continuation in
-                outputBufferOverflowWaiters.append(continuation)
-            }
-        }
-
-        func enqueueOutputLinesForTesting(_ lines: [Data]) {
-            for line in lines {
-                enqueueOutputLine(line)
-            }
-        }
-
-        func outputBufferStateForTesting() -> (unreadLineCount: Int, retainedByteCount: Int) {
-            (
-                outputLines.count - outputLineReadIndex,
-                outputLines.reduce(into: 0) { $0 += $1.count }
-            )
+        func setOutputReadTestGateForTesting(_ gate: CodexAppServerOutputReadTestGate) {
+            outputReadTestGate = gate
         }
     #endif
 
@@ -227,61 +200,37 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
         }
     }
 
-    private func startDrainsIfNeeded() {
-        // A closed transport has already released its channels. Restarting a drain here would
-        // read from a torn-down descriptor instead of reporting the closure to the caller.
-        guard !isClosed else { return }
-        startOutputDrainIfNeeded()
-        startErrorDrainIfNeeded()
-    }
-
-    private func startOutputDrainIfNeeded() {
-        guard !isOutputDrainStarted else { return }
-        isOutputDrainStarted = true
-        let (chunks, continuation) = AsyncStream<Data>.makeStream(
-            bufferingPolicy: .bufferingOldest(Self.maximumBufferedOutputChunks)
-        )
-        // The terminal outcome must not compete with chunks for stream capacity. Yielding it into a
-        // full buffer would drop it, ending the consumer without ever reporting EOF or overflow and
-        // leaving the reader suspended in receiveLine. First writer wins, so a later callback on the
-        // stopped channel cannot relabel an overflow as a clean exit.
-        let termination = OSAllocatedUnfairLock<OutputTermination?>(initialState: nil)
-        // DispatchIO keeps the blocking pipe read on ioQueue. The stream carries chunks into the
-        // actor in arrival order, which one unstructured task per chunk would not guarantee.
-        outputChannel.read(offset: 0, length: Int.max, queue: ioQueue) { done, data, errorCode in
-            if let data, !data.isEmpty {
-                // Losing even one chunk splices unrelated bytes into the next line, so a full
-                // buffer becomes the documented overflow rather than a silent discard.
-                if case .dropped = continuation.yield(Data(data)) {
-                    termination.withLock { $0 = $0 ?? .overflow }
-                    continuation.finish()
-                    return
+    private func startOutputReadIfNeeded() {
+        guard !isClosed, !didReachOutputEOF, outputError == nil,
+              outputWaiter != nil, activeOutputReadID == nil else { return }
+        let readID = UUID()
+        let relay = CodexOutputReadRelay()
+        activeOutputReadID = readID
+        #if DEBUG
+            let testGate = outputReadTestGate
+            testGate?.recordReadStarted()
+        #endif
+        outputChannel.read(
+            offset: 0,
+            length: Self.maximumOutputReadBytes,
+            queue: ioQueue
+        ) { done, data, errorCode in
+            relay.append(data.map { Data($0) } ?? Data(), done: done, errorCode: errorCode)
+            #if DEBUG
+                if done {
+                    testGate?.recordReadFinished(retainedByteCount: relay.retainedByteCount())
                 }
-            }
-            if done {
-                termination.withLock { $0 = $0 ?? .end(errorCode) }
-                continuation.finish()
-            }
+            #endif
         }
         Task { [weak self] in
-            for await chunk in chunks {
-                await self?.consumeStdout(chunk)
-            }
-            // Runs after every buffered chunk has been parsed, so a trailing partial line is still
-            // whole by the time the terminal outcome is applied.
-            switch termination.withLock({ $0 }) {
-            case .overflow:
-                await self?.failOutputDrainWithOverflow()
-            case let .end(errorCode):
-                await self?.finishOutputDrain(errorCode: errorCode)
-            case nil:
-                break
-            }
+            await self?.consumeOutputRead(readID: readID, relay: relay)
         }
     }
 
     private func startErrorDrainIfNeeded() {
-        guard !isErrorDrainStarted else { return }
+        // A closed transport has already released its channels. Restarting a drain here would
+        // read from a torn-down descriptor instead of reporting the closure to the caller.
+        guard !isClosed, !isErrorDrainStarted else { return }
         isErrorDrainStarted = true
         errorChannel.read(offset: 0, length: Int.max, queue: ioQueue) { [weak self] done, data, _ in
             let chunk = data.map { Data($0) } ?? Data()
@@ -291,39 +240,66 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
         }
     }
 
-    private func consumeStdout(_ data: Data) {
-        stdoutPending.append(data)
-        guard stdoutPending.contains(0x0A) else { return }
-        var lines = stdoutPending.split(separator: 0x0A, omittingEmptySubsequences: false)
-        stdoutPending = Data(lines.removeLast())
-        for line in lines where !line.isEmpty {
-            enqueueOutputLine(Data(line))
+    private func consumeOutputRead(readID: UUID, relay: CodexOutputReadRelay) async {
+        #if DEBUG
+            await outputReadTestGate?.waitBeforeDraining()
+        #endif
+        while activeOutputReadID == readID {
+            let snapshot = await relay.next()
+            guard activeOutputReadID == readID else { return }
+            if !snapshot.data.isEmpty, !consumeStdout(snapshot.data) {
+                return
+            }
+            guard let errorCode = snapshot.terminalErrorCode else { continue }
+            activeOutputReadID = nil
+            if errorCode != 0 || snapshot.totalByteCount < Self.maximumOutputReadBytes {
+                await finishOutputRead(errorCode: errorCode)
+            } else {
+                startOutputReadIfNeeded()
+            }
         }
     }
 
-    private func failOutputDrainWithOverflow() {
-        // Continuing to read only discards more bytes, and the buffered prefix can no longer be
-        // parsed into whole lines.
-        outputChannel.close(flags: .stop)
-        stdoutPending.removeAll()
-        latchOutputBufferOverflow()
-        guard let waiter = outputWaiter else { return }
-        outputWaiter = nil
-        waiter.continuation.resume(throwing: CodexAppServerError.outputBufferOverflow)
+    private func consumeStdout(_ data: Data) -> Bool {
+        var segmentStart = data.startIndex
+        while let newline = data[segmentStart...].firstIndex(of: 0x0A) {
+            let fragment = data[segmentStart ..< newline]
+            guard appendToPendingLine(fragment) else { return false }
+            if !stdoutPending.isEmpty {
+                let line = stdoutPending
+                stdoutPending = Data()
+                enqueueOutputLine(line)
+            }
+            segmentStart = data.index(after: newline)
+        }
+        return appendToPendingLine(data[segmentStart...])
     }
 
-    private func latchOutputBufferOverflow() {
+    private func appendToPendingLine(_ fragment: Data.SubSequence) -> Bool {
+        guard fragment.count <= Self.maximumOutputLineBytes - stdoutPending.count else {
+            failOutputLineTooLarge()
+            return false
+        }
+        stdoutPending.append(contentsOf: fragment)
+        return true
+    }
+
+    private func failOutputLineTooLarge() {
+        // The output can no longer be framed safely. Stop the shared connection without retaining
+        // or reporting any portion of the line.
+        let error = CodexAppServerError.outputLineTooLarge
+        activeOutputReadID = nil
+        outputChannel.close(flags: .stop)
+        stdoutPending.removeAll(keepingCapacity: false)
         outputLines.removeAll(keepingCapacity: false)
         outputLineReadIndex = 0
-        outputError = CodexAppServerError.outputBufferOverflow
-        #if DEBUG
-            let waiters = outputBufferOverflowWaiters
-            outputBufferOverflowWaiters.removeAll()
-            waiters.forEach { $0.resume() }
-        #endif
+        outputError = error
+        guard let waiter = outputWaiter else { return }
+        outputWaiter = nil
+        waiter.continuation.resume(throwing: error)
     }
 
-    private func finishOutputDrain(errorCode: Int32) async {
+    private func finishOutputRead(errorCode: Int32) async {
         // The child may exit after a final line that carries no trailing newline.
         if !stdoutPending.isEmpty {
             let trailing = stdoutPending
@@ -356,10 +332,6 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
             waiter.continuation.resume(returning: line)
         } else {
             guard outputError == nil else { return }
-            if outputLines.count - outputLineReadIndex >= maximumBufferedOutputLines {
-                latchOutputBufferOverflow()
-                return
-            }
             outputLines.append(line)
         }
     }

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -2061,8 +2061,8 @@ enum L10n {
         bundle: bundle
     ) }
     static var codexInvalidResponse: String { String(localized: "Codex returned an invalid response.", bundle: bundle) }
-    static var codexOutputBufferOverflow: String { String(
-        localized: "Codex produced output faster than Dahlia could process it.",
+    static var codexOutputLineTooLarge: String { String(
+        localized: "Codex returned an output line larger than Dahlia's 4 MiB safety limit.",
         bundle: bundle
     ) }
     static func codexRequestFailed(_ detail: String) -> String { String(

--- a/Tests/DahliaTests/CodexAppServerProcessTransportXCTests.swift
+++ b/Tests/DahliaTests/CodexAppServerProcessTransportXCTests.swift
@@ -7,6 +7,22 @@ import Foundation
 
     struct CodexAppServerProcessTransportTests {
         @Test
+        func outputRelayPreservesOneThousandCallbackFragmentsInOrder() async {
+            let relay = CodexOutputReadRelay()
+            let fragments = (0 ..< 1000).map { Data(String(format: "%04d,", $0).utf8) }
+
+            for (index, fragment) in fragments.enumerated() {
+                relay.append(fragment, done: index == fragments.count - 1, errorCode: 0)
+            }
+
+            let snapshot = await relay.next()
+            let expectedData = fragments.reduce(into: Data()) { $0.append($1) }
+            #expect(snapshot.data == expectedData)
+            #expect(snapshot.totalByteCount == expectedData.count)
+            #expect(snapshot.terminalErrorCode == 0)
+        }
+
+        @Test
         func exchangesMultipleLinesWithLongLivedChild() async throws {
             let transport = try CodexAppServerProcessTransport(
                 executableURL: URL(fileURLWithPath: "/bin/cat"),
@@ -37,10 +53,10 @@ import Foundation
         }
 
         @Test
-        func cleanOutputEOFIncludesStderrTail() async throws {
+        func abnormalProcessExitIncludesStderrTail() async throws {
             let transport = try CodexAppServerProcessTransport(
                 executableURL: URL(fileURLWithPath: "/bin/sh"),
-                arguments: ["-c", "printf 'codex panic detail' >&2"]
+                arguments: ["-c", "printf 'codex panic detail' >&2; exit 7"]
             )
 
             do {
@@ -58,28 +74,50 @@ import Foundation
         }
 
         @Test
-        func stdoutBufferHasAnUpperBound() async throws {
+        func delayedActorDrainPreservesOneThousandDeltaLinesWithinOneReadWindow() async throws {
+            let gate = CodexAppServerOutputReadTestGate()
             let transport = try CodexAppServerProcessTransport(
                 executableURL: URL(fileURLWithPath: "/bin/sh"),
-                arguments: ["-c", "i=0; while [ $i -lt 1200 ]; do printf '%s\\n' $i; i=$((i+1)); done; read _"]
+                arguments: [
+                    "-c",
+                    "i=0; while [ $i -lt 1000 ]; do "
+                        + "printf '{\"method\":\"delta\",\"params\":{\"index\":%04d,\"delta\":\"xxxxxxxx\"}}\\n' $i; "
+                        + "i=$((i+1)); done",
+                ]
             )
+            await transport.setOutputReadTestGateForTesting(gate)
 
-            await transport.waitUntilOutputBufferOverflowForTesting()
-            await #expect(throws: CodexAppServerError.outputBufferOverflow) {
-                _ = try await transport.receiveLine()
+            let firstLine = Task { try await transport.receiveLine() }
+            let retainedByteCount = await gate.waitUntilReadFinished()
+            #expect(retainedByteCount > 0)
+            #expect(retainedByteCount <= 64 * 1024)
+            gate.resumeDraining()
+
+            let expectedLines = (0 ..< 1000).map {
+                Data(String(format: "{\"method\":\"delta\",\"params\":{\"index\":%04d,\"delta\":\"xxxxxxxx\"}}", $0).utf8)
             }
+            let receivedFirstLine = try #require(await firstLine.value)
+            var receivedLines = [receivedFirstLine]
+            for _ in 1 ..< expectedLines.count {
+                try receivedLines.append(#require(await transport.receiveLine()))
+            }
+            #expect(receivedLines == expectedLines)
             await transport.close()
         }
 
         @Test
-        func stdoutBufferAcceptsDocumentedCapacityInFIFOOrder() async throws {
+        func burstBeyondFormerLineLimitDrainsInFIFOOrder() async throws {
+            let payload = String(repeating: "x", count: 64)
             let transport = try CodexAppServerProcessTransport(
-                executableURL: URL(fileURLWithPath: "/bin/cat"),
-                arguments: []
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: [
+                    "-c",
+                    "i=0; while [ $i -lt 2048 ]; do printf '%04d:\(payload)\\n' $i; i=$((i+1)); done",
+                ]
             )
-            let expectedLines = (0 ..< 1024).map { Data(String($0).utf8) }
-
-            await transport.enqueueOutputLinesForTesting(expectedLines)
+            let expectedLines = (0 ..< 2048).map {
+                Data((String(format: "%04d:", $0) + payload).utf8)
+            }
 
             var receivedLines: [Data] = []
             for _ in expectedLines.indices {
@@ -90,61 +128,59 @@ import Foundation
         }
 
         @Test
-        func stdoutBufferRejectsLineAfterDocumentedCapacity() async throws {
+        func lineCanCrossSixtyFourKiBReadBoundary() async throws {
             let transport = try CodexAppServerProcessTransport(
-                executableURL: URL(fileURLWithPath: "/bin/cat"),
-                arguments: []
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", "dd if=/dev/zero bs=65536 count=1 2>/dev/null | tr '\\000' a; printf 'b\\n'"]
             )
-            let lines = (0 ... 1024).map { Data(String($0).utf8) }
 
-            await transport.enqueueOutputLinesForTesting(lines)
-
-            await #expect(throws: CodexAppServerError.outputBufferOverflow) {
-                _ = try await transport.receiveLine()
-            }
+            var expectedLine = Data(repeating: 0x61, count: 64 * 1024)
+            expectedLine.append(0x62)
+            #expect(try await transport.receiveLine() == expectedLine)
             await transport.close()
         }
 
         @Test
-        func stdoutBufferPreservesFIFOWhenReplenishedAfterCompaction() async throws {
+        func eofDeliversTrailingLineWithoutNewline() async throws {
             let transport = try CodexAppServerProcessTransport(
-                executableURL: URL(fileURLWithPath: "/bin/cat"),
-                arguments: []
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", "printf trailing"]
             )
-            let initialLines = (0 ..< 1024).map { Data(String($0).utf8) }
-            let replenishedLines = (1024 ..< 1536).map { Data(String($0).utf8) }
 
-            await transport.enqueueOutputLinesForTesting(initialLines)
-            for expectedLine in initialLines.prefix(512) {
-                #expect(try await transport.receiveLine() == expectedLine)
-            }
-            await transport.enqueueOutputLinesForTesting(replenishedLines)
-
-            let expectedRemainder = Array(initialLines.dropFirst(512)) + replenishedLines
-            var receivedRemainder: [Data] = []
-            for _ in expectedRemainder.indices {
-                try receivedRemainder.append(#require(await transport.receiveLine()))
-            }
-            #expect(receivedRemainder == expectedRemainder)
+            #expect(try await transport.receiveLine() == Data("trailing".utf8))
             await transport.close()
         }
 
         @Test
-        func stdoutBufferReleasesConsumedPayloadsBeforeCompaction() async throws {
+        func lineAtFourMiBLimitIsAccepted() async throws {
             let transport = try CodexAppServerProcessTransport(
-                executableURL: URL(fileURLWithPath: "/bin/cat"),
-                arguments: []
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: [
+                    "-c",
+                    "dd if=/dev/zero bs=1048576 count=4 2>/dev/null | tr '\\000' a; printf '\\n'",
+                ]
             )
-            let line = Data(repeating: 0x61, count: 64)
-            await transport.enqueueOutputLinesForTesting(Array(repeating: line, count: 1024))
 
-            for _ in 0 ..< 256 {
+            let line = try #require(await transport.receiveLine())
+            #expect(line.count == 4 * 1024 * 1024)
+            #expect(line.first == 0x61)
+            #expect(line.last == 0x61)
+            await transport.close()
+        }
+
+        @Test
+        func lineBeyondFourMiBLimitFailsClosed() async throws {
+            let transport = try CodexAppServerProcessTransport(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: [
+                    "-c",
+                    "{ dd if=/dev/zero bs=1048576 count=4 2>/dev/null; printf '\\000'; } | tr '\\000' a",
+                ]
+            )
+
+            await #expect(throws: CodexAppServerError.outputLineTooLarge) {
                 _ = try await transport.receiveLine()
             }
-
-            let state = await transport.outputBufferStateForTesting()
-            #expect(state.unreadLineCount == 768)
-            #expect(state.retainedByteCount == 768 * line.count)
             await transport.close()
         }
 
@@ -166,13 +202,16 @@ import Foundation
 
         @Test
         func closeImmediatelyAfterStartingTheDrainDoesNotTearDownAnActiveRead() async throws {
+            let gate = CodexAppServerOutputReadTestGate()
             let transport = try CodexAppServerProcessTransport(
                 executableURL: URL(fileURLWithPath: "/bin/cat"),
                 arguments: []
             )
+            await transport.setOutputReadTestGateForTesting(gate)
 
-            // Starts the stdout drain, then closes before the drain has observed any output.
             let pending = Task { try await transport.receiveLine() }
+            await gate.waitUntilReadStarted()
+            gate.resumeDraining()
             await transport.close()
 
             #expect(try await pending.value == nil)

--- a/docs/adr/0013-expand-codex-stdout-burst-buffer.md
+++ b/docs/adr/0013-expand-codex-stdout-burst-buffer.md
@@ -1,6 +1,6 @@
 # ADR 0013: Codex stdout の burst buffer を拡張する
 
-- Status: Accepted
+- Status: Superseded by [ADR 0019](0019-pull-codex-stdout-with-backpressure.md)
 - Date: 2026-07-28
 - Amends: [ADR 0003](0003-use-a-shared-codex-app-server.md)
 

--- a/docs/adr/0019-pull-codex-stdout-with-backpressure.md
+++ b/docs/adr/0019-pull-codex-stdout-with-backpressure.md
@@ -1,0 +1,70 @@
+# ADR 0019: Codex stdout を需要駆動で読み取る
+
+## Status
+
+Accepted; supersedes 0013, amends 0003
+
+## Date
+
+2026-08-03
+
+## Context
+
+[ADR 0013](0013-expand-codex-stdout-burst-buffer.md) は、Codex app-server の stdout burst を行数上限付きの
+メモリバッファへ先読みし、1,024 行を超えた時点で共有接続を破棄する方針を採用した。その後、pipe の読み取りを
+`DispatchIO.read(length: Int.max)` と64チャンク上限の `AsyncStream` で中継する実装へ変更した。
+
+`DispatchIO` の `lowWater` は1 byteであるため、子プロセスが短いJSONL行を連続して書くと、OSは1回の長寿命readを
+多数の小さなcallbackへ分割しうる。この実装は保持バイト数や完全行数ではなくcallback由来のチャンク数を上限として
+いたため、約60 KiB・1,000行という旧1,024行上限内の出力でも、actor側のconsumerが一時的に遅れるだけでoverflowに
+なった。したがって行数上限の再調整では解決しない。
+
+長寿命readを導入した際には、長さを指定した `DispatchIO.read` は指定byte数へ到達するまで完了せず、短いJSONL行を
+即時処理できないためbackpressureには使えない、と判断していた。この判断は誤りだった。`lowWater: 1` を設定すると、
+指定長へ到達する前でも到着済みdataが `done == false` のcallbackとして配送される。readの完了を待たずにその部分配送を
+処理できる。
+
+一方、子プロセスが改行を返さない場合は、需要駆動にしても単一行を完成させるためのメモリが入力に比例して増える。
+JSON-RPC/JSONLとして妥当な通常出力と、framingが壊れた出力を区別する明示上限が必要である。
+
+## Decision
+
+- stdout は `receiveLine()` に未完のreaderがあり、完全行の手持ちがないときだけ読み進める。
+- 1回の `DispatchIO.read` は最大64 KiBとする。`lowWater: 1` を維持し、`done == false` の部分配送も到着時点で解析する。
+- 64 KiBを読み切った時点で未完のreaderが残っている場合だけ、次のread windowを開始する。完全行をreaderへ渡したか、
+  後続の完全行を保持している間は新しいwindowを開始しない。これにより、読み手が遅いときはOS pipeへbackpressureを
+  返す。
+- 1 window内のcallbackは、ロック保護された `Data` relayへ順番どおり追記する。windowごとに1つのconsumerだけが
+  relayをdrainし、callbackごとの `Task` やチャンク数制限付き `AsyncStream` は使わない。relayの保持量はcallback数では
+  なくread windowの64 KiBで有界になる。
+- 単一JSONL行の上限を新たに4 MiBとする。4 MiBちょうどは受理し、改行までに4 MiBを超えた場合はstdoutを停止して
+  待機中readerを `outputLineTooLarge` で失敗させ、共有接続を破棄する。出力本文はログやSentryへ送らない。
+- 完全行のFIFO、windowをまたぐ部分行、末尾改行なしのEOF、stderr tail、cancel、close、process終了の契約は維持する。
+- 自動再送は追加しない。共有接続を破棄した結果は既存の明示的な失敗処理へ渡す。
+
+## Consequences
+
+- OSがstdoutを多数の小さなcallbackへ分割しても、配送回数だけを理由に正常な出力を失敗させない。
+- 読み手が止まると、Dahliaのメモリへ無制限に先読みせず、最大64 KiBのread-aheadを経て子プロセス側へbackpressureが
+  かかる。
+- 旧1,024行上限を超えるburstも、consumerが継続する限りFIFOで処理できる。
+- 改行なしの異常出力だけは新しい4 MiB上限でfail-closedになる。共有app-serverを使う進行中turnへ影響しうるが、
+  framingが不明な接続を継続して別のresponseとして解釈することはない。
+- consumerが長時間進まない場合、子プロセスはpipe書き込みで待つ可能性がある。pending RPCには既存のtransport timeoutが
+  あり、Dahliaが正常出力を先読みoverflowとして即時破棄するよりも正確な失敗になる。
+
+## Alternatives considered
+
+### 行数上限またはチャンク数上限を拡張する
+
+OSの配送分割とアプリが扱う完全行の数に安定した関係がない。値を増やしても同じ誤overflowが別のburstで再発し、
+メモリ上限の意味も不明確なため却下した。
+
+### 長寿命readと無制限relayを使う
+
+consumer停止中も子プロセスの全出力をプロセス内へ取り込み続け、入力規模に応じてメモリ使用量が増えるため却下した。
+
+### 64 KiB windowのcallbackごとにTaskを作る
+
+callbackの分割数だけ非構造Taskが増え、actorへ到着する順序も別途保証する必要がある。window単位のrelayと単一consumerで
+同じ即時性を保てるため却下した。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,7 +13,7 @@ Codex は全 ADR を順番に読まず、最初にこの一覧から現在の作
 | --- | --- | --- | --- |
 | [0001](0001-summary-document-ast.md) | Summary | `SummaryDocument` AST をサマリーの正準表現にする | Accepted |
 | [0002](0002-isolate-recording-critical-path-from-main-actor.md) | Recording / Concurrency | 録音と確定データの保存を MainActor の UI projection から分離する | Accepted; partially superseded by 0006 and 0009 |
-| [0003](0003-use-a-shared-codex-app-server.md) | AI runtime | Codex app-server をアプリ共有の長寿命 backend として使う | Accepted; amended by 0013 and 0015 |
+| [0003](0003-use-a-shared-codex-app-server.md) | AI runtime | Codex app-server をアプリ共有の長寿命 backend として使う | Accepted; amended by 0013, 0015, and 0019 |
 | [0004](0004-protect-recordings-with-segmented-immutable-storage.md) | Recording storage | 録音データを分割された immutable segment として保全する | Accepted |
 | [0005](0005-vault-scoped-meeting-access-mcp.md) | Meeting access | Vault 固定・read-only の local MCP で meeting data を公開する | Accepted; amended by 0010 |
 | [0006](0006-bounded-transcript-projection.md) | Transcript UI | SQLite を正本とし、文字起こし表示を bounded projection と keyset pagination にする | Accepted; partially supersedes 0002 |
@@ -23,9 +23,10 @@ Codex は全 ADR を順番に読まず、最初にこの一覧から現在の作
 | [0010](0010-database-canonical-bounded-project-hierarchy.md) | Project workspace | DB 正本の2段階 Project 階層と派生 Summary 出力先を採用する | Accepted; amends 0005 |
 | [0011](0011-vault-scoped-customer-intelligence.md) | Customer intelligence | Vault単位の型付き正準データとAI示唆を分離する | Accepted; amends 0005, builds on 0010 |
 | [0012](0012-reviewable-customer-intelligence-workspace.md) | Customer intelligence / UI | 単一顧客の組織ビューと単数 CRUD による逐次AI更新を採用する | Accepted; amends 0011 |
-| [0013](0013-expand-codex-stdout-burst-buffer.md) | AI runtime | Codex stdout の burst buffer を拡張し、消費済み payload を即時解放する | Accepted; amends 0003 |
+| [0013](0013-expand-codex-stdout-burst-buffer.md) | AI runtime | Codex stdout の burst buffer を拡張し、消費済み payload を即時解放する | Superseded by 0019 |
 | [0014](0014-domain-driven-organization-merge.md) | Customer intelligence / Identity | メールドメイン追加を入口にルート組織を完全統合する | Accepted; amends 0011 and 0012 |
 | [0015](0015-preset-projects-optimizer-skill.md) | AI runtime / Project workspace | Projects Optimizer skill をアプリ内チャットへプリセットする | Accepted; amends 0003, builds on 0010 |
 | [0016](0016-shared-organization-domains.md) | Customer intelligence / Identity | 同じメールドメインを複数のルート組織で共有可能にする | Accepted; amends 0011 and 0014 |
 | [0017](0017-preset-customer-intelligence-skills.md) | AI runtime / Customer intelligence | 顧客インテリジェンスの curator skill を層ごとに分けてプリセットする | Accepted; amends 0015, builds on 0011 and 0012 |
 | [0018](0018-mcp-meeting-summary-update.md) | Summary / Meeting access | サマリーの訂正を MCP のドキュメント全体置換で行う | Accepted; amends 0005 and 0010, builds on 0001 |
+| [0019](0019-pull-codex-stdout-with-backpressure.md) | AI runtime | Codex stdout を64 KiB単位で需要駆動読み取りする | Accepted; supersedes 0013, amends 0003 |


### PR DESCRIPTION
## Summary

- Codex app-server の stdout を、長寿命 read とチャンク数制限から需要駆動の 64 KiB read window へ変更
- window 内の部分配送をロック保護された byte-bounded relay で順序どおりに受け渡し
- 単一 JSONL 行へ 4 MiB の明示上限を追加し、超過時のエラーと日英メッセージを更新
- ADR 0019 を追加し、ADR 0013 を supersede
- burst、64 KiB 境界、EOF、close、異常終了、4 MiB 境界の回帰テストを追加

## Root cause

`DispatchIO.read(length: Int.max)` の出力を64チャンク上限の `AsyncStream` へ中継していたため、`lowWater: 1` によるOSの細かなcallback分割がチャンク上限を消費していました。合計約60 KiB・1,000行でも、consumerが一時的に遅れると正常なstdoutをoverflowとして扱っていました。

## Impact

正常なCodex出力はcallback数によって失敗せず、consumerが遅い場合はOS pipeへbackpressureが返ります。公開インターフェース、設定、DB、Codexバージョン、自動再送動作は変更しません。

## Validation

- `swift test --filter CodexAppServerProcessTransportTests` — 12 tests passed
- `swift build`
- `swift test` — 1,318 tests in 203 suites passed
- `CI=true ./scripts/lint.sh`
- SwiftFormat and `git diff --check`
