### PR TITLE
Fix duplicate conversation analytics legends

### DIFF
--- a/Sources/Dahlia/Views/ConversationAnalyticsEnergyTrendCard.swift
+++ b/Sources/Dahlia/Views/ConversationAnalyticsEnergyTrendCard.swift
@@ -31,7 +31,6 @@ struct ConversationAnalyticsEnergyTrendCard: View {
                         y: .value(L10n.conversationAnalyticsRelativeDecibels, sample.value)
                     )
                     .foregroundStyle(by: .value(L10n.conversationAnalyticsSourceDetails, source))
-                    .symbol(by: .value(L10n.conversationAnalyticsSourceDetails, source))
                     .accessibilityLabel(source)
                     .accessibilityValue(L10n.conversationAnalyticsVoiceSampleValue(
                         Formatters.elapsedMinutesSeconds(duration: sample.start),

--- a/Sources/Dahlia/Views/ConversationAnalyticsExcitementCard.swift
+++ b/Sources/Dahlia/Views/ConversationAnalyticsExcitementCard.swift
@@ -57,7 +57,6 @@ struct ConversationAnalyticsExcitementCard: View {
                     y: .value(L10n.conversationAnalyticsExcitement, sample.value)
                 )
                 .foregroundStyle(by: .value(L10n.conversationAnalyticsSourceDetails, source))
-                .symbol(by: .value(L10n.conversationAnalyticsSourceDetails, source))
                 .accessibilityLabel(source)
                 .accessibilityValue(L10n.conversationAnalyticsVoiceSampleValue(
                     Formatters.elapsedMinutesSeconds(duration: sample.start),

--- a/Sources/Dahlia/Views/ConversationAnalyticsPaceTrendCard.swift
+++ b/Sources/Dahlia/Views/ConversationAnalyticsPaceTrendCard.swift
@@ -32,7 +32,6 @@ struct ConversationAnalyticsPaceTrendCard: View {
                         y: .value(L10n.charactersPerMinute, sample.charactersPerMinute)
                     )
                     .foregroundStyle(by: .value(L10n.conversationAnalyticsSourceDetails, source))
-                    .symbol(by: .value(L10n.conversationAnalyticsSourceDetails, source))
                     .accessibilityLabel(source)
                     .accessibilityValue(L10n.conversationAnalyticsPaceSampleValue(
                         Formatters.elapsedMinutesSeconds(duration: sample.start),


### PR DESCRIPTION
## Summary

- remove source-driven point symbol encodings from the speaking pace, excitement, and energy trend charts
- retain the existing source color scale, point marks, and accessibility labels

## Root cause

Swift Charts generated separate legends for the foreground color and symbol encodings. When only one audio source had samples, this produced a duplicate label such as “Other Side.”

## User impact

Each conversation analytics chart now shows one legend entry per audio source.

## Validation

- `swift build`
- `CI=true ./scripts/lint.sh` (SwiftFormat clean; SwiftLint completed with pre-existing non-blocking repository violations)