### PR TITLE
Fix Codex output limit for echoed image input

### DIFF
--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -844,7 +844,7 @@
 "Codex app-server exited unexpectedly: %@" = "Codex app-server exited unexpectedly: %@";
 "Codex did not respond in time (%@). Try again." = "Codex did not respond in time (%@). Try again.";
 "Codex returned an invalid response." = "Codex returned an invalid response.";
-"Codex returned an output line larger than Dahlia's 4 MiB safety limit." = "Codex returned an output line larger than Dahlia's 4 MiB safety limit.";
+"Codex returned an output line larger than Dahlia's safety limit." = "Codex returned an output line larger than Dahlia's safety limit.";
 "Codex request failed: %@" = "Codex request failed: %@";
 "Codex could not complete the request." = "Codex could not complete the request.";
 "Codex generation was interrupted." = "Codex generation was interrupted.";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -844,7 +844,7 @@
 "Codex app-server exited unexpectedly: %@" = "Codex app-server が予期せず終了しました: %@";
 "Codex did not respond in time (%@). Try again." = "Codex から時間内に応答がありませんでした（%@）。再試行してください。";
 "Codex returned an invalid response." = "Codex から不正な応答が返されました。";
-"Codex returned an output line larger than Dahlia's 4 MiB safety limit." = "Codex から Dahlia の安全上限（4 MiB）を超える1行の出力が返されました。";
+"Codex returned an output line larger than Dahlia's safety limit." = "Codex から Dahlia の安全上限を超える1行の出力が返されました。";
 "Codex request failed: %@" = "Codex リクエストに失敗しました: %@";
 "Codex could not complete the request." = "Codex がリクエストを完了できませんでした。";
 "Codex generation was interrupted." = "Codex の生成が中断されました。";

--- a/Sources/Dahlia/Services/CodexAppServerProcessTransport.swift
+++ b/Sources/Dahlia/Services/CodexAppServerProcessTransport.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Process stdio adapter. All potentially blocking pipe operations stay outside Swift's cooperative executor.
 actor CodexAppServerProcessTransport: CodexAppServerTransport {
     private static let maximumOutputReadBytes = 64 * 1024
-    private static let maximumOutputLineBytes = 4 * 1024 * 1024
+    private static let defaultMaximumOutputLineBytes = 4 * 1024 * 1024
 
     private let process: Process
     private let inputChannel: DispatchIO
@@ -22,6 +22,8 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
     private var outputError: (any Error)?
     private var didReachOutputEOF = false
     private var pendingWrites: [UUID: CheckedContinuation<Void, any Error>] = [:]
+    private let baseMaximumOutputLineBytes: Int
+    private var maximumOutputLineBytes: Int
     private var isClosed = false
     private var stderrTail = Data()
     private let minimumConsumedOutputLinesBeforeCompaction = 256
@@ -33,7 +35,8 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
         executableURL: URL,
         arguments: [String] = ["app-server"],
         environment: [String: String]? = nil,
-        currentDirectoryURL: URL? = nil
+        currentDirectoryURL: URL? = nil,
+        baseMaximumOutputLineBytes: Int = CodexAppServerProcessTransport.defaultMaximumOutputLineBytes
     ) throws {
         let process = Process()
         let standardInput = Pipe()
@@ -81,6 +84,8 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
         try? errorHandle.close()
 
         self.process = process
+        self.baseMaximumOutputLineBytes = baseMaximumOutputLineBytes
+        maximumOutputLineBytes = baseMaximumOutputLineBytes
         inputChannel = DispatchIO(type: .stream, fileDescriptor: duplicatedInput, queue: ioQueue) { _ in
             Darwin.close(duplicatedInput)
         }
@@ -99,6 +104,12 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
     func sendLine(_ data: Data) async throws {
         guard !isClosed else { throw CodexAppServerError.processExited(stderrDescription) }
         startErrorDrainIfNeeded()
+        // app-server echoes user input in item lifecycle notifications. Allow one response line to
+        // wrap the largest request we have sent while retaining a fixed allowance for its envelope.
+        maximumOutputLineBytes = max(
+            maximumOutputLineBytes,
+            baseMaximumOutputLineBytes + data.count
+        )
         var line = data
         line.append(0x0A)
         let writeID = UUID()
@@ -276,7 +287,7 @@ actor CodexAppServerProcessTransport: CodexAppServerTransport {
     }
 
     private func appendToPendingLine(_ fragment: Data.SubSequence) -> Bool {
-        guard fragment.count <= Self.maximumOutputLineBytes - stdoutPending.count else {
+        guard fragment.count <= maximumOutputLineBytes - stdoutPending.count else {
             failOutputLineTooLarge()
             return false
         }

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -2062,7 +2062,7 @@ enum L10n {
     ) }
     static var codexInvalidResponse: String { String(localized: "Codex returned an invalid response.", bundle: bundle) }
     static var codexOutputLineTooLarge: String { String(
-        localized: "Codex returned an output line larger than Dahlia's 4 MiB safety limit.",
+        localized: "Codex returned an output line larger than Dahlia's safety limit.",
         bundle: bundle
     ) }
     static func codexRequestFailed(_ detail: String) -> String { String(

--- a/Tests/DahliaTests/CodexAppServerProcessTransportXCTests.swift
+++ b/Tests/DahliaTests/CodexAppServerProcessTransportXCTests.swift
@@ -169,6 +169,27 @@ import Foundation
         }
 
         @Test
+        func sentLineAllowsLargerWrappedEcho() async throws {
+            let baseMaximumOutputLineBytes = 64
+            let transport = try CodexAppServerProcessTransport(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: [
+                    "-c",
+                    "IFS= read -r line; printf '{\"echo\":\"%s\"}\\n' \"$line\"",
+                ],
+                baseMaximumOutputLineBytes: baseMaximumOutputLineBytes
+            )
+            let sentLine = Data(repeating: 0x61, count: baseMaximumOutputLineBytes + 1)
+
+            try await transport.sendLine(sentLine)
+            let response = try #require(await transport.receiveLine())
+            #expect(response.count > sentLine.count)
+            #expect(response.starts(with: Data(#"{"echo":""#.utf8)))
+            #expect(response.suffix(2) == Data(#""}"#.utf8))
+            await transport.close()
+        }
+
+        @Test
         func lineBeyondFourMiBLimitFailsClosed() async throws {
             let transport = try CodexAppServerProcessTransport(
                 executableURL: URL(fileURLWithPath: "/bin/sh"),
@@ -178,6 +199,26 @@ import Foundation
                 ]
             )
 
+            await #expect(throws: CodexAppServerError.outputLineTooLarge) {
+                _ = try await transport.receiveLine()
+            }
+            await transport.close()
+        }
+
+        @Test
+        func lineBeyondSentLineAllowanceFailsClosed() async throws {
+            let baseMaximumOutputLineBytes = 64
+            let transport = try CodexAppServerProcessTransport(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: [
+                    "-c",
+                    "head -c 8 >/dev/null; "
+                        + "dd if=/dev/zero bs=72 count=1 2>/dev/null",
+                ],
+                baseMaximumOutputLineBytes: baseMaximumOutputLineBytes
+            )
+
+            try await transport.sendLine(Data("request".utf8))
             await #expect(throws: CodexAppServerError.outputLineTooLarge) {
                 _ = try await transport.receiveLine()
             }

--- a/docs/adr/0019-pull-codex-stdout-with-backpressure.md
+++ b/docs/adr/0019-pull-codex-stdout-with-backpressure.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted; supersedes 0013, amends 0003
+Accepted; supersedes 0013, amends 0003; amended by 0020
 
 ## Date
 

--- a/docs/adr/0020-bound-codex-output-relative-to-client-input.md
+++ b/docs/adr/0020-bound-codex-output-relative-to-client-input.md
@@ -1,0 +1,53 @@
+# ADR 0020: Codex stdout の単一行上限をclient入力に応じて拡張する
+
+## Status
+
+Accepted; amends 0019 and 0003
+
+## Date
+
+2026-08-03
+
+## Context
+
+[ADR 0019](0019-pull-codex-stdout-with-backpressure.md) は、改行のない壊れたstdoutによる無制限なメモリ使用を防ぐため、
+単一JSONL行へ4 MiBの固定上限を導入した。しかしCodex app-serverは、`turn/start`で受け取ったuser inputを
+`item/started`と`item/completed`のuser messageとしてclientへエコーする。
+
+Dahliaの要約とチャットは画像をbase64 data URIとして同じJSONL requestへ含める。複数画像を含む正常なrequestと、
+それを包むitem lifecycle notificationは4 MiBを超えうる。固定上限はframing異常ではない正常なnotificationを拒否し、
+共有接続と進行中turnを `outputLineTooLarge` で失敗させていた。
+
+一方、上限を削除すると、子プロセスが改行を返さない場合の保持量が再び入力に比例して無制限になる。clientが送信した
+入力のエコーを受理しつつ、接続ごとの明示的な上限を維持する必要がある。
+
+## Decision
+
+- 単一JSONL行の基本上限は4 MiBのまま維持する。
+- 接続中にclientが送信した最大JSONL行のbyte数を基本上限へ加え、その値を接続中の単一出力行上限とする。
+- 上限は送信開始前にactor内で単調増加させ、app-serverが入力を即座にエコーしても先に失敗しないようにする。
+- 上限を超えたstdoutはADR 0019と同様に停止し、待機中readerを `outputLineTooLarge` で失敗させて共有接続を破棄する。
+- requestおよびresponse本文、画像data URI、算出した上限値はログまたはSentryへ送らない。
+
+## Consequences
+
+- 大容量のclient入力を包む正常なitem lifecycle notificationを受理できる。
+- 接続中の保持上限は「4 MiB + 送信済み最大JSONL行」に限定され、無制限なread-aheadは再導入しない。
+- 一度大きなrequestを送ると、その接続が終了するまで上限は縮小しない。上限値だけを保持し、request本文は追加保持しない。
+- client入力に由来しない異常なstdoutが動的上限を超えた場合は、従来どおり進行中turnを含む共有接続が失敗する。
+
+## Alternatives considered
+
+### 固定上限だけを拡張する
+
+正常な入力サイズに根拠づけられず、値を超える有効な画像requestで再発する。必要以上に大きな固定値は小さなrequestしか
+送っていない接続でも同じメモリ量を許容するため採用しない。
+
+### 単一行上限を削除する
+
+改行のない壊れたstdoutを入力サイズに関係なく保持し続けるため採用しない。
+
+### 画像を一時ファイル参照へ変更する
+
+wire上のdata URIは削減できるが、要約とチャットの入力契約、temporary fileの所有権、cleanup、sandbox accessを同時に
+変更する必要がある。client入力のエコーという一般的なprotocol特性への対策にならないため、この修正には含めない。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,7 +13,7 @@ Codex は全 ADR を順番に読まず、最初にこの一覧から現在の作
 | --- | --- | --- | --- |
 | [0001](0001-summary-document-ast.md) | Summary | `SummaryDocument` AST をサマリーの正準表現にする | Accepted |
 | [0002](0002-isolate-recording-critical-path-from-main-actor.md) | Recording / Concurrency | 録音と確定データの保存を MainActor の UI projection から分離する | Accepted; partially superseded by 0006 and 0009 |
-| [0003](0003-use-a-shared-codex-app-server.md) | AI runtime | Codex app-server をアプリ共有の長寿命 backend として使う | Accepted; amended by 0013, 0015, and 0019 |
+| [0003](0003-use-a-shared-codex-app-server.md) | AI runtime | Codex app-server をアプリ共有の長寿命 backend として使う | Accepted; amended by 0013, 0015, 0019, and 0020 |
 | [0004](0004-protect-recordings-with-segmented-immutable-storage.md) | Recording storage | 録音データを分割された immutable segment として保全する | Accepted |
 | [0005](0005-vault-scoped-meeting-access-mcp.md) | Meeting access | Vault 固定・read-only の local MCP で meeting data を公開する | Accepted; amended by 0010 |
 | [0006](0006-bounded-transcript-projection.md) | Transcript UI | SQLite を正本とし、文字起こし表示を bounded projection と keyset pagination にする | Accepted; partially supersedes 0002 |
@@ -29,4 +29,5 @@ Codex は全 ADR を順番に読まず、最初にこの一覧から現在の作
 | [0016](0016-shared-organization-domains.md) | Customer intelligence / Identity | 同じメールドメインを複数のルート組織で共有可能にする | Accepted; amends 0011 and 0014 |
 | [0017](0017-preset-customer-intelligence-skills.md) | AI runtime / Customer intelligence | 顧客インテリジェンスの curator skill を層ごとに分けてプリセットする | Accepted; amends 0015, builds on 0011 and 0012 |
 | [0018](0018-mcp-meeting-summary-update.md) | Summary / Meeting access | サマリーの訂正を MCP のドキュメント全体置換で行う | Accepted; amends 0005 and 0010, builds on 0001 |
-| [0019](0019-pull-codex-stdout-with-backpressure.md) | AI runtime | Codex stdout を64 KiB単位で需要駆動読み取りする | Accepted; supersedes 0013, amends 0003 |
+| [0019](0019-pull-codex-stdout-with-backpressure.md) | AI runtime | Codex stdout を64 KiB単位で需要駆動読み取りする | Accepted; supersedes 0013, amends 0003; amended by 0020 |
+| [0020](0020-bound-codex-output-relative-to-client-input.md) | AI runtime | Codex stdout の単一行上限をclient入力に応じて拡張する | Accepted; amends 0019 and 0003 |


### PR DESCRIPTION
## Summary

- scale the Codex stdout line limit relative to the largest JSONL request sent on the shared connection
- keep the existing 4 MiB baseline and fail-closed behavior for output beyond the dynamic allowance
- update the localized error message and add regression coverage for wrapped input echoes and the dynamic boundary
- document the amended runtime decision in ADR 0020 without rewriting ADR 0019 history

## Root cause

PR #221 introduced a fixed 4 MiB stdout line limit while fixing unbounded callback accumulation. Codex app-server echoes user input in item lifecycle notifications, and Dahlia can include screenshots as base64 data URIs in that input. A valid echoed notification could therefore exceed the fixed limit and fail one-shot summary generation with `outputLineTooLarge`.

## User impact

One-shot summaries and chat requests containing large image input can complete normally while malformed or unrelated oversized stdout remains bounded.

## Validation

- `swift test --filter CodexAppServerProcessTransportTests` — 14 tests passed
- `swift test` — 1,320 Swift Testing tests and 3 XCTest tests passed
- `CI=true ./scripts/lint.sh` — SwiftFormat clean; SwiftLint reported existing non-blocking violations only
- `git diff --check`
