### PR TITLE
Fix chat thinking indicator order

### DIFF
--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel+Submission.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel+Submission.swift
@@ -54,7 +54,9 @@ extension CodexChatSessionModel {
         }
         prepareFailureStateForSubmission(liveTranscript: liveTranscript)
         isGenerating = true
-        isAwaitingTurnOutput = true
+        isPreparingTurn = liveTranscript == nil
+        isAwaitingTurnOutput = liveTranscript != nil
+        preparingManualComposerSnapshot = liveTranscript == nil ? composerSnapshot : nil
         errorMessage = nil
         isActiveTurnLiveTranscript = liveTranscript != nil
         let isLiveModeSnapshot = liveTranscript != nil || isLiveModeEnabled

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -25,6 +25,7 @@ final class CodexChatSessionModel: Identifiable {
     var errorMessage: String?
     var noticeMessage: String?
     private(set) var activeTurnID: String?
+    var isPreparingTurn = false
     var isAwaitingTurnOutput = false
     var lastSubmittedText: String?
     var attachedImages: [CodexChatImageAttachment] = []
@@ -53,6 +54,7 @@ final class CodexChatSessionModel: Identifiable {
     @ObservationIgnored private var pendingLiveTranscript: String?
     @ObservationIgnored private var didTruncatePendingLiveTranscript = false
     @ObservationIgnored var pendingManualInputs: [CodexChatManualSubmission] = []
+    @ObservationIgnored var preparingManualComposerSnapshot: CodexChatComposerSnapshot?
     @ObservationIgnored var lastManualSubmission: CodexChatManualSubmission?
     @ObservationIgnored var isActiveTurnLiveTranscript = false
     @ObservationIgnored var didSendLiveModeContext = false
@@ -170,7 +172,8 @@ final class CodexChatSessionModel: Identifiable {
             composerSnapshot: composerSnapshot
         )
         if isGenerating {
-            let isDuplicate = activeSteeringManualSubmission?.composerSnapshot == composerSnapshot
+            let isDuplicate = preparingManualComposerSnapshot == composerSnapshot
+                || activeSteeringManualSubmission?.composerSnapshot == composerSnapshot
                 || pendingManualInputs.contains(where: { $0.composerSnapshot == composerSnapshot })
             guard !isDuplicate else { return }
             enqueueManualInput(submission)
@@ -343,7 +346,7 @@ extension CodexChatSessionModel {
                 model: selectedModelID.nilIfBlank,
                 effort: selectedEffort
             )
-            var replacedLiveModePlaceholderTitle = false
+            var replacementTitleText: String?
             if liveTranscript == nil {
                 let submission = CodexChatManualSubmission(text: text ?? "", images: images)
                 clearComposer(ifMatching: composerSnapshot)
@@ -355,11 +358,18 @@ extension CodexChatSessionModel {
                     context: context,
                     images: images
                 ))
-                let titleText = submission.text.nilIfBlank ?? L10n.chatImage
-                replacedLiveModePlaceholderTitle = await replaceLiveModePlaceholderTitleIfNeeded(with: titleText)
+                replacementTitleText = submission.text.nilIfBlank ?? L10n.chatImage
             }
             messages.append(CodexChatMessage(id: responseID, role: .assistant, text: "", isStreaming: true))
             activeResponseID = responseID
+            isAwaitingTurnOutput = true
+            isPreparingTurn = false
+            preparingManualComposerSnapshot = nil
+            let replacedLiveModePlaceholderTitle = if let replacementTitleText {
+                await replaceLiveModePlaceholderTitleIfNeeded(with: replacementTitleText)
+            } else {
+                false
+            }
             if liveModeState.includesContext,
                isLiveModeEnabled,
                liveModeGeneration == liveModeState.generation {
@@ -546,6 +556,8 @@ extension CodexChatSessionModel {
     ) {
         guard activeSubmissionID == submissionID else { return }
         isGenerating = false
+        isPreparingTurn = false
+        preparingManualComposerSnapshot = nil
         activeOutputItemIDs.removeAll()
         isAwaitingTurnOutput = false
         activeTurnID = nil
@@ -868,9 +880,6 @@ extension CodexChatSessionModel {
         context: CodexChatContext?,
         awaitsOutput: Bool
     ) async {
-        if awaitsOutput {
-            isAwaitingTurnOutput = true
-        }
         switch input {
         case let .manual(submission):
             clearComposer(ifMatching: submission.composerSnapshot)
@@ -880,8 +889,14 @@ extension CodexChatSessionModel {
                 context: context,
                 images: submission.images
             ))
+            if awaitsOutput {
+                isAwaitingTurnOutput = true
+            }
             _ = await replaceLiveModePlaceholderTitleIfNeeded(with: submission.text.nilIfBlank ?? L10n.chatImage)
         case let .liveTranscript(_, wasTruncated):
+            if awaitsOutput {
+                isAwaitingTurnOutput = true
+            }
             if wasTruncated {
                 noticeMessage = L10n.chatLiveTranscriptBacklogTruncated
             }

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -346,6 +346,7 @@ extension CodexChatSessionModel {
                 model: selectedModelID.nilIfBlank,
                 effort: selectedEffort
             )
+            try ensureSubmissionCanContinue(submissionID, liveTranscript: liveTranscript)
             var replacementTitleText: String?
             if liveTranscript == nil {
                 let submission = CodexChatManualSubmission(text: text ?? "", images: images)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
@@ -65,7 +65,7 @@ struct CodexChatComposerInputRow: View {
                 CodexChatConfigurationButton(session: session)
             }
 
-            if session.isGenerating, !session.canSend {
+            if session.isGenerating, session.isPreparingTurn || !session.canSend {
                 CodexChatActionButton(
                     label: L10n.stopGenerating,
                     systemImage: "stop.fill",

--- a/Tests/DahliaTests/CodexChatImageSessionTests.swift
+++ b/Tests/DahliaTests/CodexChatImageSessionTests.swift
@@ -20,6 +20,7 @@ import Foundation
             session.sendDraft()
             await waitUntil { !session.isGenerating }
 
+            #expect(!session.isPreparingTurn)
             #expect(session.attachedImages.count == 1)
             let firstInputs = await service.sentInputs
             #expect(firstInputs.count == 1)

--- a/Tests/DahliaTests/CodexChatSessionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatSessionModelTests.swift
@@ -709,6 +709,7 @@ import Foundation
         private(set) var threadNames: [String] = []
         private(set) var interruptCount = 0
         private(set) var unsubscribedThreadIDs: [String] = []
+        private(set) var returnedSendCount = 0
         private var blockedContinuation: AsyncThrowingStream<CodexChatTurnEvent, any Error>.Continuation?
         private var delayedSendContinuation: CheckedContinuation<Void, Never>?
         private var delayedLoadContinuation: CheckedContinuation<Void, Never>?
@@ -808,6 +809,7 @@ import Foundation
                     delayedSendContinuation = continuation
                 }
             }
+            returnedSendCount += 1
             if mode == .failThenComplete, sentTextBlocks.count == 1 {
                 throw CodexAppServerError.invalidProtocolResponse
             }
@@ -951,6 +953,10 @@ import Foundation
             shouldBlock = false
             continuation?.resume()
             continuation = nil
+        }
+
+        func block() {
+            shouldBlock = true
         }
     }
 

--- a/Tests/DahliaTests/CodexChatSessionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatSessionModelTests.swift
@@ -435,6 +435,7 @@ import Foundation
             await waitUntil { !session.isGenerating }
 
             #expect(session.draft == "Keep this")
+            #expect(!session.isPreparingTurn)
             #expect(session.messages.isEmpty)
             #expect(session.errorMessage != nil)
             #expect(session.lastSubmittedText == "Keep this")
@@ -687,6 +688,7 @@ import Foundation
         enum Mode {
             case complete
             case block
+            case blockBeforeOutput
             case burstThenBlock
             case bufferedBurstThenInterrupt
             case finishesWithoutTerminal
@@ -748,7 +750,7 @@ import Foundation
                 }
             }
             let assistantMessages: [CodexChatMessage] = switch mode {
-            case .complete, .block, .burstThenBlock, .bufferedBurstThenInterrupt,
+            case .complete, .block, .blockBeforeOutput, .burstThenBlock, .bufferedBurstThenInterrupt,
                  .finishesWithoutTerminal, .interruptedThenBlock, .failThenComplete, .alwaysFail,
                  .delayFirstSendIgnoringCancellation:
                 [CodexChatMessage(role: .assistant, text: "Final answer", reasoning: "Considered the question")]
@@ -829,6 +831,8 @@ import Foundation
                 continuation.finish()
             case .block:
                 continuation.yield(.delta(itemID: "item-1", text: "Partial"))
+                blockedContinuation = continuation
+            case .blockBeforeOutput:
                 blockedContinuation = continuation
             case .burstThenBlock:
                 continuation.yield(.delta(itemID: "item-1", text: "First"))

--- a/Tests/DahliaTests/CodexChatThinkingPresentationTests.swift
+++ b/Tests/DahliaTests/CodexChatThinkingPresentationTests.swift
@@ -129,6 +129,44 @@ import Foundation
         }
 
         @Test
+        func staleSendCannotReplaceNewPreparationState() async {
+            let service = TestCodexChatService(mode: .delayFirstSendIgnoringCancellation)
+            let settings = AppSettings()
+            settings.currentVault = Self.testVault()
+            let contextProvider = TestCodexChatContextProvider()
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings,
+                contextProvider: contextProvider
+            )
+            session.draft = "Old question"
+
+            session.sendDraft()
+            await waitUntilAsync { await service.isSendWaiting }
+            session.stop()
+
+            contextProvider.block()
+            session.draft = "New question"
+            session.sendDraft()
+            await waitUntil { contextProvider.requestCount == 2 }
+            await service.resumeDelayedSend()
+            await waitUntilAsync { await service.returnedSendCount == 1 }
+
+            #expect(session.isPreparingTurn)
+            #expect(!session.showsStandaloneThinking)
+            #expect(session.draft == "New question")
+            #expect(session.messages.isEmpty)
+
+            session.sendDraft()
+            #expect(session.pendingManualInputs.isEmpty)
+
+            session.stop()
+            contextProvider.resume()
+        }
+
+        @Test
         func completedReasoningDoesNotShowThinkingWhileResponseStreams() async {
             let service = TestCodexChatService(mode: .block)
             let settings = AppSettings()

--- a/Tests/DahliaTests/CodexChatThinkingPresentationTests.swift
+++ b/Tests/DahliaTests/CodexChatThinkingPresentationTests.swift
@@ -8,7 +8,7 @@ import Foundation
     struct CodexChatThinkingPresentationTests {
         @Test
         func standaloneThinkingHandsOffToActiveResponse() async {
-            let service = TestCodexChatService(mode: .block)
+            let service = TestCodexChatService(mode: .blockBeforeOutput)
             let settings = AppSettings()
             settings.currentVault = Self.testVault()
             let contextProvider = TestCodexChatContextProvider(shouldBlock: true)
@@ -23,9 +23,28 @@ import Foundation
 
             session.sendDraft()
             await waitUntil { contextProvider.requestCount == 1 }
-            #expect(session.showsStandaloneThinking)
+            #expect(session.isPreparingTurn)
+            #expect(session.messages.isEmpty)
+            #expect(!session.showsStandaloneThinking)
 
             contextProvider.resume()
+            await waitUntil { session.activeTurnID != nil }
+            #expect(!session.isPreparingTurn)
+            #expect(session.showsStandaloneThinking)
+            let waitingItems = CodexChatConversationItem.build(
+                from: session.messages,
+                showsStandaloneThinking: session.showsStandaloneThinking
+            )
+            #expect(waitingItems.count == 2)
+            if case let .message(message) = waitingItems.first {
+                #expect(message.role == .user)
+                #expect(message.text == "Question")
+            } else {
+                Issue.record("Expected the user message before the thinking indicator")
+            }
+            #expect(waitingItems.last == .thinking)
+
+            await service.yieldBlockedEvent(.delta(itemID: "item-1", text: "Partial"))
             await waitUntil { session.messages.last?.text == "Partial" }
             #expect(!session.showsStandaloneThinking)
 
@@ -52,6 +71,61 @@ import Foundation
             session.stop()
             await waitUntil { !session.isGenerating }
             #expect(!session.showsStandaloneThinking)
+        }
+
+        @Test
+        func liveTranscriptShowsThinkingDuringContextResolution() async {
+            let service = TestCodexChatService(mode: .complete)
+            let settings = AppSettings()
+            settings.currentVault = Self.testVault()
+            let contextProvider = TestCodexChatContextProvider(shouldBlock: true)
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings,
+                contextProvider: contextProvider
+            )
+
+            session.toggleLiveMode()
+            session.receiveFinalizedLiveTranscript("Live speech")
+            await waitUntil { contextProvider.requestCount == 1 }
+
+            #expect(!session.isPreparingTurn)
+            #expect(session.messages.isEmpty)
+            #expect(session.showsStandaloneThinking)
+
+            session.stop()
+            await waitUntil { !session.isGenerating }
+            contextProvider.resume()
+        }
+
+        @Test
+        func repeatedManualSubmitWhilePreparingIsIgnored() async {
+            let service = TestCodexChatService(mode: .complete)
+            let settings = AppSettings()
+            settings.currentVault = Self.testVault()
+            let contextProvider = TestCodexChatContextProvider(shouldBlock: true)
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings,
+                contextProvider: contextProvider
+            )
+            session.draft = "Question"
+
+            session.sendDraft()
+            await waitUntil { contextProvider.requestCount == 1 }
+            #expect(session.isPreparingTurn)
+
+            session.sendDraft()
+            #expect(session.pendingManualInputs.isEmpty)
+
+            contextProvider.resume()
+            await waitUntil { !session.isGenerating }
+            #expect(await service.sentTextBlocks == [["Question"]])
+            #expect(session.messages.filter { $0.role == .user }.map(\.text) == ["Question"])
         }
 
         @Test


### PR DESCRIPTION
## Summary
- keep Thinking hidden while a manual turn is preparing
- show the stop action during preparation and place Thinking after the user message
- preserve immediate Thinking feedback for live transcripts
- prevent identical manual submissions from being queued twice during preparation

## Root cause
The awaiting-output state was enabled before context resolution and stream setup completed, so the standalone indicator rendered before the user message had been appended.

## Impact
Manual chat submissions now render in user-message then Thinking order without changing live-mode feedback or follow-up input behavior.

## Validation
- swift build
- swift test: 1322 tests in 203 Swift Testing suites plus 3 XCTest tests
- CodexChatThinkingPresentationTests: 5 tests
- CI=true ./scripts/lint.sh
- git diff --check