### PR TITLE
Recover expired Databricks authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A macOS native real-time transcription app. Captures microphone and system audio
 - Swift 6.2
 - Xcode 26+ (for Swift toolchain)
 
-Dahlia keeps its bundled Codex state and authentication separate from other Codex apps and the Codex CLI. In **Settings → AI Connection**, choose either a ChatGPT Subscription or an OAuth profile created by `databricks auth login`. The ChatGPT login is stored under Dahlia's Application Support directory; Databricks tokens remain managed by Databricks CLI.
+Dahlia keeps its bundled Codex state and authentication separate from other Codex apps and the Codex CLI. In **Settings → AI Connection**, choose either a ChatGPT Subscription or an OAuth profile created by `databricks auth login`. The ChatGPT login is stored under Dahlia's Application Support directory; Databricks tokens remain managed by Databricks CLI. Before loading Databricks-backed models or chat data and before starting summary or chat generation, Dahlia validates the selected profile and opens the Databricks CLI browser login when its cached authentication has expired.
 
 Automatic batch transcription downloads the pinned multilingual WhisperKit `tiny` model and tokenizer on first use and caches them in Dahlia's Application Support directory. Language detection and transcription run on-device; recording audio is not uploaded.
 

--- a/Sources/Dahlia/Services/CodexAppServerService+Authentication.swift
+++ b/Sources/Dahlia/Services/CodexAppServerService+Authentication.swift
@@ -1,6 +1,131 @@
 import Foundation
 
 extension CodexAppServerService {
+    func prepareProviderAuthentication() async throws {
+        guard !isShuttingDown else { throw CancellationError() }
+
+        if let state = providerAuthenticationPreparationState, state.waiters.isEmpty {
+            do {
+                try await Self.waitCancellably(for: state.task)
+            } catch {
+                try Task.checkCancellation()
+            }
+            finishProviderAuthenticationPreparation(state.id)
+            return try await prepareProviderAuthentication()
+        }
+
+        let waiterID = UUID()
+        let preparationID: UUID
+        let task: Task<Void, Error>
+        if var state = providerAuthenticationPreparationState {
+            state.waiters.insert(waiterID)
+            providerAuthenticationPreparationState = state
+            preparationID = state.id
+            task = state.task
+        } else {
+            preparationID = UUID()
+            let preparation = providerAuthenticationPreparation
+            task = Task { [weak self] in
+                guard let self else { throw CancellationError() }
+                let requiresReload = try await preparation { [self] in
+                    await markProviderAuthenticationReloadRequired()
+                }
+                if requiresReload {
+                    await markProviderAuthenticationReloadRequired()
+                }
+                if await providerAuthenticationReloadRequired {
+                    try await reloadConfiguration()
+                }
+            }
+            providerAuthenticationPreparationState = ProviderAuthenticationPreparationState(
+                id: preparationID,
+                task: task,
+                waiters: [waiterID]
+            )
+            Task { [weak self] in
+                _ = await task.result
+                await self?.finishProviderAuthenticationPreparation(preparationID)
+            }
+        }
+
+        do {
+            try await withTaskCancellationHandler {
+                try await Self.waitCancellably(for: task)
+            } onCancel: {
+                Task { await self.cancelProviderAuthenticationWaiter(waiterID, preparationID: preparationID) }
+            }
+            finishProviderAuthenticationWaiter(waiterID, preparationID: preparationID)
+            finishProviderAuthenticationPreparation(preparationID)
+            try Task.checkCancellation()
+        } catch {
+            if Task.isCancelled {
+                cancelProviderAuthenticationWaiter(waiterID, preparationID: preparationID)
+            } else {
+                finishProviderAuthenticationWaiter(waiterID, preparationID: preparationID)
+                finishProviderAuthenticationPreparation(preparationID)
+            }
+            throw error
+        }
+    }
+
+    nonisolated static func prepareConfiguredDatabricksAuthentication(
+        authenticationMayChange: @Sendable () async -> Void
+    ) async throws -> Bool {
+        let profileName = await MainActor.run { () -> String? in
+            let settings = AppSettings.shared
+            guard settings.codexAccountProvider == .databricks,
+                  settings.isCodexAccountConfigurationCurrent
+            else { return nil }
+            return settings.codexDatabricksProfile.nilIfBlank
+        }
+        guard let profileName else { return false }
+
+        let result = try await DatabricksCLIClient().ensureAuthenticated(
+            profileName: profileName,
+            onBrowserLoginRequired: authenticationMayChange
+        )
+        return result == .browserLoginCompleted
+    }
+
+    func markProviderAuthenticationReloadRequired() {
+        providerAuthenticationReloadRequired = true
+    }
+
+    private func cancelProviderAuthenticationWaiter(_ waiterID: UUID, preparationID: UUID) {
+        guard var state = providerAuthenticationPreparationState,
+              state.id == preparationID,
+              state.waiters.remove(waiterID) != nil
+        else { return }
+
+        if state.waiters.isEmpty {
+            state.task.cancel()
+        }
+        providerAuthenticationPreparationState = state
+    }
+
+    private func finishProviderAuthenticationWaiter(_ waiterID: UUID, preparationID: UUID) {
+        guard var state = providerAuthenticationPreparationState,
+              state.id == preparationID
+        else { return }
+
+        state.waiters.remove(waiterID)
+        providerAuthenticationPreparationState = state
+    }
+
+    private func finishProviderAuthenticationPreparation(_ preparationID: UUID) {
+        guard providerAuthenticationPreparationState?.id == preparationID else { return }
+        providerAuthenticationPreparationState = nil
+    }
+
+    private nonisolated static func waitCancellably(for task: Task<Void, Error>) async throws {
+        let waiter = ProviderAuthenticationPreparationWaiter()
+        Task {
+            let result = await task.result
+            await waiter.finish(with: result)
+        }
+        try await waiter.wait()
+    }
+
     nonisolated static func isAuthenticationRPCError(
         data: JSONValue?,
         message: String,
@@ -37,5 +162,31 @@ extension CodexAppServerService {
         let message = rawMessage.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard message.hasPrefix("unexpected status 401 unauthorized:") else { return false }
         return message.contains("credential was not sent or was of an unsupported type for this api.")
+    }
+}
+
+private actor ProviderAuthenticationPreparationWaiter {
+    private var continuation: CheckedContinuation<Void, Error>?
+    private var result: Result<Void, Error>?
+
+    func wait() async throws {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if let result {
+                    continuation.resume(with: result)
+                } else {
+                    self.continuation = continuation
+                }
+            }
+        } onCancel: {
+            Task { await self.finish(with: .failure(CancellationError())) }
+        }
+    }
+
+    func finish(with result: Result<Void, Error>) {
+        guard self.result == nil else { return }
+        self.result = result
+        continuation?.resume(with: result)
+        continuation = nil
     }
 }

--- a/Sources/Dahlia/Services/CodexAppServerService.swift
+++ b/Sources/Dahlia/Services/CodexAppServerService.swift
@@ -8,6 +8,9 @@ import OSLog
 actor CodexAppServerService {
     typealias TransportFactory = @Sendable () throws -> any CodexAppServerTransport
     typealias ConfigurationReadiness = @Sendable () async -> Bool
+    typealias ProviderAuthenticationPreparation = @Sendable (
+        _ authenticationMayChange: @Sendable () async -> Void
+    ) async throws -> Bool
 
     struct AccountStatus: Equatable {
         let isAuthenticated: Bool
@@ -49,6 +52,12 @@ actor CodexAppServerService {
         var didSendInterrupt = false
     }
 
+    struct ProviderAuthenticationPreparationState {
+        let id: UUID
+        let task: Task<Void, Error>
+        var waiters: Set<UUID>
+    }
+
     private enum LoginOutcome {
         case succeeded
         case failed(String?)
@@ -59,6 +68,7 @@ actor CodexAppServerService {
     private let clock: any CodexAppServerClock
     private let transportTimeout: Duration
     private let summaryTimeout: Duration
+    let providerAuthenticationPreparation: ProviderAuthenticationPreparation
     private let logger = Logger(subsystem: "com.dahlia", category: "CodexAppServer")
     private var transport: (any CodexAppServerTransport)?
     private var readerTask: Task<Void, Never>?
@@ -71,6 +81,11 @@ actor CodexAppServerService {
     private var startupWaiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
     private var generations: [UUID: GenerationContext] = [:]
     private var generationDrainWaiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
+    private var activeCodexOperations: Set<UUID> = []
+    private var codexOperationDrainWaiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
+    private var pendingChatTurnStarts: Set<UUID> = []
+    private var chatTurnDrainWaiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
+    private var configurationReloadWaiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
     private var cachedModels: [CodexModel]?
     private var cachedAccountStatus: AccountStatus?
     private var cachedConfigReadResult: JSONValue?
@@ -80,12 +95,16 @@ actor CodexAppServerService {
     private var ignoredLoginIDs: Set<String> = []
     private var isStarting = false
     private var isStoppingConnection = false
+    private var isConfigurationReloading = false
     private var connectionStopWaiters: [UUID: CheckedContinuation<Void, Never>] = [:]
     private var isInitialized = false
-    private var isShuttingDown = false
+    var isShuttingDown = false
+    var providerAuthenticationReloadRequired = false
+    var providerAuthenticationPreparationState: ProviderAuthenticationPreparationState?
     #if DEBUG
         private var activeTurnTestWaiters: [CheckedContinuation<Void, Never>] = []
         private var generationDrainTestWaiters: [CheckedContinuation<Void, Never>] = []
+        private var chatTurnDrainTestWaiters: [CheckedContinuation<Void, Never>] = []
     #endif
 
     init(
@@ -93,6 +112,8 @@ actor CodexAppServerService {
         clock: any CodexAppServerClock = ContinuousCodexAppServerClock(),
         transportTimeout: Duration = .seconds(15),
         summaryTimeout: Duration = .seconds(270),
+        providerAuthenticationPreparation: @escaping ProviderAuthenticationPreparation =
+            CodexAppServerService.prepareConfiguredDatabricksAuthentication,
         configurationReadiness: @escaping ConfigurationReadiness = {
             await MainActor.run { AppSettings.shared.isCodexAccountConfigurationCurrent }
         }
@@ -102,6 +123,7 @@ actor CodexAppServerService {
         self.clock = clock
         self.transportTimeout = transportTimeout
         self.summaryTimeout = summaryTimeout
+        self.providerAuthenticationPreparation = providerAuthenticationPreparation
     }
 
     init(
@@ -109,6 +131,7 @@ actor CodexAppServerService {
         clock: any CodexAppServerClock = ContinuousCodexAppServerClock(),
         transportTimeout: Duration = .seconds(15),
         summaryTimeout: Duration = .seconds(270),
+        providerAuthenticationPreparation: @escaping ProviderAuthenticationPreparation = { _ in false },
         configurationReadiness: @escaping ConfigurationReadiness = { true }
     ) {
         self.transportFactory = transportFactory
@@ -116,6 +139,7 @@ actor CodexAppServerService {
         self.clock = clock
         self.transportTimeout = transportTimeout
         self.summaryTimeout = summaryTimeout
+        self.providerAuthenticationPreparation = providerAuthenticationPreparation
     }
 
     func start() async throws {
@@ -146,20 +170,40 @@ actor CodexAppServerService {
 
     func shutdown() async {
         isShuttingDown = true
+        providerAuthenticationPreparationState?.task.cancel()
+        providerAuthenticationPreparationState = nil
         cachedModels = nil
         cachedAccountStatus = nil
         await stopConnection(error: CancellationError())
         resumeStartupWaiters(throwing: CancellationError())
         resumeGenerationDrainWaiters(throwing: CancellationError())
+        resumeCodexOperationDrainWaiters(throwing: CancellationError())
+        resumeChatTurnDrainWaiters(throwing: CancellationError())
+        resumeConfigurationReloadWaiters(throwing: CancellationError())
         isStarting = false
     }
 
     func reloadConfiguration() async throws {
         guard !isShuttingDown else { throw CancellationError() }
-        try await waitForGenerationsToFinish()
-        await stopConnection(error: CancellationError())
-        try Task.checkCancellation()
-        try await start()
+        if isConfigurationReloading {
+            try await waitForConfigurationReloadToFinish()
+            return
+        }
+
+        isConfigurationReloading = true
+        do {
+            try await waitForCodexOperationsToFinish()
+            try await waitForGenerationsToFinish()
+            try await waitForChatTurnsToFinish()
+            await stopConnection(error: CancellationError())
+            try Task.checkCancellation()
+            try await start()
+            providerAuthenticationReloadRequired = false
+            finishConfigurationReload()
+        } catch {
+            finishConfigurationReload(throwing: error)
+            throw error
+        }
     }
 
     func request(
@@ -177,11 +221,20 @@ actor CodexAppServerService {
 
     func models(
         forceRefresh: Bool = false,
-        bypassConfigurationCheck: Bool = false
+        bypassConfigurationCheck: Bool = false,
+        bypassProviderAuthenticationPreparation: Bool = false,
+        bypassConfigurationReloadAdmission: Bool = false
     ) async throws -> [CodexModel] {
+        if !bypassProviderAuthenticationPreparation {
+            try await prepareProviderAuthentication()
+        }
         if !bypassConfigurationCheck {
             try await requireCurrentConfiguration()
         }
+        let operationID = try await beginCodexOperation(
+            bypassingAdmission: bypassConfigurationReloadAdmission
+        )
+        defer { finishCodexOperation(operationID) }
         let account = try await accountStatus(forceRefresh: false)
         guard account.canUseCodex else { throw CodexAppServerError.notLoggedIn }
         if !forceRefresh, let cachedModels { return cachedModels }
@@ -325,13 +378,47 @@ actor CodexAppServerService {
         }
     }
 
+    func startChatTurn(
+        threadID: String,
+        params: JSONValue
+    ) async throws -> (turnID: String, notifications: AsyncThrowingStream<JSONValue, any Error>) {
+        try await waitForConfigurationReloadToFinish()
+        let startID = UUID()
+        pendingChatTurnStarts.insert(startID)
+        defer {
+            pendingChatTurnStarts.remove(startID)
+            resumeChatTurnDrainWaitersIfIdle()
+        }
+        try await start()
+        let generation = connectionGeneration
+        let result = try await requestOnCurrentConnection(
+            method: "turn/start",
+            params: params,
+            timeout: transportTimeout
+        )
+        guard generation == connectionGeneration else { throw CancellationError() }
+        guard let turnID = result.objectValue?["turn"]?.objectValue?["id"]?.stringValue else {
+            throw CodexAppServerError.invalidProtocolResponse
+        }
+        return (turnID, notifications(threadID: threadID, turnID: turnID))
+    }
+
     // swiftformat:disable:next modifierOrder
     nonisolated private static func isTurnCompletionMessage(_ message: JSONValue) -> Bool {
         message.objectValue?["method"]?.stringValue == "turn/completed"
     }
 
-    func chatThreadConfiguration(reasoningEffort: String, vaultID: UUID, helperURL: URL) async throws -> JSONValue {
+    func chatThreadConfiguration(
+        reasoningEffort: String,
+        vaultID: UUID,
+        helperURL: URL,
+        bypassConfigurationReloadAdmission: Bool = false
+    ) async throws -> JSONValue {
         try await requireCurrentConfiguration()
+        let operationID = try await beginCodexOperation(
+            bypassingAdmission: bypassConfigurationReloadAdmission
+        )
+        defer { finishCodexOperation(operationID) }
         let configuration = try await configReadResult()
         return try Self.chatThreadConfig(
             from: configuration,
@@ -341,13 +428,36 @@ actor CodexAppServerService {
         )
     }
 
+    func chatRequest(
+        method: String,
+        params: JSONValue,
+        bypassConfigurationReloadAdmission: Bool = false
+    ) async throws -> JSONValue {
+        let operationID = try await beginCodexOperation(
+            bypassingAdmission: bypassConfigurationReloadAdmission
+        )
+        defer { finishCodexOperation(operationID) }
+        return try await request(method: method, params: params)
+    }
+
+    func withChatOperation<Result: Sendable>(
+        _ operation: @Sendable (isolated CodexAppServerService) async throws -> Result
+    ) async throws -> Result {
+        try await prepareProviderAuthentication()
+        let operationID = try await beginCodexOperation()
+        defer { finishCodexOperation(operationID) }
+        return try await operation(self)
+    }
+
     func generate(
         _ request: CodexAppServerRequest,
         bypassConfigurationCheck: Bool = false
     ) async throws -> String {
+        try await prepareProviderAuthentication()
         if !bypassConfigurationCheck {
             try await requireCurrentConfiguration()
         }
+        try await waitForConfigurationReloadToFinish()
         let generationID = UUID()
         generations[generationID] = GenerationContext()
 
@@ -549,7 +659,10 @@ private extension CodexAppServerService {
 
         let account = try await accountStatus(forceRefresh: false)
         guard account.canUseCodex else { throw CodexAppServerError.notLoggedIn }
-        let availableModels = try await models()
+        let availableModels = try await models(
+            bypassProviderAuthenticationPreparation: true,
+            bypassConfigurationReloadAdmission: true
+        )
         let selectedModel = request.model
             .flatMap { requestedModel in availableModels.first { $0.model == requestedModel } }
             ?? availableModels.first(where: \CodexModel.isDefault)
@@ -1029,6 +1142,7 @@ private extension CodexAppServerService {
         let subscribers = turnSubscribers.values.flatMap(\.values)
         turnSubscribers.removeAll()
         subscribers.forEach { $0.finish(throwing: error) }
+        resumeChatTurnDrainWaiters(throwing: error)
         await currentTransport?.close()
     }
 
@@ -1086,11 +1200,13 @@ private extension CodexAppServerService {
         if turnSubscribers[key]?.isEmpty == true {
             turnSubscribers.removeValue(forKey: key)
         }
+        resumeChatTurnDrainWaitersIfIdle()
     }
 
     private func finishTurnSubscribers(for key: TurnKey) {
         guard let subscribers = turnSubscribers.removeValue(forKey: key)?.values else { return }
         subscribers.forEach { $0.finish() }
+        resumeChatTurnDrainWaitersIfIdle()
     }
 
     private func waitForStartup() async throws {
@@ -1137,6 +1253,146 @@ private extension CodexAppServerService {
 
     private func cancelGenerationDrainWaiter(_ waiterID: UUID) {
         generationDrainWaiters.removeValue(forKey: waiterID)?.resume(throwing: CancellationError())
+    }
+
+    private func beginCodexOperation() async throws -> UUID {
+        try await waitForConfigurationReloadToFinish()
+        let operationID = UUID()
+        activeCodexOperations.insert(operationID)
+        return operationID
+    }
+
+    private func beginCodexOperation(bypassingAdmission: Bool) async throws -> UUID? {
+        guard !bypassingAdmission else { return nil }
+        return try await beginCodexOperation()
+    }
+
+    private func finishCodexOperation(_ operationID: UUID) {
+        activeCodexOperations.remove(operationID)
+        guard activeCodexOperations.isEmpty else { return }
+        resumeCodexOperationDrainWaiters()
+    }
+
+    private func finishCodexOperation(_ operationID: UUID?) {
+        guard let operationID else { return }
+        finishCodexOperation(operationID)
+    }
+
+    private func waitForCodexOperationsToFinish() async throws {
+        guard !activeCodexOperations.isEmpty else { return }
+        let waiterID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else if activeCodexOperations.isEmpty {
+                    continuation.resume()
+                } else {
+                    codexOperationDrainWaiters[waiterID] = continuation
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelCodexOperationDrainWaiter(waiterID) }
+        }
+    }
+
+    private func cancelCodexOperationDrainWaiter(_ waiterID: UUID) {
+        codexOperationDrainWaiters.removeValue(forKey: waiterID)?.resume(throwing: CancellationError())
+    }
+
+    private func resumeCodexOperationDrainWaiters(throwing error: (any Error)? = nil) {
+        let waiters = codexOperationDrainWaiters.values
+        codexOperationDrainWaiters.removeAll()
+        for waiter in waiters {
+            if let error {
+                waiter.resume(throwing: error)
+            } else {
+                waiter.resume()
+            }
+        }
+    }
+
+    private func waitForChatTurnsToFinish() async throws {
+        guard !pendingChatTurnStarts.isEmpty || !turnSubscribers.isEmpty else { return }
+        let waiterID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else if pendingChatTurnStarts.isEmpty, turnSubscribers.isEmpty {
+                    continuation.resume()
+                } else {
+                    chatTurnDrainWaiters[waiterID] = continuation
+                    #if DEBUG
+                        let testWaiters = chatTurnDrainTestWaiters
+                        chatTurnDrainTestWaiters.removeAll()
+                        testWaiters.forEach { $0.resume() }
+                    #endif
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelChatTurnDrainWaiter(waiterID) }
+        }
+    }
+
+    private func cancelChatTurnDrainWaiter(_ waiterID: UUID) {
+        chatTurnDrainWaiters.removeValue(forKey: waiterID)?.resume(throwing: CancellationError())
+    }
+
+    private func resumeChatTurnDrainWaitersIfIdle() {
+        guard pendingChatTurnStarts.isEmpty, turnSubscribers.isEmpty else { return }
+        resumeChatTurnDrainWaiters()
+    }
+
+    private func resumeChatTurnDrainWaiters(throwing error: (any Error)? = nil) {
+        let waiters = chatTurnDrainWaiters.values
+        chatTurnDrainWaiters.removeAll()
+        for waiter in waiters {
+            if let error {
+                waiter.resume(throwing: error)
+            } else {
+                waiter.resume()
+            }
+        }
+    }
+
+    private func waitForConfigurationReloadToFinish() async throws {
+        guard isConfigurationReloading else { return }
+        let waiterID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else if isConfigurationReloading {
+                    configurationReloadWaiters[waiterID] = continuation
+                } else {
+                    continuation.resume()
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelConfigurationReloadWaiter(waiterID) }
+        }
+    }
+
+    private func cancelConfigurationReloadWaiter(_ waiterID: UUID) {
+        configurationReloadWaiters.removeValue(forKey: waiterID)?.resume(throwing: CancellationError())
+    }
+
+    private func finishConfigurationReload(throwing error: (any Error)? = nil) {
+        isConfigurationReloading = false
+        resumeConfigurationReloadWaiters(throwing: error)
+    }
+
+    private func resumeConfigurationReloadWaiters(throwing error: (any Error)? = nil) {
+        let waiters = configurationReloadWaiters.values
+        configurationReloadWaiters.removeAll()
+        for waiter in waiters {
+            if let error {
+                waiter.resume(throwing: error)
+            } else {
+                waiter.resume()
+            }
+        }
     }
 
     private func resumeGenerationDrainWaitersIfIdle() {
@@ -1263,6 +1519,17 @@ private extension CodexAppServerService {
             await withCheckedContinuation { continuation in
                 generationDrainTestWaiters.append(continuation)
             }
+        }
+
+        func waitUntilChatTurnReloadIsWaitingForTesting() async {
+            if !chatTurnDrainWaiters.isEmpty { return }
+            await withCheckedContinuation { continuation in
+                chatTurnDrainTestWaiters.append(continuation)
+            }
+        }
+
+        var providerAuthenticationWaiterCountForTesting: Int {
+            providerAuthenticationPreparationState?.waiters.count ?? 0
         }
     }
 #endif

--- a/Sources/Dahlia/Services/CodexChatService.swift
+++ b/Sources/Dahlia/Services/CodexChatService.swift
@@ -45,6 +45,8 @@ actor CodexChatService: CodexChatServicing {
     }
 
     func listThreads(cursor: String? = nil, vaultID: UUID) async throws -> CodexChatThreadPage {
+        try await appServer.prepareProviderAuthentication()
+
         let workspaceURL = try workspaceLocator.workspaceURL(vaultID: vaultID)
         var params: [String: JSONValue] = [
             "archived": .bool(false),
@@ -59,7 +61,7 @@ actor CodexChatService: CodexChatServicing {
             params["cursor"] = .string(cursor)
         }
 
-        let result = try await appServer.request(method: "thread/list", params: .object(params))
+        let result = try await appServer.chatRequest(method: "thread/list", params: .object(params))
         guard let object = result.objectValue,
               let data = object["data"]?.arrayValue
         else {
@@ -73,7 +75,9 @@ actor CodexChatService: CodexChatServicing {
     }
 
     func loadThread(id: String) async throws -> CodexChatThread {
-        let result = try await appServer.request(
+        try await appServer.prepareProviderAuthentication()
+
+        let result = try await appServer.chatRequest(
             method: "thread/read",
             params: .object([
                 "includeTurns": .bool(true),
@@ -89,22 +93,26 @@ actor CodexChatService: CodexChatServicing {
     func resumeThread(id: String, vaultID: UUID) async throws -> CodexChatThread {
         let workspaceURL = try workspaceLocator.workspaceURL(vaultID: vaultID)
         let helperURL = try resolvedMCPExecutableURL()
-        let config = try await appServer.chatThreadConfiguration(
-            reasoningEffort: CodexReasoningEffortOption.defaultValue,
-            vaultID: vaultID,
-            helperURL: helperURL
-        )
-        let result = try await appServer.request(
-            method: "thread/resume",
-            params: .object([
-                "approvalPolicy": .string("on-request"),
-                "config": config,
-                "cwd": .string(workspaceURL.path),
-                "developerInstructions": .string(Self.developerInstructions),
-                "sandbox": .string("read-only"),
-                "threadId": .string(id),
-            ])
-        )
+        let result = try await appServer.withChatOperation { appServer in
+            let config = try await appServer.chatThreadConfiguration(
+                reasoningEffort: CodexReasoningEffortOption.defaultValue,
+                vaultID: vaultID,
+                helperURL: helperURL,
+                bypassConfigurationReloadAdmission: true
+            )
+            return try await appServer.chatRequest(
+                method: "thread/resume",
+                params: .object([
+                    "approvalPolicy": .string("on-request"),
+                    "config": config,
+                    "cwd": .string(workspaceURL.path),
+                    "developerInstructions": .string(Self.developerInstructions),
+                    "sandbox": .string("read-only"),
+                    "threadId": .string(id),
+                ]),
+                bypassConfigurationReloadAdmission: true
+            )
+        }
         guard let object = result.objectValue,
               let thread = object["thread"]?.objectValue
         else {
@@ -120,32 +128,40 @@ actor CodexChatService: CodexChatServicing {
     func startThread(model: String?, effort: String, vaultID: UUID) async throws -> CodexChatThread {
         let workspaceURL = try workspaceLocator.workspaceURL(vaultID: vaultID)
         let helperURL = try resolvedMCPExecutableURL()
-        let availableModels = try await appServer.models()
-        let selectedModel = model
-            .flatMap { requested in availableModels.first { $0.model == requested } }
-            ?? availableModels.first(where: \CodexModel.isDefault)
-            ?? availableModels.first
-        guard let selectedModel else {
-            throw CodexAppServerError.invalidProtocolResponse
-        }
+        let (result, selectedModel) = try await appServer.withChatOperation { appServer in
+            let availableModels = try await appServer.models(
+                bypassProviderAuthenticationPreparation: true,
+                bypassConfigurationReloadAdmission: true
+            )
+            let selectedModel = model
+                .flatMap { requested in availableModels.first { $0.model == requested } }
+                ?? availableModels.first(where: \CodexModel.isDefault)
+                ?? availableModels.first
+            guard let selectedModel else {
+                throw CodexAppServerError.invalidProtocolResponse
+            }
 
-        let config = try await appServer.chatThreadConfiguration(
-            reasoningEffort: effort,
-            vaultID: vaultID,
-            helperURL: helperURL
-        )
-        let result = try await appServer.request(
-            method: "thread/start",
-            params: .object([
-                "approvalPolicy": .string("on-request"),
-                "config": config,
-                "cwd": .string(workspaceURL.path),
-                "developerInstructions": .string(Self.developerInstructions),
-                "ephemeral": .bool(false),
-                "model": .string(selectedModel.model),
-                "sandbox": .string("read-only"),
-            ])
-        )
+            let config = try await appServer.chatThreadConfiguration(
+                reasoningEffort: effort,
+                vaultID: vaultID,
+                helperURL: helperURL,
+                bypassConfigurationReloadAdmission: true
+            )
+            let result = try await appServer.chatRequest(
+                method: "thread/start",
+                params: .object([
+                    "approvalPolicy": .string("on-request"),
+                    "config": config,
+                    "cwd": .string(workspaceURL.path),
+                    "developerInstructions": .string(Self.developerInstructions),
+                    "ephemeral": .bool(false),
+                    "model": .string(selectedModel.model),
+                    "sandbox": .string("read-only"),
+                ]),
+                bypassConfigurationReloadAdmission: true
+            )
+            return (result, selectedModel)
+        }
         guard let object = result.objectValue,
               let thread = object["thread"]?.objectValue
         else {
@@ -164,6 +180,8 @@ actor CodexChatService: CodexChatServicing {
         model: String?,
         effort: String
     ) async throws -> AsyncThrowingStream<CodexChatTurnEvent, any Error> {
+        try await appServer.prepareProviderAuthentication()
+
         var params: [String: JSONValue] = [
             "approvalsReviewer": .string("auto_review"),
             "effort": .string(effort),
@@ -175,17 +193,13 @@ actor CodexChatService: CodexChatServicing {
             params["model"] = .string(model)
         }
 
-        let result = try await appServer.request(method: "turn/start", params: .object(params))
-        guard let turnID = result.objectValue?["turn"]?.objectValue?["id"]?.stringValue else {
-            throw CodexAppServerError.invalidProtocolResponse
-        }
-        let notifications = await appServer.notifications(threadID: threadID, turnID: turnID)
+        let turn = try await appServer.startChatTurn(threadID: threadID, params: .object(params))
 
         return AsyncThrowingStream { continuation in
             let task = Task {
-                continuation.yield(.started(turnID: turnID))
+                continuation.yield(.started(turnID: turn.turnID))
                 do {
-                    for try await notification in notifications {
+                    for try await notification in turn.notifications {
                         if let event = try Self.parseTurnEvent(notification) {
                             continuation.yield(event)
                         }

--- a/Sources/Dahlia/Services/DatabricksCLIClient.swift
+++ b/Sources/Dahlia/Services/DatabricksCLIClient.swift
@@ -2,6 +2,11 @@ import Foundation
 import os
 
 struct DatabricksCLIClient {
+    enum AuthenticationResult: Equatable, Sendable {
+        case alreadyAuthenticated
+        case browserLoginCompleted
+    }
+
     struct CommandOutput {
         let standardOutput: Data
         let standardError: Data
@@ -80,7 +85,10 @@ struct DatabricksCLIClient {
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
     }
 
-    func ensureAuthenticated(profileName: String) async throws {
+    func ensureAuthenticated(
+        profileName: String,
+        onBrowserLoginRequired: @Sendable () async -> Void = {}
+    ) async throws -> AuthenticationResult {
         let tokenArguments = [
             "auth",
             "token",
@@ -91,12 +99,14 @@ struct DatabricksCLIClient {
         ]
         let tokenOutput = try await runCommand(tokenArguments)
         try Task.checkCancellation()
-        guard tokenOutput.terminationStatus != 0 else { return }
+        guard tokenOutput.terminationStatus != 0 else { return .alreadyAuthenticated }
         guard requiresBrowserLogin(tokenOutput) else {
             try validate(tokenOutput)
-            return
+            return .alreadyAuthenticated
         }
 
+        await onBrowserLoginRequired()
+        try Task.checkCancellation()
         _ = try await runValidatedCommand([
             "auth",
             "login",
@@ -104,6 +114,7 @@ struct DatabricksCLIClient {
             profileName,
         ])
         _ = try await runValidatedCommand(tokenArguments)
+        return .browserLoginCompleted
     }
 
     static func locateExecutable(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL? {

--- a/Sources/Dahlia/ViewModels/DatabricksAccountController.swift
+++ b/Sources/Dahlia/ViewModels/DatabricksAccountController.swift
@@ -83,14 +83,24 @@ final class DatabricksAccountController {
         do {
             try Task.checkCancellation()
             try configurationManager.validateDatabricks(profile: profile)
-            try await client.ensureAuthenticated(profileName: profile.name)
+            let authenticationResult = try await client.ensureAuthenticated(
+                profileName: profile.name,
+                onBrowserLoginRequired: {
+                    await service.markProviderAuthenticationReloadRequired()
+                }
+            )
             try Task.checkCancellation()
             configurationStore.invalidateCodexAccountConfiguration()
-            if try configurationManager.configureDatabricks(profile: profile) {
+            let configurationChanged = try configurationManager.configureDatabricks(profile: profile)
+            if configurationChanged || authenticationResult == .browserLoginCompleted {
                 try await service.reloadConfiguration()
             }
             try Task.checkCancellation()
-            _ = try await service.models(forceRefresh: true, bypassConfigurationCheck: true)
+            _ = try await service.models(
+                forceRefresh: true,
+                bypassConfigurationCheck: true,
+                bypassProviderAuthenticationPreparation: true
+            )
             try Task.checkCancellation()
             configurationStore.markCodexAccountConfigurationCurrent(
                 provider: .databricks,

--- a/Tests/DahliaTests/CodexAppServerServiceTests.swift
+++ b/Tests/DahliaTests/CodexAppServerServiceTests.swift
@@ -10,6 +10,22 @@ import Foundation
     // Protocol lifecycle scenarios share test doubles and are kept in one auditable suite.
     // swiftlint:disable:next type_body_length
     struct CodexAppServerServiceTests {
+        private actor CompletionGate {
+            private var isOpen = false
+            private var continuation: CheckedContinuation<Void, Never>?
+
+            func wait() async {
+                if isOpen { return }
+                await withCheckedContinuation { continuation = $0 }
+            }
+
+            func open() {
+                isOpen = true
+                continuation?.resume()
+                continuation = nil
+            }
+        }
+
         @Test
         func connectionIsInitializedOnceAndReused() async throws {
             let transport = TestCodexAppServerTransport(mode: .models)
@@ -327,6 +343,348 @@ import Foundation
             #expect(await first.isClosed)
             #expect(await !second.isClosed)
             #expect(try await service.models().map(\.model) == ["default-model"])
+            await service.shutdown()
+        }
+
+        @Test
+        func browserLoginReloadsConfigurationBeforeGeneration() async throws {
+            let first = TestCodexAppServerTransport(mode: .models)
+            let second = TestCodexAppServerTransport(mode: .generationCompletes)
+            let transports = Mutex([first, second])
+            let launchCount = Mutex(0)
+            let preparationCount = Mutex(0)
+            let service = makeTestCodexAppServerService(
+                transportFactory: {
+                    launchCount.withLock { $0 += 1 }
+                    return transports.withLock { $0.removeFirst() }
+                },
+                providerAuthenticationPreparation: { _ in
+                    preparationCount.withLock { $0 += 1 }
+                    return true
+                }
+            )
+            try await service.start()
+
+            let result = try await service.generate(.init(
+                model: nil,
+                developerInstructions: "Summarize.",
+                inputs: [.text("Transcript")],
+                outputSchema: Data(#"{"type":"object"}"#.utf8)
+            ))
+
+            #expect(result == #"{"status":"ok"}"#)
+            #expect(preparationCount.withLock { $0 } == 1)
+            #expect(launchCount.withLock { $0 } == 2)
+            #expect(await first.isClosed)
+            await service.shutdown()
+        }
+
+        @Test
+        func concurrentRequestsShareProviderAuthenticationPreparation() async throws {
+            let first = TestCodexAppServerTransport(mode: .models)
+            let second = TestCodexAppServerTransport(mode: .models)
+            let transports = Mutex([first, second])
+            let preparationCount = Mutex(0)
+            let preparationStarted = AsyncStream.makeStream(of: Void.self)
+            let releasePreparation = AsyncStream.makeStream(of: Void.self)
+            let service = makeTestCodexAppServerService(
+                transportFactory: { transports.withLock { $0.removeFirst() } },
+                providerAuthenticationPreparation: { _ in
+                    preparationCount.withLock { $0 += 1 }
+                    preparationStarted.continuation.yield()
+                    for await _ in releasePreparation.stream {
+                        break
+                    }
+                    return true
+                }
+            )
+            try await service.start()
+
+            let firstPreparation = Task { try await service.prepareProviderAuthentication() }
+            for await _ in preparationStarted.stream {
+                break
+            }
+            let secondPreparation = Task { try await service.prepareProviderAuthentication() }
+            await Task.yield()
+            releasePreparation.continuation.yield()
+
+            try await firstPreparation.value
+            try await secondPreparation.value
+            #expect(preparationCount.withLock { $0 } == 1)
+            #expect(await first.isClosed)
+            await service.shutdown()
+        }
+
+        @Test
+        func cancellingOneAuthenticationWaiterReturnsWithoutCancellingSharedPreparation() async throws {
+            let firstTransport = TestCodexAppServerTransport(mode: .models)
+            let secondTransport = TestCodexAppServerTransport(mode: .models)
+            let transports = Mutex([firstTransport, secondTransport])
+            let preparationCount = Mutex(0)
+            let firstFinished = Mutex(false)
+            let preparationStarted = AsyncStream.makeStream(of: Void.self)
+            let releasePreparation = AsyncStream.makeStream(of: Void.self)
+            let service = makeTestCodexAppServerService(
+                transportFactory: { transports.withLock { $0.removeFirst() } },
+                providerAuthenticationPreparation: { _ in
+                    preparationCount.withLock { $0 += 1 }
+                    preparationStarted.continuation.yield()
+                    for await _ in releasePreparation.stream {
+                        break
+                    }
+                    return true
+                }
+            )
+            try await service.start()
+
+            let first = Task {
+                defer { firstFinished.withLock { $0 = true } }
+                try await service.prepareProviderAuthentication()
+            }
+            for await _ in preparationStarted.stream {
+                break
+            }
+            let second = Task { try await service.prepareProviderAuthentication() }
+            #expect(await pollUntil(timeout: .seconds(10)) {
+                await service.providerAuthenticationWaiterCountForTesting == 2
+            })
+
+            first.cancel()
+            #expect(await pollUntil(timeout: .seconds(10)) { firstFinished.withLock { $0 } })
+            #expect(preparationCount.withLock { $0 } == 1)
+
+            releasePreparation.continuation.yield()
+            await #expect(throws: CancellationError.self) { try await first.value }
+            try await second.value
+            #expect(preparationCount.withLock { $0 } == 1)
+            await service.shutdown()
+        }
+
+        @Test
+        func cancellingOnlyAuthenticationWaiterCancelsUnderlyingPreparation() async throws {
+            let transport = TestCodexAppServerTransport(mode: .models)
+            let preparationCancelled = Mutex(false)
+            let preparationStarted = AsyncStream.makeStream(of: Void.self)
+            let service = makeTestCodexAppServerService(
+                transportFactory: { transport },
+                providerAuthenticationPreparation: { _ in
+                    preparationStarted.continuation.yield()
+                    do {
+                        try await Task.sleep(for: .seconds(60))
+                    } catch is CancellationError {
+                        preparationCancelled.withLock { $0 = true }
+                        throw CancellationError()
+                    }
+                    return true
+                }
+            )
+            try await service.start()
+
+            let preparation = Task { try await service.prepareProviderAuthentication() }
+            for await _ in preparationStarted.stream {
+                break
+            }
+            preparation.cancel()
+
+            await #expect(throws: CancellationError.self) { try await preparation.value }
+            #expect(await pollUntil(timeout: .seconds(10)) { preparationCancelled.withLock { $0 } })
+            #expect(await !transport.isClosed)
+            await service.shutdown()
+        }
+
+        @Test
+        func replacementAuthenticationWaitsForCancelledPreparationToFinish() async throws {
+            let transport = TestCodexAppServerTransport(mode: .models)
+            let preparationCount = Mutex(0)
+            let preparationStarted = AsyncStream.makeStream(of: Void.self)
+            let cancellationObserved = AsyncStream.makeStream(of: Void.self)
+            let cancellationCompletion = CompletionGate()
+            let service = makeTestCodexAppServerService(
+                transportFactory: { transport },
+                providerAuthenticationPreparation: { _ in
+                    let attempt = preparationCount.withLock { count in
+                        count += 1
+                        return count
+                    }
+                    guard attempt == 1 else { return false }
+                    preparationStarted.continuation.yield()
+                    do {
+                        try await Task.sleep(for: .seconds(60))
+                    } catch is CancellationError {
+                        cancellationObserved.continuation.yield()
+                        await cancellationCompletion.wait()
+                        throw CancellationError()
+                    }
+                    return false
+                }
+            )
+            try await service.start()
+
+            let cancelled = Task { try await service.prepareProviderAuthentication() }
+            for await _ in preparationStarted.stream {
+                break
+            }
+            cancelled.cancel()
+            await #expect(throws: CancellationError.self) { try await cancelled.value }
+            for await _ in cancellationObserved.stream {
+                break
+            }
+
+            let replacement = Task { try await service.prepareProviderAuthentication() }
+            await Task.yield()
+            #expect(preparationCount.withLock { $0 } == 1)
+
+            await cancellationCompletion.open()
+            try await replacement.value
+            #expect(preparationCount.withLock { $0 } == 2)
+            #expect(await !transport.isClosed)
+            await service.shutdown()
+        }
+
+        @Test
+        func failedLoginAttemptKeepsReloadRequiredForNextPreparation() async throws {
+            let first = TestCodexAppServerTransport(mode: .models)
+            let second = TestCodexAppServerTransport(mode: .models)
+            let transports = Mutex([first, second])
+            let preparationCount = Mutex(0)
+            let service = makeTestCodexAppServerService(
+                transportFactory: { transports.withLock { $0.removeFirst() } },
+                providerAuthenticationPreparation: { authenticationMayChange in
+                    let attempt = preparationCount.withLock { count in
+                        count += 1
+                        return count
+                    }
+                    if attempt == 1 {
+                        await authenticationMayChange()
+                        throw CodexAppServerError.notLoggedIn
+                    }
+                    return false
+                }
+            )
+            try await service.start()
+
+            await #expect(throws: CodexAppServerError.notLoggedIn) {
+                try await service.prepareProviderAuthentication()
+            }
+            try await service.prepareProviderAuthentication()
+
+            #expect(preparationCount.withLock { $0 } == 2)
+            #expect(await first.isClosed)
+            #expect(await !second.isClosed)
+            await service.shutdown()
+        }
+
+        @Test
+        func configurationReloadWaitsForActiveChatTurn() async throws {
+            let first = TestCodexAppServerTransport(mode: .generationBlocks)
+            let second = TestCodexAppServerTransport(mode: .models)
+            let transports = Mutex([first, second])
+            let launchCount = Mutex(0)
+            let service = makeTestCodexAppServerService(transportFactory: {
+                launchCount.withLock { $0 += 1 }
+                return transports.withLock { $0.removeFirst() }
+            })
+            let turn = try await service.startChatTurn(
+                threadID: "thread-1",
+                params: .object([
+                    "input": .array([.object(["type": .string("text"), "text": .string("Hi")])]),
+                    "threadId": .string("thread-1"),
+                ])
+            )
+            let consumption = Task {
+                for try await _ in turn.notifications {}
+            }
+
+            let reload = Task { try await service.reloadConfiguration() }
+            await service.waitUntilChatTurnReloadIsWaitingForTesting()
+            #expect(launchCount.withLock { $0 } == 1)
+            #expect(await !first.isClosed)
+
+            await first.sendFromServer(.object([
+                "method": .string("turn/completed"),
+                "params": .object([
+                    "threadId": .string("thread-1"),
+                    "turn": .object([
+                        "id": .string(turn.turnID),
+                        "status": .string("completed"),
+                    ]),
+                ]),
+            ]))
+
+            try await consumption.value
+            try await reload.value
+            #expect(launchCount.withLock { $0 } == 2)
+            #expect(await first.isClosed)
+            await service.shutdown()
+        }
+
+        @Test
+        func summaryAdmissionWaitsForReloadThatIsDrainingChat() async throws {
+            let first = TestCodexAppServerTransport(mode: .generationBlocks)
+            let second = TestCodexAppServerTransport(mode: .generationCompletes)
+            let transports = Mutex([first, second])
+            let configurationReadCount = Mutex(0)
+            let configurationReadStarted = AsyncStream.makeStream(of: Void.self)
+            let releaseConfigurationRead = AsyncStream.makeStream(of: Void.self)
+            let service = makeTestCodexAppServerService(
+                transportFactory: { transports.withLock { $0.removeFirst() } },
+                configurationReadiness: {
+                    let readCount = configurationReadCount.withLock { count in
+                        count += 1
+                        return count
+                    }
+                    guard readCount == 1 else { return true }
+                    configurationReadStarted.continuation.yield()
+                    for await _ in releaseConfigurationRead.stream {
+                        break
+                    }
+                    return true
+                }
+            )
+            let chatTurn = try await service.startChatTurn(
+                threadID: "chat-thread",
+                params: .object([
+                    "input": .array([.object(["type": .string("text"), "text": .string("Hi")])]),
+                    "threadId": .string("chat-thread"),
+                ])
+            )
+            let chatConsumption = Task {
+                for try await _ in chatTurn.notifications {}
+            }
+            let summary = Task {
+                try await service.generate(.init(
+                    model: nil,
+                    developerInstructions: "Summarize.",
+                    inputs: [.text("Transcript")],
+                    outputSchema: Data(#"{"type":"object"}"#.utf8)
+                ))
+            }
+            for await _ in configurationReadStarted.stream {
+                break
+            }
+
+            let reload = Task { try await service.reloadConfiguration() }
+            await service.waitUntilChatTurnReloadIsWaitingForTesting()
+            releaseConfigurationRead.continuation.yield()
+            await Task.yield()
+            #expect(await !methodsSent(to: first).contains("thread/start"))
+
+            await first.sendFromServer(.object([
+                "method": .string("turn/completed"),
+                "params": .object([
+                    "threadId": .string("chat-thread"),
+                    "turn": .object([
+                        "id": .string(chatTurn.turnID),
+                        "status": .string("completed"),
+                    ]),
+                ]),
+            ]))
+
+            try await chatConsumption.value
+            try await reload.value
+            #expect(try await summary.value == #"{"status":"ok"}"#)
+            #expect(await first.isClosed)
+            #expect(await methodsSent(to: second).contains("thread/start"))
             await service.shutdown()
         }
 

--- a/Tests/DahliaTests/CodexChatAuthenticationTests.swift
+++ b/Tests/DahliaTests/CodexChatAuthenticationTests.swift
@@ -1,0 +1,232 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Synchronization
+    import Testing
+
+    @MainActor
+    struct CodexChatAuthenticationTests {
+        private struct AuthenticationFailure: Error {}
+
+        private struct WorkspaceLocator: CodexChatWorkspaceLocating {
+            let url: URL
+
+            func workspaceURL(vaultID: UUID) throws -> URL {
+                url.appending(path: vaultID.uuidString.lowercased(), directoryHint: .isDirectory)
+            }
+        }
+
+        @Test
+        func sendWaitsForProviderAuthenticationPreparation() async throws {
+            let transport = TestCodexChatAppServerTransport()
+            let preparationStarted = AsyncStream.makeStream(of: Void.self)
+            let releasePreparation = AsyncStream.makeStream(of: Void.self)
+            let appServer = makeTestCodexAppServerService(
+                transportFactory: { transport },
+                providerAuthenticationPreparation: { _ in
+                    preparationStarted.continuation.yield()
+                    for await _ in releasePreparation.stream {
+                        break
+                    }
+                    return false
+                }
+            )
+            let service = CodexChatService(appServer: appServer)
+
+            let send = Task {
+                try await service.send(
+                    threadID: "thread-1",
+                    inputs: [.text("Hi")],
+                    model: "default-model",
+                    effort: "medium"
+                )
+            }
+            for await _ in preparationStarted.stream {
+                break
+            }
+            #expect(await transport.messages().isEmpty)
+
+            releasePreparation.continuation.yield()
+            let stream = try await send.value
+            for try await _ in stream {}
+            #expect(await transport.messages().contains {
+                $0.objectValue?["method"]?.stringValue == "turn/start"
+            })
+            await appServer.shutdown()
+        }
+
+        @Test
+        func authenticationFailureDoesNotStartTurn() async {
+            let transport = TestCodexChatAppServerTransport()
+            let appServer = makeTestCodexAppServerService(
+                transportFactory: { transport },
+                providerAuthenticationPreparation: { _ in throw AuthenticationFailure() }
+            )
+            let service = CodexChatService(appServer: appServer)
+
+            await #expect(throws: AuthenticationFailure.self) {
+                _ = try await service.send(
+                    threadID: "thread-1",
+                    inputs: [.text("Hi")],
+                    model: "default-model",
+                    effort: "medium"
+                )
+            }
+            #expect(await transport.messages().isEmpty)
+            await appServer.shutdown()
+        }
+
+        @Test
+        func chatHistoryOperationsShareAuthenticationBeforeSendingRequests() async throws {
+            let first = TestCodexChatAppServerTransport()
+            let second = TestCodexChatAppServerTransport()
+            let transports = Mutex([first, second])
+            let preparationCount = Mutex(0)
+            let preparationStarted = AsyncStream.makeStream(of: Void.self)
+            let releasePreparation = AsyncStream.makeStream(of: Void.self)
+            let appServer = makeTestCodexAppServerService(
+                transportFactory: { transports.withLock { $0.removeFirst() } },
+                providerAuthenticationPreparation: { _ in
+                    preparationCount.withLock { $0 += 1 }
+                    preparationStarted.continuation.yield()
+                    for await _ in releasePreparation.stream {
+                        break
+                    }
+                    return true
+                }
+            )
+            let service = CodexChatService(
+                appServer: appServer,
+                workspaceLocator: WorkspaceLocator(url: URL(filePath: "/tmp/dahlia-chat-auth")),
+                mcpExecutableURL: URL(filePath: "/tmp/dahlia-mcp")
+            )
+            let vaultID = UUID.v7()
+            try await appServer.start()
+
+            let models = Task { try await service.models() }
+            let list = Task { try await service.listThreads(vaultID: vaultID) }
+            let load = Task { try await service.loadThread(id: "thread-history") }
+            let resume = Task { try await service.resumeThread(id: "thread-history", vaultID: vaultID) }
+            for await _ in preparationStarted.stream {
+                break
+            }
+            #expect(await pollUntil(timeout: .seconds(10)) {
+                await appServer.providerAuthenticationWaiterCountForTesting == 4
+            })
+            let firstMethods = await first.messages().compactMap { $0.objectValue?["method"]?.stringValue }
+            #expect(!firstMethods.contains("model/list"))
+            #expect(!firstMethods.contains("thread/list"))
+            #expect(!firstMethods.contains("thread/read"))
+            #expect(!firstMethods.contains("thread/resume"))
+
+            releasePreparation.continuation.yield()
+            _ = try await models.value
+            _ = try await list.value
+            _ = try await load.value
+            _ = try await resume.value
+
+            let secondMethods = await second.messages().compactMap { $0.objectValue?["method"]?.stringValue }
+            #expect(secondMethods.contains("model/list"))
+            #expect(secondMethods.contains("thread/list"))
+            #expect(secondMethods.contains("thread/read"))
+            #expect(secondMethods.contains("thread/resume"))
+            #expect(preparationCount.withLock { $0 } == 1)
+            await appServer.shutdown()
+        }
+
+        @Test
+        func modelAndNewThreadWaitForReloadThatIsDrainingChat() async throws {
+            let first = TestCodexChatAppServerTransport(turnOutcome: .disconnected)
+            let second = TestCodexChatAppServerTransport()
+            let transports = Mutex([first, second])
+            let appServer = makeTestCodexAppServerService(
+                transportFactory: { transports.withLock { $0.removeFirst() } }
+            )
+            let service = CodexChatService(
+                appServer: appServer,
+                workspaceLocator: WorkspaceLocator(url: URL(filePath: "/tmp/dahlia-chat-reload")),
+                mcpExecutableURL: URL(filePath: "/tmp/dahlia-mcp")
+            )
+            let activeTurn = try await appServer.startChatTurn(
+                threadID: "chat-thread",
+                params: .object([
+                    "input": .array([.object(["type": .string("text"), "text": .string("Hi")])]),
+                    "threadId": .string("chat-thread"),
+                ])
+            )
+            let consumption = Task {
+                for try await _ in activeTurn.notifications {}
+            }
+            let reload = Task { try await appServer.reloadConfiguration() }
+            await appServer.waitUntilChatTurnReloadIsWaitingForTesting()
+            let newThread = Task {
+                try await service.startThread(model: nil, effort: "medium", vaultID: UUID.v7())
+            }
+            await Task.yield()
+            let firstMethods = await first.messages().compactMap { $0.objectValue?["method"]?.stringValue }
+            #expect(!firstMethods.contains("model/list"))
+            #expect(!firstMethods.contains("thread/start"))
+
+            await first.sendFromServer(.object([
+                "method": .string("turn/completed"),
+                "params": .object([
+                    "threadId": .string("chat-thread"),
+                    "turn": .object([
+                        "id": .string(activeTurn.turnID),
+                        "status": .string("completed"),
+                    ]),
+                ]),
+            ]))
+
+            try await consumption.value
+            try await reload.value
+            _ = try await newThread.value
+            let secondMethods = await second.messages().compactMap { $0.objectValue?["method"]?.stringValue }
+            #expect(secondMethods.contains("model/list"))
+            #expect(secondMethods.contains("thread/start"))
+            await appServer.shutdown()
+        }
+
+        @Test
+        func newThreadKeepsOneConnectionWhileReloadStartsDuringModelSelection() async throws {
+            let first = TestCodexChatAppServerTransport(automaticallyRespondsToModelList: false)
+            let second = TestCodexChatAppServerTransport()
+            let transports = Mutex([first, second])
+            let appServer = makeTestCodexAppServerService(
+                transportFactory: { transports.withLock { $0.removeFirst() } }
+            )
+            let service = CodexChatService(
+                appServer: appServer,
+                workspaceLocator: WorkspaceLocator(url: URL(filePath: "/tmp/dahlia-chat-reload")),
+                mcpExecutableURL: URL(filePath: "/tmp/dahlia-mcp")
+            )
+
+            let newThread = Task {
+                try await service.startThread(model: nil, effort: "medium", vaultID: UUID.v7())
+            }
+            #expect(await pollUntil(timeout: .seconds(10)) {
+                await first.messages().contains { $0.objectValue?["method"]?.stringValue == "model/list" }
+            })
+            let modelRequestID = try #require(await first.messages().first {
+                $0.objectValue?["method"]?.stringValue == "model/list"
+            }?.objectValue?["id"]?.intValue)
+
+            let reload = Task { try await appServer.reloadConfiguration() }
+            await first.sendFromServer(.object([
+                "id": .number(Double(modelRequestID)),
+                "result": TestCodexChatFixtures.modelList,
+            ]))
+
+            _ = try await newThread.value
+            try await reload.value
+            let firstMethods = await first.messages().compactMap { $0.objectValue?["method"]?.stringValue }
+            #expect(firstMethods.contains("config/read"))
+            #expect(firstMethods.contains("thread/start"))
+            let secondMethods = await second.messages().compactMap { $0.objectValue?["method"]?.stringValue }
+            #expect(!secondMethods.contains("model/list"))
+            #expect(!secondMethods.contains("thread/start"))
+            await appServer.shutdown()
+        }
+    }
+#endif

--- a/Tests/DahliaTests/DatabricksCLIClientTests.swift
+++ b/Tests/DahliaTests/DatabricksCLIClientTests.swift
@@ -62,8 +62,9 @@ import Foundation
                 return .init(standardOutput: Data(), standardError: Data(), terminationStatus: 0)
             }
 
-            try await client.ensureAuthenticated(profileName: "DEFAULT")
+            let result = try await client.ensureAuthenticated(profileName: "DEFAULT")
 
+            #expect(result == .alreadyAuthenticated)
             #expect(await recorder.commands == [
                 [
                     "auth",
@@ -87,8 +88,9 @@ import Foundation
                 await responder.run(arguments)
             }
 
-            try await client.ensureAuthenticated(profileName: "Team Profile")
+            let result = try await client.ensureAuthenticated(profileName: "Team Profile")
 
+            #expect(result == .browserLoginCompleted)
             #expect(await responder.commands == [
                 [
                     "auth",
@@ -125,7 +127,7 @@ import Foundation
             }
 
             await #expect(throws: DatabricksCLIError.self) {
-                try await client.ensureAuthenticated(profileName: "DEFAULT")
+                _ = try await client.ensureAuthenticated(profileName: "DEFAULT")
             }
             #expect(await responder.commands.count == 1)
         }
@@ -141,7 +143,7 @@ import Foundation
             }
 
             do {
-                try await client.ensureAuthenticated(profileName: "DEFAULT")
+                _ = try await client.ensureAuthenticated(profileName: "DEFAULT")
                 Issue.record("Expected browser login to fail")
             } catch {
                 #expect(error.localizedDescription.contains("browser login timed out"))
@@ -161,7 +163,7 @@ import Foundation
             }
 
             do {
-                try await client.ensureAuthenticated(profileName: "DEFAULT")
+                _ = try await client.ensureAuthenticated(profileName: "DEFAULT")
                 Issue.record("Expected token recheck to fail")
             } catch {
                 #expect(error.localizedDescription.contains("token still unavailable"))

--- a/Tests/DahliaTests/TestCodexAppServerService.swift
+++ b/Tests/DahliaTests/TestCodexAppServerService.swift
@@ -12,6 +12,7 @@ func makeTestCodexAppServerService(
     transportFactory: @escaping CodexAppServerService.TransportFactory,
     clock: any CodexAppServerClock = ContinuousCodexAppServerClock(),
     summaryTimeout: Duration = .seconds(270),
+    providerAuthenticationPreparation: @escaping CodexAppServerService.ProviderAuthenticationPreparation = { _ in false },
     configurationReadiness: @escaping CodexAppServerService.ConfigurationReadiness = { true }
 ) -> CodexAppServerService {
     CodexAppServerService(
@@ -19,6 +20,7 @@ func makeTestCodexAppServerService(
         clock: clock,
         transportTimeout: .seconds(600),
         summaryTimeout: summaryTimeout,
+        providerAuthenticationPreparation: providerAuthenticationPreparation,
         configurationReadiness: configurationReadiness
     )
 }

--- a/Tests/DahliaTests/TestCodexChatAppServerTransport.swift
+++ b/Tests/DahliaTests/TestCodexChatAppServerTransport.swift
@@ -10,13 +10,15 @@ actor TestCodexChatAppServerTransport: CodexAppServerTransport {
     }
 
     private let turnOutcome: TurnOutcome
+    private let automaticallyRespondsToModelList: Bool
     private var responses: [Data] = []
     private var sentMessages: [JSONValue] = []
     private var receiveContinuation: CheckedContinuation<Data?, Never>?
     private var isClosed = false
 
-    init(turnOutcome: TurnOutcome = .completed) {
+    init(turnOutcome: TurnOutcome = .completed, automaticallyRespondsToModelList: Bool = true) {
         self.turnOutcome = turnOutcome
+        self.automaticallyRespondsToModelList = automaticallyRespondsToModelList
     }
 
     func sendLine(_ data: Data) throws {
@@ -58,7 +60,9 @@ actor TestCodexChatAppServerTransport: CodexAppServerTransport {
                 "requiresOpenaiAuth": .bool(true),
             ]))
         case "model/list":
-            enqueueResponse(requestID, result: TestCodexChatFixtures.modelList)
+            if automaticallyRespondsToModelList {
+                enqueueResponse(requestID, result: TestCodexChatFixtures.modelList)
+            }
         case "config/read":
             enqueueResponse(requestID, result: .object([
                 "config": .object([
@@ -134,6 +138,10 @@ actor TestCodexChatAppServerTransport: CodexAppServerTransport {
 
     func simulateDisconnect() async {
         await close()
+    }
+
+    func sendFromServer(_ value: JSONValue) {
+        enqueue(value)
     }
 
     private func enqueueTurn(requestID: Int) {

--- a/docs/adr/0003-use-a-shared-codex-app-server.md
+++ b/docs/adr/0003-use-a-shared-codex-app-server.md
@@ -100,10 +100,11 @@ Databricks:
 2. 選択したプロファイルの HTTPS workspace host を Databricks AI Gateway の `/ai-gateway/codex/v1` に変換する。
 3. Dahlia 専用 `config.toml` に `model_provider = "Databricks"` と Responses wire API を設定する。
 4. provider の auth command は `databricks auth token --profile <profile> --output json` の出力から macOS 標準の `plutil` で短期アクセストークンを取得する。Dahlia はトークンを保存しない。
-5. 設定変更後は共有 app-server connection を閉じて再初期化し、`model/list` が成功した場合だけ設定完了とする。
-6. 成功後に account と model cache を無効化し、`account/read` で表示状態を更新する。
+5. 要約生成、モデル一覧、AI チャットの thread 一覧・読込・復元・開始と turn 開始の前に選択中のプロファイルを検証する。Databricks CLI が未ログインまたは無効な refresh token を明示した場合は、同じプロファイルで `databricks auth login` を実行してブラウザ認証を待つ。同時要求は1回の認証処理を共有し、個別の待機要求のキャンセルは残りの要求を中断しない。
+6. 設定変更またはブラウザ再認証の開始後は共有 app-server connection を閉じて再初期化し、古い provider token cache を破棄する。token の再検証が失敗またはキャンセルされた場合も再初期化の必要性を保持し、次回の認証 preflight で実行する。設定時は `model/list` が成功した場合だけ設定完了とする。
+7. 成功後に account と model cache を無効化し、`account/read` で表示状態を更新する。
 
-設定変更による connection の再初期化は、進行中の要約 generation が完了して unsubscribe されるまで待機する。account 設定が検証済みの選択と一致しない間は、service 層が通常の `model/list` と generation を拒否し、設定 controller の検証 request だけが明示的にこの guard を迂回する。
+設定変更または再認証による connection の再初期化は、進行中の要約 generation が完了して unsubscribe され、購読中の AI チャット turn が完了するまで待機する。チャットの `turn/start` 応答と通知購読は同じ connection generation 上で登録し、再初期化との間に購読不能な turn を残さない。account 設定が検証済みの選択と一致しない間は、service 層が通常の `model/list` と generation を拒否し、設定 controller の検証 request だけが明示的にこの guard を迂回する。
 
 ログイン待機 Task のキャンセル、ブラウザを開けなかった場合、ユーザーのキャンセルでは `account/login/cancel` を送る。notification が waiter 登録より先に到着する場合に備え、直近 10 件の login outcome を一時保持する。ログアウトは `account/logout` を明示的に呼ぶ。
 


### PR DESCRIPTION
## Summary

- validate the selected Databricks CLI profile before Codex summary and chat operations
- transparently run browser login when the CLI reports an expired or missing login, then reload the shared Codex app-server
- single-flight concurrent authentication and drain active summary/chat operations before reloading
- keep multi-step chat thread creation and resume requests on one app-server connection

## Root cause

Databricks CLI authentication was only ensured while configuring the AI provider. Expired credentials discovered during later summary or chat requests therefore reached Codex as a 401 without invoking the existing browser login flow.

## Impact

When Databricks credentials expire, Dahlia now opens the Databricks CLI browser login flow before sending the Codex request. After authentication, it discards the app-server's cached provider token and continues the original operation. Login failures and cancellation still stop the Codex request and preserve the existing localized errors.

## Validation

- `swift test --filter 'CodexChatAuthenticationTests|CodexChatServiceTests|CodexAppServerServiceTests'` — 55 tests passed
- `swift test` — 1333 tests in 204 suites passed
- `swift build`
- `CI=true ./scripts/lint.sh` — SwiftFormat clean; existing non-blocking SwiftLint violations remain
- `git diff --check`
