### PR TITLE
Add recent project organization chat shortcut

### DIFF
--- a/Sources/Dahlia/Models/CodexChatProjectOrganizationShortcut.swift
+++ b/Sources/Dahlia/Models/CodexChatProjectOrganizationShortcut.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum CodexChatProjectOrganizationShortcut {
+    static let periodDays = 30
+
+    static var title: String {
+        L10n.chatProjectOrganizationShortcutTitle(periodDays)
+    }
+
+    static func prompt(
+        now: Date = .now,
+        calendar: Calendar = .current
+    ) -> String {
+        let createdFrom = calendar.date(byAdding: .day, value: -periodDays, to: now) ?? now
+        return L10n.chatProjectOrganizationShortcutPrompt(
+            days: periodDays,
+            createdFrom: CodexChatPromptCodec.format(createdFrom),
+            createdBefore: CodexChatPromptCodec.format(now)
+        )
+    }
+}

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -928,6 +928,8 @@
 "This chat is no longer available." = "This chat is no longer available.";
 "Resize" = "Resize";
 "Show all chats" = "Show all";
+"Organize meetings and Projects from the last %lld days" = "Organize meetings and Projects from the last %lld days";
+"Project organization chat shortcut prompt" = "Use $projects-optimizer to organize Dahlia Meetings and Projects from the last %1$lld days.\ncreated_from: %2$@\ncreated_before: %3$@\n\nReview the Meetings in this period together with the existing Project hierarchy, improve Project descriptions when supported by evidence, and update Meeting assignments.";
 "Copy message" = "Copy message";
 "Thought process" = "Thought process";
 "Selected" = "Selected";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -928,6 +928,8 @@
 "This chat is no longer available." = "このチャットは利用できなくなりました。";
 "Resize" = "サイズを変更";
 "Show all chats" = "すべて表示";
+"Organize meetings and Projects from the last %lld days" = "直近%lld日のミーティングとProjectを整理";
+"Project organization chat shortcut prompt" = "$projects-optimizer を使って、直近%1$lld日の Dahlia ミーティングと Project を整理してください。\ncreated_from: %2$@\ncreated_before: %3$@\n\nこの期間のミーティングと既存の Project 階層をまとめて確認し、根拠がある場合は Project の説明を改善して、ミーティングの割り当てを更新してください。";
 "Copy message" = "メッセージをコピー";
 "Thought process" = "思考プロセス";
 "Selected" = "選択中";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -2545,6 +2545,24 @@ enum L10n {
     static var chatWindowUnavailable: String { String(localized: "This chat is no longer available.", bundle: bundle) }
     static var resize: String { String(localized: "Resize", bundle: bundle) }
     static var chatShowAll: String { String(localized: "Show all chats", bundle: bundle) }
+    static func chatProjectOrganizationShortcutTitle(_ days: Int) -> String {
+        String(localized: "Organize meetings and Projects from the last \(days) days", bundle: bundle)
+    }
+
+    static func chatProjectOrganizationShortcutPrompt(
+        days: Int,
+        createdFrom: String,
+        createdBefore: String
+    ) -> String {
+        String(
+            format: String(localized: "Project organization chat shortcut prompt", bundle: bundle),
+            locale: .current,
+            Int64(days),
+            createdFrom,
+            createdBefore
+        )
+    }
+
     static var copyChatMessage: String { String(localized: "Copy message", bundle: bundle) }
     static var chatReasoning: String { String(localized: "Thought process", bundle: bundle) }
     static var selected: String { String(localized: "Selected", bundle: bundle) }

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel+ProjectOrganizationShortcut.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel+ProjectOrganizationShortcut.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+extension CodexChatSessionModel {
+    var showsProjectOrganizationShortcut: Bool {
+        backendThreadID == nil && messages.isEmpty
+    }
+
+    var canSendProjectOrganizationShortcut: Bool {
+        showsProjectOrganizationShortcut && isBoundToCurrentVault && !isGenerating
+    }
+
+    func sendProjectOrganizationShortcut(
+        now: Date = .now,
+        calendar: Calendar = .current
+    ) {
+        guard canSendProjectOrganizationShortcut else { return }
+        submit(CodexChatProjectOrganizationShortcut.prompt(now: now, calendar: calendar))
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatEmptyStateView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatEmptyStateView.swift
@@ -3,39 +3,59 @@ import SwiftUI
 struct CodexChatEmptyStateView: View {
     let recentThreads: [CodexChatThreadSummary]
     let meetingNamesByID: [UUID: String]
+    let showsProjectOrganizationShortcut: Bool
+    let isProjectOrganizationShortcutEnabled: Bool
+    let onOrganizeRecentMeetingsAndProjects: () -> Void
     let onOpenThread: (CodexChatThreadSummary) -> Void
     let onShowAll: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: 0) {
+            if showsProjectOrganizationShortcut {
+                Button(action: onOrganizeRecentMeetingsAndProjects) {
+                    Label(CodexChatProjectOrganizationShortcut.title, systemImage: "sparkles")
+                        .font(.callout)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.horizontal, 4)
+                        .frame(minHeight: 28)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .disabled(!isProjectOrganizationShortcutEnabled)
+                .padding(.top, 12)
+            }
+
             Spacer(minLength: 40)
 
             if !recentThreads.isEmpty {
-                Text(L10n.recentChats)
-                    .font(.subheadline)
-                    .foregroundStyle(.tertiary)
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(L10n.recentChats)
+                        .font(.subheadline)
+                        .foregroundStyle(.tertiary)
 
-                ForEach(recentThreads) { thread in
-                    Button {
-                        onOpenThread(thread)
-                    } label: {
-                        CodexChatThreadRow(
-                            thread: thread,
-                            meetingNamesByID: meetingNamesByID
-                        )
+                    ForEach(recentThreads) { thread in
+                        Button {
+                            onOpenThread(thread)
+                        } label: {
+                            CodexChatThreadRow(
+                                thread: thread,
+                                meetingNamesByID: meetingNamesByID
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.secondary)
                     }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
-                }
 
-                Button(L10n.chatShowAll, action: onShowAll)
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.tertiary)
-                    .padding(.top, 4)
+                    Button(L10n.chatShowAll, action: onShowAll)
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.tertiary)
+                        .padding(.top, 4)
+                }
             }
         }
         .padding(.horizontal, CodexChatDesign.contentHorizontalPadding)
         .padding(.bottom, 22)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatView.swift
@@ -45,6 +45,9 @@ struct CodexChatView: View {
                 CodexChatEmptyStateView(
                     recentThreads: Array(coordinator.history.prefix(3)),
                     meetingNamesByID: session.meetingNamesByID,
+                    showsProjectOrganizationShortcut: session.showsProjectOrganizationShortcut,
+                    isProjectOrganizationShortcutEnabled: session.canSendProjectOrganizationShortcut,
+                    onOrganizeRecentMeetingsAndProjects: { session.sendProjectOrganizationShortcut() },
                     onOpenThread: openHistoryThread,
                     onShowAll: showHistory
                 )

--- a/Tests/DahliaTests/CodexAppServerLauncherTests.swift
+++ b/Tests/DahliaTests/CodexAppServerLauncherTests.swift
@@ -91,6 +91,21 @@ import Foundation
         }
 
         @Test
+        func projectsOptimizerDefaultsToTheMostRecentNinetyDays() throws {
+            let rootURL = URL.temporaryDirectory
+                .appending(path: "dahlia-codex-projects-default-\(UUID().uuidString)", directoryHint: .isDirectory)
+            defer { try? FileManager.default.removeItem(at: rootURL) }
+
+            let homeURL = try ApplicationSupportCodexHomeLocator(applicationSupportURL: rootURL).homeURL()
+            try BundledCodexPresetSkillInstaller().install(into: homeURL)
+            let skillURL = homeURL
+                .appending(path: "skills/projects-optimizer/SKILL.md")
+            let body = try String(contentsOf: skillURL, encoding: .utf8)
+
+            #expect(body.contains("For a broad request without dates, use the most recent 90 days"))
+        }
+
+        @Test
         func replacesSymlinkedPresetWithoutModifyingItsTarget() throws {
             let rootURL = URL.temporaryDirectory
                 .appending(path: "dahlia-codex-skill-link-\(UUID().uuidString)", directoryHint: .isDirectory)

--- a/Tests/DahliaTests/CodexChatProjectOrganizationShortcutTests.swift
+++ b/Tests/DahliaTests/CodexChatProjectOrganizationShortcutTests.swift
@@ -1,0 +1,135 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct CodexChatProjectOrganizationShortcutTests {
+        @Test
+        func usesFixedThirtyDayBoundaries() throws {
+            var calendar = Calendar(identifier: .gregorian)
+            calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+            let now = Date(timeIntervalSince1970: 1_800_000_000.125)
+            let createdFrom = try #require(
+                calendar.date(
+                    byAdding: .day,
+                    value: -CodexChatProjectOrganizationShortcut.periodDays,
+                    to: now
+                )
+            )
+
+            let prompt = CodexChatProjectOrganizationShortcut.prompt(now: now, calendar: calendar)
+
+            #expect(CodexChatProjectOrganizationShortcut.periodDays == 30)
+            #expect(
+                CodexChatProjectOrganizationShortcut.title
+                    == L10n.chatProjectOrganizationShortcutTitle(CodexChatProjectOrganizationShortcut.periodDays)
+            )
+            #expect(prompt.contains("$projects-optimizer"))
+            #expect(prompt.contains("created_from: \(CodexChatPromptCodec.format(createdFrom))"))
+            #expect(prompt.contains("created_before: \(CodexChatPromptCodec.format(now))"))
+        }
+
+        @Test
+        func sendsWithoutChangingComposer() async throws {
+            let service = TestCodexChatService(mode: .staleRollout)
+            let settings = AppSettings()
+            let vault = Self.testVault()
+            settings.currentVault = vault
+            let session = CodexChatSessionModel(
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings
+            )
+            let meeting = Self.meetingReference(name: "Keep reference")
+            let attachment = CodexChatImageAttachment(data: Data([0x01]), mimeType: "image/png")
+            session.updateAvailableMeetings([meeting], catalogVaultID: vault.id)
+            session.addMeetingReference(meeting)
+            session.attachedImages = [attachment]
+            session.draft = "Keep draft"
+            var calendar = Calendar(identifier: .gregorian)
+            calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+            let now = Date(timeIntervalSince1970: 1_800_000_000.125)
+            let expectedPrompt = CodexChatProjectOrganizationShortcut.prompt(now: now, calendar: calendar)
+
+            session.sendProjectOrganizationShortcut(now: now, calendar: calendar)
+            #expect(await pollUntil { !session.isGenerating })
+
+            #expect(await service.sentTextBlocks == [[expectedPrompt]])
+            #expect(session.draft == "Keep draft")
+            #expect(session.selectedMeetingReferenceIDs == [meeting.id])
+            #expect(session.attachedImages == [attachment])
+        }
+
+        @Test
+        func requiresCurrentVaultAndIdleSession() async {
+            let service = TestCodexChatService(mode: .block)
+            let settings = AppSettings()
+            let boundVault = Self.testVault()
+            settings.currentVault = boundVault
+            let session = CodexChatSessionModel(
+                vaultID: boundVault.id,
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings
+            )
+
+            settings.currentVault = Self.testVault()
+            session.sendProjectOrganizationShortcut()
+            #expect(!session.isGenerating)
+            #expect(await service.sentTextBlocks.isEmpty)
+
+            settings.currentVault = boundVault
+            session.sendProjectOrganizationShortcut()
+            #expect(await pollUntil { await service.sentTextBlocks.count == 1 })
+            session.sendProjectOrganizationShortcut()
+            await Task.yield()
+
+            #expect(await service.sentTextBlocks.count == 1)
+            session.stop()
+            #expect(await pollUntil { !session.isGenerating })
+        }
+
+        @Test
+        func unavailableWhileAHistoryThreadIsRestoring() async {
+            let service = TestCodexChatService(mode: .staleRollout)
+            let settings = AppSettings()
+            let vault = Self.testVault()
+            settings.currentVault = vault
+            let session = CodexChatSessionModel(
+                vaultID: vault.id,
+                backendThreadID: "history-thread",
+                modelID: "default-model",
+                effort: "medium",
+                service: service,
+                settings: settings
+            )
+
+            #expect(session.messages.isEmpty)
+            #expect(!session.showsProjectOrganizationShortcut)
+            #expect(!session.canSendProjectOrganizationShortcut)
+
+            session.sendProjectOrganizationShortcut()
+            await Task.yield()
+
+            #expect(await service.sentTextBlocks.isEmpty)
+        }
+
+        private static func testVault() -> VaultRecord {
+            VaultRecord(
+                id: .v7(),
+                path: "/tmp/chat-shortcut-test-vault",
+                name: "Chat Shortcut Test",
+                createdAt: .now,
+                lastOpenedAt: .now
+            )
+        }
+
+        private static func meetingReference(name: String) -> CodexChatMeetingReference {
+            CodexChatMeetingReference(id: .v7(), name: name, createdAt: .now)
+        }
+    }
+#endif

--- a/docs/customer-intelligence-workspace.md
+++ b/docs/customer-intelligence-workspace.md
@@ -51,6 +51,11 @@ Dahlia の「顧客インテリジェンス」画面は、選択中の Vault に
 人物はドメインだけで所属を決めず、議事録などの証拠に基づいて `set_contact_organization_membership` で
 明示的に所属させます。
 
+新しい AI チャットの上部には「直近30日のミーティングとProjectを整理」ショートカットがあります。選択時に
+直近30日の開始・終了日時を確定して依頼を自動送信し、`projects-optimizer` が Meeting、Project 階層、説明、
+Meeting assignment を整理します。この30日はショートカット固有の明示指定であり、期間を指定せずに
+`projects-optimizer` を依頼した場合は既定の90日を使用します。
+
 アプリ内チャットには、この整理手順を層ごとに固定した preset skill が同梱されています。人物・組織・所属は
 `contacts-organizations-curator`、継続トピックは `conversation-topics-curator`、インサイトは
 `insights-curator` が担当し、依頼内容に応じてチャットが自動で選択します。3つは互いを参照しないため、


### PR DESCRIPTION
## Summary

- add a top-of-chat shortcut that automatically organizes Meetings and Projects from the last 30 days
- calculate explicit inclusive/exclusive ISO 8601 boundaries in Swift while preserving the projects-optimizer 90-day default for unspecified periods
- preserve the current draft, image attachments, and Meeting references when sending the preset
- hide the shortcut for existing/history conversations and allow the English label to wrap at compact widths
- add Japanese and English localization, documentation, and regression coverage

## Why

A dedicated shortcut makes the common recent-work organization flow discoverable while keeping its 30-day scope explicit and deterministic. The underlying projects-optimizer remains reusable with its existing 90-day default when no period is supplied.

## Validation

- `swift build`
- `swift test --filter CodexChatProjectOrganizationShortcutTests` (4 tests)
- `swift test --filter CodexAppServerLauncherTests` (5 tests)
- `CI=true ./scripts/lint.sh`
- strict SwiftLint on changed Swift files (0 violations)
- `plutil -lint` for English and Japanese localization files
- `git diff --check`