### PR TITLE
Clarify chat preset shortcut

### DIFF
--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -928,6 +928,7 @@
 "This chat is no longer available." = "This chat is no longer available.";
 "Resize" = "Resize";
 "Show all chats" = "Show all";
+"Presets" = "Presets";
 "Organize meetings and Projects from the last %lld days" = "Organize meetings and Projects from the last %lld days";
 "Project organization chat shortcut prompt" = "Use $projects-optimizer to organize Dahlia Meetings and Projects from the last %1$lld days.\ncreated_from: %2$@\ncreated_before: %3$@\n\nReview the Meetings in this period together with the existing Project hierarchy, improve Project descriptions when supported by evidence, and update Meeting assignments.";
 "Copy message" = "Copy message";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -928,6 +928,7 @@
 "This chat is no longer available." = "このチャットは利用できなくなりました。";
 "Resize" = "サイズを変更";
 "Show all chats" = "すべて表示";
+"Presets" = "プリセット";
 "Organize meetings and Projects from the last %lld days" = "直近%lld日のミーティングとProjectを整理";
 "Project organization chat shortcut prompt" = "$projects-optimizer を使って、直近%1$lld日の Dahlia ミーティングと Project を整理してください。\ncreated_from: %2$@\ncreated_before: %3$@\n\nこの期間のミーティングと既存の Project 階層をまとめて確認し、根拠がある場合は Project の説明を改善して、ミーティングの割り当てを更新してください。";
 "Copy message" = "メッセージをコピー";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -2545,6 +2545,7 @@ enum L10n {
     static var chatWindowUnavailable: String { String(localized: "This chat is no longer available.", bundle: bundle) }
     static var resize: String { String(localized: "Resize", bundle: bundle) }
     static var chatShowAll: String { String(localized: "Show all chats", bundle: bundle) }
+    static var chatPresets: String { String(localized: "Presets", bundle: bundle) }
     static func chatProjectOrganizationShortcutTitle(_ days: Int) -> String {
         String(localized: "Organize meetings and Projects from the last \(days) days", bundle: bundle)
     }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatEmptyStateView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatEmptyStateView.swift
@@ -15,54 +15,62 @@ struct CodexChatEmptyStateView: View {
 
             VStack(alignment: .leading, spacing: 28) {
                 if showsProjectOrganizationShortcut {
-                    VStack(alignment: .leading, spacing: 10) {
-                        Text(L10n.chatPresets)
-                            .font(.subheadline)
-                            .foregroundStyle(.tertiary)
-
-                        Button(action: onOrganizeRecentMeetingsAndProjects) {
-                            Label(CodexChatProjectOrganizationShortcut.title, systemImage: "sparkles")
-                                .font(.callout)
-                                .lineLimit(2)
-                                .fixedSize(horizontal: false, vertical: true)
-                                .padding(.horizontal, 4)
-                                .frame(minHeight: 28)
-                        }
-                        .buttonStyle(.bordered)
-                        .controlSize(.large)
-                        .disabled(!isProjectOrganizationShortcutEnabled)
-                    }
+                    projectOrganizationPresetSection
                 }
 
                 if !recentThreads.isEmpty {
-                    VStack(alignment: .leading, spacing: 10) {
-                        Text(L10n.recentChats)
-                            .font(.subheadline)
-                            .foregroundStyle(.tertiary)
-
-                        ForEach(recentThreads) { thread in
-                            Button {
-                                onOpenThread(thread)
-                            } label: {
-                                CodexChatThreadRow(
-                                    thread: thread,
-                                    meetingNamesByID: meetingNamesByID
-                                )
-                            }
-                            .buttonStyle(.plain)
-                            .foregroundStyle(.secondary)
-                        }
-
-                        Button(L10n.chatShowAll, action: onShowAll)
-                            .buttonStyle(.plain)
-                            .foregroundStyle(.tertiary)
-                            .padding(.top, 4)
-                    }
+                    recentChatsSection
                 }
             }
         }
         .padding(.horizontal, CodexChatDesign.contentHorizontalPadding)
         .padding(.bottom, 22)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var projectOrganizationPresetSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(L10n.chatPresets)
+                .font(.subheadline)
+                .foregroundStyle(.tertiary)
+
+            Button(action: onOrganizeRecentMeetingsAndProjects) {
+                Label(CodexChatProjectOrganizationShortcut.title, systemImage: "sparkles")
+                    .font(.callout)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 4)
+                    .frame(minHeight: 28)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.large)
+            .disabled(!isProjectOrganizationShortcutEnabled)
+        }
+    }
+
+    private var recentChatsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(L10n.recentChats)
+                .font(.subheadline)
+                .foregroundStyle(.tertiary)
+
+            ForEach(recentThreads) { thread in
+                Button {
+                    onOpenThread(thread)
+                } label: {
+                    CodexChatThreadRow(
+                        thread: thread,
+                        meetingNamesByID: meetingNamesByID
+                    )
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+            }
+
+            Button(L10n.chatShowAll, action: onShowAll)
+                .buttonStyle(.plain)
+                .foregroundStyle(.tertiary)
+                .padding(.top, 4)
+        }
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatEmptyStateView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatEmptyStateView.swift
@@ -12,18 +12,26 @@ struct CodexChatEmptyStateView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             if showsProjectOrganizationShortcut {
-                Button(action: onOrganizeRecentMeetingsAndProjects) {
-                    Label(CodexChatProjectOrganizationShortcut.title, systemImage: "sparkles")
-                        .font(.callout)
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .padding(.horizontal, 4)
-                        .frame(minHeight: 28)
+                Spacer(minLength: 24)
+
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(L10n.chatPresets)
+                        .font(.subheadline)
+                        .foregroundStyle(.tertiary)
+
+                    Button(action: onOrganizeRecentMeetingsAndProjects) {
+                        Label(CodexChatProjectOrganizationShortcut.title, systemImage: "sparkles")
+                            .font(.callout)
+                            .lineLimit(2)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.horizontal, 4)
+                            .frame(minHeight: 28)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
+                    .disabled(!isProjectOrganizationShortcutEnabled)
                 }
-                .buttonStyle(.bordered)
-                .controlSize(.large)
-                .disabled(!isProjectOrganizationShortcutEnabled)
-                .padding(.top, 12)
+                .frame(maxWidth: .infinity, alignment: .center)
             }
 
             Spacer(minLength: 40)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatEmptyStateView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatEmptyStateView.swift
@@ -11,54 +11,53 @@ struct CodexChatEmptyStateView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if showsProjectOrganizationShortcut {
-                Spacer(minLength: 24)
-
-                VStack(alignment: .leading, spacing: 10) {
-                    Text(L10n.chatPresets)
-                        .font(.subheadline)
-                        .foregroundStyle(.tertiary)
-
-                    Button(action: onOrganizeRecentMeetingsAndProjects) {
-                        Label(CodexChatProjectOrganizationShortcut.title, systemImage: "sparkles")
-                            .font(.callout)
-                            .lineLimit(2)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .padding(.horizontal, 4)
-                            .frame(minHeight: 28)
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.large)
-                    .disabled(!isProjectOrganizationShortcutEnabled)
-                }
-                .frame(maxWidth: .infinity, alignment: .center)
-            }
-
             Spacer(minLength: 40)
 
-            if !recentThreads.isEmpty {
-                VStack(alignment: .leading, spacing: 10) {
-                    Text(L10n.recentChats)
-                        .font(.subheadline)
-                        .foregroundStyle(.tertiary)
+            VStack(alignment: .leading, spacing: 28) {
+                if showsProjectOrganizationShortcut {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text(L10n.chatPresets)
+                            .font(.subheadline)
+                            .foregroundStyle(.tertiary)
 
-                    ForEach(recentThreads) { thread in
-                        Button {
-                            onOpenThread(thread)
-                        } label: {
-                            CodexChatThreadRow(
-                                thread: thread,
-                                meetingNamesByID: meetingNamesByID
-                            )
+                        Button(action: onOrganizeRecentMeetingsAndProjects) {
+                            Label(CodexChatProjectOrganizationShortcut.title, systemImage: "sparkles")
+                                .font(.callout)
+                                .lineLimit(2)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .padding(.horizontal, 4)
+                                .frame(minHeight: 28)
                         }
-                        .buttonStyle(.plain)
-                        .foregroundStyle(.secondary)
+                        .buttonStyle(.bordered)
+                        .controlSize(.large)
+                        .disabled(!isProjectOrganizationShortcutEnabled)
                     }
+                }
 
-                    Button(L10n.chatShowAll, action: onShowAll)
-                        .buttonStyle(.plain)
-                        .foregroundStyle(.tertiary)
-                        .padding(.top, 4)
+                if !recentThreads.isEmpty {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text(L10n.recentChats)
+                            .font(.subheadline)
+                            .foregroundStyle(.tertiary)
+
+                        ForEach(recentThreads) { thread in
+                            Button {
+                                onOpenThread(thread)
+                            } label: {
+                                CodexChatThreadRow(
+                                    thread: thread,
+                                    meetingNamesByID: meetingNamesByID
+                                )
+                            }
+                            .buttonStyle(.plain)
+                            .foregroundStyle(.secondary)
+                        }
+
+                        Button(L10n.chatShowAll, action: onShowAll)
+                            .buttonStyle(.plain)
+                            .foregroundStyle(.tertiary)
+                            .padding(.top, 4)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- add a localized Presets label above the project-organization shortcut
- left-align the preset action with the recent-chat section
- place the preset directly above recent chats as a compact empty-state action group

## Why

The shortcut looked like the first message in a conversation because it used a chat-like pill at the top of the empty state. Naming the action and grouping it immediately above recent chats makes its preset role clear while keeping the empty-state content on one consistent left edge.

## Validation

- `swift test --filter DahliaTests.CodexChatProjectOrganizationShortcutTests` — 4 tests passed
- Swift build completed successfully as part of the targeted test run
- `CI=true ./scripts/lint.sh` — SwiftFormat passed; SwiftLint reported only pre-existing repository-wide violations outside the changed files
- localized strings passed `plutil -lint`
- `git diff --check` passed