### PR TITLE
Fix chat placeholder during text input

### DIFF
--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
@@ -86,6 +86,7 @@ struct CodexChatComposerInputRow: View {
 
 struct CodexChatComposerTextEditor: View {
     @Binding var text: String
+    @FocusState private var isFocused: Bool
     let onSubmit: () -> Void
     let onMoveCommand: (MoveCommandDirection) -> Void
     let onExitCommand: () -> Void
@@ -108,6 +109,7 @@ struct CodexChatComposerTextEditor: View {
                 ZStack(alignment: .topLeading) {
                     TextEditor(text: $text)
                         .font(.body)
+                        .focused($isFocused)
                         .scrollContentBackground(.hidden)
                         .padding(.leading, 3)
                         .padding(.vertical, 6)
@@ -121,7 +123,7 @@ struct CodexChatComposerTextEditor: View {
                             return .handled
                         }
 
-                    if text.isEmpty {
+                    if Self.shouldShowPlaceholder(text: text, isFocused: isFocused) {
                         Text(L10n.messageCodex)
                             .font(.body)
                             .foregroundStyle(.tertiary)
@@ -134,6 +136,10 @@ struct CodexChatComposerTextEditor: View {
                 .contentShape(.rect)
                 .onContinuousHover(perform: onHover)
             }
+    }
+
+    static func shouldShowPlaceholder(text: String, isFocused: Bool) -> Bool {
+        text.isEmpty && !isFocused
     }
 
     private func handleReturnKey(_ keyPress: KeyPress) -> KeyPress.Result {

--- a/Tests/DahliaTests/CodexChatComposerTextEditorTests.swift
+++ b/Tests/DahliaTests/CodexChatComposerTextEditorTests.swift
@@ -8,6 +8,13 @@ import SwiftUI
     @MainActor
     struct CodexChatComposerTextEditorTests {
         @Test
+        func placeholderIsHiddenWhileEditorIsFocused() {
+            #expect(CodexChatComposerTextEditor.shouldShowPlaceholder(text: "", isFocused: false))
+            #expect(!CodexChatComposerTextEditor.shouldShowPlaceholder(text: "", isFocused: true))
+            #expect(!CodexChatComposerTextEditor.shouldShowPlaceholder(text: "Draft", isFocused: false))
+        }
+
+        @Test
         func editorGrowsWithContentAndCapsItsVisibleHeight() throws {
             let singleLine = ComposerTextEditorHarness(text: "One line")
             let longDraft = ComposerTextEditorHarness(text: String(repeating: "Line\n", count: 20))


### PR DESCRIPTION
## Summary

- hide the AI chat composer placeholder while the editor is focused
- prevent the placeholder from overlapping Japanese IME marked text
- add regression coverage for focused and non-empty composer states

## Root cause

During Japanese IME composition, the native text editor contains marked text before SwiftUI updates the bound draft. The placeholder was rendered from `text.isEmpty` alone, so it remained visible over the in-progress composition.

## User impact

The composer now removes the placeholder as soon as editing begins, keeping IME input readable without changing submission behavior.

## Validation

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter CodexChatComposerTextEditorTests` (6 tests passed)
- SwiftFormat check passed
- SwiftLint on the two changed files reported 0 violations
- `git diff --check`
