### PR TITLE
Polish meeting detail and project management UI

### DIFF
--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -1,5 +1,6 @@
 /* Common */
 "Delete" = "Delete";
+"Remove from Project" = "Remove from Project";
 "Backups" = "Backups";
 "Database Backup" = "Database Backup";
 "Backups include transcripts and other database content. Audio files and their references are excluded." = "Backups include transcripts and other database content. Audio files and their references are excluded.";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -1,5 +1,6 @@
 /* Common */
 "Delete" = "削除";
+"Remove from Project" = "プロジェクトを解除";
 "Backups" = "バックアップ";
 "Database Backup" = "データベースのバックアップ";
 "Backups include transcripts and other database content. Audio files and their references are excluded." = "文字起こしなどのデータベース内容を保存します。音声ファイルとその参照情報は含まれません。";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -35,6 +35,7 @@ enum L10n {
 
     static var delete: String { String(localized: "Delete", bundle: bundle) }
     static var remove: String { String(localized: "Remove", bundle: bundle) }
+    static var removeProjectAssignment: String { String(localized: "Remove from Project", bundle: bundle) }
     static var rename: String { String(localized: "Rename", bundle: bundle) }
     static var retry: String { String(localized: "Retry", bundle: bundle) }
     static var create: String { String(localized: "Create", bundle: bundle) }

--- a/Sources/Dahlia/Views/CalendarEventMetadataButton.swift
+++ b/Sources/Dahlia/Views/CalendarEventMetadataButton.swift
@@ -6,6 +6,7 @@ struct CalendarEventMetadataButton: View {
     private let attributedDescription: AttributedString?
 
     @State private var isPresented = false
+    @State private var isHovered = false
 
     init(text: String, event: CalendarEventDisplayInfo) {
         self.text = text
@@ -24,15 +25,14 @@ struct CalendarEventMetadataButton: View {
                     .font(.caption2)
             }
             .foregroundStyle(.secondary)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(Color.primary.opacity(0.06))
-            )
-            .contentShape(RoundedRectangle(cornerRadius: 6))
+            .dahliaChipSurface(isHovered: isHovered)
+            .contentShape(Capsule())
         }
         .buttonStyle(.plain)
+        .pointerStyle(.link)
+        .onHover { hovering in
+            isHovered = hovering
+        }
         .help(L10n.calendarEventOrigin(event.resolvedTitle))
         .accessibilityLabel(L10n.calendarEventOrigin(event.resolvedTitle))
         .accessibilityValue(detailLines.joined(separator: ", "))

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -218,7 +218,7 @@ struct ControlPanelView: View {
     let recordingCoordinator: RecordingCoordinator
     let allowsTranscriptReferencePopovers: Bool
     @ObservedObject private var appSettings = AppSettings.shared
-    @State private var selectedTab: DetailTab = .notes
+    @State private var selectedTab: DetailTab = .summary
     @State private var expandedScreenshot: ExpandedScreenshotPresentation?
     @State private var screenshotMinimumWidth = ScreenshotGridSizing.defaultMinimumWidth
     @State private var isSelectingScreenshots = false
@@ -600,14 +600,6 @@ struct ControlPanelView: View {
         return nil
     }
 
-    private var persistedSummaryExists: Bool {
-        currentMeetingItem?.hasSummary == true
-    }
-
-    private var hasSummaryTab: Bool {
-        persistedSummaryExists || viewModel.hasCurrentMeetingSummary
-    }
-
     private var tabContentBackgroundColor: Color {
         selectedTab == .notes ? Color(nsColor: .textBackgroundColor) : Color(nsColor: .windowBackgroundColor)
     }
@@ -705,7 +697,7 @@ struct ControlPanelView: View {
     }
 
     private var initialTabSelection: DetailTab {
-        hasSummaryTab ? .summary : .notes
+        .summary
     }
 
 }

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -45,6 +45,8 @@ private struct MeetingNameHeader: View {
     let onCommit: () -> Void
     let onCancel: () -> Void
     let onEditorTap: () -> Void
+    @State private var isHovered = false
+    @FocusState private var isTitleButtonFocused: Bool
 
     private var displayName: String {
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -85,10 +87,16 @@ private struct MeetingNameHeader: View {
                         Image(systemName: "pencil")
                             .font(.system(size: 11, weight: .medium))
                             .foregroundStyle(.tertiary)
+                            .opacity(isHovered || isTitleButtonFocused ? 1 : 0)
                     }
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .focusable()
+                .focused($isTitleButtonFocused)
+                .onHover { hovering in
+                    isHovered = hovering
+                }
                 .help(L10n.rename)
             }
         }
@@ -154,7 +162,7 @@ private struct MeetingDetailHeader: View {
     let onDelete: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 10) {
             MeetingNameHeader(
                 title: title,
                 isEditing: $isEditing,
@@ -183,29 +191,12 @@ private struct MeetingDetailHeader: View {
     }
 
     private var metadataStack: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            FlowLayout(spacing: 8, rowSpacing: 8) {
-                if let calendarEvent {
-                    CalendarEventMetadataButton(
-                        text: metadataText,
-                        event: calendarEvent
-                    )
-                } else {
-                    MeetingMetadataPill(systemImage: "calendar", text: metadataText)
-                }
-
-                MeetingProjectPicker(
-                    viewModel: viewModel,
-                    sidebarViewModel: sidebarViewModel,
-                    style: .regular
-                )
-            }
-
-            MeetingMetadataBar(
-                viewModel: viewModel,
-                sidebarViewModel: sidebarViewModel
-            )
-        }
+        MeetingMetadataBar(
+            viewModel: viewModel,
+            sidebarViewModel: sidebarViewModel,
+            metadataText: metadataText,
+            calendarEvent: calendarEvent
+        )
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
@@ -217,29 +208,6 @@ private struct MeetingDetailHeader: View {
         )
         .controlSize(.regular)
         .fixedSize(horizontal: true, vertical: false)
-    }
-}
-
-private struct MeetingMetadataPill: View {
-    let systemImage: String
-    let text: String
-
-    var body: some View {
-        Label {
-            Text(text)
-                .font(.caption.weight(.medium))
-                .lineLimit(1)
-        } icon: {
-            Image(systemName: systemImage)
-                .font(.caption2)
-        }
-        .foregroundStyle(.secondary)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(
-            RoundedRectangle(cornerRadius: 6)
-                .fill(Color.primary.opacity(0.06))
-        )
     }
 }
 
@@ -265,36 +233,43 @@ struct ControlPanelView: View {
     @FocusState private var isNotesFieldFocused: Bool
 
     var body: some View {
-        VStack(spacing: 12) {
-            // 準備中プログレス
-            if viewModel.isPreparingAnalyzer {
-                ProgressView(L10n.preparingSpeechRecognition)
-                    .progressViewStyle(.linear)
-            }
+        VStack(spacing: 0) {
+            VStack(spacing: 12) {
+                // 準備中プログレス
+                if viewModel.isPreparingAnalyzer {
+                    ProgressView(L10n.preparingSpeechRecognition)
+                        .progressViewStyle(.linear)
+                }
 
-            if let meetingTitle = displayedMeetingTitle,
-               viewModel.hasDraftMeeting || viewModel.currentMeetingId != nil {
-                MeetingDetailHeader(
-                    viewModel: viewModel,
-                    sidebarViewModel: sidebarViewModel,
-                    title: meetingTitle,
-                    metadataText: meetingMetadataText,
-                    calendarEvent: displayedCalendarEvent,
-                    isEditing: $isEditingMeetingName,
-                    editingName: $editingMeetingName,
-                    isFocused: $isMeetingNameFieldFocused,
-                    onBeginEditing: beginMeetingRename,
-                    onCommit: commitMeetingRename,
-                    onCancel: cancelMeetingRename,
-                    onEditorTap: markMeetingNameEditorTap,
-                    onDelete: requestCurrentMeetingDeletion
+                if let meetingTitle = displayedMeetingTitle,
+                   viewModel.hasDraftMeeting || viewModel.currentMeetingId != nil {
+                    MeetingDetailHeader(
+                        viewModel: viewModel,
+                        sidebarViewModel: sidebarViewModel,
+                        title: meetingTitle,
+                        metadataText: meetingMetadataText,
+                        calendarEvent: displayedCalendarEvent,
+                        isEditing: $isEditingMeetingName,
+                        editingName: $editingMeetingName,
+                        isFocused: $isMeetingNameFieldFocused,
+                        onBeginEditing: beginMeetingRename,
+                        onCommit: commitMeetingRename,
+                        onCancel: cancelMeetingRename,
+                        onEditorTap: markMeetingNameEditorTap,
+                        onDelete: requestCurrentMeetingDeletion
+                    )
+                }
+
+                MeetingDetailNavigationBar(
+                    selection: $selectedTab,
+                    viewModel: viewModel
                 )
             }
+            .padding(.horizontal, DahliaDesign.detailHorizontalPadding)
+            .padding(.top, DahliaDesign.detailTopPadding)
 
-            MeetingDetailNavigationBar(
-                selection: $selectedTab,
-                viewModel: viewModel
-            )
+            Divider()
+                .opacity(0.5)
 
             // タブコンテンツ
             Group {
@@ -330,49 +305,25 @@ struct ControlPanelView: View {
                     )
                 }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .frame(minHeight: 280)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(tabContentBackgroundColor)
-            )
+            .background {
+                Rectangle().fill(tabContentBackgroundColor)
+            }
 
             // エラー表示
             if let error = viewModel.errorMessage {
-                HStack {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundStyle(.orange)
-                    Text(error)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                    Spacer()
-                }
+                detailErrorBanner(message: error, tint: .red)
             }
 
             if let summaryError = viewModel.summaryError {
-                HStack {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundStyle(.orange)
-                    Text(summaryError)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                    Spacer()
-                }
+                detailErrorBanner(message: summaryError, tint: .red)
             }
 
             if let googleDocsExportError = viewModel.googleDocsExportError {
-                HStack {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundStyle(.orange)
-                    Text(googleDocsExportError)
-                        .font(.caption)
-                        .foregroundStyle(.orange)
-                    Spacer()
-                }
+                detailErrorBanner(message: googleDocsExportError, tint: .orange)
             }
-
         }
-        .padding(28)
         .frame(minWidth: 500, minHeight: 500)
         .simultaneousGesture(
             TapGesture().onEnded {
@@ -466,6 +417,21 @@ struct ControlPanelView: View {
 
     // MARK: - Tab Contents
 
+    private func detailErrorBanner(message: String, tint: Color) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(tint)
+            Spacer()
+        }
+        .padding(8)
+        .background(Color.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
+        .padding(.horizontal, DahliaDesign.detailHorizontalPadding)
+        .padding(.vertical, 4)
+    }
+
     private var summaryTabContent: some View {
         SummaryTabContentView(
             screenshotStore: viewModel.screenshotStore,
@@ -501,15 +467,10 @@ struct ControlPanelView: View {
                             .allowsHitTesting(false)
                     }
                 }
-                .background(
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(.background)
-                )
-
                 Spacer(minLength: 0)
             }
         }
-        .padding(12)
+        .padding(DahliaDesign.tabContentInset)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
@@ -648,7 +609,7 @@ struct ControlPanelView: View {
     }
 
     private var tabContentBackgroundColor: Color {
-        selectedTab == .notes ? Color(nsColor: .textBackgroundColor) : Color(nsColor: .controlBackgroundColor)
+        selectedTab == .notes ? Color(nsColor: .textBackgroundColor) : Color(nsColor: .windowBackgroundColor)
     }
 
     private var showsToolbarRecordButton: Bool {

--- a/Sources/Dahlia/Views/ConversationAnalyticsDashboardContent.swift
+++ b/Sources/Dahlia/Views/ConversationAnalyticsDashboardContent.swift
@@ -30,7 +30,7 @@ struct ConversationAnalyticsDashboardContent: View {
                 }
                 ConversationAnalyticsNotesView(metrics: metrics)
             }
-            .padding(16)
+            .padding(DahliaDesign.tabContentInset)
         }
     }
 }

--- a/Sources/Dahlia/Views/DahliaDesign.swift
+++ b/Sources/Dahlia/Views/DahliaDesign.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+enum DahliaDesign {
+    static let readingMaxWidth: CGFloat = 720
+    static let readingHorizontalPadding: CGFloat = 20
+
+    static let paragraphLineSpacing: CGFloat = 3
+    static let listItemSpacing: CGFloat = 6
+    static let blockSpacing: CGFloat = 14
+    static let sectionHeadingTopPadding: CGFloat = 12
+
+    static let chipHorizontalPadding: CGFloat = 8
+    static let chipVerticalPadding: CGFloat = 3.5
+    static let chipStaticOpacity = 0.055
+    static let chipHoverOpacity = 0.10
+    static let chipTintOpacity = 0.10
+    static let chipTintHoverOpacity = 0.16
+    static let chipSpacing: CGFloat = 6
+    static let chipRowSpacing: CGFloat = 7
+
+    static let timestampChipHorizontalPadding: CGFloat = 5
+    static let timestampChipVerticalPadding: CGFloat = 1.5
+    static let timestampChipBackgroundOpacity = 0.05
+
+    static let tabHorizontalPadding: CGFloat = 12
+    static let tabVerticalPadding: CGFloat = 7
+    static let tabIndicatorHeight: CGFloat = 2
+
+    static let detailHorizontalPadding: CGFloat = 24
+    static let detailTopPadding: CGFloat = 20
+    static let tabContentInset: CGFloat = 16
+}
+
+private struct DahliaChipSurface: ViewModifier {
+    let isHovered: Bool
+    let tint: Color?
+
+    func body(content: Content) -> some View {
+        content
+            .padding(.horizontal, DahliaDesign.chipHorizontalPadding)
+            .padding(.vertical, DahliaDesign.chipVerticalPadding)
+            .background {
+                Capsule()
+                    .fill(surfaceColor)
+            }
+    }
+
+    private var surfaceColor: Color {
+        if let tint {
+            return tint.opacity(isHovered ? DahliaDesign.chipTintHoverOpacity : DahliaDesign.chipTintOpacity)
+        }
+        return Color.primary.opacity(isHovered ? DahliaDesign.chipHoverOpacity : DahliaDesign.chipStaticOpacity)
+    }
+}
+
+extension View {
+    func dahliaChipSurface(isHovered: Bool = false, tint: Color? = nil) -> some View {
+        modifier(DahliaChipSurface(isHovered: isHovered, tint: tint))
+    }
+}

--- a/Sources/Dahlia/Views/DetailTabBar.swift
+++ b/Sources/Dahlia/Views/DetailTabBar.swift
@@ -17,6 +17,9 @@ struct DetailTabBar: View {
     @Binding var selection: DetailTab
     @ObservedObject var viewModel: CaptionViewModel
     @ObservedObject private var settings = AppSettings.shared
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Namespace private var selectionIndicator
+    @State private var hoveredTab: DetailTab?
 
     private var isFolderOnly: Bool {
         viewModel.currentMeetingId == nil && !viewModel.isListening && !viewModel.hasDraftMeeting
@@ -32,32 +35,73 @@ struct DetailTabBar: View {
         ScrollView(.horizontal) {
             HStack(spacing: 4) {
                 ForEach(availableTabs) { tab in
-                    Button(tab.label) { selection = tab }
-                        .buttonStyle(.plain)
-                        .font(.body)
-                        .bold(tab == selection)
-                        .foregroundStyle(tab == selection ? .primary : .secondary)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 6)
-                        .contentShape(.rect)
-                        .overlay(alignment: .bottom) {
-                            if tab == selection {
-                                Capsule()
-                                    .fill(.primary)
-                                    .frame(height: 2)
-                                    .padding(.horizontal, 8)
-                            }
+                    let isSelected = tab == selection
+
+                    Button {
+                        select(tab)
+                    } label: {
+                        ZStack {
+                            Text(tab.label)
+                                .font(.body.weight(.semibold))
+                                .hidden()
+                            Text(tab.label)
+                                .font(.body.weight(isSelected ? .semibold : .regular))
                         }
-                        .keyboardShortcut(tab.keyboardShortcut, modifiers: .command)
-                        .help(tab.label)
-                        .accessibilityAddTraits(tab == selection ? .isSelected : [])
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(isSelected ? .primary : .secondary)
+                    .padding(.horizontal, DahliaDesign.tabHorizontalPadding)
+                    .padding(.vertical, DahliaDesign.tabVerticalPadding)
+                    .background {
+                        if !isFolderOnly, hoveredTab == tab {
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(Color.primary.opacity(0.05))
+                        }
+                    }
+                    .contentShape(.rect)
+                    .overlay(alignment: .bottom) {
+                        if isSelected {
+                            Capsule()
+                                .fill(.primary)
+                                .frame(height: DahliaDesign.tabIndicatorHeight)
+                                .padding(.horizontal, 8)
+                                .matchedGeometryEffect(id: "detail-tab-selection", in: selectionIndicator)
+                        }
+                    }
+                    .onHover { hovering in
+                        guard !isFolderOnly else { return }
+                        if hovering {
+                            hoveredTab = tab
+                        } else if hoveredTab == tab {
+                            hoveredTab = nil
+                        }
+                    }
+                    .keyboardShortcut(tab.keyboardShortcut, modifiers: .command)
+                    .help(tab.label)
+                    .accessibilityAddTraits(isSelected ? .isSelected : [])
                 }
             }
             .fixedSize(horizontal: true, vertical: false)
         }
         .scrollIndicators(.hidden)
         .disabled(isFolderOnly)
+        .onChange(of: isFolderOnly) { _, folderOnly in
+            if folderOnly {
+                hoveredTab = nil
+            }
+        }
         .accessibilityElement(children: .contain)
         .accessibilityLabel(L10n.meetingContent)
+    }
+
+    private func select(_ tab: DetailTab) {
+        guard tab != selection else { return }
+        if reduceMotion {
+            selection = tab
+        } else {
+            withAnimation(.easeInOut(duration: 0.18)) {
+                selection = tab
+            }
+        }
     }
 }

--- a/Sources/Dahlia/Views/MeetingMetadataBar.swift
+++ b/Sources/Dahlia/Views/MeetingMetadataBar.swift
@@ -1,10 +1,14 @@
 import SwiftUI
 
-/// ミーティング詳細ヘッダーの下に配置するメタデータバー。
-/// タグチップ群を横並びで表示する。
+/// ミーティング詳細ヘッダーのメタデータを一つの折り返し行にまとめる。
 struct MeetingMetadataBar: View {
     @ObservedObject var viewModel: CaptionViewModel
     var sidebarViewModel: SidebarViewModel
+    let metadataText: String
+    let calendarEvent: CalendarEventDisplayInfo?
+
+    @State private var showTagPopover = false
+    @State private var tagInput = ""
 
     private var tags: [TagInfo] {
         guard let meetingId = viewModel.currentMeetingId,
@@ -12,22 +16,6 @@ struct MeetingMetadataBar: View {
               item.meetingId == meetingId else { return [] }
         return item.tags
     }
-
-    var body: some View {
-        MeetingTagsView(viewModel: viewModel, tags: tags, sidebarViewModel: sidebarViewModel)
-            .frame(maxWidth: .infinity, alignment: .leading)
-    }
-}
-
-// MARK: - Tag Management
-
-private struct MeetingTagsView: View {
-    @ObservedObject var viewModel: CaptionViewModel
-    let tags: [TagInfo]
-    var sidebarViewModel: SidebarViewModel
-
-    @State private var showTagPopover = false
-    @State private var tagInput = ""
 
     private var trimmedTagInput: String {
         tagInput.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -48,7 +36,19 @@ private struct MeetingTagsView: View {
     }
 
     var body: some View {
-        FlowLayout(spacing: 6, rowSpacing: 7) {
+        FlowLayout(spacing: DahliaDesign.chipSpacing, rowSpacing: DahliaDesign.chipRowSpacing) {
+            if let calendarEvent {
+                CalendarEventMetadataButton(text: metadataText, event: calendarEvent)
+            } else {
+                MeetingMetadataPill(systemImage: "calendar", text: metadataText)
+            }
+
+            MeetingProjectPicker(
+                viewModel: viewModel,
+                sidebarViewModel: sidebarViewModel,
+                style: .regular
+            )
+
             ForEach(tags, id: \.name) { tag in
                 TagChip(tag: tag) {
                     guard let meetingId = viewModel.currentMeetingId else { return }
@@ -58,6 +58,7 @@ private struct MeetingTagsView: View {
 
             addTagButton
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var addTagButton: some View {
@@ -66,16 +67,16 @@ private struct MeetingTagsView: View {
             showTagPopover.toggle()
         } label: {
             HStack(spacing: 4) {
-                Image(systemName: "tag")
+                Image(systemName: "tag.badge.plus")
                     .font(.caption2)
                 Text(L10n.addTag)
                     .font(.caption.weight(.medium))
             }
             .foregroundStyle(.secondary)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
+            .padding(.horizontal, DahliaDesign.chipHorizontalPadding)
+            .padding(.vertical, DahliaDesign.chipVerticalPadding)
             .background(
-                RoundedRectangle(cornerRadius: 6)
+                Capsule()
                     .strokeBorder(style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
                     .foregroundStyle(Color.secondary.opacity(0.4))
             )
@@ -172,6 +173,24 @@ private struct MeetingTagsView: View {
     }
 }
 
+private struct MeetingMetadataPill: View {
+    let systemImage: String
+    let text: String
+
+    var body: some View {
+        Label {
+            Text(text)
+                .font(.caption.weight(.medium))
+                .lineLimit(1)
+        } icon: {
+            Image(systemName: systemImage)
+                .font(.caption2)
+        }
+        .foregroundStyle(.secondary)
+        .dahliaChipSurface()
+    }
+}
+
 // MARK: - Tag Chip
 
 private struct TagChip: View {
@@ -179,42 +198,49 @@ private struct TagChip: View {
     let onRemove: () -> Void
 
     @State private var isHovered = false
+    @FocusState private var isRemoveFocused: Bool
+
+    private var showsRemoveButton: Bool {
+        isHovered || isRemoveFocused
+    }
 
     var body: some View {
         HStack(spacing: 4) {
             ZStack {
                 Circle()
                     .fill(Color(hex: tag.colorHex))
-                    .opacity(isHovered ? 0 : 1)
+                    .opacity(showsRemoveButton ? 0 : 1)
 
                 Button(action: onRemove) {
                     Image(systemName: "xmark")
                         .font(.system(size: 8, weight: .bold))
                         .foregroundStyle(.secondary)
-                        .frame(width: 10, height: 10)
+                        .frame(minWidth: 16, minHeight: 16)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .opacity(isHovered ? 1 : 0)
-                .allowsHitTesting(isHovered)
+                .focusable()
+                .focused($isRemoveFocused)
+                .opacity(showsRemoveButton ? 1 : 0)
+                .allowsHitTesting(showsRemoveButton)
                 .accessibilityLabel(L10n.delete)
             }
-            .frame(width: 10, height: 10)
+            .frame(width: 16, height: 16)
 
             Text(tag.name)
                 .font(.caption.weight(.medium))
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(
-            RoundedRectangle(cornerRadius: 6)
-                .fill(Color(hex: tag.colorHex).opacity(isHovered ? 0.16 : 0.1))
-        )
+        .dahliaChipSurface(isHovered: isHovered, tint: Color(hex: tag.colorHex))
         .frame(maxWidth: 220)
         .onHover { hovering in
             isHovered = hovering
         }
+        .contextMenu {
+            Button(L10n.delete, role: .destructive, action: onRemove)
+        }
+        .accessibilityAction(named: Text(L10n.delete), onRemove)
     }
 }
 
@@ -233,7 +259,16 @@ struct MeetingProjectPicker: View {
     @State private var showProjectPopover = false
     @State private var projectInput = ""
     @FocusState private var isProjectFieldFocused: Bool
+    @FocusState private var isRemoveFocused: Bool
     @State private var isHovered = false
+
+    private var hasProjectAssignment: Bool {
+        viewModel.currentProjectId != nil
+    }
+
+    private var showsRemoveButton: Bool {
+        hasProjectAssignment && (isHovered || isRemoveFocused)
+    }
 
     private var trimmedProjectInput: String {
         projectInput.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -269,51 +304,67 @@ struct MeetingProjectPicker: View {
                 Image(systemName: "folder")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
-                    .opacity(isHovered && viewModel.currentProjectId != nil ? 0 : 1)
+                    .opacity(showsRemoveButton ? 0 : 1)
 
-                if viewModel.currentProjectId != nil {
+                if hasProjectAssignment {
                     Button(action: clearProject) {
                         Image(systemName: "xmark")
                             .font(.system(size: 8, weight: .bold))
                             .foregroundStyle(.secondary)
-                            .frame(width: 10, height: 10)
+                            .frame(minWidth: 16, minHeight: 16)
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
-                    .opacity(isHovered ? 1 : 0)
-                    .allowsHitTesting(isHovered)
-                    .accessibilityLabel(L10n.delete)
+                    .focusable()
+                    .focused($isRemoveFocused)
+                    .opacity(showsRemoveButton ? 1 : 0)
+                    .allowsHitTesting(showsRemoveButton)
+                    .accessibilityLabel(L10n.removeProjectAssignment)
                 }
             }
-            .frame(width: 10, height: 10)
+            .frame(width: 16, height: 16)
 
-            Button(action: presentProjectPopover) {
-                HStack(spacing: 4) {
-                    if style == .regular {
-                        Text(currentProjectName ?? L10n.noProject)
-                            .font(.caption.weight(.medium))
-                            .lineLimit(1)
-                    }
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 8, weight: .medium))
-                }
-            }
-            .buttonStyle(.plain)
+            projectSelectionButton
         }
         .foregroundStyle(.secondary)
-        .padding(.horizontal, style == .compact ? 6 : 8)
-        .padding(.vertical, 3)
-        .background(
-            RoundedRectangle(cornerRadius: 6)
-                .fill(Color.primary.opacity(isHovered ? 0.08 : 0.06))
-        )
+        .dahliaChipSurface(isHovered: isHovered)
+        .contentShape(Capsule())
         .fixedSize(horizontal: true, vertical: false)
+        .pointerStyle(.link)
         .onHover { hovering in
             isHovered = hovering
+        }
+        .contextMenu {
+            if hasProjectAssignment {
+                Button(L10n.removeProjectAssignment, role: .destructive, action: clearProject)
+            }
         }
         .popover(isPresented: $showProjectPopover, arrowEdge: .bottom) {
             projectPopoverContent
         }
         .help(currentProjectName ?? L10n.noProject)
+    }
+
+    @ViewBuilder
+    private var projectSelectionButton: some View {
+        let button = Button(action: presentProjectPopover) {
+            HStack(spacing: 4) {
+                if style == .regular {
+                    Text(currentProjectName ?? L10n.noProject)
+                        .font(.caption.weight(.medium))
+                        .lineLimit(1)
+                }
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8, weight: .medium))
+            }
+        }
+        .buttonStyle(.plain)
+
+        if hasProjectAssignment {
+            button.accessibilityAction(named: Text(L10n.removeProjectAssignment), clearProject)
+        } else {
+            button
+        }
     }
 
     private func presentProjectPopover() {

--- a/Sources/Dahlia/Views/ProjectContextSectionView.swift
+++ b/Sources/Dahlia/Views/ProjectContextSectionView.swift
@@ -11,32 +11,39 @@ struct ProjectContextSectionView: View {
         Section(L10n.projectOverview) {
             LabeledContent(L10n.vault) {
                 Label(vaultName, systemImage: "externaldrive")
+                    .foregroundStyle(.primary)
             }
 
             LabeledContent(L10n.projectLocation) {
                 Text(projectPath)
+                    .foregroundStyle(.primary)
                     .textSelection(.enabled)
             }
 
             LabeledContent(L10n.parentProject) {
                 Text(parentName ?? L10n.vaultRoot)
+                    .foregroundStyle(.secondary)
             }
 
             LabeledContent(L10n.projectType) {
                 Text(L10n.projectTypeName(project.effectiveProjectType))
+                    .foregroundStyle(.primary)
             }
 
             LabeledContent(L10n.meetingsInThisProject) {
                 Text(L10n.meetingCount(project.meetingCount))
+                    .foregroundStyle(.secondary)
             }
 
             if includedSubprojectCount > 0 {
                 LabeledContent(L10n.includedSubprojects) {
                     Text(L10n.includedSubprojectCount(includedSubprojectCount))
+                        .foregroundStyle(.secondary)
                 }
 
                 LabeledContent(L10n.meetingsInHierarchy) {
                     Text(L10n.meetingCount(hierarchyMeetingCount))
+                        .foregroundStyle(.secondary)
                 }
             }
 

--- a/Sources/Dahlia/Views/ProjectManagementRowContent.swift
+++ b/Sources/Dahlia/Views/ProjectManagementRowContent.swift
@@ -6,31 +6,16 @@ struct ProjectManagementRowContent: View {
 
     var body: some View {
         Label {
-            HStack(spacing: 6) {
-                Text(node.displayName)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .layoutPriority(1)
-
-                Text("\(node.meetingCount)")
-                    .font(.caption.weight(.semibold).monospacedDigit())
-                    .foregroundStyle(isSelected ? Color.white : Color(nsColor: .secondaryLabelColor))
-                    .lineLimit(1)
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 1)
-                    .frame(minWidth: 18)
-                    .background(meetingCountBackground, in: .capsule)
-                    .fixedSize(horizontal: true, vertical: false)
-                    .accessibilityHidden(true)
-
-                Spacer(minLength: 0)
-            }
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(accessibilityLabel)
+            Text(node.displayName)
+                .lineLimit(1)
+                .truncationMode(.middle)
         } icon: {
             Image(systemName: folderSystemImage)
                 .foregroundStyle(folderColor)
         }
+        .badge(node.meetingCount)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
     }
 
     private var folderSystemImage: String {
@@ -39,10 +24,6 @@ struct ProjectManagementRowContent: View {
         } else {
             "folder"
         }
-    }
-
-    private var meetingCountBackground: Color {
-        isSelected ? Color.white.opacity(0.20) : Color(nsColor: .secondaryLabelColor).opacity(0.14)
     }
 
     private var folderColor: Color {

--- a/Sources/Dahlia/Views/ProjectManagementView.swift
+++ b/Sources/Dahlia/Views/ProjectManagementView.swift
@@ -273,8 +273,8 @@ private extension ProjectManagementView {
             )
 
             projectNameSection(for: project)
-            hierarchySection(for: project)
             descriptionSection
+            hierarchySection(for: project)
             destinationSection(for: project)
             projectDeletionSection
         }

--- a/Sources/Dahlia/Views/ScreenshotTabContentView.swift
+++ b/Sources/Dahlia/Views/ScreenshotTabContentView.swift
@@ -53,6 +53,8 @@ struct ScreenshotTabContentView: View {
                     download: download,
                     delete: delete
                 )
+                .padding(.horizontal, DahliaDesign.tabContentInset)
+                .padding(.bottom, DahliaDesign.tabContentInset)
             }
         }
     }

--- a/Sources/Dahlia/Views/SummaryActionItemsView.swift
+++ b/Sources/Dahlia/Views/SummaryActionItemsView.swift
@@ -8,13 +8,13 @@ struct SummaryActionItemsView: View {
         let displayableItems = actionItems.filter { $0.title.nilIfBlank != nil }
 
         if !displayableItems.isEmpty {
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: DahliaDesign.blockSpacing) {
                 Text(L10n.actionItems)
                     .font(.title3.bold())
                     .fixedSize(horizontal: false, vertical: true)
-                    .padding(.top, 4)
+                    .padding(.top, DahliaDesign.sectionHeadingTopPadding)
 
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: DahliaDesign.listItemSpacing) {
                     ForEach(Array(displayableItems.enumerated()), id: \.offset) { _, item in
                         HStack(alignment: .firstTextBaseline, spacing: 6) {
                             Image(systemName: "square")
@@ -24,6 +24,7 @@ struct SummaryActionItemsView: View {
                             Text(inlineMarkdown(item.title))
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .fixedSize(horizontal: false, vertical: true)
+                                .lineSpacing(DahliaDesign.paragraphLineSpacing)
 
                             if let assignee = item.assignee.nilIfBlank {
                                 Text("(\(assignee))")

--- a/Sources/Dahlia/Views/SummaryDocumentView.swift
+++ b/Sources/Dahlia/Views/SummaryDocumentView.swift
@@ -24,7 +24,7 @@ struct SummaryDocumentView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: DahliaDesign.blockSpacing) {
             if !document.title.isEmpty {
                 inlineMarkdownText(document.title)
                     .font(.title2.bold())
@@ -47,7 +47,7 @@ struct SummaryDocumentView: View {
             inlineMarkdownText(section.heading)
                 .font(.title3.bold())
                 .fixedSize(horizontal: false, vertical: true)
-                .padding(.top, 4)
+                .padding(.top, DahliaDesign.sectionHeadingTopPadding)
         }
 
         ForEach(section.blocks) { block in
@@ -63,21 +63,24 @@ struct SummaryDocumentView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .fixedSize(horizontal: false, vertical: true)
                     .font(.body)
+                    .lineSpacing(DahliaDesign.paragraphLineSpacing)
             case let .bulletedList(items):
-                VStack(alignment: .leading, spacing: 3) {
+                VStack(alignment: .leading, spacing: DahliaDesign.listItemSpacing) {
                     ForEach(Array(items.enumerated()), id: \.offset) { _, item in
                         HStack(alignment: .firstTextBaseline, spacing: 6) {
                             Text("•")
+                                .foregroundStyle(.secondary)
                             summaryTextView(item)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .fixedSize(horizontal: false, vertical: true)
+                                .lineSpacing(DahliaDesign.paragraphLineSpacing)
                         }
                         .font(.body)
                     }
                 }
                 .padding(.leading, 8)
             case let .numberedList(items):
-                VStack(alignment: .leading, spacing: 3) {
+                VStack(alignment: .leading, spacing: DahliaDesign.listItemSpacing) {
                     ForEach(Array(items.enumerated()), id: \.offset) { index, item in
                         HStack(alignment: .firstTextBaseline, spacing: 6) {
                             Text("\(index + 1).")
@@ -85,13 +88,14 @@ struct SummaryDocumentView: View {
                             summaryTextView(item)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .fixedSize(horizontal: false, vertical: true)
+                                .lineSpacing(DahliaDesign.paragraphLineSpacing)
                         }
                         .font(.body)
                     }
                 }
                 .padding(.leading, 8)
             case let .checklist(items):
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: DahliaDesign.listItemSpacing) {
                     ForEach(Array(items.enumerated()), id: \.offset) { _, item in
                         HStack(alignment: .firstTextBaseline, spacing: 6) {
                             Image(systemName: item.checked ? "checkmark.square" : "square")
@@ -99,6 +103,7 @@ struct SummaryDocumentView: View {
                             summaryTextView(item.text)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .fixedSize(horizontal: false, vertical: true)
+                                .lineSpacing(DahliaDesign.paragraphLineSpacing)
                         }
                         .font(.body)
                     }
@@ -114,6 +119,7 @@ struct SummaryDocumentView: View {
                         .foregroundStyle(.secondary)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .fixedSize(horizontal: false, vertical: true)
+                        .lineSpacing(DahliaDesign.paragraphLineSpacing)
                         .padding(.leading, 8)
                 }
                 .padding(.vertical, 2)
@@ -142,7 +148,7 @@ struct SummaryDocumentView: View {
         case 1, 2:
             summaryTextView(content)
                 .font(.title3.bold())
-                .padding(.top, 4)
+                .padding(.top, DahliaDesign.sectionHeadingTopPadding)
         case 3:
             summaryTextView(content)
                 .font(.headline)
@@ -335,11 +341,12 @@ private struct TranscriptReferenceChip: View {
 
     var body: some View {
         Text(reference.time)
-            .font(.caption)
+            .font(.caption2.weight(.medium))
+            .monospacedDigit()
             .foregroundStyle(.secondary)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(Color.primary.opacity(0.06), in: Capsule())
+            .padding(.horizontal, DahliaDesign.timestampChipHorizontalPadding)
+            .padding(.vertical, DahliaDesign.timestampChipVerticalPadding)
+            .background(Color.primary.opacity(DahliaDesign.timestampChipBackgroundOpacity), in: Capsule())
             .onHover { isHovering in
                 isTranscriptPopoverPresented = allowsPopover
                     && isHovering

--- a/Sources/Dahlia/Views/SummaryTabContentView.swift
+++ b/Sources/Dahlia/Views/SummaryTabContentView.swift
@@ -12,18 +12,17 @@ struct SummaryTabContentView: View {
     var body: some View {
         if let document, hasSummary {
             ScrollView {
-                VStack(alignment: .leading, spacing: 20) {
-                    SummaryDocumentView(
-                        document: document,
-                        screenshotProvider: screenshot,
-                        onOpenImage: openScreenshot,
-                        transcriptTextProvider: transcriptText,
-                        allowsTranscriptReferencePopovers: allowsTranscriptReferencePopovers
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .padding(16)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                SummaryDocumentView(
+                    document: document,
+                    screenshotProvider: screenshot,
+                    onOpenImage: openScreenshot,
+                    transcriptTextProvider: transcriptText,
+                    allowsTranscriptReferencePopovers: allowsTranscriptReferencePopovers
+                )
+                .frame(maxWidth: DahliaDesign.readingMaxWidth, alignment: .leading)
+                .padding(.horizontal, DahliaDesign.readingHorizontalPadding)
+                .padding(.vertical, DahliaDesign.tabContentInset)
+                .frame(maxWidth: .infinity)
             }
         } else {
             ContentUnavailableView {

--- a/Sources/Dahlia/Views/TranscriptTabView.swift
+++ b/Sources/Dahlia/Views/TranscriptTabView.swift
@@ -120,7 +120,7 @@ struct TranscriptTabView: View {
                     }
                 }
                 .scrollTargetLayout()
-                .padding(8)
+                .padding(DahliaDesign.tabContentInset)
             }
             .scrollPosition($scrollPosition)
             .onScrollTargetVisibilityChange(idType: TranscriptSegment.ID.self, threshold: 0.1) { ids in


### PR DESCRIPTION
## Summary

- add a lightweight Dahlia design token layer for reading width, spacing, chips, tabs, and detail layout
- improve summary readability, unify meeting metadata chips, and add keyboard/VoiceOver removal paths
- remove nested detail cards, refine tab transitions and full-bleed notes, and clarify project management hierarchy
- add the localized “Remove from Project” action in English and Japanese

## User impact

Meeting details read more like a focused document, metadata and tabs behave consistently, and project management has clearer visual hierarchy. Hover-only removal actions now have context-menu, keyboard-focus, and accessibility alternatives.

## Validation

- `swift build`
- `CI=true ./scripts/lint.sh` (SwiftFormat clean; existing repository-wide SwiftLint violations remain non-blocking)
- targeted UI-related tests: 9 tests in 2 suites passed
- local full suite ran 1,342 tests in 205 suites; one unrelated Keychain-dependent `GoogleCalendarConfigurationTests.clientSecretOverrideIsPreferredOverEnvironment` test failed because the unsigned test process could not persist the temporary Keychain override
- `git diff --check`
- development build launch and visual smoke checks for summary, notes, and project management
