### PR TITLE
Stabilize AI chat rendering

### DIFF
--- a/Sources/Dahlia/Models/CodexChatConversationItem.swift
+++ b/Sources/Dahlia/Models/CodexChatConversationItem.swift
@@ -2,14 +2,14 @@ import Foundation
 
 enum CodexChatConversationItem: Identifiable, Equatable {
     case contextDivider(id: String, context: CodexChatContext?)
-    case message(CodexChatMessage)
+    case message(CodexChatMessage, showsInlineActivity: Bool = false)
     case thinking
 
     var id: String {
         switch self {
         case let .contextDivider(id, _):
             "context-\(id)"
-        case let .message(message):
+        case let .message(message, _):
             "message-\(message.id)"
         case .thinking:
             "thinking"
@@ -44,7 +44,19 @@ enum CodexChatConversationItem: Identifiable, Equatable {
                 items.append(.message(message))
             }
         }
-        if showsStandaloneThinking {
+
+        var showsInlineActivity = false
+        if let lastIndex = items.indices.last,
+           case let .message(message, _) = items[lastIndex],
+           message.role == .assistant,
+           message.isStreaming,
+           message.text.isEmpty,
+           !message.reasoning.isEmpty {
+            items[lastIndex] = .message(message, showsInlineActivity: true)
+            showsInlineActivity = true
+        }
+
+        if showsStandaloneThinking, !showsInlineActivity {
             items.append(.thinking)
         }
         return items

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -932,6 +932,7 @@
 "Organize meetings and Projects from the last %lld days" = "Organize meetings and Projects from the last %lld days";
 "Project organization chat shortcut prompt" = "Use $projects-optimizer to organize Dahlia Meetings and Projects from the last %1$lld days.\ncreated_from: %2$@\ncreated_before: %3$@\n\nReview the Meetings in this period together with the existing Project hierarchy, improve Project descriptions when supported by evidence, and update Meeting assignments.";
 "Copy message" = "Copy message";
+"Copy code" = "Copy code";
 "Thought process" = "Thought process";
 "Selected" = "Selected";
 "Response performance" = "Response performance";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -932,6 +932,7 @@
 "Organize meetings and Projects from the last %lld days" = "直近%lld日のミーティングとProjectを整理";
 "Project organization chat shortcut prompt" = "$projects-optimizer を使って、直近%1$lld日の Dahlia ミーティングと Project を整理してください。\ncreated_from: %2$@\ncreated_before: %3$@\n\nこの期間のミーティングと既存の Project 階層をまとめて確認し、根拠がある場合は Project の説明を改善して、ミーティングの割り当てを更新してください。";
 "Copy message" = "メッセージをコピー";
+"Copy code" = "コードをコピー";
 "Thought process" = "思考プロセス";
 "Selected" = "選択中";
 "Response performance" = "応答性能";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -2565,6 +2565,7 @@ enum L10n {
     }
 
     static var copyChatMessage: String { String(localized: "Copy message", bundle: bundle) }
+    static var copyCodeBlock: String { String(localized: "Copy code", bundle: bundle) }
     static var chatReasoning: String { String(localized: "Thought process", bundle: bundle) }
     static var selected: String { String(localized: "Selected", bundle: bundle) }
     static var responsePerformance: String { String(localized: "Response performance", bundle: bundle) }

--- a/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
+++ b/Sources/Dahlia/ViewModels/CodexChatSessionModel.swift
@@ -27,6 +27,7 @@ final class CodexChatSessionModel: Identifiable {
     private(set) var activeTurnID: String?
     var isPreparingTurn = false
     var isAwaitingTurnOutput = false
+    var isFinalizingTurn = false
     var lastSubmittedText: String?
     var attachedImages: [CodexChatImageAttachment] = []
     private(set) var pendingImagePreparationCount = 0
@@ -42,7 +43,9 @@ final class CodexChatSessionModel: Identifiable {
         set { setLiveModeEnabled(newValue) }
     }
 
-    var showsStandaloneThinking: Bool { isGenerating && isAwaitingTurnOutput }
+    var showsStandaloneThinking: Bool {
+        isGenerating && (isAwaitingTurnOutput || isFinalizingTurn)
+    }
 
     @ObservationIgnored private let service: any CodexChatServicing
     @ObservationIgnored let settings: AppSettings
@@ -387,6 +390,7 @@ extension CodexChatSessionModel {
             updateLimiter.submit(force: true)
             completeTurnResponse(responseID: responseID)
             if turnCompleted {
+                isFinalizingTurn = true
                 await reconcileFromRollout(
                     preservingReasoningFrom: responseID,
                     submissionID: submissionID
@@ -561,6 +565,7 @@ extension CodexChatSessionModel {
         preparingManualComposerSnapshot = nil
         activeOutputItemIDs.removeAll()
         isAwaitingTurnOutput = false
+        isFinalizingTurn = false
         activeTurnID = nil
         isStopRequested = false
         isActiveTurnLiveTranscript = false

--- a/Sources/Dahlia/Views/CodexChat/CodexChatConversationView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatConversationView.swift
@@ -20,9 +20,10 @@ struct CodexChatConversationView: View {
                     switch item {
                     case let .contextDivider(_, context):
                         CodexChatContextDivider(context: context)
-                    case let .message(message):
+                    case let .message(message, showsInlineActivity):
                         CodexChatMessageRow(
                             message: message,
+                            showsInlineActivity: showsInlineActivity,
                             meetingNamesByID: meetingNamesByID,
                             meetingReferencesByID: meetingReferencesByID
                         )

--- a/Sources/Dahlia/Views/CodexChat/CodexChatCopyButton.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatCopyButton.swift
@@ -2,10 +2,11 @@ import SwiftUI
 
 struct CodexChatCopyButton: View {
     let text: String
+    var title = L10n.copyChatMessage
 
     var body: some View {
         Button(action: copyMessage) {
-            Label(L10n.copyChatMessage, systemImage: "square.on.square")
+            Label(title, systemImage: "square.on.square")
                 .labelStyle(.iconOnly)
                 .frame(width: 24, height: 24)
                 .contentShape(Rectangle())
@@ -13,7 +14,7 @@ struct CodexChatCopyButton: View {
         .buttonStyle(.plain)
         .font(.caption)
         .foregroundStyle(.tertiary)
-        .help(L10n.copyChatMessage)
+        .help(title)
     }
 
     private func copyMessage() {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownBlockRenderer.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownBlockRenderer.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+enum CodexChatMarkdownBlockRenderer {
+    static func render(
+        _ blocks: [CodexChatMarkdownBlock]
+    ) throws -> [CodexChatMarkdownRenderedBlock] {
+        var renderedBlocks: [CodexChatMarkdownRenderedBlock] = []
+        renderedBlocks.reserveCapacity(blocks.count)
+        for block in blocks {
+            try Task.checkCancellation()
+            try renderedBlocks.append(render(block))
+        }
+        return renderedBlocks
+    }
+
+    static func render(_ block: CodexChatMarkdownBlock) throws -> CodexChatMarkdownRenderedBlock {
+        try Task.checkCancellation()
+        return switch block {
+        case let .paragraph(text):
+            .paragraph(attributedMarkdown(text))
+        case let .heading(level, text):
+            .heading(level: level, text: attributedMarkdown(text))
+        case let .unorderedList(items):
+            try .unorderedList(items.map { item in
+                try Task.checkCancellation()
+                return attributedMarkdown(item)
+            })
+        case let .orderedList(items):
+            try .orderedList(items.map { item in
+                try Task.checkCancellation()
+                return CodexChatMarkdownRenderedOrderedItem(
+                    marker: item.marker,
+                    text: attributedMarkdown(item.text)
+                )
+            })
+        case let .blockquote(text):
+            .blockquote(attributedMarkdown(text))
+        case let .table(table):
+            try .table(CodexChatMarkdownRenderedTable(
+                header: table.header.map { value in
+                    try Task.checkCancellation()
+                    return attributedMarkdown(value)
+                },
+                rows: table.rows.map { row in
+                    try Task.checkCancellation()
+                    return try row.map { value in
+                        try Task.checkCancellation()
+                        return attributedMarkdown(value)
+                    }
+                },
+                alignments: table.alignments
+            ))
+        case let .code(language, text):
+            .code(language: language, text: text)
+        case .divider:
+            .divider
+        }
+    }
+
+    private static func attributedMarkdown(_ value: String) -> AttributedString {
+        (try? AttributedString(
+            markdown: value,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )) ?? AttributedString(value)
+    }
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownCache.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownCache.swift
@@ -3,7 +3,7 @@ actor CodexChatMarkdownCache {
 
     private let capacity: Int
     private let maximumCost: Int
-    private var blocksByMarkdown: [String: [CodexChatMarkdownRenderedBlock]] = [:]
+    private var resultsByMarkdown: [String: CodexChatMarkdownRenderResult] = [:]
     private var costsByMarkdown: [String: Int] = [:]
     private var insertionOrder: [String] = []
     private var totalCost = 0
@@ -16,15 +16,15 @@ actor CodexChatMarkdownCache {
         self.maximumCost = maximumCost
     }
 
-    func blocks(for markdown: String) -> [CodexChatMarkdownRenderedBlock]? {
-        blocksByMarkdown[markdown]
+    func result(for markdown: String) -> CodexChatMarkdownRenderResult? {
+        resultsByMarkdown[markdown]
     }
 
     func insert(
-        _ blocks: [CodexChatMarkdownRenderedBlock],
+        _ result: CodexChatMarkdownRenderResult,
         for markdown: String
     ) {
-        guard blocksByMarkdown[markdown] == nil,
+        guard resultsByMarkdown[markdown] == nil,
               capacity > 0,
               maximumCost > 0
         else { return }
@@ -34,19 +34,19 @@ actor CodexChatMarkdownCache {
 
         while insertionOrder.count >= capacity || totalCost + cost > maximumCost {
             guard let oldest = insertionOrder.first else { break }
-            blocksByMarkdown.removeValue(forKey: oldest)
+            resultsByMarkdown.removeValue(forKey: oldest)
             totalCost -= costsByMarkdown.removeValue(forKey: oldest) ?? 0
             insertionOrder.removeFirst()
         }
 
-        blocksByMarkdown[markdown] = blocks
+        resultsByMarkdown[markdown] = result
         costsByMarkdown[markdown] = cost
         insertionOrder.append(markdown)
         totalCost += cost
     }
 
     func cachedEntryCount() -> Int {
-        blocksByMarkdown.count
+        resultsByMarkdown.count
     }
 
     func cachedCost() -> Int {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownCodeBlockView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownCodeBlockView.swift
@@ -6,10 +6,14 @@ struct CodexChatMarkdownCodeBlockView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            if let language {
-                Text(language)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+            HStack {
+                if let language {
+                    Text(language)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                CodexChatCopyButton(text: text, title: L10n.copyCodeBlock)
             }
             ScrollView(.horizontal) {
                 Text(text)

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownParseResult.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownParseResult.swift
@@ -1,0 +1,5 @@
+struct CodexChatMarkdownParseResult: Equatable {
+    let blocks: [CodexChatMarkdownBlock]
+    let stablePrefixBlockCount: Int
+    let reparseSource: String
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownParser.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownParser.swift
@@ -2,6 +2,10 @@ import Foundation
 
 enum CodexChatMarkdownParser {
     static func parse(_ markdown: String) throws -> [CodexChatMarkdownBlock] {
+        try parseTrackingUnstableTail(markdown).blocks
+    }
+
+    static func parseTrackingUnstableTail(_ markdown: String) throws -> CodexChatMarkdownParseResult {
         try Task.checkCancellation()
         let normalizedLineEndings = markdown.replacingOccurrences(of: "\r\n", with: "\n")
         try Task.checkCancellation()
@@ -10,6 +14,7 @@ enum CodexChatMarkdownParser {
         let lines = normalized.components(separatedBy: "\n")
         try Task.checkCancellation()
         var blocks: [CodexChatMarkdownBlock] = []
+        var blockStartLineIndices: [Int] = []
         var index = 0
 
         while index < lines.count {
@@ -18,6 +23,8 @@ enum CodexChatMarkdownParser {
                 index += 1
                 continue
             }
+
+            blockStartLineIndices.append(index)
 
             if let block = try parseFence(lines, index: &index) {
                 blocks.append(block)
@@ -38,21 +45,90 @@ enum CodexChatMarkdownParser {
             }
         }
 
-        return blocks
+        return try makeParseResult(
+            markdown: markdown,
+            lines: lines,
+            blocks: blocks,
+            blockStartLineIndices: blockStartLineIndices
+        )
+    }
+}
+
+private extension CodexChatMarkdownParser {
+    static func makeParseResult(
+        markdown: String,
+        lines: [String],
+        blocks: [CodexChatMarkdownBlock],
+        blockStartLineIndices: [Int]
+    ) throws -> CodexChatMarkdownParseResult {
+        guard let finalBlockStartLine = blockStartLineIndices.last else {
+            return CodexChatMarkdownParseResult(
+                blocks: blocks,
+                stablePrefixBlockCount: 0,
+                reparseSource: markdown
+            )
+        }
+
+        let includesPreviousBlock = shouldIncludePreviousBlock(
+            lines: lines,
+            blocks: blocks,
+            finalBlockStartLine: finalBlockStartLine
+        )
+        let reparseBlockIndex = includesPreviousBlock ? blocks.count - 2 : blocks.count - 1
+        let reparseStartLine = blockStartLineIndices[reparseBlockIndex]
+        let sourceStartIndex = try sourceStartIndex(
+            ofLine: reparseStartLine,
+            in: markdown
+        )
+        return CodexChatMarkdownParseResult(
+            blocks: blocks,
+            stablePrefixBlockCount: reparseBlockIndex,
+            reparseSource: String(markdown[sourceStartIndex...])
+        )
     }
 
-    private enum ListKind: Equatable {
+    static func shouldIncludePreviousBlock(
+        lines: [String],
+        blocks: [CodexChatMarkdownBlock],
+        finalBlockStartLine: Int
+    ) -> Bool {
+        guard blocks.count > 1,
+              finalBlockStartLine == lines.count - 1
+        else { return false }
+
+        let finalLine = lines[finalBlockStartLine]
+        let precedingLine = lines[finalBlockStartLine - 1]
+        let previousBlock = blocks[blocks.count - 2]
+        let finalLineCanInvalidateItsBlockStart = !isAppendStableBlockStart(line: finalLine)
+        let finalLineCanJoinPreviousTable = !precedingLine.trimmingCharacters(in: .whitespaces).isEmpty
+            && previousBlock.isTable
+        let finalLineCanCompleteTableDelimiter = canBecomeTableDelimiter(
+            finalLine,
+            forHeader: precedingLine
+        )
+        let finalLineCanJoinPreviousList = potentialListKind(afterAppendingTo: finalLine)
+            .map { $0 == listKind(previousBlock) } ?? false
+
+        return [
+            finalLineCanInvalidateItsBlockStart,
+            finalLineCanJoinPreviousTable,
+            finalLineCanCompleteTableDelimiter,
+            finalLineCanJoinPreviousList,
+        ].contains(true)
+    }
+
+    enum ListKind: Equatable {
         case unordered
         case ordered
     }
 
-    private struct ListMarker {
+    struct ListMarker {
         let kind: ListKind
         let orderedMarker: String?
         let content: String
     }
 
-    private static func parseFence(
+    static func parseFence(
         _ lines: [String],
         index: inout Int
     ) throws -> CodexChatMarkdownBlock? {
@@ -78,7 +154,7 @@ enum CodexChatMarkdownParser {
         )
     }
 
-    private static func parseTable(
+    static func parseTable(
         _ lines: [String],
         index: inout Int
     ) throws -> CodexChatMarkdownBlock? {
@@ -107,7 +183,7 @@ enum CodexChatMarkdownParser {
         ))
     }
 
-    private static func tableCells(in line: String) -> [String] {
+    static func tableCells(in line: String) -> [String] {
         let trimmed = line.trimmingCharacters(in: .whitespaces)
         guard trimmed.contains("|") else { return [] }
 
@@ -137,7 +213,7 @@ enum CodexChatMarkdownParser {
         return cells
     }
 
-    private static func tableAlignments(
+    static func tableAlignments(
         in delimiterCells: [String]
     ) -> [CodexChatMarkdownTableAlignment]? {
         var alignments: [CodexChatMarkdownTableAlignment] = []
@@ -159,14 +235,14 @@ enum CodexChatMarkdownParser {
         return alignments
     }
 
-    private static func normalizedTableRow(
+    static func normalizedTableRow(
         _ cells: [String],
         columnCount: Int
     ) -> [String] {
         Array((cells + Array(repeating: "", count: columnCount)).prefix(columnCount))
     }
 
-    private static func parseHeading(_ line: String) -> CodexChatMarkdownBlock? {
+    static func parseHeading(_ line: String) -> CodexChatMarkdownBlock? {
         let trimmed = line.trimmingCharacters(in: .whitespaces)
         let level = trimmed.prefix(while: { $0 == "#" }).count
         guard (1 ... 6).contains(level),
@@ -179,7 +255,7 @@ enum CodexChatMarkdownParser {
         )
     }
 
-    private static func parseBlockquote(
+    static func parseBlockquote(
         _ lines: [String],
         index: inout Int
     ) throws -> CodexChatMarkdownBlock {
@@ -193,7 +269,7 @@ enum CodexChatMarkdownParser {
         return .blockquote(joinedText(quoteLines))
     }
 
-    private static func parseList(
+    static func parseList(
         _ lines: [String],
         index: inout Int,
         kind: ListKind
@@ -241,7 +317,7 @@ enum CodexChatMarkdownParser {
         }
     }
 
-    private static func parseParagraph(
+    static func parseParagraph(
         _ lines: [String],
         index: inout Int
     ) throws -> CodexChatMarkdownBlock {
@@ -258,7 +334,7 @@ enum CodexChatMarkdownParser {
         return .paragraph(joinedText(paragraphLines))
     }
 
-    private static func joinedText(_ lines: [String]) -> String {
+    static func joinedText(_ lines: [String]) -> String {
         lines.enumerated().reduce(into: "") { result, element in
             let (offset, line) = element
             let hasHardBreak = line.hasSuffix("  ")
@@ -269,7 +345,7 @@ enum CodexChatMarkdownParser {
         }
     }
 
-    private static func listMarker(in line: String) -> ListMarker? {
+    static func listMarker(in line: String) -> ListMarker? {
         let trimmed = removingLeadingWhitespace(from: line)
         if let first = trimmed.first,
            ["-", "*", "+"].contains(first),
@@ -295,7 +371,7 @@ enum CodexChatMarkdownParser {
         )
     }
 
-    private static func nextNonemptyLine(in lines: [String], after index: Int) -> Int? {
+    static func nextNonemptyLine(in lines: [String], after index: Int) -> Int? {
         var candidate = index + 1
         while candidate < lines.count {
             if !lines[candidate].trimmingCharacters(in: .whitespaces).isEmpty {
@@ -306,11 +382,11 @@ enum CodexChatMarkdownParser {
         return nil
     }
 
-    private static func removingLeadingWhitespace(from line: String) -> String {
+    static func removingLeadingWhitespace(from line: String) -> String {
         String(line.drop(while: { $0 == " " || $0 == "\t" }))
     }
 
-    private static func isBlockStart(_ line: String) -> Bool {
+    static func isBlockStart(_ line: String) -> Bool {
         parseHeading(line) != nil ||
             isDivider(line) ||
             isBlockquote(line) ||
@@ -318,13 +394,99 @@ enum CodexChatMarkdownParser {
             listMarker(in: line) != nil
     }
 
-    private static func isBlockquote(_ line: String) -> Bool {
+    static func isBlockquote(_ line: String) -> Bool {
         line.trimmingCharacters(in: .whitespaces).hasPrefix(">")
     }
 
-    private static func isDivider(_ line: String) -> Bool {
+    static func isDivider(_ line: String) -> Bool {
         let compact = line.filter { !$0.isWhitespace }
         guard compact.count >= 3, let marker = compact.first else { return false }
         return ["-", "*", "_"].contains(marker) && compact.allSatisfy { $0 == marker }
+    }
+
+    static func isAppendStableBlockStart(line: String) -> Bool {
+        !isDivider(line)
+    }
+
+    static func canBecomeTableDelimiter(
+        _ line: String,
+        forHeader headerLine: String
+    ) -> Bool {
+        let header = tableCells(in: headerLine)
+        guard !header.isEmpty else { return false }
+
+        let candidate = line.trimmingCharacters(in: .whitespaces)
+        guard !candidate.isEmpty else { return false }
+        return candidate.allSatisfy { character in
+            character == "-"
+                || character == ":"
+                || character == "|"
+                || character.isWhitespace
+        }
+    }
+
+    static func potentialListKind(afterAppendingTo line: String) -> ListKind? {
+        let trimmed = removingLeadingWhitespace(from: line)
+        if trimmed.count == 1, let marker = trimmed.first,
+           ["-", "*", "+"].contains(marker) {
+            return .unordered
+        }
+
+        let number = trimmed.prefix(while: { $0.isNumber })
+        guard !number.isEmpty else { return nil }
+        let suffix = trimmed.dropFirst(number.count)
+        guard suffix.isEmpty || suffix == "." || suffix == ")" else { return nil }
+        return .ordered
+    }
+
+    static func listKind(_ block: CodexChatMarkdownBlock) -> ListKind? {
+        switch block {
+        case .unorderedList:
+            .unordered
+        case .orderedList:
+            .ordered
+        default:
+            nil
+        }
+    }
+
+    static func sourceStartIndex(
+        ofLine targetLine: Int,
+        in markdown: String
+    ) throws -> String.Index {
+        guard targetLine > 0 else { return markdown.startIndex }
+
+        var line = 0
+        var index = markdown.unicodeScalars.startIndex
+        var scannedScalarCount = 0
+
+        while index < markdown.unicodeScalars.endIndex {
+            if scannedScalarCount.isMultiple(of: 1024) {
+                try Task.checkCancellation()
+            }
+            scannedScalarCount += 1
+
+            let scalar = markdown.unicodeScalars[index]
+            index = markdown.unicodeScalars.index(after: index)
+            guard scalar == "\r" || scalar == "\n" else { continue }
+
+            if scalar == "\r",
+               index < markdown.unicodeScalars.endIndex,
+               markdown.unicodeScalars[index] == "\n" {
+                index = markdown.unicodeScalars.index(after: index)
+            }
+            line += 1
+            if line == targetLine {
+                return index
+            }
+        }
+
+        return markdown.endIndex
+    }
+}
+
+private extension CodexChatMarkdownBlock {
+    var isTable: Bool {
+        if case .table = self { true } else { false }
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownProjection.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownProjection.swift
@@ -1,4 +1,14 @@
-struct CodexChatMarkdownProjection: Sendable {
+struct CodexChatMarkdownProjection: Equatable, Sendable {
     let markdown: String
     let blocks: [CodexChatMarkdownRenderedBlock]
+    let stablePrefixBlockCount: Int
+    let reparseSource: String
+
+    var renderResult: CodexChatMarkdownRenderResult {
+        CodexChatMarkdownRenderResult(
+            blocks: blocks,
+            stablePrefixBlockCount: stablePrefixBlockCount,
+            reparseSource: reparseSource
+        )
+    }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownProjectionModel.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownProjectionModel.swift
@@ -5,21 +5,15 @@ import Observation
 @Observable
 final class CodexChatMarkdownProjectionModel {
     private(set) var projection: CodexChatMarkdownProjection?
-    private(set) var pendingSuffix: String?
+    private(set) var displayBlocks: [CodexChatMarkdownRenderedBlock]?
     private(set) var canDisplayProjection = false
-
-    var canDisplayPendingSuffix: Bool {
-        guard let pendingSuffix else { return true }
-        guard projection?.markdown.last?.isNewline != true,
-              !pendingSuffix.contains(where: \.isNewline)
-        else { return false }
-        return projection?.blocks.last?.acceptsPendingSuffix == true
-    }
 
     @ObservationIgnored private let renderer: any CodexChatMarkdownRendering
     @ObservationIgnored private var currentInput: CodexChatMarkdownInput?
     @ObservationIgnored private var pendingInput: CodexChatMarkdownInput?
     @ObservationIgnored private var renderTask: Task<Void, Never>?
+    @ObservationIgnored private var pendingDisplayInput: DisplayInput?
+    @ObservationIgnored private var displayTask: Task<Void, Never>?
 
     init(renderer: any CodexChatMarkdownRendering = CodexChatMarkdownRenderer()) {
         self.renderer = renderer
@@ -35,7 +29,7 @@ final class CodexChatMarkdownProjectionModel {
             pendingInput = nil
             let renderer = renderer
             Task {
-                await renderer.cache(projection.blocks, for: input.markdown)
+                await renderer.cache(projection.renderResult, for: input.markdown)
             }
             return
         }
@@ -48,6 +42,8 @@ final class CodexChatMarkdownProjectionModel {
         currentInput = nil
         pendingInput = nil
         renderTask?.cancel()
+        pendingDisplayInput = nil
+        displayTask?.cancel()
     }
 
     private func startNextRenderIfNeeded() {
@@ -56,32 +52,37 @@ final class CodexChatMarkdownProjectionModel {
         let renderer = renderer
 
         renderTask = Task { [weak self] in
-            let blocks = try? await renderer.blocks(
+            let result = try? await renderer.blocks(
                 for: input.markdown,
                 cacheResult: !input.isStreaming
             )
             self?.finishRender(
-                blocks: blocks,
+                result: result,
                 input: input
             )
         }
     }
 
     private func finishRender(
-        blocks: [CodexChatMarkdownRenderedBlock]?,
+        result: CodexChatMarkdownRenderResult?,
         input: CodexChatMarkdownInput
     ) {
         renderTask = nil
-        if let blocks,
+        if let result,
            let currentInput,
            currentInput.markdown.hasPrefix(input.markdown) {
-            projection = CodexChatMarkdownProjection(markdown: input.markdown, blocks: blocks)
+            projection = CodexChatMarkdownProjection(
+                markdown: input.markdown,
+                blocks: result.blocks,
+                stablePrefixBlockCount: result.stablePrefixBlockCount,
+                reparseSource: result.reparseSource
+            )
             updateDisplay(for: currentInput)
             if !currentInput.isStreaming,
                currentInput.markdown == input.markdown {
                 let renderer = renderer
                 Task {
-                    await renderer.cache(blocks, for: input.markdown)
+                    await renderer.cache(result, for: input.markdown)
                 }
             }
             if pendingInput?.markdown == input.markdown {
@@ -96,12 +97,63 @@ final class CodexChatMarkdownProjectionModel {
               input.markdown.hasPrefix(projection.markdown)
         else {
             canDisplayProjection = false
-            pendingSuffix = nil
+            displayBlocks = nil
+            pendingDisplayInput = nil
+            displayTask?.cancel()
             return
         }
 
         canDisplayProjection = true
         let suffix = String(input.markdown.dropFirst(projection.markdown.count))
-        pendingSuffix = suffix.nilIfBlank == nil ? nil : suffix
+        guard !suffix.isEmpty else {
+            pendingDisplayInput = nil
+            displayBlocks = projection.blocks
+            return
+        }
+
+        if displayBlocks == nil {
+            displayBlocks = projection.blocks
+        }
+        pendingDisplayInput = DisplayInput(
+            input: input,
+            projection: projection,
+            suffix: suffix
+        )
+        startNextDisplayIfNeeded()
+    }
+
+    private func startNextDisplayIfNeeded() {
+        guard displayTask == nil, let displayInput = pendingDisplayInput else { return }
+        pendingDisplayInput = nil
+        let renderer = renderer
+
+        displayTask = Task { [weak self] in
+            let blocks = try? await renderer.pendingBlocks(
+                reparseSource: displayInput.projection.reparseSource,
+                suffix: displayInput.suffix
+            )
+            self?.finishDisplay(blocks: blocks, displayInput: displayInput)
+        }
+    }
+
+    private func finishDisplay(
+        blocks: [CodexChatMarkdownRenderedBlock]?,
+        displayInput: DisplayInput
+    ) {
+        displayTask = nil
+        if let blocks,
+           currentInput == displayInput.input,
+           projection == displayInput.projection {
+            displayBlocks = Array(displayInput.projection.blocks.prefix(
+                displayInput.projection.stablePrefixBlockCount
+            )) + blocks
+        }
+        startNextDisplayIfNeeded()
+    }
+
+    private struct DisplayInput: Equatable, Sendable {
+        let input: CodexChatMarkdownInput
+        let projection: CodexChatMarkdownProjection
+        let suffix: String
     }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownProjectionView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownProjectionView.swift
@@ -2,15 +2,6 @@ import SwiftUI
 
 struct CodexChatMarkdownProjectionView: View {
     let blocks: [CodexChatMarkdownRenderedBlock]
-    let pendingSuffix: String?
-
-    init(
-        blocks: [CodexChatMarkdownRenderedBlock],
-        pendingSuffix: String? = nil
-    ) {
-        self.blocks = blocks
-        self.pendingSuffix = pendingSuffix
-    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -19,7 +10,7 @@ struct CodexChatMarkdownProjectionView: View {
     }
 
     private var groupViews: some View {
-        let groups = CodexChatMarkdownRenderedGroup.build(from: displayedBlocks)
+        let groups = CodexChatMarkdownRenderedGroup.build(from: blocks)
         return ForEach(groups.indices, id: \.self) { index in
             switch groups[index] {
             case let .text(blocks):
@@ -30,14 +21,4 @@ struct CodexChatMarkdownProjectionView: View {
         }
     }
 
-    private var displayedBlocks: [CodexChatMarkdownRenderedBlock] {
-        guard let lastIndex = blocks.indices.last,
-              let pendingSuffix,
-              let lastBlock = blocks[lastIndex].appendingPendingSuffix(pendingSuffix)
-        else { return blocks }
-
-        var displayedBlocks = blocks
-        displayedBlocks[lastIndex] = lastBlock
-        return displayedBlocks
-    }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRenderResult.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRenderResult.swift
@@ -1,0 +1,5 @@
+struct CodexChatMarkdownRenderResult: Equatable, Sendable {
+    let blocks: [CodexChatMarkdownRenderedBlock]
+    let stablePrefixBlockCount: Int
+    let reparseSource: String
+}

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRenderedBlock.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRenderedBlock.swift
@@ -10,51 +10,6 @@ enum CodexChatMarkdownRenderedBlock: Equatable, Sendable {
     case code(language: String?, text: String)
     case divider
 
-    var acceptsPendingSuffix: Bool {
-        switch self {
-        case let .unorderedList(items):
-            !items.isEmpty
-        case let .orderedList(items):
-            !items.isEmpty
-        case .divider, .table:
-            false
-        default:
-            true
-        }
-    }
-
-    func appendingPendingSuffix(_ suffix: String) -> Self? {
-        let attributedSuffix = AttributedString(suffix)
-        switch self {
-        case var .paragraph(text):
-            text.append(attributedSuffix)
-            return .paragraph(text)
-        case let .heading(level, originalText):
-            var text = originalText
-            text.append(attributedSuffix)
-            return .heading(level: level, text: text)
-        case var .unorderedList(items):
-            guard let lastIndex = items.indices.last else { return nil }
-            items[lastIndex].append(attributedSuffix)
-            return .unorderedList(items)
-        case var .orderedList(items):
-            guard let lastIndex = items.indices.last else { return nil }
-            let item = items[lastIndex]
-            var text = item.text
-            text.append(attributedSuffix)
-            items[lastIndex] = CodexChatMarkdownRenderedOrderedItem(marker: item.marker, text: text)
-            return .orderedList(items)
-        case var .blockquote(text):
-            text.append(attributedSuffix)
-            return .blockquote(text)
-        case .table:
-            return nil
-        case let .code(language, text):
-            return .code(language: language, text: text + suffix)
-        case .divider:
-            return nil
-        }
-    }
 }
 
 struct CodexChatMarkdownRenderedTable: Equatable, Sendable {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRenderer.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRenderer.swift
@@ -31,7 +31,7 @@ actor CodexChatMarkdownRenderer: CodexChatMarkdownRendering {
         return result
     }
 
-    nonisolated func pendingBlocks(
+    @concurrent nonisolated func pendingBlocks(
         reparseSource: String,
         suffix: String
     ) async throws -> [CodexChatMarkdownRenderedBlock] {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRenderer.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRenderer.swift
@@ -12,25 +12,39 @@ actor CodexChatMarkdownRenderer: CodexChatMarkdownRendering {
     func blocks(
         for markdown: String,
         cacheResult: Bool
-    ) async throws -> [CodexChatMarkdownRenderedBlock] {
+    ) async throws -> CodexChatMarkdownRenderResult {
         try Task.checkCancellation()
-        if cacheResult, let blocks = await cache.blocks(for: markdown) {
-            return blocks
+        if cacheResult, let result = await cache.result(for: markdown) {
+            return result
         }
 
-        let parsedBlocks = try CodexChatMarkdownParser.parse(markdown)
-        let blocks = try renderReusingStablePrefix(parsedBlocks)
+        let parsed = try CodexChatMarkdownParser.parseTrackingUnstableTail(markdown)
+        let blocks = try renderReusingStablePrefix(parsed.blocks)
+        let result = CodexChatMarkdownRenderResult(
+            blocks: blocks,
+            stablePrefixBlockCount: parsed.stablePrefixBlockCount,
+            reparseSource: parsed.reparseSource
+        )
         if cacheResult {
-            await cache.insert(blocks, for: markdown)
+            await cache.insert(result, for: markdown)
         }
-        return blocks
+        return result
+    }
+
+    nonisolated func pendingBlocks(
+        reparseSource: String,
+        suffix: String
+    ) async throws -> [CodexChatMarkdownRenderedBlock] {
+        try Task.checkCancellation()
+        let blocks = try CodexChatMarkdownParser.parse(reparseSource + suffix)
+        return try CodexChatMarkdownBlockRenderer.render(blocks)
     }
 
     func cache(
-        _ blocks: [CodexChatMarkdownRenderedBlock],
+        _ result: CodexChatMarkdownRenderResult,
         for markdown: String
     ) async {
-        await cache.insert(blocks, for: markdown)
+        await cache.insert(result, for: markdown)
     }
 
     private func renderReusingStablePrefix(
@@ -43,61 +57,11 @@ actor CodexChatMarkdownRenderer: CodexChatMarkdownRendering {
         renderedBlocks.reserveCapacity(parsedBlocks.count)
         for block in parsedBlocks.dropFirst(reusableCount) {
             try Task.checkCancellation()
-            try renderedBlocks.append(render(block))
+            try renderedBlocks.append(CodexChatMarkdownBlockRenderer.render(block))
         }
         previousParsedBlocks = parsedBlocks
         previousRenderedBlocks = renderedBlocks
         return renderedBlocks
     }
 
-    private func render(_ block: CodexChatMarkdownBlock) throws -> CodexChatMarkdownRenderedBlock {
-        try Task.checkCancellation()
-        return switch block {
-        case let .paragraph(text):
-            .paragraph(attributedMarkdown(text))
-        case let .heading(level, text):
-            .heading(level: level, text: attributedMarkdown(text))
-        case let .unorderedList(items):
-            try .unorderedList(items.map { item in
-                try Task.checkCancellation()
-                return attributedMarkdown(item)
-            })
-        case let .orderedList(items):
-            try .orderedList(items.map { item in
-                try Task.checkCancellation()
-                return CodexChatMarkdownRenderedOrderedItem(
-                    marker: item.marker,
-                    text: attributedMarkdown(item.text)
-                )
-            })
-        case let .blockquote(text):
-            .blockquote(attributedMarkdown(text))
-        case let .table(table):
-            try .table(CodexChatMarkdownRenderedTable(
-                header: table.header.map { value in
-                    try Task.checkCancellation()
-                    return attributedMarkdown(value)
-                },
-                rows: table.rows.map { row in
-                    try Task.checkCancellation()
-                    return try row.map { value in
-                        try Task.checkCancellation()
-                        return attributedMarkdown(value)
-                    }
-                },
-                alignments: table.alignments
-            ))
-        case let .code(language, text):
-            .code(language: language, text: text)
-        case .divider:
-            .divider
-        }
-    }
-
-    private func attributedMarkdown(_ value: String) -> AttributedString {
-        (try? AttributedString(
-            markdown: value,
-            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        )) ?? AttributedString(value)
-    }
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRendering.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownRendering.swift
@@ -2,10 +2,15 @@ protocol CodexChatMarkdownRendering: Sendable {
     func blocks(
         for markdown: String,
         cacheResult: Bool
+    ) async throws -> CodexChatMarkdownRenderResult
+
+    func pendingBlocks(
+        reparseSource: String,
+        suffix: String
     ) async throws -> [CodexChatMarkdownRenderedBlock]
 
     func cache(
-        _ blocks: [CodexChatMarkdownRenderedBlock],
+        _ result: CodexChatMarkdownRenderResult,
         for markdown: String
     ) async
 }

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMarkdownView.swift
@@ -16,35 +16,12 @@ struct CodexChatMarkdownView: View {
     }
 
     var body: some View {
-        let projection = projectionModel.projection
-        let showsProjection = projection != nil
-            && projectionModel.canDisplayProjection
-            && projectionModel.canDisplayPendingSuffix
-        let pendingSuffix: String? = if projectionModel.canDisplayPendingSuffix {
-            projectionModel.pendingSuffix
-        } else {
-            nil
-        }
-
-        ZStack(alignment: .topLeading) {
-            Text(markdown)
-                .textSelection(.enabled)
-                .opacity(showsProjection ? 0 : 1)
-                .frame(height: showsProjection ? 0 : nil, alignment: .top)
-                .clipped()
-                .allowsHitTesting(!showsProjection)
-                .accessibilityHidden(showsProjection)
-
-            if let projection {
-                CodexChatMarkdownProjectionView(
-                    blocks: projection.blocks,
-                    pendingSuffix: pendingSuffix
-                )
-                .opacity(showsProjection ? 1 : 0)
-                .frame(height: showsProjection ? nil : 0, alignment: .top)
-                .clipped()
-                .allowsHitTesting(showsProjection)
-                .accessibilityHidden(!showsProjection)
+        Group {
+            if let displayBlocks = projectionModel.displayBlocks {
+                CodexChatMarkdownProjectionView(blocks: displayBlocks)
+            } else {
+                Text(markdown)
+                    .textSelection(.enabled)
             }
         }
         .transaction { transaction in

--- a/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatMessageRow.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CodexChatMessageRow: View {
     let message: CodexChatMessage
+    let showsInlineActivity: Bool
     let meetingNamesByID: [UUID: String]
     let meetingReferencesByID: [UUID: CodexChatMeetingReference]
 
@@ -35,7 +36,8 @@ struct CodexChatMessageRow: View {
                     if !displayReasoning.isEmpty {
                         CodexChatReasoningView(
                             reasoning: displayReasoning,
-                            isStreaming: message.isStreaming
+                            isStreaming: message.isStreaming,
+                            showsActivity: showsInlineActivity
                         )
                     }
 

--- a/Sources/Dahlia/Views/CodexChat/CodexChatReasoningView.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatReasoningView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct CodexChatReasoningView: View {
     let reasoning: String
     let isStreaming: Bool
+    let showsActivity: Bool
 
     @State private var isExpanded = false
 
@@ -14,8 +15,13 @@ struct CodexChatReasoningView: View {
             )
             .padding(.top, 8)
         } label: {
-            Text(L10n.chatReasoning)
-                .foregroundStyle(.secondary)
+            HStack {
+                Text(L10n.chatReasoning)
+                if showsActivity {
+                    CodexChatThinkingIndicator()
+                }
+            }
+            .foregroundStyle(.secondary)
         }
         .textSelection(.enabled)
     }

--- a/Tests/DahliaTests/CodexChatConversationItemTests.swift
+++ b/Tests/DahliaTests/CodexChatConversationItemTests.swift
@@ -59,6 +59,49 @@ import Foundation
         }
 
         @Test
+        func reasoningOnlyLatestResponseUsesInlineActivityWithoutStandaloneThinking() {
+            let response = CodexChatMessage(
+                id: "response",
+                role: .assistant,
+                text: "",
+                reasoning: "Working through it",
+                isStreaming: true
+            )
+
+            let items = CodexChatConversationItem.build(
+                from: [response],
+                showsStandaloneThinking: true
+            )
+
+            #expect(items == [.message(response, showsInlineActivity: true)])
+            #expect(!items.contains(.thinking))
+        }
+
+        @Test
+        func steeredReasoningResponseMovesActivityToConversationTail() {
+            let response = CodexChatMessage(
+                id: "response",
+                role: .assistant,
+                text: "",
+                reasoning: "Working through it",
+                isStreaming: true
+            )
+            let followUp = CodexChatMessage(
+                id: "follow-up",
+                role: .user,
+                text: "Additional context"
+            )
+
+            let items = CodexChatConversationItem.build(
+                from: [response, followUp],
+                showsStandaloneThinking: true
+            )
+
+            #expect(items == [.message(response), .message(followUp), .thinking])
+            #expect(items.count { $0 == .thinking } == 1)
+        }
+
+        @Test
         func completedResponseDoesNotRegainThinkingDuringReconciliation() {
             let message = CodexChatMessage(
                 id: "answer",

--- a/Tests/DahliaTests/CodexChatMarkdownCacheTests.swift
+++ b/Tests/DahliaTests/CodexChatMarkdownCacheTests.swift
@@ -27,14 +27,19 @@
         @Test func keepsCompletedProjectionCacheCostBounded() async {
             let cache = CodexChatMarkdownCache(capacity: 10, maximumCost: 8)
             let blocks: [CodexChatMarkdownRenderedBlock] = [.paragraph(AttributedString("value"))]
+            let result = CodexChatMarkdownRenderResult(
+                blocks: blocks,
+                stablePrefixBlockCount: 0,
+                reparseSource: "value"
+            )
 
-            await cache.insert(blocks, for: "1234")
-            await cache.insert(blocks, for: "5678")
-            await cache.insert(blocks, for: "oversized")
+            await cache.insert(result, for: "1234")
+            await cache.insert(result, for: "5678")
+            await cache.insert(result, for: "oversized")
 
             #expect(await cache.cachedEntryCount() == 2)
             #expect(await cache.cachedCost() == 8)
-            #expect(await cache.blocks(for: "oversized") == nil)
+            #expect(await cache.result(for: "oversized") == nil)
         }
     }
 #endif

--- a/Tests/DahliaTests/CodexChatMarkdownParserTests.swift
+++ b/Tests/DahliaTests/CodexChatMarkdownParserTests.swift
@@ -151,5 +151,91 @@
             #expect(blocks.count == 1)
             #expect(items.count == 2000)
         }
+
+        @Test func tracksTheUnstableTailSource() throws {
+            let paragraph = try CodexChatMarkdownParser.parseTrackingUnstableTail("single paragraph")
+            #expect(paragraph.stablePrefixBlockCount == 0)
+            #expect(paragraph.reparseSource == "single paragraph")
+
+            let multiple = try CodexChatMarkdownParser.parseTrackingUnstableTail("First\n\n# Heading\n")
+            #expect(multiple.stablePrefixBlockCount == 1)
+            #expect(multiple.reparseSource == "# Heading\n")
+
+            let fence = try CodexChatMarkdownParser.parseTrackingUnstableTail("Intro\n\n```swift\nlet value = 1")
+            #expect(fence.stablePrefixBlockCount == 1)
+            #expect(fence.reparseSource == "```swift\nlet value = 1")
+
+            let empty = try CodexChatMarkdownParser.parseTrackingUnstableTail("")
+            #expect(empty.blocks.isEmpty)
+            #expect(empty.stablePrefixBlockCount == 0)
+            #expect(empty.reparseSource.isEmpty)
+        }
+
+        @Test func expandsTheUnstableTailAcrossADividerBoundary() throws {
+            let result = try CodexChatMarkdownParser.parseTrackingUnstableTail("paragraph\n---")
+
+            #expect(result.blocks == [.paragraph("paragraph"), .divider])
+            #expect(result.stablePrefixBlockCount == 0)
+            #expect(result.reparseSource == "paragraph\n---")
+        }
+
+        @Test func unstableTailReparseMatchesFullParseAtEveryStreamingSplit() throws {
+            let documents = [
+                "Paragraph soft\nline  \nhard\n\n# Heading\n\n- one\n- two",
+                "Before\n\n```swift\nlet value = 1\n```\n\nAfter",
+                "| Name | Value |\n| --- | ---: |\n| one | 1 |\n| two | 2 |",
+                "paragraph\n---x",
+                "```swift\nlet x = 1 ```",
+                "First\r\nsecond\r\n\r\n# Heading",
+                "First\rsecond\r\r# Heading",
+                "# A | B\n--- | ---",
+                "> A | B\n--- | ---",
+                "- A | B\n--- | ---",
+                "- one\n\n- two",
+                "1. one\n\n2. two",
+            ]
+
+            for markdown in documents {
+                let expected = try CodexChatMarkdownParser.parse(markdown)
+                for splitIndex in markdown.indicesIncludingEnd {
+                    let prefix = String(markdown[..<splitIndex])
+                    let suffix = String(markdown[splitIndex...])
+                    let partial = try CodexChatMarkdownParser.parseTrackingUnstableTail(prefix)
+                    let reparsedTail = try CodexChatMarkdownParser.parse(partial.reparseSource + suffix)
+                    let combined = Array(partial.blocks.prefix(partial.stablePrefixBlockCount)) + reparsedTail
+                    #expect(combined == expected, "Mismatch at split \(markdown.distance(from: markdown.startIndex, to: splitIndex)) in \(markdown)")
+                }
+            }
+        }
+
+        @Test func boundarySensitiveStreamingSplitsMatchFullParse() throws {
+            let cases = [
+                ("```swift\nlet x ", "```"),
+                ("```sw", "ift\nlet x = 1"),
+                ("a ", " \nb"),
+                ("paragraph\n---", "x"),
+                ("first\r", "\nsecond"),
+                ("# A | B\n--- | --", "-"),
+                ("> A | B\n--- | --", "-"),
+                ("- A | B\n--", "- | ---"),
+                ("- one\n\n-", " two"),
+                ("1. one\n\n2", ". two"),
+            ]
+
+            for (prefix, suffix) in cases {
+                let partial = try CodexChatMarkdownParser.parseTrackingUnstableTail(prefix)
+                let reparsedTail = try CodexChatMarkdownParser.parse(partial.reparseSource + suffix)
+                let combined = Array(partial.blocks.prefix(partial.stablePrefixBlockCount))
+                    + reparsedTail
+                let expected = try CodexChatMarkdownParser.parse(prefix + suffix)
+                #expect(combined == expected)
+            }
+        }
+    }
+
+    private extension String {
+        var indicesIncludingEnd: [Index] {
+            Array(indices) + [endIndex]
+        }
     }
 #endif

--- a/Tests/DahliaTests/CodexChatMarkdownProjectionModelTests.swift
+++ b/Tests/DahliaTests/CodexChatMarkdownProjectionModelTests.swift
@@ -4,6 +4,7 @@
     @testable import Dahlia
 
     @MainActor
+    // swiftlint:disable:next type_body_length
     struct CodexChatMarkdownProjectionModelTests {
         @Test func coalescesPendingInputsAndPublishesOnlyLatestProjection() async {
             let renderer = ControlledCodexChatMarkdownRenderer()
@@ -24,37 +25,48 @@
             #expect(model.projection?.markdown == "third")
         }
 
-        @Test func keepsAppendedRawSuffixVisibleWhileRendering() async {
+        @Test func rendersAppendedSuffixAsStyledBlocks() async {
             let renderer = ControlledCodexChatMarkdownRenderer()
             let model = CodexChatMarkdownProjectionModel(renderer: renderer)
 
-            model.submit(input("rendered"))
-            await waitForRequest("rendered", renderer: renderer)
-            await renderer.complete("rendered")
-            await waitForProjection("rendered", model: model)
+            await prepareProjection("rendered", renderer: renderer, model: model)
 
             model.submit(input("rendered tail"))
+            await waitForPendingRequest(
+                reparseSource: "rendered",
+                suffix: " tail",
+                renderer: renderer
+            )
+            await renderer.completePending(reparseSource: "rendered", suffix: " tail")
+            await waitForDisplayBlocks([.paragraph(AttributedString("rendered tail"))], model: model)
 
             #expect(model.canDisplayProjection)
-            #expect(model.canDisplayPendingSuffix)
-            #expect(model.pendingSuffix == " tail")
+            #expect(model.displayBlocks == [.paragraph(AttributedString("rendered tail"))])
             model.cancel()
             await renderer.complete("rendered tail")
         }
 
-        @Test func fallsBackToRawTextWhenSuffixCrossesALineBoundary() async {
+        @Test func rendersSuffixCrossingABlockBoundaryAsStyledBlocks() async {
             let renderer = ControlledCodexChatMarkdownRenderer()
             let model = CodexChatMarkdownProjectionModel(renderer: renderer)
 
-            model.submit(input("paragraph"))
-            await waitForRequest("paragraph", renderer: renderer)
-            await renderer.complete("paragraph")
-            await waitForProjection("paragraph", model: model)
+            await prepareProjection("paragraph", renderer: renderer, model: model)
 
             model.submit(input("paragraph\n\n# Heading"))
+            await waitForPendingRequest(
+                reparseSource: "paragraph",
+                suffix: "\n\n# Heading",
+                renderer: renderer
+            )
+            await renderer.completePending(reparseSource: "paragraph", suffix: "\n\n# Heading")
+            let expected: [CodexChatMarkdownRenderedBlock] = [
+                .paragraph(AttributedString("paragraph")),
+                .heading(level: 1, text: AttributedString("Heading")),
+            ]
+            await waitForDisplayBlocks(expected, model: model)
 
             #expect(model.canDisplayProjection)
-            #expect(!model.canDisplayPendingSuffix)
+            #expect(model.displayBlocks == expected)
             model.cancel()
             await renderer.complete("paragraph\n\n# Heading")
         }
@@ -68,22 +80,14 @@
             model.submit(input("Hello world"))
             await renderer.complete("Hello")
             await waitForProjection("Hello", model: model)
+            await waitForPendingRequest(reparseSource: "Hello", suffix: " world", renderer: renderer)
+            await renderer.completePending(reparseSource: "Hello", suffix: " world")
+            await waitForDisplayBlocks([.paragraph(AttributedString("Hello world"))], model: model)
 
             #expect(model.canDisplayProjection)
-            #expect(model.pendingSuffix == " world")
+            #expect(model.displayBlocks == [.paragraph(AttributedString("Hello world"))])
             model.cancel()
             await renderer.complete("Hello world")
-        }
-
-        @Test func appendsPendingSuffixToTheLastRenderedBlock() {
-            let block = CodexChatMarkdownRenderedBlock.paragraph(AttributedString("Hello"))
-
-            guard case let .paragraph(text) = block.appendingPendingSuffix(" world") else {
-                Issue.record("Expected a paragraph with an appended suffix")
-                return
-            }
-
-            #expect(String(text.characters) == "Hello world")
         }
 
         @Test func completionCachesExistingProjectionWithoutRenderingAgain() async {
@@ -104,15 +108,12 @@
             let renderer = ControlledCodexChatMarkdownRenderer()
             let model = CodexChatMarkdownProjectionModel(renderer: renderer)
 
-            model.submit(input("original"))
-            await waitForRequest("original", renderer: renderer)
-            await renderer.complete("original")
-            await waitForProjection("original", model: model)
+            await prepareProjection("original", renderer: renderer, model: model)
 
             model.submit(input("replacement"))
 
             #expect(!model.canDisplayProjection)
-            #expect(model.pendingSuffix == nil)
+            #expect(model.displayBlocks == nil)
             model.cancel()
             await renderer.complete("replacement")
         }
@@ -128,17 +129,192 @@
             await Task.yield()
 
             #expect(model.projection == nil)
+            #expect(model.displayBlocks == nil)
+        }
+
+        @Test func pendingCodeBlockContainsAllVisibleCode() async {
+            let renderer = ControlledCodexChatMarkdownRenderer()
+            let model = CodexChatMarkdownProjectionModel(renderer: renderer)
+            let base = "```swift\nlet a = 1"
+            let suffix = "\nlet b = 2"
+
+            await prepareProjection(base, renderer: renderer, model: model)
+            model.submit(input(base + suffix))
+            await waitForPendingRequest(reparseSource: base, suffix: suffix, renderer: renderer)
+            await renderer.completePending(reparseSource: base, suffix: suffix)
+            await waitForDisplayBlocks([
+                .code(language: "swift", text: "let a = 1\nlet b = 2"),
+            ], model: model)
+
+            #expect(model.displayBlocks == [
+                .code(language: "swift", text: "let a = 1\nlet b = 2"),
+            ])
+            model.cancel()
+            await renderer.complete(base + suffix)
+        }
+
+        @Test func pendingFenceCanOpenCloseAndContinueWithParagraph() async {
+            let renderer = ControlledCodexChatMarkdownRenderer()
+            let model = CodexChatMarkdownProjectionModel(renderer: renderer)
+            let base = "```"
+            let suffix = "swift\nlet value = 1\n```\nAfter"
+
+            await prepareProjection(base, renderer: renderer, model: model)
+            model.submit(input(base + suffix))
+            await waitForPendingRequest(reparseSource: base, suffix: suffix, renderer: renderer)
+            await renderer.completePending(reparseSource: base, suffix: suffix)
+            await waitForDisplayBlocks([
+                .code(language: "swift", text: "let value = 1"),
+                .paragraph(AttributedString("After")),
+            ], model: model)
+
+            model.cancel()
+            await renderer.complete(base + suffix)
+        }
+
+        @Test func pendingDisplayCoalescesBurstToLatestInput() async {
+            let renderer = ControlledCodexChatMarkdownRenderer()
+            let model = CodexChatMarkdownProjectionModel(renderer: renderer)
+
+            await prepareProjection("base", renderer: renderer, model: model)
+            model.submit(input("base one"))
+            await waitForPendingRequest(reparseSource: "base", suffix: " one", renderer: renderer)
+            model.submit(input("base two"))
+            model.submit(input("base three"))
+
+            await renderer.completePending(reparseSource: "base", suffix: " one")
+            await waitForPendingRequest(reparseSource: "base", suffix: " three", renderer: renderer)
+            #expect(await renderer.requestedPendingInputs().map(\.suffix) == [" one", " three"])
+            await renderer.completePending(reparseSource: "base", suffix: " three")
+            await waitForDisplayBlocks([.paragraph(AttributedString("base three"))], model: model)
+
+            model.cancel()
+            for markdown in await renderer.requestedMarkdown() where markdown != "base" {
+                await renderer.complete(markdown)
+            }
+        }
+
+        @Test func baseProjectionPublishesWhilePendingRebuildIsBlocked() async {
+            let renderer = ControlledCodexChatMarkdownRenderer()
+            let model = CodexChatMarkdownProjectionModel(renderer: renderer)
+
+            model.submit(input("base"))
+            await waitForRequest("base", renderer: renderer)
+            model.submit(input("base suffix"))
+            await renderer.complete("base")
+            await waitForProjection("base", model: model)
+            await waitForPendingRequest(reparseSource: "base", suffix: " suffix", renderer: renderer)
+
+            #expect(model.displayBlocks == [.paragraph(AttributedString("base"))])
+
+            model.cancel()
+            await renderer.completePending(reparseSource: "base", suffix: " suffix")
+            await renderer.complete("base suffix")
+        }
+
+        @Test func stalePendingCompletionCannotPublishAfterReplacement() async {
+            let renderer = ControlledCodexChatMarkdownRenderer()
+            let model = CodexChatMarkdownProjectionModel(renderer: renderer)
+
+            await prepareProjection("base", renderer: renderer, model: model)
+            model.submit(input("base old"))
+            await waitForPendingRequest(reparseSource: "base", suffix: " old", renderer: renderer)
+            model.submit(input("replacement"))
+            #expect(model.displayBlocks == nil)
+
+            await renderer.completePending(reparseSource: "base", suffix: " old")
+            await Task.yield()
+            #expect(model.displayBlocks == nil)
+
+            model.cancel()
+            await renderer.complete("base old")
+            await renderer.complete("replacement")
+        }
+
+        @Test func cancelledPendingRebuildCannotPublish() async {
+            let renderer = ControlledCodexChatMarkdownRenderer()
+            let model = CodexChatMarkdownProjectionModel(renderer: renderer)
+
+            await prepareProjection("base", renderer: renderer, model: model)
+            model.submit(input("base suffix"))
+            await waitForPendingRequest(reparseSource: "base", suffix: " suffix", renderer: renderer)
+            model.cancel()
+            await renderer.completePending(reparseSource: "base", suffix: " suffix")
+            await Task.yield()
+
+            #expect(model.displayBlocks == [.paragraph(AttributedString("base"))])
+            await renderer.complete("base suffix")
+        }
+
+        @Test func reparsesNewlineDividerAndTableTails() async {
+            let cases: [(base: String, suffix: String, expected: [CodexChatMarkdownRenderedBlock])] = [
+                (
+                    "paragraph\n",
+                    "\n# Heading",
+                    [.paragraph(AttributedString("paragraph")), .heading(level: 1, text: AttributedString("Heading"))]
+                ),
+                (
+                    "paragraph\n---",
+                    "x",
+                    [.paragraph(AttributedString("paragraph ---x"))]
+                ),
+                (
+                    "| Name | Value |\n| --- | --- |",
+                    "\n| one | 1 |",
+                    [
+                        .table(CodexChatMarkdownRenderedTable(
+                            header: [AttributedString("Name"), AttributedString("Value")],
+                            rows: [[AttributedString("one"), AttributedString("1")]],
+                            alignments: [.left, .left]
+                        )),
+                    ]
+                ),
+            ]
+
+            for testCase in cases {
+                let renderer = ControlledCodexChatMarkdownRenderer()
+                let model = CodexChatMarkdownProjectionModel(renderer: renderer)
+                await prepareProjection(testCase.base, renderer: renderer, model: model)
+                guard let projection = model.projection else {
+                    Issue.record("Expected base projection")
+                    continue
+                }
+                model.submit(input(testCase.base + testCase.suffix))
+                await waitForPendingRequest(
+                    reparseSource: projection.reparseSource,
+                    suffix: testCase.suffix,
+                    renderer: renderer
+                )
+                await renderer.completePending(
+                    reparseSource: projection.reparseSource,
+                    suffix: testCase.suffix
+                )
+                await waitForDisplayBlocks(testCase.expected, model: model)
+                model.cancel()
+                await renderer.complete(testCase.base + testCase.suffix)
+            }
         }
 
         private func input(_ markdown: String) -> CodexChatMarkdownInput {
             CodexChatMarkdownInput(markdown: markdown, isStreaming: true)
         }
 
+        private func prepareProjection(
+            _ markdown: String,
+            renderer: ControlledCodexChatMarkdownRenderer,
+            model: CodexChatMarkdownProjectionModel
+        ) async {
+            model.submit(input(markdown))
+            await waitForRequest(markdown, renderer: renderer)
+            await renderer.complete(markdown)
+            await waitForProjection(markdown, model: model)
+        }
+
         private func waitForRequest(
             _ markdown: String,
             renderer: ControlledCodexChatMarkdownRenderer
         ) async {
-            for _ in 0 ..< 1_000 {
+            for _ in 0 ..< 1000 {
                 if await renderer.requestedMarkdown().contains(markdown) {
                     return
                 }
@@ -151,7 +327,7 @@
             _ markdown: String,
             model: CodexChatMarkdownProjectionModel
         ) async {
-            for _ in 0 ..< 1_000 {
+            for _ in 0 ..< 1000 {
                 if model.projection?.markdown == markdown {
                     return
                 }
@@ -160,11 +336,41 @@
             Issue.record("Projection did not publish \(markdown)")
         }
 
+        private func waitForPendingRequest(
+            reparseSource: String,
+            suffix: String,
+            renderer: ControlledCodexChatMarkdownRenderer
+        ) async {
+            for _ in 0 ..< 1000 {
+                if await renderer.requestedPendingInputs().contains(.init(
+                    reparseSource: reparseSource,
+                    suffix: suffix
+                )) {
+                    return
+                }
+                await Task.yield()
+            }
+            Issue.record("Renderer did not receive pending suffix \(suffix)")
+        }
+
+        private func waitForDisplayBlocks(
+            _ blocks: [CodexChatMarkdownRenderedBlock],
+            model: CodexChatMarkdownProjectionModel
+        ) async {
+            for _ in 0 ..< 1000 {
+                if model.displayBlocks == blocks {
+                    return
+                }
+                await Task.yield()
+            }
+            Issue.record("Display blocks did not publish expected content")
+        }
+
         private func waitForCachedValue(
             _ markdown: String,
             renderer: ControlledCodexChatMarkdownRenderer
         ) async {
-            for _ in 0 ..< 1_000 {
+            for _ in 0 ..< 1000 {
                 if await renderer.cachedValues().contains(markdown) {
                     return
                 }

--- a/Tests/DahliaTests/CodexChatSteeringTests.swift
+++ b/Tests/DahliaTests/CodexChatSteeringTests.swift
@@ -49,6 +49,20 @@ import Foundation
             ])
             #expect(await service.steeredTextBlocks == [["Follow-up while responding"]])
             #expect(session.showsStandaloneThinking)
+            let items = CodexChatConversationItem.build(
+                from: session.messages,
+                showsStandaloneThinking: session.showsStandaloneThinking
+            )
+            #expect(items.count { item in
+                switch item {
+                case let .message(_, showsInlineActivity):
+                    showsInlineActivity
+                case .thinking:
+                    true
+                case .contextDivider:
+                    false
+                }
+            } == 1)
             session.stop()
             await waitUntil { !session.isGenerating }
             #expect(!session.showsStandaloneThinking)

--- a/Tests/DahliaTests/CodexChatThinkingPresentationTests.swift
+++ b/Tests/DahliaTests/CodexChatThinkingPresentationTests.swift
@@ -36,7 +36,7 @@ import Foundation
                 showsStandaloneThinking: session.showsStandaloneThinking
             )
             #expect(waitingItems.count == 2)
-            if case let .message(message) = waitingItems.first {
+            if case let .message(message, _) = waitingItems.first {
                 #expect(message.role == .user)
                 #expect(message.text == "Question")
             } else {
@@ -60,6 +60,16 @@ import Foundation
             ))
             await waitUntil { !session.showsStandaloneThinking }
             #expect(session.messages.last?.reasoning == "More reasoning")
+            let reasoningItems = CodexChatConversationItem.build(
+                from: session.messages,
+                showsStandaloneThinking: session.showsStandaloneThinking
+            )
+            #expect(!reasoningItems.contains(.thinking))
+            if case let .message(_, showsInlineActivity) = reasoningItems.last {
+                #expect(!showsInlineActivity)
+            } else {
+                Issue.record("Expected the active response message")
+            }
 
             await service.yieldBlockedEvent(.reasoningCompleted(itemID: "reasoning-1", text: "More reasoning"))
             await waitUntil { session.showsStandaloneThinking }
@@ -204,7 +214,7 @@ import Foundation
         }
 
         @Test
-        func completedResponseDoesNotShowThinkingDuringReconciliation() async {
+        func completedResponseShowsThinkingDuringReconciliation() async {
             let service = TestCodexChatService(mode: .complete, delaysLoad: true)
             let settings = AppSettings()
             settings.currentVault = Self.testVault()
@@ -222,10 +232,11 @@ import Foundation
             #expect(session.isGenerating)
             #expect(session.messages.last?.text == "Final answer")
             #expect(session.messages.last?.isStreaming == false)
-            #expect(!session.showsStandaloneThinking)
+            #expect(session.showsStandaloneThinking)
 
             await service.resumeDelayedLoad()
             await waitUntil { !session.isGenerating }
+            #expect(!session.showsStandaloneThinking)
         }
 
         private static func testVault() -> VaultRecord {

--- a/Tests/DahliaTests/ControlledCodexChatMarkdownRenderer.swift
+++ b/Tests/DahliaTests/ControlledCodexChatMarkdownRenderer.swift
@@ -4,38 +4,74 @@
 
     actor ControlledCodexChatMarkdownRenderer: CodexChatMarkdownRendering {
         private var requests: [String] = []
+        private var pendingRequests: [PendingRequest] = []
         private var cachedMarkdown: [String] = []
-        private var continuations: [String: CheckedContinuation<[CodexChatMarkdownRenderedBlock], Never>] = [:]
+        private var continuations: [String: CheckedContinuation<CodexChatMarkdownRenderResult, Never>] = [:]
+        private var pendingContinuations: [PendingRequest: CheckedContinuation<[CodexChatMarkdownRenderedBlock], Never>] = [:]
 
         func blocks(
             for markdown: String,
             cacheResult _: Bool
-        ) async -> [CodexChatMarkdownRenderedBlock] {
+        ) async -> CodexChatMarkdownRenderResult {
             requests.append(markdown)
             return await withCheckedContinuation { continuation in
                 continuations[markdown] = continuation
             }
         }
 
+        func pendingBlocks(
+            reparseSource: String,
+            suffix: String
+        ) async -> [CodexChatMarkdownRenderedBlock] {
+            let request = PendingRequest(reparseSource: reparseSource, suffix: suffix)
+            pendingRequests.append(request)
+            return await withCheckedContinuation { continuation in
+                pendingContinuations[request] = continuation
+            }
+        }
+
         func cache(
-            _: [CodexChatMarkdownRenderedBlock],
+            _: CodexChatMarkdownRenderResult,
             for markdown: String
         ) {
             cachedMarkdown.append(markdown)
         }
 
         func complete(_ markdown: String) {
-            continuations.removeValue(forKey: markdown)?.resume(
-                returning: [.paragraph(AttributedString(markdown))]
-            )
+            let parsed = try? CodexChatMarkdownParser.parseTrackingUnstableTail(markdown)
+            let rendered = parsed.flatMap { try? CodexChatMarkdownBlockRenderer.render($0.blocks) }
+            continuations.removeValue(forKey: markdown)?.resume(returning: CodexChatMarkdownRenderResult(
+                blocks: rendered ?? [],
+                stablePrefixBlockCount: parsed?.stablePrefixBlockCount ?? 0,
+                reparseSource: parsed?.reparseSource ?? markdown
+            ))
+        }
+
+        func completePending(
+            reparseSource: String,
+            suffix: String
+        ) {
+            let request = PendingRequest(reparseSource: reparseSource, suffix: suffix)
+            let parsed = try? CodexChatMarkdownParser.parse(reparseSource + suffix)
+            let rendered = parsed.flatMap { try? CodexChatMarkdownBlockRenderer.render($0) }
+            pendingContinuations.removeValue(forKey: request)?.resume(returning: rendered ?? [])
         }
 
         func requestedMarkdown() -> [String] {
             requests
         }
 
+        func requestedPendingInputs() -> [PendingRequest] {
+            pendingRequests
+        }
+
         func cachedValues() -> [String] {
             cachedMarkdown
+        }
+
+        struct PendingRequest: Equatable, Hashable, Sendable {
+            let reparseSource: String
+            let suffix: String
         }
     }
 #endif


### PR DESCRIPTION
## Summary

- rebuild the unstable Markdown tail with the shared parser during streaming, using an independent coalesced latest-wins worker
- remove styled-to-raw fallback flicker and the permanently mounted hidden fallback text
- add localized copy buttons to individual code blocks
- keep an activity indicator visible during reasoning-only streaming and turn reconciliation

## Root cause

The previous pending-suffix path appended raw text to an already rendered block. It could not represent syntax whose meaning changes across streaming boundaries, so block boundaries frequently forced the entire message back to raw text. Thinking presentation also depended only on awaiting output, leaving gaps during reasoning-only output and reconciliation.

## Impact

Streaming responses retain styled rendering across paragraphs, lists, tables, dividers, and code fences without the previous full-message layout flip. Code can be copied independently, and generation activity remains visible through the relevant turn phases.

## Validation

- Targeted chat suites: 46 tests passed
- CodexChatMarkdownParserTests: 11 tests passed
- CodexChatMarkdownProjectionModelTests: 14 tests passed
- `swift build`
- `CI=true ./scripts/lint.sh` (SwiftFormat clean; existing SwiftLint violations remain non-blocking)
- `git diff --check`

A full `swift test` run executed 1,354 tests; one unrelated existing Keychain-dependent test, `GoogleCalendarConfigurationTests.clientSecretOverrideIsPreferredOverEnvironment`, failed in this environment and also failed when rerun alone outside the sandbox.