### PR TITLE
Update Codex CLI to 0.146.0

### DIFF
--- a/Resources/Codex-NOTICE.txt
+++ b/Resources/Codex-NOTICE.txt
@@ -1,10 +1,10 @@
-Dahlia includes Codex CLI 0.144.6 from the OpenAI Codex project.
+Dahlia includes Codex CLI 0.146.0 from the OpenAI Codex project.
 
 Source: https://github.com/openai/codex
-Release: rust-v0.144.6
-Commit: 5d1fbf26c43abc65a203928b2e31561cb039e06d
+Release: rust-v0.146.0
+Commit: e363b08c9175ac1cbe5893615dd2cb9ddf95043b
 Asset: codex-aarch64-apple-darwin.tar.gz
-SHA-256: 023590f828bc9507ac61132ee35e74d3c5d33fb5ba3e1ca4fc2e013a2f71a3d7
+SHA-256: 2750132d300e64f1dbffb95e3d913fd9c9dc7812bc8e1bce5c61357248b7929e
 
 Codex is licensed under the Apache License 2.0. The complete license text is
 included alongside this notice.

--- a/Sources/Dahlia/Services/CodexBundle.swift
+++ b/Sources/Dahlia/Services/CodexBundle.swift
@@ -11,8 +11,8 @@ struct BundleCodexExecutableLocator: CodexExecutableLocating {
 }
 
 enum CodexBundle {
-    nonisolated static let version = "0.144.6"
-    nonisolated static let sourceCommit = "5d1fbf26c43abc65a203928b2e31561cb039e06d"
+    nonisolated static let version = "0.146.0"
+    nonisolated static let sourceCommit = "e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 
     nonisolated static func executableURL(in bundle: Bundle = .main) throws -> URL {
         let url = bundle.bundleURL

--- a/scripts/build-codex.sh
+++ b/scripts/build-codex.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-CODEX_VERSION="0.144.6"
+CODEX_VERSION="0.146.0"
 TARGET="aarch64-apple-darwin"
 ASSET_NAME="codex-${TARGET}.tar.gz"
-ASSET_SHA256="023590f828bc9507ac61132ee35e74d3c5d33fb5ba3e1ca4fc2e013a2f71a3d7"
+ASSET_SHA256="2750132d300e64f1dbffb95e3d913fd9c9dc7812bc8e1bce5c61357248b7929e"
 ARCHIVE_BINARY="codex-${TARGET}"
 DOWNLOAD_URL="https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/${ASSET_NAME}"
 


### PR DESCRIPTION
## Summary

- update the bundled Codex CLI from 0.144.6 to 0.146.0
- pin the 0.146.0 source commit and Apple Silicon archive SHA-256
- refresh the bundled Codex notice metadata

## Impact

Dahlia will bundle and report Codex CLI 0.146.0.

## Validation

- `bash scripts/build-codex.sh`
- `bash scripts/build-codex.sh --validate-only`
- `swift build`
- `CI=true ./scripts/lint.sh` (SwiftFormat clean; SwiftLint completed with pre-existing non-blocking repository violations)