### PR TITLE
Restore Databricks authentication for Codex app server

### DIFF
--- a/Sources/Dahlia/Services/CodexAppServerLauncher.swift
+++ b/Sources/Dahlia/Services/CodexAppServerLauncher.swift
@@ -24,7 +24,6 @@ struct BundledCodexAppServerLauncher: CodexAppServerLaunching {
         try presetSkillInstaller.install(into: homeURL)
         var environment = ProcessInfo.processInfo.environment
         environment["CODEX_HOME"] = homeURL.path
-        environment["HOME"] = homeURL.path
         environment["PATH"] = CommandLineToolLocator.searchPath(environment: environment)
         return try CodexAppServerProcessTransport(
             executableURL: executableLocator.executableURL(),

--- a/Tests/DahliaTests/CodexAppServerLauncherTests.swift
+++ b/Tests/DahliaTests/CodexAppServerLauncherTests.swift
@@ -6,14 +6,15 @@ import Foundation
 
     struct CodexAppServerLauncherTests {
         @Test
-        func launchesAppServerFromPrivateCodexHome() async throws {
+        func launchesAppServerWithPrivateCodexHomeAndUserHome() async throws {
             let rootURL = URL.temporaryDirectory
                 .appending(path: "dahlia-codex-launcher-\(UUID().uuidString)", directoryHint: .isDirectory)
             defer { try? FileManager.default.removeItem(at: rootURL) }
             try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
 
             let executableURL = rootURL.appending(path: "print-working-directory")
-            try Data("#!/bin/sh\n/bin/pwd\n/usr/bin/printenv HOME\n".utf8).write(to: executableURL)
+            try Data("#!/bin/sh\n/bin/pwd\n/usr/bin/printenv CODEX_HOME\n/usr/bin/printenv HOME\n".utf8)
+                .write(to: executableURL)
             try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executableURL.path)
 
             let homeLocator = ApplicationSupportCodexHomeLocator(applicationSupportURL: rootURL)
@@ -46,8 +47,11 @@ import Foundation
                 URL(filePath: workingDirectory, directoryHint: .isDirectory).resolvingSymlinksInPath()
                     == expectedHomeURL.resolvingSymlinksInPath()
             )
-            let homeEnvironment = try #require(await transport.receiveLine())
-            #expect(String(data: homeEnvironment, encoding: .utf8) == expectedHomeURL.path)
+            let codexHomeEnvironment = try #require(await transport.receiveLine())
+            #expect(String(data: codexHomeEnvironment, encoding: .utf8) == expectedHomeURL.path)
+            let userHomeEnvironment = try #require(await transport.receiveLine())
+            let inheritedHome = try #require(ProcessInfo.processInfo.environment["HOME"])
+            #expect(String(data: userHomeEnvironment, encoding: .utf8) == inheritedHome)
             for (skillName, installedSkillURL) in zip(
                 BundledCodexPresetSkillInstaller.skillNames,
                 installedSkillURLs

--- a/docs/adr/0021-preserve-user-home-for-databricks-authentication.md
+++ b/docs/adr/0021-preserve-user-home-for-databricks-authentication.md
@@ -1,0 +1,35 @@
+# ADR 0021: Databricks 認証のため app-server に user HOME を継承する
+
+- Status: Accepted
+- Date: 2026-08-04
+- Partially supersedes: ADR 0015
+- Amends: ADR 0003
+
+## Context
+
+ADR 0015 は、Dahlia の preset skills だけを discovery 対象にするため、Codex app-server 子 process の
+`CODEX_HOME` と `HOME` をどちらも Dahlia 専用 `CODEX_HOME` に固定した。
+
+Databricks provider の auth command は app-server から `databricks auth token` を起動する。Databricks CLI は
+実ユーザーの `HOME` を使って profile と credential context を解決するため、`HOME` を Dahlia 専用領域へ
+差し替えると、設定画面で検証済みの profile でも app-server からは未認証になる。
+
+## Decision
+
+- app-server 子 process には Dahlia 専用 `CODEX_HOME` を設定するが、`HOME` は実ユーザーの値を継承する。
+- Databricks provider の auth command は `HOME` を上書きせず、`databricks auth token` を直接実行する。
+- config、OpenAI auth、logs、sessions、preset skills の ownership は引き続き Dahlia 専用 `CODEX_HOME` に置く。
+  `~/.codex` の state は参照しない。
+- user `HOME` の継承により `$HOME/.agents/skills` も discovery 対象になり得ることは、Databricks 認証を
+  復旧するための既知のトレードオフとして当面許容する。認証を維持したまま user skill discovery を分離する
+  後続対応は [GitHub Issue #234](https://github.com/dahlia-org/dahlia/issues/234) で追跡する。
+- summary thread の skills 無効化、Dahlia MCP の Vault 境界、chat の tool policy は変更しない。
+
+## Consequences
+
+- app-server の Databricks auth command は、設定画面の Databricks CLI と同じ profile と credential context を
+  参照できる。
+- `$HOME/.agents/skills` が chat の discovery 対象になる可能性がある。これらは Dahlia が同梱・監査する
+  preset ではないため、Dahlia MCP の validation と tool policy を最終 authority とする。
+- launcher の実 process test で、`CODEX_HOME` が専用領域を指し、`HOME` が親 process の値を維持することを
+  検証する。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,7 +13,7 @@ Codex は全 ADR を順番に読まず、最初にこの一覧から現在の作
 | --- | --- | --- | --- |
 | [0001](0001-summary-document-ast.md) | Summary | `SummaryDocument` AST をサマリーの正準表現にする | Accepted |
 | [0002](0002-isolate-recording-critical-path-from-main-actor.md) | Recording / Concurrency | 録音と確定データの保存を MainActor の UI projection から分離する | Accepted; partially superseded by 0006 and 0009 |
-| [0003](0003-use-a-shared-codex-app-server.md) | AI runtime | Codex app-server をアプリ共有の長寿命 backend として使う | Accepted; amended by 0013, 0015, 0019, and 0020 |
+| [0003](0003-use-a-shared-codex-app-server.md) | AI runtime | Codex app-server をアプリ共有の長寿命 backend として使う | Accepted; amended by 0013, 0015, 0019, 0020, and 0021 |
 | [0004](0004-protect-recordings-with-segmented-immutable-storage.md) | Recording storage | 録音データを分割された immutable segment として保全する | Accepted |
 | [0005](0005-vault-scoped-meeting-access-mcp.md) | Meeting access | Vault 固定・read-only の local MCP で meeting data を公開する | Accepted; amended by 0010 |
 | [0006](0006-bounded-transcript-projection.md) | Transcript UI | SQLite を正本とし、文字起こし表示を bounded projection と keyset pagination にする | Accepted; partially supersedes 0002 |
@@ -25,9 +25,10 @@ Codex は全 ADR を順番に読まず、最初にこの一覧から現在の作
 | [0012](0012-reviewable-customer-intelligence-workspace.md) | Customer intelligence / UI | 単一顧客の組織ビューと単数 CRUD による逐次AI更新を採用する | Accepted; amends 0011 |
 | [0013](0013-expand-codex-stdout-burst-buffer.md) | AI runtime | Codex stdout の burst buffer を拡張し、消費済み payload を即時解放する | Superseded by 0019 |
 | [0014](0014-domain-driven-organization-merge.md) | Customer intelligence / Identity | メールドメイン追加を入口にルート組織を完全統合する | Accepted; amends 0011 and 0012 |
-| [0015](0015-preset-projects-optimizer-skill.md) | AI runtime / Project workspace | Projects Optimizer skill をアプリ内チャットへプリセットする | Accepted; amends 0003, builds on 0010 |
+| [0015](0015-preset-projects-optimizer-skill.md) | AI runtime / Project workspace | Projects Optimizer skill をアプリ内チャットへプリセットする | Accepted; partially superseded by 0021, amends 0003, builds on 0010 |
 | [0016](0016-shared-organization-domains.md) | Customer intelligence / Identity | 同じメールドメインを複数のルート組織で共有可能にする | Accepted; amends 0011 and 0014 |
 | [0017](0017-preset-customer-intelligence-skills.md) | AI runtime / Customer intelligence | 顧客インテリジェンスの curator skill を層ごとに分けてプリセットする | Accepted; amends 0015, builds on 0011 and 0012 |
 | [0018](0018-mcp-meeting-summary-update.md) | Summary / Meeting access | サマリーの訂正を MCP のドキュメント全体置換で行う | Accepted; amends 0005 and 0010, builds on 0001 |
 | [0019](0019-pull-codex-stdout-with-backpressure.md) | AI runtime | Codex stdout を64 KiB単位で需要駆動読み取りする | Accepted; supersedes 0013, amends 0003; amended by 0020 |
 | [0020](0020-bound-codex-output-relative-to-client-input.md) | AI runtime | Codex stdout の単一行上限をclient入力に応じて拡張する | Accepted; amends 0019 and 0003 |
+| [0021](0021-preserve-user-home-for-databricks-authentication.md) | AI runtime / Authentication | app-server では `CODEX_HOME` だけを分離し、Databricks CLI のため user `HOME` を継承する | Accepted; partially supersedes 0015, amends 0003 |


### PR DESCRIPTION
## Summary

- isolate the bundled Codex app-server with `CODEX_HOME` while preserving the user's inherited `HOME`
- verify the environment boundary with a real child-process regression test
- record the architecture change in ADR 0021 and track user skill discovery follow-up in #234

## Root cause

The launcher set both `CODEX_HOME` and `HOME` to Dahlia's private Codex directory. The Databricks provider auth command runs `databricks auth token` from the app-server process, so the CLI could no longer resolve the user's Databricks profile and credential context and Codex reported that it was not signed in.

This was independent of the bundled Codex 0.146.0 update.

## Impact

Databricks-backed Codex now uses the same user profile and credential context as the settings validation flow while config, OpenAI auth, logs, sessions, and preset skills remain owned by Dahlia's private `CODEX_HOME`.

Inheriting `HOME` can also expose `$HOME/.agents/skills` to discovery. This is accepted for now and tracked separately in #234.

## Validation

- `swift build`
- `swift test --filter CodexAppServerLauncherTests` — 5 tests passed
- `swift test` — 1,354 tests across 205 suites passed
- changed-file SwiftFormat and SwiftLint checks passed
- `git diff --check` passed
- repository lint completed; existing repository-wide SwiftLint violations remain outside this diff