### PR TITLE
Add collapsible running tasks panel

### DIFF
--- a/Sources/Dahlia/Views/SummaryProgressToastView.swift
+++ b/Sources/Dahlia/Views/SummaryProgressToastView.swift
@@ -5,6 +5,7 @@ struct SummaryProgressToastView: View {
     let jobs: [SummaryGenerationJob]
     let onDismiss: (UUID) -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isExpanded = true
 
     var body: some View {
@@ -31,9 +32,7 @@ struct SummaryProgressToastView: View {
                 Spacer(minLength: 8)
 
                 Button {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        isExpanded.toggle()
-                    }
+                    setExpanded(!isExpanded)
                 } label: {
                     Label(
                         isExpanded ? L10n.collapse : L10n.expand,
@@ -68,8 +67,16 @@ struct SummaryProgressToastView: View {
         .shadow(color: .black.opacity(0.06), radius: 3, y: 1)
         .onChange(of: jobs.map(\.id)) { oldIDs, newIDs in
             guard !isExpanded, newIDs.contains(where: { !oldIDs.contains($0) }) else { return }
+            setExpanded(true)
+        }
+    }
+
+    private func setExpanded(_ expanded: Bool) {
+        if reduceMotion {
+            isExpanded = expanded
+        } else {
             withAnimation(.easeInOut(duration: 0.2)) {
-                isExpanded = true
+                isExpanded = expanded
             }
         }
     }

--- a/Sources/Dahlia/Views/SummaryProgressToastView.swift
+++ b/Sources/Dahlia/Views/SummaryProgressToastView.swift
@@ -5,28 +5,73 @@ struct SummaryProgressToastView: View {
     let jobs: [SummaryGenerationJob]
     let onDismiss: (UUID) -> Void
 
+    @State private var isExpanded = true
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text(L10n.runningTasks)
-                .font(.callout)
-                .bold()
-                .foregroundStyle(.primary)
+            HStack(spacing: 8) {
+                HStack(spacing: 6) {
+                    Text(L10n.runningTasks)
+                        .font(.callout)
+                        .bold()
+                        .foregroundStyle(.primary)
 
-            ScrollView {
-                LazyVStack(spacing: 10) {
-                    ForEach(jobs) { job in
-                        SummaryGenerationJobProgressView(job: job, onDismiss: onDismiss)
+                    Text(jobs.count, format: .number)
+                        .font(.caption2.weight(.semibold))
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 6)
+                        .frame(minWidth: 20, minHeight: 20)
+                        .background(Color.primary.opacity(0.1), in: Capsule())
+                }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(L10n.runningTasks)
+                .accessibilityValue(jobs.count.formatted())
+
+                Spacer(minLength: 8)
+
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        isExpanded.toggle()
+                    }
+                } label: {
+                    Label(
+                        isExpanded ? L10n.collapse : L10n.expand,
+                        systemImage: isExpanded ? "minus" : "chevron.up"
+                    )
+                    .labelStyle(.iconOnly)
+                    .frame(width: 24, height: 24)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .help(isExpanded ? L10n.collapse : L10n.expand)
+            }
+
+            if isExpanded {
+                ScrollView {
+                    LazyVStack(spacing: 10) {
+                        ForEach(jobs) { job in
+                            SummaryGenerationJobProgressView(job: job, onDismiss: onDismiss)
+                        }
                     }
                 }
+                .scrollIndicators(.automatic)
+                .frame(maxHeight: 360)
+                .transition(.opacity)
             }
-            .scrollIndicators(.automatic)
-            .frame(maxHeight: 360)
         }
         .padding(12)
         .frame(minWidth: 260, idealWidth: 300, maxWidth: 340)
         .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 10))
         .shadow(color: .black.opacity(0.12), radius: 12, y: 4)
         .shadow(color: .black.opacity(0.06), radius: 3, y: 1)
+        .onChange(of: jobs.map(\.id)) { oldIDs, newIDs in
+            guard !isExpanded, newIDs.contains(where: { !oldIDs.contains($0) }) else { return }
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isExpanded = true
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- add a minimize/expand control to the running tasks panel
- keep a compact header visible while minimized so task details can be restored
- show the current task count in a badge in both expanded and minimized states
- automatically re-expand when a new task is added

## Why

Transcription and summary jobs can occupy the lower-right corner for an extended period. This lets users reclaim the space without losing access to current progress.

## Validation

- `swift build`
- SwiftFormat (`0/610 files require formatting`)
- SwiftLint on `SummaryProgressToastView.swift`
- `git diff --check`
- deep review across correctness, UI/accessibility, performance, security, and test coverage
