### PR TITLE
Navigate screenshots with arrow keys in the expanded view

### DIFF
--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -51,6 +51,8 @@
 "Clear" = "Clear";
 "Close" = "Close";
 "Copy Image" = "Copy Image";
+"Previous Image" = "Previous Image";
+"Next Image" = "Next Image";
 "Done" = "Done";
 "Select" = "Select";
 "Select All" = "Select All";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -51,6 +51,8 @@
 "Clear" = "クリア";
 "Close" = "閉じる";
 "Copy Image" = "画像をコピー";
+"Previous Image" = "前の画像";
+"Next Image" = "次の画像";
 "Done" = "完了";
 "Select" = "選択";
 "Select All" = "すべて選択";

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -46,6 +46,8 @@ enum L10n {
     static var reload: String { String(localized: "Reload", bundle: bundle) }
     static var close: String { String(localized: "Close", bundle: bundle) }
     static var copyImage: String { String(localized: "Copy Image", bundle: bundle) }
+    static var previousImage: String { String(localized: "Previous Image", bundle: bundle) }
+    static var nextImage: String { String(localized: "Next Image", bundle: bundle) }
     static var done: String { String(localized: "Done", bundle: bundle) }
     static var select: String { String(localized: "Select", bundle: bundle) }
     static var selectAll: String { String(localized: "Select All", bundle: bundle) }

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -30,9 +30,18 @@ enum DetailTab: String, CaseIterable, Identifiable {
 }
 
 private struct ExpandedScreenshotPresentation {
+    /// 前後送りの対象範囲。開いた画面の文脈をそのまま保つ。
+    enum Scope {
+        /// スクリーンショット一覧タブ。ミーティングの全スクリーンショットを撮影順にたどる。
+        case allScreenshots
+        /// 要約タブ。要約本文に埋め込まれた画像だけを出現順にたどる。
+        case summary
+    }
+
     let screenshot: MeetingScreenshotRecord
     let previewImage: CGImage?
     let requestedAt: ContinuousClock.Instant
+    let scope: Scope
 }
 
 /// ミーティング詳細のタイトル。クリックでインライン編集できる。
@@ -308,6 +317,10 @@ struct ControlPanelView: View {
                     screenshot: presentation.screenshot,
                     previewImage: presentation.previewImage,
                     requestedAt: presentation.requestedAt,
+                    canGoPrevious: canStepExpandedScreenshot(by: -1),
+                    canGoNext: canStepExpandedScreenshot(by: 1),
+                    onPrevious: { stepExpandedScreenshot(by: -1) },
+                    onNext: { stepExpandedScreenshot(by: 1) },
                     onDismiss: dismissExpandedScreenshot
                 )
                 .transition(.opacity)
@@ -426,18 +439,23 @@ struct ControlPanelView: View {
             selectedScreenshotIDs: $selectedScreenshotIds,
             referencedScreenshotIDs: referencedScreenshotIds,
             isDeletionDisabled: viewModel.isSummaryGenerating || viewModel.isDeletingScreenshots,
-            open: openScreenshot,
+            open: { openScreenshot($0, previewImage: $1, scope: .allScreenshots) },
             download: viewModel.downloadScreenshot,
             delete: viewModel.deleteScreenshot,
             deleteSelected: deleteSelectedScreenshots
         )
     }
 
-    private func openScreenshot(_ screenshot: MeetingScreenshotRecord, previewImage: CGImage?) {
+    private func openScreenshot(
+        _ screenshot: MeetingScreenshotRecord,
+        previewImage: CGImage?,
+        scope: ExpandedScreenshotPresentation.Scope
+    ) {
         let presentation = ExpandedScreenshotPresentation(
             screenshot: screenshot,
             previewImage: previewImage,
-            requestedAt: .now
+            requestedAt: .now,
+            scope: scope
         )
         withAnimation(.easeOut(duration: 0.15)) {
             expandedScreenshot = presentation
@@ -446,11 +464,47 @@ struct ControlPanelView: View {
 
     private func openSummaryScreenshot(_ screenshotID: UUID, previewImage: CGImage) {
         guard let screenshot = screenshotRecord(withID: screenshotID) else { return }
-        openScreenshot(screenshot, previewImage: previewImage)
+        openScreenshot(screenshot, previewImage: previewImage, scope: .summary)
     }
 
     private func screenshotRecord(withID id: UUID) -> MeetingScreenshotRecord? {
         viewModel.screenshotStore.records.first { $0.id == id }
+    }
+
+    /// 拡大表示中に削除や再生成が起きても追従できるよう、移動対象は都度現在の state から組み立てる。
+    private func expandedScreenshotNavigationIDs(for scope: ExpandedScreenshotPresentation.Scope) -> [UUID] {
+        switch scope {
+        case .allScreenshots:
+            viewModel.screenshotStore.records.map(\.id)
+        case .summary:
+            (viewModel.currentSummaryDocument?.orderedScreenshotIds ?? [])
+                .filter { screenshotRecord(withID: $0) != nil }
+        }
+    }
+
+    private func neighborExpandedScreenshot(by offset: Int) -> MeetingScreenshotRecord? {
+        guard let presentation = expandedScreenshot else { return nil }
+        guard let neighborID = ScreenshotOverlayNavigation.neighborID(
+            in: expandedScreenshotNavigationIDs(for: presentation.scope),
+            from: presentation.screenshot.id,
+            offset: offset
+        ) else { return nil }
+        return screenshotRecord(withID: neighborID)
+    }
+
+    private func canStepExpandedScreenshot(by offset: Int) -> Bool {
+        neighborExpandedScreenshot(by: offset) != nil
+    }
+
+    private func stepExpandedScreenshot(by offset: Int) {
+        guard let presentation = expandedScreenshot,
+              let neighbor = neighborExpandedScreenshot(by: offset) else { return }
+        expandedScreenshot = ExpandedScreenshotPresentation(
+            screenshot: neighbor,
+            previewImage: nil,
+            requestedAt: .now,
+            scope: presentation.scope
+        )
     }
 
     private func dismissExpandedScreenshot() {

--- a/Sources/Dahlia/Views/ScreenshotOverlayInputMonitor.swift
+++ b/Sources/Dahlia/Views/ScreenshotOverlayInputMonitor.swift
@@ -3,9 +3,11 @@ import SwiftUI
 
 struct ScreenshotOverlayInputMonitor: NSViewRepresentable {
     let onDismiss: () -> Void
+    var onPrevious: () -> Void = {}
+    var onNext: () -> Void = {}
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onDismiss: onDismiss)
+        Coordinator(onDismiss: onDismiss, onPrevious: onPrevious, onNext: onNext)
     }
 
     func makeNSView(context: Context) -> NSView {
@@ -16,6 +18,8 @@ struct ScreenshotOverlayInputMonitor: NSViewRepresentable {
 
     func updateNSView(_: NSView, context: Context) {
         context.coordinator.onDismiss = onDismiss
+        context.coordinator.onPrevious = onPrevious
+        context.coordinator.onNext = onNext
     }
 
     static func dismantleNSView(_: NSView, coordinator: Coordinator) {
@@ -25,13 +29,23 @@ struct ScreenshotOverlayInputMonitor: NSViewRepresentable {
     @MainActor
     final class Coordinator {
         private static let escapeKeyCode: UInt16 = 53
+        private static let leftArrowKeyCode: UInt16 = 123
+        private static let rightArrowKeyCode: UInt16 = 124
 
         var onDismiss: () -> Void
+        var onPrevious: () -> Void
+        var onNext: () -> Void
 
         private var eventMonitor: Any?
 
-        init(onDismiss: @escaping () -> Void) {
+        init(
+            onDismiss: @escaping () -> Void,
+            onPrevious: @escaping () -> Void = {},
+            onNext: @escaping () -> Void = {}
+        ) {
             self.onDismiss = onDismiss
+            self.onPrevious = onPrevious
+            self.onNext = onNext
         }
 
         func startMonitoring(view: NSView) {
@@ -48,8 +62,17 @@ struct ScreenshotOverlayInputMonitor: NSViewRepresentable {
 
             switch event.type {
             case .keyDown:
-                guard event.keyCode == Self.escapeKeyCode else { return event }
-                onDismiss()
+                switch event.keyCode {
+                case Self.escapeKeyCode:
+                    onDismiss()
+                case Self.leftArrowKeyCode:
+                    onPrevious()
+                case Self.rightArrowKeyCode:
+                    onNext()
+                default:
+                    return event
+                }
+                // 端で移動できない場合も、背後の一覧へ矢印キーを漏らさない。
                 return nil
             case .leftMouseDown, .rightMouseDown, .otherMouseDown:
                 break

--- a/Sources/Dahlia/Views/ScreenshotOverlayView.swift
+++ b/Sources/Dahlia/Views/ScreenshotOverlayView.swift
@@ -19,9 +19,49 @@ enum ScreenshotOverlayLayout {
     }
 }
 
+enum ScreenshotOverlayNavigation {
+    /// 端を越える移動と、一覧から外れた現在 ID には nil を返す。巡回はしない。
+    static func neighborID(in ids: [UUID], from currentID: UUID, offset: Int) -> UUID? {
+        guard let index = ids.firstIndex(of: currentID) else { return nil }
+        let neighborIndex = index + offset
+        guard ids.indices.contains(neighborIndex) else { return nil }
+        return ids[neighborIndex]
+    }
+}
+
+/// 拡大表示に重ねる丸型ボタン。閉じる・コピー・前後送りで見た目を揃える。
+private struct ScreenshotOverlayControlButton: View {
+    let title: String
+    let systemImage: String
+    var isEnabled = true
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            // クリック判定はラベルの形で決まる。contentShape をボタンの外に置くと
+            // グリフの矩形しか反応せず、chevron のような細い記号は押しにくい。
+            Label(title, systemImage: systemImage)
+                .labelStyle(.iconOnly)
+                .font(.title2)
+                .foregroundStyle(.black)
+                .padding(8)
+                .background(.white, in: .circle)
+                .contentShape(.circle)
+        }
+        .buttonStyle(.plain)
+        .shadow(color: .black.opacity(0.35), radius: 4, y: 2)
+        .pointerStyle(.link)
+        .help(title)
+        .disabled(!isEnabled)
+        .opacity(isEnabled ? 1 : 0.35)
+    }
+}
+
 /// スクリーンショット拡大表示。手元の thumbnail を即時表示し、詳細画像へ段階更新する。
 struct ScreenshotOverlayView: View {
     private static let imagePadding: CGFloat = 24
+    private static let navigationButtonWidth: CGFloat = 44
+    private static let navigationSpacing: CGFloat = 12
 
     /// Retina の全画面キャプチャを元解像度でレイヤー化すると、RenderBox の
     /// surface allocation が枯渇し得る。画面表示には十分なサイズへ制限する。
@@ -30,6 +70,10 @@ struct ScreenshotOverlayView: View {
     let screenshot: MeetingScreenshotRecord
     let previewImage: CGImage?
     let requestedAt: ContinuousClock.Instant
+    let canGoPrevious: Bool
+    let canGoNext: Bool
+    let onPrevious: () -> Void
+    let onNext: () -> Void
     let onDismiss: () -> Void
 
     @StateObject private var imageLoader = ScreenshotImageLoadModel()
@@ -41,6 +85,10 @@ struct ScreenshotOverlayView: View {
         return previewImage
     }
 
+    private var hasNavigation: Bool {
+        canGoPrevious || canGoNext
+    }
+
     var body: some View {
         ZStack(alignment: .topTrailing) {
             Color.black.opacity(0.7)
@@ -48,16 +96,16 @@ struct ScreenshotOverlayView: View {
                 .allowsHitTesting(false)
 
             GeometryReader { proxy in
-                Group {
+                navigationChrome {
                     if let displayedImage {
                         expandedImage(displayedImage, availableSize: proxy.size)
                     } else if case .failed = imageLoader.state {
-                        monitoredContent {
+                        placeholder(availableSize: proxy.size) {
                             Text(L10n.summaryImageUnavailable)
                                 .foregroundStyle(.secondary)
                         }
                     } else {
-                        monitoredContent {
+                        placeholder(availableSize: proxy.size) {
                             ProgressView()
                         }
                     }
@@ -65,17 +113,12 @@ struct ScreenshotOverlayView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
             }
 
-            Button(L10n.close, systemImage: "xmark.circle.fill", action: onDismiss)
-                .labelStyle(.iconOnly)
-                .font(.title2)
-                .foregroundStyle(.black)
-                .padding(8)
-                .background(.white, in: .circle)
-                .shadow(color: .black.opacity(0.35), radius: 4, y: 2)
-                .padding(16)
-                .buttonStyle(.plain)
-                .pointerStyle(.link)
-                .help(L10n.close)
+            ScreenshotOverlayControlButton(
+                title: L10n.close,
+                systemImage: "xmark.circle.fill",
+                action: onDismiss
+            )
+            .padding(16)
         }
         .onAppear {
             ScreenshotImageDecodeWorker.recordOverlayPresented(
@@ -93,14 +136,26 @@ struct ScreenshotOverlayView: View {
         .onDisappear(perform: imageLoader.unload)
     }
 
-    private func expandedImage(_ image: CGImage, availableSize: CGSize) -> some View {
-        let contentSize = CGSize(
-            width: max(0, availableSize.width - Self.imagePadding * 2),
+    /// 送りボタンの列を差し引いた、画像が使える領域。
+    private func contentSize(availableSize: CGSize) -> CGSize {
+        let navigationInset = hasNavigation ? (Self.navigationButtonWidth + Self.navigationSpacing) * 2 : 0
+        return CGSize(
+            width: max(0, availableSize.width - Self.imagePadding * 2 - navigationInset),
             height: max(0, availableSize.height - Self.imagePadding * 2)
         )
+    }
+
+    /// 読み込み中と失敗時も画像と同じ幅を占め、送りボタンが左右に動かないようにする。
+    /// 高さは広げない。上下の余白はそのまま「外側クリックで閉じる」領域として残る。
+    private func placeholder(availableSize: CGSize, @ViewBuilder content: () -> some View) -> some View {
+        content()
+            .frame(width: contentSize(availableSize: availableSize).width)
+    }
+
+    private func expandedImage(_ image: CGImage, availableSize: CGSize) -> some View {
         let imageSize = ScreenshotOverlayLayout.fittedSize(
             imageSize: CGSize(width: image.width, height: image.height),
-            availableSize: contentSize
+            availableSize: contentSize(availableSize: availableSize)
         )
 
         return Image(decorative: image, scale: 1)
@@ -108,31 +163,64 @@ struct ScreenshotOverlayView: View {
             .frame(width: imageSize.width, height: imageSize.height)
             .clipShape(.rect(cornerRadius: 8))
             .overlay(alignment: .topTrailing) {
-                Button(L10n.copyImage, systemImage: "doc.on.doc", action: copyImageToGeneralPasteboard)
-                    .labelStyle(.iconOnly)
-                    .font(.title2)
-                    .foregroundStyle(.black)
-                    .padding(8)
-                    .background(.white, in: .circle)
-                    .shadow(color: .black.opacity(0.35), radius: 4, y: 2)
-                    .padding(12)
-                    .buttonStyle(.plain)
-                    .pointerStyle(.link)
-                    .help(L10n.copyImage)
+                ScreenshotOverlayControlButton(
+                    title: L10n.copyImage,
+                    systemImage: "doc.on.doc",
+                    action: copyImageToGeneralPasteboard
+                )
+                .padding(12)
             }
             .contextMenu {
                 Button(L10n.copyImage, systemImage: "doc.on.doc", action: copyImageToGeneralPasteboard)
             }
-            .background {
-                ScreenshotOverlayInputMonitor(onDismiss: onDismiss)
-            }
     }
 
-    private func monitoredContent(@ViewBuilder content: () -> some View) -> some View {
-        content()
-            .background {
-                ScreenshotOverlayInputMonitor(onDismiss: onDismiss)
+    /// 送りボタンごと監視ビューの内側に置く。ボタンが bounds の外にあると、
+    /// クリックが「オーバーレイ外クリック」と判定されて拡大表示が閉じてしまう。
+    private func navigationChrome(@ViewBuilder content: () -> some View) -> some View {
+        HStack(spacing: Self.navigationSpacing) {
+            if hasNavigation {
+                navigationButton(
+                    title: L10n.previousImage,
+                    systemImage: "chevron.backward",
+                    isEnabled: canGoPrevious,
+                    action: onPrevious
+                )
             }
+
+            content()
+
+            if hasNavigation {
+                navigationButton(
+                    title: L10n.nextImage,
+                    systemImage: "chevron.forward",
+                    isEnabled: canGoNext,
+                    action: onNext
+                )
+            }
+        }
+        .background {
+            ScreenshotOverlayInputMonitor(
+                onDismiss: onDismiss,
+                onPrevious: onPrevious,
+                onNext: onNext
+            )
+        }
+    }
+
+    private func navigationButton(
+        title: String,
+        systemImage: String,
+        isEnabled: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        ScreenshotOverlayControlButton(
+            title: title,
+            systemImage: systemImage,
+            isEnabled: isEnabled,
+            action: action
+        )
+        .frame(width: Self.navigationButtonWidth)
     }
 
     private func copyImageToGeneralPasteboard() {

--- a/Sources/DahliaRuntimeSupport/SummaryDocument.swift
+++ b/Sources/DahliaRuntimeSupport/SummaryDocument.swift
@@ -55,11 +55,18 @@ public struct SummaryDocument: Codable, Equatable, Sendable {
         try JSONDecoder().decode(SummaryDocument.self, from: Data(databaseJSON.utf8))
     }
 
-    public var referencedScreenshotIds: Set<UUID> {
-        Set(sections.flatMap(\.blocks).compactMap { block in
-            guard case let .image(screenshotId, _) = block.content else { return nil }
+    /// 本文の出現順。重複した参照は最初の出現位置だけ残す。
+    public var orderedScreenshotIds: [UUID] {
+        var seen = Set<UUID>()
+        return sections.flatMap(\.blocks).compactMap { block in
+            guard case let .image(screenshotId, _) = block.content,
+                  seen.insert(screenshotId).inserted else { return nil }
             return screenshotId
-        })
+        }
+    }
+
+    public var referencedScreenshotIds: Set<UUID> {
+        Set(orderedScreenshotIds)
     }
 
     public func removingScreenshotReferences(_ screenshotIds: Set<UUID>) -> SummaryDocument {

--- a/Tests/DahliaTests/ScreenshotOverlayViewTests.swift
+++ b/Tests/DahliaTests/ScreenshotOverlayViewTests.swift
@@ -49,7 +49,11 @@ struct ScreenshotOverlayViewTests {
         let view = ScreenshotOverlayView(
             screenshot: screenshot,
             previewImage: nil,
-            requestedAt: .now
+            requestedAt: .now,
+            canGoPrevious: false,
+            canGoNext: false,
+            onPrevious: {},
+            onNext: {}
         ) {
             dismissCount += 1
         }
@@ -166,6 +170,83 @@ struct ScreenshotOverlayViewTests {
 
         #expect(handledEvent === fixture.event)
         #expect(dismissCount == 0)
+    }
+
+    @Test
+    func arrowKeysInOverlayWindowAreConsumedAndNavigate() throws {
+        let cases: [(keyCode: UInt16, expectedPrevious: Int, expectedNext: Int)] = [
+            (123, 1, 0),
+            (124, 0, 1),
+        ]
+
+        for testCase in cases {
+            let fixture = try makeKeyFixture(keyCode: testCase.keyCode)
+            var dismissCount = 0
+            var previousCount = 0
+            var nextCount = 0
+            let coordinator = ScreenshotOverlayInputMonitor.Coordinator(
+                onDismiss: { dismissCount += 1 },
+                onPrevious: { previousCount += 1 },
+                onNext: { nextCount += 1 }
+            )
+
+            let handledEvent = coordinator.handle(fixture.event, in: fixture.view)
+
+            #expect(handledEvent == nil)
+            #expect(previousCount == testCase.expectedPrevious)
+            #expect(nextCount == testCase.expectedNext)
+            #expect(dismissCount == 0)
+        }
+    }
+
+    @Test
+    func arrowKeyInAnotherWindowIsForwardedWithoutNavigating() throws {
+        let fixture = try makeKeyFixture(keyCode: 124)
+        let otherWindow = makeWindow()
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: otherWindow.windowNumber,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: 124
+        ))
+        var nextCount = 0
+        let coordinator = ScreenshotOverlayInputMonitor.Coordinator(
+            onDismiss: {},
+            onPrevious: {},
+            onNext: { nextCount += 1 }
+        )
+
+        let handledEvent = coordinator.handle(event, in: fixture.view)
+
+        #expect(handledEvent === event)
+        #expect(nextCount == 0)
+    }
+
+    @Test
+    func neighborIDStopsAtBothEndsWithoutWrapping() {
+        let ids = [UUID.v7(), UUID.v7(), UUID.v7()]
+
+        #expect(ScreenshotOverlayNavigation.neighborID(in: ids, from: ids[1], offset: -1) == ids[0])
+        #expect(ScreenshotOverlayNavigation.neighborID(in: ids, from: ids[1], offset: 1) == ids[2])
+        #expect(ScreenshotOverlayNavigation.neighborID(in: ids, from: ids[0], offset: -1) == nil)
+        #expect(ScreenshotOverlayNavigation.neighborID(in: ids, from: ids[2], offset: 1) == nil)
+    }
+
+    @Test
+    func neighborIDReturnsNilForSingleEntryOrUnlistedCurrentID() {
+        let single = UUID.v7()
+
+        #expect(ScreenshotOverlayNavigation.neighborID(in: [single], from: single, offset: 1) == nil)
+        #expect(ScreenshotOverlayNavigation.neighborID(in: [single], from: single, offset: -1) == nil)
+        // 拡大表示中に対象が削除された場合。
+        #expect(ScreenshotOverlayNavigation.neighborID(in: [single], from: .v7(), offset: 1) == nil)
+        #expect(ScreenshotOverlayNavigation.neighborID(in: [], from: single, offset: 1) == nil)
     }
 
     @Test

--- a/Tests/DahliaTests/SummaryDocumentCodableTests.swift
+++ b/Tests/DahliaTests/SummaryDocumentCodableTests.swift
@@ -129,6 +129,37 @@ import Foundation
         }
 
         @Test
+        func ordersScreenshotIdsByFirstAppearanceAcrossSections() {
+            let firstImageId = UUID.v7()
+            let secondImageId = UUID.v7()
+            let thirdImageId = UUID.v7()
+            let document = SummaryDocument(
+                title: "Summary",
+                sections: [
+                    SummarySection(
+                        id: .v7(),
+                        heading: "Design",
+                        blocks: [
+                            .image(screenshotId: secondImageId, caption: "Second"),
+                            .paragraph("Notes"),
+                            .image(screenshotId: firstImageId, caption: "First"),
+                        ]
+                    ),
+                    SummarySection(
+                        id: .v7(),
+                        heading: "Follow-up",
+                        blocks: [
+                            .image(screenshotId: secondImageId, caption: "Duplicate"),
+                            .image(screenshotId: thirdImageId, caption: "Third"),
+                        ]
+                    ),
+                ]
+            )
+
+            #expect(document.orderedScreenshotIds == [secondImageId, firstImageId, thirdImageId])
+        }
+
+        @Test
         func removingScreenshotReferencesPreservesCaptionsAsParagraphs() {
             let removedImageId = UUID.v7()
             let retainedImageId = UUID.v7()


### PR DESCRIPTION
拡大表示中に ←/→ キーと左右の送りボタンで前後の画像へ移動できるようにする。

- スクリーンショット一覧から開いた場合はミーティングの全スクリーンショットを撮影順に、
  要約から開いた場合は要約本文に埋め込まれた画像だけを出現順にたどる。
  移動対象は表示のたびに現在の state から組み立てるため、拡大表示中の削除にも追従する。
- 送りボタンは端で無効化し、巡回はしない。対象が1枚のときは表示しない。
- 送りボタンは入力監視ビューの内側に置く。外側に置くと、クリックが
  「オーバーレイ外クリック」と判定されて拡大表示が閉じてしまう。
- 閉じる・コピー・前後送りで重複していた丸型ボタンの装飾を共通化し、
  クリック判定をラベル側の contentShape に移して円全体を押せるようにする。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WziHgw3zeY7CD9215rKmZW