### PR TITLE
Clear AI chat composer focus on outside click

### DIFF
--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposer.swift
@@ -12,6 +12,7 @@ struct CodexChatComposer: View {
     @State private var isImageImporterPresented = false
     @State private var isImageDropTargeted = false
     @State private var showsAddPanel = false
+    @FocusState private var isComposerFocused: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -36,6 +37,7 @@ struct CodexChatComposer: View {
 
             CodexChatComposerInputRow(
                 session: session,
+                isComposerFocused: $isComposerFocused,
                 showsAddPanel: showsAddPanel,
                 showsMeetingPicker: showsMeetingPicker,
                 suggestions: suggestions,
@@ -55,6 +57,7 @@ struct CodexChatComposer: View {
         .background {
             CodexChatComposerBackground(isDropTargeted: isImageDropTargeted)
         }
+        .codexChatDismissOnOutsideClick(perform: dismissComposerFocus)
         .shadow(color: .black.opacity(0.05), radius: 12, y: 3)
         .onChange(of: session.draft, handleDraftChange)
         .onChange(of: session.availableMeetingReferences) {
@@ -74,6 +77,17 @@ struct CodexChatComposer: View {
         }
         .onDropSessionUpdated(updateDropTarget)
         .pasteDestination(for: CodexChatTransferImage.self, action: addTransferImages)
+    }
+
+    /// 追加パネルと候補リストは「+」ボタンの overlay としてコンポーザーの矩形外に描画される。
+    /// 表示中は候補のクリックが外側クリックに見えるため、フォーカスを保持して参照挿入後の入力を続けられるようにする。
+    static func dismissesComposerFocus(showsAddPanel: Bool) -> Bool {
+        !showsAddPanel
+    }
+
+    private func dismissComposerFocus() {
+        guard Self.dismissesComposerFocus(showsAddPanel: showsAddPanel) else { return }
+        isComposerFocused = false
     }
 
     private func showImageImporter() {

--- a/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
+++ b/Sources/Dahlia/Views/CodexChat/CodexChatComposerInputRow.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct CodexChatComposerInputRow: View {
     @Bindable var session: CodexChatSessionModel
+    @FocusState.Binding var isComposerFocused: Bool
     let showsAddPanel: Bool
     let showsMeetingPicker: Bool
     let suggestions: [CodexChatMeetingReference]
@@ -49,6 +50,7 @@ struct CodexChatComposerInputRow: View {
 
             CodexChatComposerTextEditor(
                 text: $session.draft,
+                isFocused: $isComposerFocused,
                 onSubmit: onSubmit,
                 onMoveCommand: onMoveCommand,
                 onExitCommand: onExitCommand,
@@ -86,7 +88,7 @@ struct CodexChatComposerInputRow: View {
 
 struct CodexChatComposerTextEditor: View {
     @Binding var text: String
-    @FocusState private var isFocused: Bool
+    @FocusState.Binding var isFocused: Bool
     let onSubmit: () -> Void
     let onMoveCommand: (MoveCommandDirection) -> Void
     let onExitCommand: () -> Void

--- a/Tests/DahliaTests/CodexChatComposerFocusDismissalTests.swift
+++ b/Tests/DahliaTests/CodexChatComposerFocusDismissalTests.swift
@@ -1,0 +1,18 @@
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct CodexChatComposerFocusDismissalTests {
+        @Test
+        func outsideClickClearsComposerFocus() {
+            #expect(CodexChatComposer.dismissesComposerFocus(showsAddPanel: false))
+        }
+
+        @Test
+        func addPanelKeepsComposerFocusWhileSelectingASuggestion() {
+            #expect(!CodexChatComposer.dismissesComposerFocus(showsAddPanel: true))
+        }
+    }
+#endif

--- a/Tests/DahliaTests/CodexChatComposerTextEditorTests.swift
+++ b/Tests/DahliaTests/CodexChatComposerTextEditorTests.swift
@@ -136,9 +136,12 @@ import SwiftUI
         @Binding var text: String
         let onSubmit: () -> Void
 
+        @FocusState private var isFocused: Bool
+
         var body: some View {
             CodexChatComposerTextEditor(
                 text: $text,
+                isFocused: $isFocused,
                 onSubmit: onSubmit,
                 onMoveCommand: { _ in },
                 onExitCommand: {},


### PR DESCRIPTION
チャット履歴エリアやパネルの余白、チャット外をクリックしても入力欄の
フォーカスが外れなかった。TextEditor が包む NSTextView は、クリック先が
first responder を奪わない限りフォーカスを保持し続けるため、SwiftUI の
背景や ScrollView の空白をクリックしても resign されない。

CodexChatComposerTextEditor が持っていた FocusState をコンポーザーへ
持ち上げ、既存の codexChatDismissOnOutsideClick を角丸ボックスに適用して
外側クリックでフォーカスを解除する。追加パネルは「+」ボタンの overlay と
してコンポーザーの矩形外に描画されるため、表示中はフォーカスを保持し、
@メンション候補を選んだあとも入力を続けられるようにする。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011SL3UZSoehKatq42GC2C4H