### PR TITLE
Improve menu bar meeting visibility

### DIFF
--- a/Sources/Dahlia/Views/MenuBarCalendarEventRow.swift
+++ b/Sources/Dahlia/Views/MenuBarCalendarEventRow.swift
@@ -25,6 +25,7 @@ struct MenuBarCalendarEventRow: View {
         } label: {
             Label {
                 Text(menuTitle)
+                    .foregroundStyle(event.isAttending ? Color.primary : Color.secondary)
             } icon: {
                 MenuBarCalendarParticipationIndicator(isAttending: event.isAttending)
             }

--- a/Sources/Dahlia/Views/MenuBarCalendarParticipationIndicator.swift
+++ b/Sources/Dahlia/Views/MenuBarCalendarParticipationIndicator.swift
@@ -5,28 +5,23 @@ struct MenuBarCalendarParticipationIndicator: View {
     let isAttending: Bool
 
     var body: some View {
-        Image(nsImage: isAttending ? Self.solidIndicator : Self.dottedIndicator)
+        Image(nsImage: isAttending ? Self.attendingIndicator : Self.notAttendingIndicator)
             .renderingMode(.template)
             .accessibilityHidden(true)
     }
 
-    private static let solidIndicator = makeIndicator(isSolid: true)
-    private static let dottedIndicator = makeIndicator(isSolid: false)
+    private static let attendingIndicator = makeIndicator(isAttending: true)
+    private static let notAttendingIndicator = makeIndicator(isAttending: false)
 
-    private static func makeIndicator(isSolid: Bool) -> NSImage {
+    private static func makeIndicator(isAttending: Bool) -> NSImage {
         let image = NSImage(size: NSSize(width: 6, height: 14), flipped: true) { _ in
-            NSColor.black.setFill()
-            if isSolid {
-                NSBezierPath(
-                    roundedRect: NSRect(x: 2, y: 1, width: 2, height: 12),
-                    xRadius: 1,
-                    yRadius: 1
-                ).fill()
-            } else {
-                for y in [1.5, 6, 10.5] {
-                    NSBezierPath(ovalIn: NSRect(x: 2, y: y, width: 2, height: 2)).fill()
-                }
-            }
+            let width: CGFloat = isAttending ? 4 : 2
+            NSColor.black.withAlphaComponent(isAttending ? 1 : 0.35).setFill()
+            NSBezierPath(
+                roundedRect: NSRect(x: (6 - width) / 2, y: 1, width: width, height: 12),
+                xRadius: width / 2,
+                yRadius: width / 2
+            ).fill()
             return true
         }
         image.isTemplate = true


### PR DESCRIPTION
## Summary

- replace the similar solid-bar/dotted participation indicators with a stronger 4 pt attending bar and a subdued 2 pt non-attending bar
- preserve template rendering so the indicators continue to follow native menu text colors in light and dark appearances
- render non-attending event titles with the secondary foreground style when the native menu bridge preserves it

## Why

Attending and non-attending meetings currently have similar visual weight in the menu bar dropdown, making it difficult to identify meetings the user plans to join at a glance. This change strengthens the attending state while allowing other events to recede without changing the native menu structure or interaction model.

## Impact

The menu structure, event filtering and sorting, menu bar label, localization, and accessibility labels remain unchanged.

## Validation

- `swift build`
- `swift test --filter 'DahliaTests.MenuBarCalendarAgendaTests'` — 11 tests passed
- `CI=true ./scripts/lint.sh` — completed; existing repository-wide SwiftLint violations were reported as non-blocking
- `git diff --check`

Visual verification of the native menu bridge was intentionally not completed because the production app was actively recording. The secondary title styling may therefore require follow-up confirmation on-device.