### PR TITLE
Handle stalled batch transcription

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>42</string>
+    <string>43</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.8.4</string>
+    <string>0.9.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundleVersion</key>
     <string>43</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.0</string>
+    <string>0.8.5</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/Models/AppSettings.swift
+++ b/Sources/Dahlia/Models/AppSettings.swift
@@ -98,6 +98,7 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     nonisolated static let exportBatchSummaryToGoogleDocsUserDefaultsKey = "exportBatchSummaryToGoogleDocs"
     nonisolated static let summaryPreviousMeetingCountUserDefaultsKey = "summaryPreviousMeetingCount"
     nonisolated static let transcriptionLanguageScopeUserDefaultsKey = "transcriptionLanguageScope"
+    nonisolated static let batchTranscriptionStallTimeoutUserDefaultsKey = "batchTranscriptionStallTimeoutMinutes"
     nonisolated static let customerIntelligenceBetaEnabledUserDefaultsKey = "customerIntelligenceBetaEnabled"
     nonisolated static let conversationAnalyticsBetaEnabledUserDefaultsKey = "conversationAnalyticsBetaEnabled"
     nonisolated static let automaticOrganizationMembershipEnabledUserDefaultsKey = "automaticOrganizationMembershipEnabled"
@@ -114,6 +115,7 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
 
     init() {
         Self.migrateCalendarEventFilterSettings(in: .standard)
+        batchTranscriptionStallTimeoutRawValue = batchTranscriptionStallTimeout.rawValue
     }
 
     // MARK: - ベータ機能
@@ -191,6 +193,8 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     @AppStorage(TranscriptionMode.userDefaultsKey) var transcriptionModeRawValue = TranscriptionMode.defaultMode.rawValue
     @AppStorage("forceEchoCancellationForExternalMicrophone") var forceEchoCancellationForExternalMicrophone = false
     @AppStorage("retainAudioAfterBatchTranscription") var retainAudioAfterBatchTranscription = false
+    @AppStorage(AppSettings.batchTranscriptionStallTimeoutUserDefaultsKey) private var batchTranscriptionStallTimeoutRawValue =
+        BatchTranscriptionStallTimeout.defaultValue.rawValue
     @AppStorage(AppSettings.generateSummaryAfterBatchTranscriptionUserDefaultsKey) var generateSummaryAfterBatchTranscription = false
     @AppStorage(AppSettings.exportBatchSummaryToVaultUserDefaultsKey) var exportBatchSummaryToVault = true
     @AppStorage(AppSettings.exportBatchSummaryToGoogleDocsUserDefaultsKey) var exportBatchSummaryToGoogleDocs = false
@@ -215,6 +219,11 @@ final class AppSettings: ObservableObject, GoogleDriveExportFolderSettingsProvid
     var isRealtimeTranscriptionEnabled: Bool {
         get { transcriptionMode == .realtime }
         set { transcriptionMode = newValue ? .realtime : .batch }
+    }
+
+    var batchTranscriptionStallTimeout: BatchTranscriptionStallTimeout {
+        get { BatchTranscriptionStallTimeout.resolved(rawValue: batchTranscriptionStallTimeoutRawValue) }
+        set { batchTranscriptionStallTimeoutRawValue = newValue.rawValue }
     }
 
     var batchSummaryGenerationOptions: SummaryGenerationOptions {

--- a/Sources/Dahlia/Models/BatchFailureKind.swift
+++ b/Sources/Dahlia/Models/BatchFailureKind.swift
@@ -5,4 +5,5 @@ enum BatchFailureKind: String, Codable, DatabaseValueConvertible {
     case recordingRecovery
     case recordingAudioPermanent
     case transcription
+    case transcriptionStalled
 }

--- a/Sources/Dahlia/Models/BatchTranscriptionStallTimeout.swift
+++ b/Sources/Dahlia/Models/BatchTranscriptionStallTimeout.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum BatchTranscriptionStallTimeout: Int, CaseIterable, Identifiable, Sendable {
+    case oneMinute = 1
+    case twoMinutes = 2
+    case threeMinutes = 3
+
+    static let defaultValue: Self = .oneMinute
+
+    var id: Int { rawValue }
+
+    var duration: Duration {
+        .seconds(rawValue * 60)
+    }
+
+    var displayName: String {
+        L10n.batchTranscriptionStallTimeoutMinutes(rawValue)
+    }
+
+    static func resolved(rawValue: Int) -> Self {
+        Self(rawValue: rawValue) ?? defaultValue
+    }
+}

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -1267,3 +1267,8 @@
 "Relative dB" = "Relative dB";
 "Voice indicators show relative changes from speaker and recording-session baselines; they do not determine emotions or psychological state." = "Voice indicators show relative changes from speaker and recording-session baselines; they do not determine emotions or psychological state.";
 "Voice features are measured only during batch transcription." = "Voice features are measured only during batch transcription.";
+"Batch transcription stopped because Apple Speech made no progress for %@. The recording audio was kept for retry." = "Batch transcription stopped because Apple Speech made no progress for %@. The recording audio was kept for retry.";
+"No-progress Timeout" = "No-progress Timeout";
+"Stop batch transcription when Apple Speech makes no progress for this long." = "Stop batch transcription when Apple Speech makes no progress for this long.";
+"%lld minute" = "%lld minute";
+"%lld minutes" = "%lld minutes";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -1267,3 +1267,8 @@
 "Relative dB" = "相対dB";
 "Voice indicators show relative changes from speaker and recording-session baselines; they do not determine emotions or psychological state." = "音声指標は話者・録音セッションごとの基準からの相対変化であり、感情や心理状態を断定するものではありません。";
 "Voice features are measured only during batch transcription." = "音声特徴はバッチ文字起こし時のみ計測されます。";
+"Batch transcription stopped because Apple Speech made no progress for %@. The recording audio was kept for retry." = "Apple Speech に %@進捗がなかったため、バッチ文字起こしを停止しました。再試行できるよう録音音声は保持されています。";
+"No-progress Timeout" = "進捗停止の検出時間";
+"Stop batch transcription when Apple Speech makes no progress for this long." = "Apple Speech の処理に進捗がない状態がこの時間続くと、バッチ文字起こしを停止します。";
+"%lld minute" = "%lld分間";
+"%lld minutes" = "%lld分間";

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator+Scheduling.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator+Scheduling.swift
@@ -10,7 +10,8 @@ extension BatchTranscriptionCoordinator: BatchTranscriptionScheduling {
               session.batchCompletedAt == nil || session.isBatchRetranscriptionPending,
               session.batchDiscardedAt == nil else { return false }
         guard session.batchFailureKind != .recordingRecovery,
-              session.batchFailureKind != .recordingAudioPermanent else { return false }
+              session.batchFailureKind != .recordingAudioPermanent,
+              session.batchFailureKind != .transcriptionStalled else { return false }
         guard session.batchLastAttemptAt != nil || session.batchLastError?.nilIfBlank != nil else {
             return false
         }

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -497,11 +497,15 @@ actor BatchTranscriptionCoordinator {
 
     private func recordFailure(sessionId: UUID, error: Error) async {
         let message = error.localizedDescription
-        let kind: BatchFailureKind = switch error as? RecordingAudioStoreError {
-        case .ambiguousFiles, .integrityMismatch, .invalidPath, .invalidState, .missingFile:
-            .recordingAudioPermanent
-        default:
-            .transcription
+        let kind: BatchFailureKind = if case .analysisStalled = error as? BatchSpeechTranscriberError {
+            .transcriptionStalled
+        } else {
+            switch error as? RecordingAudioStoreError {
+            case .ambiguousFiles, .integrityMismatch, .invalidPath, .invalidState, .missingFile:
+                .recordingAudioPermanent
+            default:
+                .transcription
+            }
         }
         await persistFailure(sessionId: sessionId, message: message, kind: kind)
         var context = [
@@ -677,6 +681,10 @@ extension BatchTranscriptionCoordinator {
                 WHERE sessions.transcriptionMode = ?
                   AND sessions.batchCompletedAt IS NOT NULL
                   AND sessions.batchDiscardedAt IS NULL
+                  AND (
+                      sessions.batchLastAttemptAt IS NULL
+                      OR sessions.batchLastAttemptAt <= sessions.batchCompletedAt
+                  )
                   AND sessions.audioRetentionPolicy = ?
                   AND EXISTS (
                       SELECT 1 FROM recording_audio_segments AS segments

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -527,7 +527,9 @@ actor BatchTranscriptionCoordinator {
                 sql: """
                 UPDATE recording_sessions
                 SET batchLastError = ?, batchFailureKind = ?, updatedAt = ?
-                WHERE id = ? AND batchDiscardedAt IS NULL
+                WHERE id = ?
+                  AND batchDiscardedAt IS NULL
+                  AND (batchCompletedAt IS NULL OR batchLastAttemptAt > batchCompletedAt)
                 """,
                 arguments: [message, kind, Date.now, sessionId]
             )

--- a/Sources/Dahlia/Services/BatchTranscriptionPersistence.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionPersistence.swift
@@ -12,8 +12,13 @@ enum BatchTranscriptionPersistence {
     ) throws {
         try dbQueue.write { db in
             guard let session = try RecordingSessionRecord.fetchOne(db, key: sessionId),
+                  session.meetingId == meetingId,
                   try MeetingRecord.fetchOne(db, key: meetingId) != nil else {
                 throw CocoaError(.fileNoSuchFile)
+            }
+            guard session.batchDiscardedAt == nil,
+                  session.batchCompletedAt == nil || session.isBatchRetranscriptionPending else {
+                throw CancellationError()
             }
             let persistedCompletedAt = max(completedAt, session.batchLastAttemptAt ?? completedAt)
             _ = try TranscriptSegmentRecord

--- a/Sources/Dahlia/Speech/BatchSpeechAnalysisWatchdog.swift
+++ b/Sources/Dahlia/Speech/BatchSpeechAnalysisWatchdog.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+protocol BatchSpeechWatchdogClock: Sendable {
+    func sleep(for duration: Duration) async throws
+}
+
+struct ContinuousBatchSpeechWatchdogClock: BatchSpeechWatchdogClock {
+    func sleep(for duration: Duration) async throws {
+        try await Task.sleep(for: duration)
+    }
+}
+
+actor BatchSpeechAnalysisWatchdog {
+    typealias TimeoutAction = @Sendable () async -> Void
+
+    private let timeout: Duration
+    private let clock: any BatchSpeechWatchdogClock
+    private let timeoutAction: TimeoutAction
+    private var timerTask: Task<Void, Never>?
+    private var generation = 0
+    private(set) var didTimeOut = false
+
+    init(
+        timeout: Duration,
+        clock: any BatchSpeechWatchdogClock = ContinuousBatchSpeechWatchdogClock(),
+        timeoutAction: @escaping TimeoutAction
+    ) {
+        self.timeout = timeout
+        self.clock = clock
+        self.timeoutAction = timeoutAction
+    }
+
+    func start() {
+        recordProgress()
+    }
+
+    func recordProgress() {
+        guard !didTimeOut else { return }
+        generation += 1
+        let expectedGeneration = generation
+        timerTask?.cancel()
+        let timeout = timeout
+        let clock = clock
+        timerTask = Task { [weak self] in
+            do {
+                try await clock.sleep(for: timeout)
+                guard let timeoutAction = await self?.markTimedOut(ifGenerationIs: expectedGeneration) else {
+                    return
+                }
+                await timeoutAction()
+                await self?.finishTimeoutAction(ifGenerationIs: expectedGeneration)
+            } catch {
+                return
+            }
+        }
+    }
+
+    func stop() {
+        generation += 1
+        timerTask?.cancel()
+        timerTask = nil
+    }
+
+    private func markTimedOut(ifGenerationIs expectedGeneration: Int) -> TimeoutAction? {
+        guard generation == expectedGeneration, !didTimeOut else { return nil }
+        didTimeOut = true
+        return timeoutAction
+    }
+
+    private func finishTimeoutAction(ifGenerationIs expectedGeneration: Int) {
+        guard generation == expectedGeneration else { return }
+        timerTask = nil
+    }
+}

--- a/Sources/Dahlia/Speech/BatchSpeechAnalyzerInputSequence.swift
+++ b/Sources/Dahlia/Speech/BatchSpeechAnalyzerInputSequence.swift
@@ -21,6 +21,7 @@ struct BatchSpeechAnalyzerInputSequence: AsyncSequence, Sendable {
         sourceFormat: AVAudioFormat,
         analyzerFormat: AVAudioFormat,
         onSliceConsumed: @escaping @Sendable (Int) async -> Void = { _ in },
+        onBufferConsumed: @escaping @Sendable () async -> Void = {},
         converterFactory: AnalyzerInputConverterFactory = { sourceFormat, analyzerFormat in
             try AVAudioAnalyzerInputConverter(
                 sourceFormat: sourceFormat,
@@ -33,7 +34,8 @@ struct BatchSpeechAnalyzerInputSequence: AsyncSequence, Sendable {
             sourceFormat: sourceFormat,
             analyzerFormat: analyzerFormat,
             converter: converterFactory(sourceFormat, analyzerFormat),
-            onSliceConsumed: onSliceConsumed
+            onSliceConsumed: onSliceConsumed,
+            onBufferConsumed: onBufferConsumed
         )
     }
 
@@ -50,6 +52,7 @@ actor BatchSpeechAudioSliceReader {
     private let analyzerFormat: AVAudioFormat
     private let converter: any AnalyzerInputConverting
     private let onSliceConsumed: @Sendable (Int) async -> Void
+    private let onBufferConsumed: @Sendable () async -> Void
     private var sliceIndex = 0
     private var currentFile: AVAudioFile?
     private var remainingFrameCount: Int64 = 0
@@ -63,7 +66,8 @@ actor BatchSpeechAudioSliceReader {
         sourceFormat: AVAudioFormat,
         analyzerFormat: AVAudioFormat,
         converter: any AnalyzerInputConverting,
-        onSliceConsumed: @escaping @Sendable (Int) async -> Void
+        onSliceConsumed: @escaping @Sendable (Int) async -> Void,
+        onBufferConsumed: @escaping @Sendable () async -> Void
     ) throws {
         guard !slices.isEmpty else {
             throw BatchSpeechTranscriberError.invalidAudioRange
@@ -73,6 +77,7 @@ actor BatchSpeechAudioSliceReader {
         self.analyzerFormat = analyzerFormat
         self.converter = converter
         self.onSliceConsumed = onSliceConsumed
+        self.onBufferConsumed = onBufferConsumed
     }
 
     func next() async throws -> AnalyzerInput? {
@@ -88,7 +93,9 @@ actor BatchSpeechAudioSliceReader {
                 continue
             }
             if remainingFrameCount > 0 {
-                if let input = try readNextBuffer() {
+                let input = try readNextBuffer()
+                await onBufferConsumed()
+                if let input {
                     return input
                 }
                 continue

--- a/Sources/Dahlia/Speech/BatchSpeechRecognizing.swift
+++ b/Sources/Dahlia/Speech/BatchSpeechRecognizing.swift
@@ -42,33 +42,47 @@ extension BatchSpeechRecognizing {
 
 struct AppleBatchSpeechRecognizer: BatchSpeechRecognizing {
     typealias StallTimeoutProvider = @Sendable () async -> BatchTranscriptionStallTimeout
+    typealias AnalyzerPreparation = @Sendable (SpeechAnalyzer, AVAudioFormat) async throws -> Void
 
     private let assetPreparer: AppleSpeechAssetPreparer
     private let stallTimeoutProvider: StallTimeoutProvider
     private let watchdogClock: any BatchSpeechWatchdogClock
+    private let analyzerPreparation: AnalyzerPreparation
 
     init(
         assetPreparer: AppleSpeechAssetPreparer = AppleSpeechAssetPreparer(),
         stallTimeoutProvider: @escaping StallTimeoutProvider = {
             await MainActor.run { AppSettings.shared.batchTranscriptionStallTimeout }
         },
-        watchdogClock: any BatchSpeechWatchdogClock = ContinuousBatchSpeechWatchdogClock()
+        watchdogClock: any BatchSpeechWatchdogClock = ContinuousBatchSpeechWatchdogClock(),
+        analyzerPreparation: @escaping AnalyzerPreparation = { analyzer, audioFormat in
+            try await analyzer.prepareToAnalyze(in: audioFormat)
+        }
     ) {
         self.assetPreparer = assetPreparer
         self.stallTimeoutProvider = stallTimeoutProvider
         self.watchdogClock = watchdogClock
+        self.analyzerPreparation = analyzerPreparation
     }
 
     func recognize(audioURL: URL, locale: Locale) async throws -> [BatchSpeechRecognition] {
         let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
         try await assetPreparer.prepare(transcriber: transcriber, localeIdentifier: locale.identifier)
         let audioFile = try AVAudioFile(forReading: audioURL)
+        let audioFormat = audioFile.processingFormat
+        let audioFrameCount = audioFile.length
         return try await recognize(
             transcriber: transcriber,
-            audioFormat: audioFile.processingFormat
+            audioFormat: audioFormat
         ) { analyzer, recordProgress in
+            let inputSequence = try BatchSpeechAnalyzerInputSequence(
+                slices: [BatchSpeechAudioSlice(audioURL: audioURL, startFrame: 0, frameCount: audioFrameCount)],
+                sourceFormat: audioFormat,
+                analyzerFormat: audioFormat,
+                onBufferConsumed: recordProgress
+            )
             await recordProgress()
-            return try await analyzer.analyzeSequence(from: audioFile)
+            return try await analyzer.analyzeSequence(inputSequence)
         }
     }
 
@@ -107,6 +121,8 @@ struct AppleBatchSpeechRecognizer: BatchSpeechRecognizing {
             ) { sliceIndex in
                 await recordProgress()
                 await onSliceConsumed(sliceIndex)
+            } onBufferConsumed: {
+                await recordProgress()
             }
             await recordProgress()
             return try await analyzer.analyzeSequence(inputSequence)
@@ -126,7 +142,6 @@ struct AppleBatchSpeechRecognizer: BatchSpeechRecognizing {
             modules: [transcriber],
             options: SpeechAnalyzer.Options(priority: .userInitiated, modelRetention: .lingering)
         )
-        try await analyzer.prepareToAnalyze(in: audioFormat)
         let watchdog = BatchSpeechAnalysisWatchdog(
             timeout: stallTimeout.duration,
             clock: watchdogClock
@@ -134,6 +149,20 @@ struct AppleBatchSpeechRecognizer: BatchSpeechRecognizing {
             await analyzer.cancelAndFinishNow()
         }
         await watchdog.start()
+
+        do {
+            try await analyzerPreparation(analyzer, audioFormat)
+            try await throwIfAnalysisStalled(watchdog: watchdog, timeout: stallTimeout)
+            await watchdog.recordProgress()
+        } catch {
+            let didTimeOut = await watchdog.didTimeOut
+            await watchdog.stop()
+            if didTimeOut {
+                throw BatchSpeechTranscriberError.analysisStalled(minutes: stallTimeout.rawValue)
+            }
+            await analyzer.cancelAndFinishNow()
+            throw error
+        }
 
         let resultTask = Task<[BatchSpeechRecognition], Error> {
             var recognitions: [BatchSpeechRecognition] = []

--- a/Sources/Dahlia/Speech/BatchSpeechRecognizing.swift
+++ b/Sources/Dahlia/Speech/BatchSpeechRecognizing.swift
@@ -41,10 +41,22 @@ extension BatchSpeechRecognizing {
 }
 
 struct AppleBatchSpeechRecognizer: BatchSpeechRecognizing {
-    private let assetPreparer: AppleSpeechAssetPreparer
+    typealias StallTimeoutProvider = @Sendable () async -> BatchTranscriptionStallTimeout
 
-    init(assetPreparer: AppleSpeechAssetPreparer = AppleSpeechAssetPreparer()) {
+    private let assetPreparer: AppleSpeechAssetPreparer
+    private let stallTimeoutProvider: StallTimeoutProvider
+    private let watchdogClock: any BatchSpeechWatchdogClock
+
+    init(
+        assetPreparer: AppleSpeechAssetPreparer = AppleSpeechAssetPreparer(),
+        stallTimeoutProvider: @escaping StallTimeoutProvider = {
+            await MainActor.run { AppSettings.shared.batchTranscriptionStallTimeout }
+        },
+        watchdogClock: any BatchSpeechWatchdogClock = ContinuousBatchSpeechWatchdogClock()
+    ) {
         self.assetPreparer = assetPreparer
+        self.stallTimeoutProvider = stallTimeoutProvider
+        self.watchdogClock = watchdogClock
     }
 
     func recognize(audioURL: URL, locale: Locale) async throws -> [BatchSpeechRecognition] {
@@ -54,8 +66,9 @@ struct AppleBatchSpeechRecognizer: BatchSpeechRecognizing {
         return try await recognize(
             transcriber: transcriber,
             audioFormat: audioFile.processingFormat
-        ) { analyzer in
-            try await analyzer.analyzeSequence(from: audioFile)
+        ) { analyzer, recordProgress in
+            await recordProgress()
+            return try await analyzer.analyzeSequence(from: audioFile)
         }
     }
 
@@ -83,34 +96,50 @@ struct AppleBatchSpeechRecognizer: BatchSpeechRecognizing {
         ) else {
             throw BatchSpeechTranscriberError.audioFormatUnavailable
         }
-        let inputSequence = try BatchSpeechAnalyzerInputSequence(
-            slices: audioSlices,
-            sourceFormat: sourceFormat,
-            analyzerFormat: analyzerFormat,
-            onSliceConsumed: onSliceConsumed
-        )
         return try await recognize(
             transcriber: transcriber,
             audioFormat: analyzerFormat
-        ) { analyzer in
-            try await analyzer.analyzeSequence(inputSequence)
+        ) { analyzer, recordProgress in
+            let inputSequence = try BatchSpeechAnalyzerInputSequence(
+                slices: audioSlices,
+                sourceFormat: sourceFormat,
+                analyzerFormat: analyzerFormat
+            ) { sliceIndex in
+                await recordProgress()
+                await onSliceConsumed(sliceIndex)
+            }
+            await recordProgress()
+            return try await analyzer.analyzeSequence(inputSequence)
         }
     }
 
     private func recognize(
         transcriber: SpeechTranscriber,
         audioFormat: AVAudioFormat,
-        analyze: @escaping @Sendable (SpeechAnalyzer) async throws -> CMTime?
+        analyze: @escaping @Sendable (
+            SpeechAnalyzer,
+            @escaping @Sendable () async -> Void
+        ) async throws -> CMTime?
     ) async throws -> [BatchSpeechRecognition] {
+        let stallTimeout = await stallTimeoutProvider()
         let analyzer = SpeechAnalyzer(
             modules: [transcriber],
             options: SpeechAnalyzer.Options(priority: .userInitiated, modelRetention: .lingering)
         )
         try await analyzer.prepareToAnalyze(in: audioFormat)
+        let watchdog = BatchSpeechAnalysisWatchdog(
+            timeout: stallTimeout.duration,
+            clock: watchdogClock
+        ) {
+            await analyzer.cancelAndFinishNow()
+        }
+        await watchdog.start()
 
         let resultTask = Task<[BatchSpeechRecognition], Error> {
             var recognitions: [BatchSpeechRecognition] = []
-            for try await result in transcriber.results where result.isFinal {
+            for try await result in transcriber.results {
+                await watchdog.recordProgress()
+                guard result.isFinal else { continue }
                 recognitions.append(
                     BatchSpeechRecognition(
                         startSeconds: result.range.start.seconds,
@@ -123,16 +152,37 @@ struct AppleBatchSpeechRecognizer: BatchSpeechRecognizing {
         }
 
         do {
-            guard let lastSampleTime = try await analyze(analyzer) else {
+            let recordProgress: @Sendable () async -> Void = {
+                await watchdog.recordProgress()
+            }
+            guard let lastSampleTime = try await analyze(analyzer, recordProgress) else {
                 throw BatchSpeechTranscriberError.analysisDidNotAdvance
             }
+            try await throwIfAnalysisStalled(watchdog: watchdog, timeout: stallTimeout)
             try await analyzer.finalizeAndFinish(through: lastSampleTime)
-            return try await resultTask.value
+            let recognitions = try await resultTask.value
+            try await throwIfAnalysisStalled(watchdog: watchdog, timeout: stallTimeout)
+            await watchdog.stop()
+            return recognitions
         } catch {
-            await analyzer.cancelAndFinishNow()
+            let didTimeOut = await watchdog.didTimeOut
+            await watchdog.stop()
             resultTask.cancel()
+            if didTimeOut {
+                throw BatchSpeechTranscriberError.analysisStalled(minutes: stallTimeout.rawValue)
+            }
+            await analyzer.cancelAndFinishNow()
             _ = try? await resultTask.value
             throw error
+        }
+    }
+
+    private func throwIfAnalysisStalled(
+        watchdog: BatchSpeechAnalysisWatchdog,
+        timeout: BatchTranscriptionStallTimeout
+    ) async throws {
+        if await watchdog.didTimeOut {
+            throw BatchSpeechTranscriberError.analysisStalled(minutes: timeout.rawValue)
         }
     }
 

--- a/Sources/Dahlia/Speech/BatchSpeechTranscriberError.swift
+++ b/Sources/Dahlia/Speech/BatchSpeechTranscriberError.swift
@@ -4,6 +4,7 @@ enum BatchSpeechTranscriberError: LocalizedError {
     case audioFormatUnavailable
     case invalidAudioRange
     case analysisDidNotAdvance
+    case analysisStalled(minutes: Int)
     case languageModelPreparationFailed
     case noAutomaticLanguageCandidates
     case languageDetectionAudioLoadingFailed
@@ -15,6 +16,7 @@ enum BatchSpeechTranscriberError: LocalizedError {
         case .audioFormatUnavailable: "audioFormatUnavailable"
         case .invalidAudioRange: "invalidAudioRange"
         case .analysisDidNotAdvance: "analysisDidNotAdvance"
+        case .analysisStalled: "analysisStalled"
         case .languageModelPreparationFailed: "languageModelPreparationFailed"
         case .noAutomaticLanguageCandidates: "noAutomaticLanguageCandidates"
         case .languageDetectionAudioLoadingFailed: "languageDetectionAudioLoadingFailed"
@@ -31,6 +33,8 @@ enum BatchSpeechTranscriberError: LocalizedError {
             L10n.batchAudioRangeInvalid
         case .analysisDidNotAdvance:
             L10n.batchAnalysisDidNotAdvance
+        case let .analysisStalled(minutes):
+            L10n.batchAnalysisStalled(minutes: minutes)
         case .languageModelPreparationFailed:
             L10n.batchLanguageModelPreparationFailed
         case .noAutomaticLanguageCandidates:

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1353,6 +1353,18 @@ enum L10n {
     static var batchAudioFormatUnavailable: String { String(localized: "No compatible audio format is available.", bundle: bundle) }
     static var batchAudioRangeInvalid: String { String(localized: "The recorded audio range is invalid or damaged.", bundle: bundle) }
     static var batchAnalysisDidNotAdvance: String { String(localized: "Speech analysis could not read the recorded audio.", bundle: bundle) }
+
+    static func batchAnalysisStalled(minutes: Int) -> String {
+        let duration = localizedCount(minutes, singular: "%lld minute", plural: "%lld minutes")
+        return String(
+            format: String(
+                localized: "Batch transcription stopped because Apple Speech made no progress for %@. The recording audio was kept for retry.",
+                bundle: bundle
+            ),
+            duration
+        )
+    }
+
     static var assignee: String { String(localized: "Assignee", bundle: bundle) }
     static var assignToMe: String { String(localized: "Assign to me", bundle: bundle) }
     static var editAssignee: String { String(localized: "Edit assignee", bundle: bundle) }
@@ -1608,6 +1620,16 @@ enum L10n {
         localized: "Record audio first, then create a higher-accuracy transcript after recording stops.",
         bundle: bundle
     ) }
+    static var batchTranscriptionStallTimeout: String { String(localized: "No-progress Timeout", bundle: bundle) }
+    static var batchTranscriptionStallTimeoutDescription: String { String(
+        localized: "Stop batch transcription when Apple Speech makes no progress for this long.",
+        bundle: bundle
+    ) }
+
+    static func batchTranscriptionStallTimeoutMinutes(_ minutes: Int) -> String {
+        localizedCount(minutes, singular: "%lld minute", plural: "%lld minutes")
+    }
+
     static var retainBatchAudio: String { String(localized: "Keep Audio After Transcription", bundle: bundle) }
     static var retainBatchAudioDescription: String { String(
         localized: "Keep the protected audio in Dahlia after batch transcription succeeds.",

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -1175,17 +1175,28 @@ final class CaptionViewModel: ObservableObject {
     }
 
     private func refreshBatchTranscriptionState(meetingId: UUID, dbQueue: DatabaseQueue) throws {
-        let sessions = try dbQueue.read { db in
-            try RecordingSessionRecord
+        let (state, retryableSessionIds) = try dbQueue.read { db in
+            let sessions = try RecordingSessionRecord
                 .filter(Column("meetingId") == meetingId)
                 .order(Column("startedAt").asc)
                 .fetchAll(db)
+            let state = sessions
+                .reversed()
+                .compactMap { BatchTranscriptionState.derive(from: $0) }
+                .first(where: \.blocksSummaryGeneration)
+            let eligibleSessionIds = try Self.fetchEligibleBatchAudioSessionIds(meetingId: meetingId, db: db)
+            return (
+                state,
+                Self.retryableBatchSessionIds(
+                    state: state,
+                    sessions: sessions,
+                    eligibleSessionIds: eligibleSessionIds
+                )
+            )
         }
         guard currentMeetingId == meetingId else { return }
-        batchTranscriptionState = sessions
-            .reversed()
-            .compactMap { BatchTranscriptionState.derive(from: $0) }
-            .first(where: \.blocksSummaryGeneration)
+        batchTranscriptionState = state
+        retranscribableBatchSessionIds = retryableSessionIds
     }
 
     func handleBatchTranscriptionUpdate(_ update: BatchTranscriptionUpdate) async {

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -201,7 +201,26 @@ final class CaptionViewModel: ObservableObject {
     @Published var currentSummaryDocument: SummaryDocument?
 
     var canRetranscribeBatchAudio: Bool {
-        !retranscribableBatchSessionIds.isEmpty && batchTranscriptionState == nil && !isListening
+        guard !retranscribableBatchSessionIds.isEmpty, !isListening else { return false }
+        return switch batchTranscriptionState {
+        case nil, .failed, .retranscriptionFailed:
+            true
+        default:
+            false
+        }
+    }
+
+    var batchTranscriptionFailureMessage: String? {
+        switch batchTranscriptionState {
+        case let .failed(_, message), let .retranscriptionFailed(_, message):
+            message
+        default:
+            nil
+        }
+    }
+
+    var isBatchRetranscriptionFailure: Bool {
+        if case .retranscriptionFailed = batchTranscriptionState { true } else { false }
     }
 
     /// Summary タブへの切り替えをリクエストするフラグ。
@@ -667,7 +686,8 @@ final class CaptionViewModel: ObservableObject {
     func retryBatchTranscription() {
         switch batchTranscriptionState {
         case let .failed(sessionId, _):
-            guard let meetingId = currentMeetingId else { return }
+            guard canRetranscribeBatchAudio,
+                  let meetingId = currentMeetingId else { return }
             presentBatchTranscriptionConfirmation(
                 sessionId: sessionId,
                 meetingId: meetingId,
@@ -679,15 +699,17 @@ final class CaptionViewModel: ObservableObject {
             guard let meetingId = currentMeetingId,
                   let dbQueue = currentDbQueue else { return }
             Task {
-                guard let sessionIds = await Self.pendingBatchRetranscriptionSessionIds(
+                let sessionIds = await (try? Self.fetchRetryableBatchSessionIds(
                     meetingId: meetingId,
+                    state: batchTranscriptionState,
                     dbQueue: dbQueue
-                ),
-                    !sessionIds.isEmpty,
-                    currentMeetingId == meetingId,
-                    case .retranscriptionFailed = batchTranscriptionState else { return }
+                )) ?? []
+                guard !sessionIds.isEmpty,
+                      currentMeetingId == meetingId,
+                      case .retranscriptionFailed = batchTranscriptionState else { return }
+                retranscribableBatchSessionIds = sessionIds
                 presentBatchRetranscriptionConfirmation(
-                    sessionId: sessionId,
+                    sessionId: sessionIds.contains(sessionId) ? sessionId : sessionIds[sessionIds.count - 1],
                     sessionIds: sessionIds,
                     meetingId: meetingId
                 )
@@ -706,6 +728,15 @@ final class CaptionViewModel: ObservableObject {
             sessionIds: retranscribableBatchSessionIds,
             meetingId: meetingId
         )
+    }
+
+    func presentAvailableBatchRetranscription() {
+        switch batchTranscriptionState {
+        case .failed, .retranscriptionFailed:
+            retryBatchTranscription()
+        default:
+            presentBatchRetranscriptionConfirmation()
+        }
     }
 
     private func presentBatchRetranscriptionConfirmation(
@@ -1162,6 +1193,19 @@ final class CaptionViewModel: ObservableObject {
         if isVisibleMeeting,
            !(isBatchRecording && recordingMeetingId == update.meetingId) {
             batchTranscriptionState = update.state
+            switch update.state {
+            case .failed, .retranscriptionFailed:
+                let sessionIds = await (try? Self.fetchRetryableBatchSessionIds(
+                    meetingId: update.meetingId,
+                    state: update.state,
+                    dbQueue: currentDbQueue
+                )) ?? []
+                if currentMeetingId == update.meetingId, batchTranscriptionState == update.state {
+                    retranscribableBatchSessionIds = sessionIds
+                }
+            default:
+                break
+            }
         }
         updatePendingBatchSummaryProgress(for: update)
         guard case .completed = update.state else { return }
@@ -1335,7 +1379,7 @@ final class CaptionViewModel: ObservableObject {
         let googleFileId: String?
         let lastSummaryURL: URL?
         let note: MeetingNoteRecord?
-        let retranscribableBatchSessionIds: [UUID]
+        let eligibleBatchAudioSessionIds: [UUID]
     }
 
     private nonisolated static func fetchLoadedMeetingData(
@@ -1363,10 +1407,81 @@ final class CaptionViewModel: ObservableObject {
             nil
         }
 
-        let retranscribableBatchSessionIds = try dbQueue.read { db in
-            try UUID.fetchAll(
-                db,
-                sql: """
+        let eligibleBatchAudioSessionIds = try fetchEligibleBatchAudioSessionIds(
+            meetingId: meetingId,
+            dbQueue: dbQueue
+        )
+
+        return try LoadedMeetingData(
+            createdAt: detail.meeting?.createdAt,
+            recordingSessionRecords: detail.recordingSessions,
+            recordingSessions: recordingSessions,
+            initialTranscriptPage: initialTranscriptPage,
+            hasTranscriptSegments: !initialTranscriptPage.segments.isEmpty,
+            screenshots: detail.screenshots,
+            summaryDocument: detail.summary?.loadDocument(),
+            googleFileId: googleDocsExport?.googleDocumentID,
+            lastSummaryURL: lastSummaryURL,
+            note: detail.note,
+            eligibleBatchAudioSessionIds: eligibleBatchAudioSessionIds
+        )
+    }
+
+    private nonisolated static func fetchEligibleBatchAudioSessionIds(
+        meetingId: UUID,
+        dbQueue: DatabaseQueue
+    ) throws -> [UUID] {
+        try dbQueue.read { db in
+            try fetchEligibleBatchAudioSessionIds(meetingId: meetingId, db: db)
+        }
+    }
+
+    private nonisolated static func fetchRetryableBatchSessionIds(
+        meetingId: UUID,
+        state: BatchTranscriptionState?,
+        dbQueue: DatabaseQueue?
+    ) async throws -> [UUID] {
+        guard let dbQueue else { return [] }
+        return try await dbQueue.read { db in
+            let eligibleSessionIds = try fetchEligibleBatchAudioSessionIds(meetingId: meetingId, db: db)
+            let sessions = try RecordingSessionRecord
+                .filter(Column("meetingId") == meetingId)
+                .order(Column("startedAt").asc)
+                .fetchAll(db)
+            return retryableBatchSessionIds(
+                state: state,
+                sessions: sessions,
+                eligibleSessionIds: eligibleSessionIds
+            )
+        }
+    }
+
+    private nonisolated static func retryableBatchSessionIds(
+        state: BatchTranscriptionState?,
+        sessions: [RecordingSessionRecord],
+        eligibleSessionIds: [UUID]
+    ) -> [UUID] {
+        let eligibleSessionIdSet = Set(eligibleSessionIds)
+        switch state {
+        case let .failed(sessionId, _):
+            return eligibleSessionIdSet.contains(sessionId) ? [sessionId] : []
+        case .retranscriptionFailed:
+            let pendingSessionIds = sessions.filter(\.isBatchRetranscriptionPending).map(\.id)
+            guard !pendingSessionIds.isEmpty,
+                  pendingSessionIds.allSatisfy(eligibleSessionIdSet.contains) else { return [] }
+            return pendingSessionIds
+        default:
+            return eligibleSessionIds
+        }
+    }
+
+    private nonisolated static func fetchEligibleBatchAudioSessionIds(
+        meetingId: UUID,
+        db: Database
+    ) throws -> [UUID] {
+        try UUID.fetchAll(
+            db,
+            sql: """
                 SELECT DISTINCT sessions.id
                 FROM recording_sessions AS sessions
                 JOIN recording_audio_segments AS segments
@@ -1375,10 +1490,15 @@ final class CaptionViewModel: ObservableObject {
                   ON ranges.audioSegmentId = segments.id
                 WHERE sessions.meetingId = ?
                   AND sessions.transcriptionMode = ?
-                  AND sessions.batchCompletedAt IS NOT NULL
                   AND sessions.batchDiscardedAt IS NULL
-                  AND sessions.retainAudioAfterBatch = 1
-                  AND (sessions.batchLastAttemptAt IS NULL OR sessions.batchLastAttemptAt <= sessions.batchCompletedAt)
+                  AND (
+                      (
+                          sessions.batchCompletedAt IS NOT NULL
+                          AND sessions.retainAudioAfterBatch = 1
+                          AND (sessions.batchLastAttemptAt IS NULL OR sessions.batchLastAttemptAt <= sessions.batchCompletedAt)
+                      )
+                      OR sessions.batchLastError IS NOT NULL
+                  )
                   AND segments.state = ?
                   AND segments.purgedAt IS NULL
                   AND NOT EXISTS (
@@ -1394,28 +1514,13 @@ final class CaptionViewModel: ObservableObject {
                         )
                   )
                 ORDER BY sessions.startedAt
-                """,
-                arguments: [
-                    meetingId,
-                    TranscriptionMode.batch.rawValue,
-                    RecordingAudioSegmentState.ready.rawValue,
-                    RecordingAudioSegmentState.ready.rawValue,
-                ]
-            )
-        }
-
-        return try LoadedMeetingData(
-            createdAt: detail.meeting?.createdAt,
-            recordingSessionRecords: detail.recordingSessions,
-            recordingSessions: recordingSessions,
-            initialTranscriptPage: initialTranscriptPage,
-            hasTranscriptSegments: !initialTranscriptPage.segments.isEmpty,
-            screenshots: detail.screenshots,
-            summaryDocument: detail.summary?.loadDocument(),
-            googleFileId: googleDocsExport?.googleDocumentID,
-            lastSummaryURL: lastSummaryURL,
-            note: detail.note,
-            retranscribableBatchSessionIds: retranscribableBatchSessionIds
+            """,
+            arguments: [
+                meetingId,
+                TranscriptionMode.batch.rawValue,
+                RecordingAudioSegmentState.ready.rawValue,
+                RecordingAudioSegmentState.ready.rawValue,
+            ]
         )
     }
 
@@ -1832,11 +1937,16 @@ final class CaptionViewModel: ObservableObject {
         hasNote = loaded.note != nil
         currentNoteCreatedAt = loaded.note?.createdAt
         lastSavedNoteText = noteText
-        batchTranscriptionState = loaded.recordingSessionRecords
+        let restoredBatchTranscriptionState = loaded.recordingSessionRecords
             .reversed()
             .compactMap { BatchTranscriptionState.derive(from: $0) }
             .first(where: \.blocksSummaryGeneration)
-        retranscribableBatchSessionIds = loaded.retranscribableBatchSessionIds
+        batchTranscriptionState = restoredBatchTranscriptionState
+        retranscribableBatchSessionIds = Self.retryableBatchSessionIds(
+            state: restoredBatchTranscriptionState,
+            sessions: loaded.recordingSessionRecords,
+            eligibleSessionIds: loaded.eligibleBatchAudioSessionIds
+        )
         setupNoteAutoSave()
 
         guard let coordinator = batchTranscriptionCoordinator,

--- a/Sources/Dahlia/Views/BatchTranscriptionFailureBanner.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionFailureBanner.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct BatchTranscriptionFailureBanner: View {
+    let message: String
+    let canRetry: Bool
+    let isRetranscription: Bool
+    let onRetry: () -> Void
+    let onDiscard: () -> Void
+    let onKeepCurrentTranscript: () -> Void
+    @State private var isConfirmingDiscard = false
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Label(L10n.batchTranscriptionFailed(message), systemImage: "exclamationmark.triangle.fill")
+                .foregroundStyle(.red)
+
+            HStack {
+                if canRetry {
+                    Button(L10n.retryBatchTranscription, systemImage: "arrow.clockwise", action: onRetry)
+                        .buttonStyle(.borderedProminent)
+                }
+
+                Spacer()
+
+                if isRetranscription {
+                    Button(L10n.keepCurrentTranscript, action: onKeepCurrentTranscript)
+                } else {
+                    Button(L10n.discardFailedBatchRecording, role: .destructive) {
+                        isConfirmingDiscard = true
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
+        .padding(.horizontal, DahliaDesign.detailHorizontalPadding)
+        .padding(.vertical, 4)
+        .confirmationDialog(
+            L10n.discardFailedBatchRecordingConfirmation,
+            isPresented: $isConfirmingDiscard,
+            titleVisibility: .visible
+        ) {
+            Button(L10n.discardFailedBatchRecording, role: .destructive, action: onDiscard)
+            Button(L10n.cancel, role: .cancel) {}
+        } message: {
+            Text(L10n.discardFailedBatchRecordingDescription)
+        }
+    }
+}

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -253,6 +253,17 @@ struct ControlPanelView: View {
                 Rectangle().fill(tabContentBackgroundColor)
             }
 
+            if let failureMessage = viewModel.batchTranscriptionFailureMessage {
+                BatchTranscriptionFailureBanner(
+                    message: failureMessage,
+                    canRetry: viewModel.canRetranscribeBatchAudio,
+                    isRetranscription: viewModel.isBatchRetranscriptionFailure,
+                    onRetry: viewModel.presentAvailableBatchRetranscription,
+                    onDiscard: viewModel.discardFailedBatchTranscription,
+                    onKeepCurrentTranscript: viewModel.cancelFailedBatchRetranscription
+                )
+            }
+
             // エラー表示
             if let error = viewModel.errorMessage {
                 detailErrorBanner(message: error, tint: .red)

--- a/Sources/Dahlia/Views/MeetingDetailNavigationBar.swift
+++ b/Sources/Dahlia/Views/MeetingDetailNavigationBar.swift
@@ -21,7 +21,7 @@ private struct MeetingActionsMenu: View {
                 Button(
                     L10n.retranscribe,
                     systemImage: "arrow.clockwise",
-                    action: viewModel.presentBatchRetranscriptionConfirmation
+                    action: viewModel.presentAvailableBatchRetranscription
                 )
             }
 

--- a/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/TranscriptionSettingsView.swift
@@ -24,6 +24,16 @@ struct TranscriptionSettingsView: View {
                 .toggleStyle(.switch)
 
                 if !settings.isRealtimeTranscriptionEnabled {
+                    Picker(selection: $settings.batchTranscriptionStallTimeout) {
+                        ForEach(BatchTranscriptionStallTimeout.allCases) { timeout in
+                            Text(timeout.displayName).tag(timeout)
+                        }
+                    } label: {
+                        Text(L10n.batchTranscriptionStallTimeout)
+                        Text(L10n.batchTranscriptionStallTimeoutDescription)
+                    }
+                    .pickerStyle(.menu)
+
                     Toggle(isOn: $settings.retainAudioAfterBatchTranscription) {
                         Text(L10n.retainBatchAudio)
                         Text(L10n.retainBatchAudioDescription)

--- a/Tests/DahliaTests/BatchRetranscriptionRecoveryTests.swift
+++ b/Tests/DahliaTests/BatchRetranscriptionRecoveryTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct BatchRetranscriptionRecoveryTests {
+        @Test
+        func cancelledRetranscriptionRejectsAStaleCompletion() async throws {
+            let completedAt = Date(timeIntervalSince1970: 1_776_384_060)
+            let fixture = try BatchAudioTestFixture(
+                name: "CancelRetranscriptionStaleCompletion",
+                endedAt: completedAt.addingTimeInterval(-30),
+                duration: 30,
+                retainAudioAfterBatch: true,
+                batchCompletedAt: completedAt
+            )
+            defer { fixture.removeFiles() }
+            try await fixture.recordMicrophoneAudio()
+            let previousTranscript = makeTranscriptRecord(fixture: fixture, text: "previous transcript")
+            try await fixture.database.dbQueue.write { db in
+                try previousTranscript.insert(db)
+            }
+            _ = try await BatchTranscriptionConfirmationService.confirmRetranscription(
+                sessionIds: [fixture.session.id],
+                languageSelection: .manual(localeIdentifier: "en_US"),
+                automaticLanguageCandidates: nil,
+                retainAudioAfterBatch: false,
+                dbQueue: fixture.database.dbQueue
+            )
+            _ = try await BatchTranscriptionConfirmationService.cancelRetranscription(
+                sessionIds: [fixture.session.id],
+                dbQueue: fixture.database.dbQueue
+            )
+
+            #expect(throws: CancellationError.self) {
+                try BatchTranscriptionPersistence.complete(
+                    sessionId: fixture.session.id,
+                    meetingId: fixture.meeting.id,
+                    records: [makeTranscriptRecord(fixture: fixture, text: "stale replacement")],
+                    completedAt: completedAt.addingTimeInterval(10),
+                    dbQueue: fixture.database.dbQueue
+                )
+            }
+            let transcripts = try await fixture.database.dbQueue.read { db in
+                try TranscriptSegmentRecord
+                    .filter(Column("sessionId") == fixture.session.id)
+                    .fetchAll(db)
+            }
+            #expect(transcripts.map(\.text) == ["previous transcript"])
+        }
+
+        @Test
+        func startupRecoveryKeepsAudioForAStalledRetranscription() async throws {
+            let completedAt = Date(timeIntervalSince1970: 1_776_384_060)
+            let fixture = try BatchAudioTestFixture(
+                name: "StalledRetranscriptionAudioRecovery",
+                endedAt: completedAt.addingTimeInterval(-30),
+                duration: 30,
+                retainAudioAfterBatch: true,
+                batchCompletedAt: completedAt
+            )
+            defer { fixture.removeFiles() }
+            try await fixture.recordMicrophoneAudio()
+            _ = try await BatchTranscriptionConfirmationService.confirmRetranscription(
+                sessionIds: [fixture.session.id],
+                languageSelection: .manual(localeIdentifier: "en_US"),
+                automaticLanguageCandidates: nil,
+                retainAudioAfterBatch: false,
+                dbQueue: fixture.database.dbQueue
+            )
+            try await fixture.database.dbQueue.write { db in
+                try db.execute(
+                    sql: "UPDATE recording_sessions SET batchLastError = ?, batchFailureKind = ? WHERE id = ?",
+                    arguments: [
+                        L10n.batchAnalysisStalled(minutes: 1),
+                        BatchFailureKind.transcriptionStalled.rawValue,
+                        fixture.session.id,
+                    ]
+                )
+            }
+
+            let coordinator = BatchTranscriptionCoordinator(
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL,
+                onStateChange: { _ in }
+            )
+            await coordinator.recoverAndEnqueue()
+            let segments = try await fixture.database.dbQueue.read { db in
+                try RecordingAudioSegmentRecord
+                    .filter(Column("recordingSessionId") == fixture.session.id)
+                    .fetchAll(db)
+            }
+
+            #expect(segments.map(\.state) == [.ready])
+            #expect(segments.allSatisfy { $0.purgedAt == nil })
+            #expect(segments.allSatisfy {
+                FileManager.default.fileExists(
+                    atPath: fixture.managedRootURL.appending(path: $0.finalRelativePath).path
+                )
+            })
+        }
+
+        private func makeTranscriptRecord(
+            fixture: BatchAudioTestFixture,
+            text: String
+        ) -> TranscriptSegmentRecord {
+            TranscriptSegmentRecord(
+                id: .v7(),
+                meetingId: fixture.meeting.id,
+                sessionId: fixture.session.id,
+                startTime: fixture.now,
+                endTime: fixture.now.addingTimeInterval(1),
+                text: text,
+                translatedText: nil,
+                isConfirmed: true,
+                speakerLabel: "mic"
+            )
+        }
+    }
+#endif

--- a/Tests/DahliaTests/BatchRetranscriptionRecoveryTests.swift
+++ b/Tests/DahliaTests/BatchRetranscriptionRecoveryTests.swift
@@ -103,6 +103,55 @@ import GRDB
             })
         }
 
+        @Test
+        func cancelledRetranscriptionRejectsAStaleFailure() async throws {
+            let completedAt = Date(timeIntervalSince1970: 1_776_384_060)
+            let fixture = try BatchAudioTestFixture(
+                name: "CancelRetranscriptionStaleFailure",
+                endedAt: completedAt.addingTimeInterval(-30),
+                duration: 30,
+                retainAudioAfterBatch: true,
+                batchCompletedAt: completedAt
+            )
+            defer { fixture.removeFiles() }
+            try await fixture.recordMicrophoneAudio()
+            let recognitionGate = DeferredRecognitionFailureGate()
+            let updateProbe = BatchUpdateProbe()
+            let coordinator = BatchTranscriptionCoordinator(
+                dbQueue: fixture.database.dbQueue,
+                managedRootURL: fixture.managedRootURL,
+                speechRecognizer: DeferredFailureBatchSpeechRecognizer(gate: recognitionGate),
+                onStateChange: { update in
+                    await updateProbe.record(update)
+                }
+            )
+
+            try await coordinator.confirmRetranscriptionAndEnqueue(
+                sessionIds: [fixture.session.id],
+                languageSelection: .manual(localeIdentifier: "en_US"),
+                automaticLanguageCandidates: nil,
+                retainAudioAfterBatch: true,
+                onConfirmed: { _ in }
+            )
+            #expect(await pollUntil { await recognitionGate.didStart })
+
+            _ = try await BatchTranscriptionConfirmationService.cancelRetranscription(
+                sessionIds: [fixture.session.id],
+                dbQueue: fixture.database.dbQueue
+            )
+            await recognitionGate.release()
+            #expect(await pollUntil {
+                await coordinator.runningState(sessionId: fixture.session.id) == nil
+            })
+
+            let session = try await fixture.database.dbQueue.read { db in
+                try #require(try RecordingSessionRecord.fetchOne(db, key: fixture.session.id))
+            }
+            #expect(session.batchLastError == nil)
+            #expect(BatchTranscriptionState.derive(from: session) == .completed(sessionId: fixture.session.id))
+            #expect(!(await updateProbe.hasFailure))
+        }
+
         private func makeTranscriptRecord(
             fixture: BatchAudioTestFixture,
             text: String
@@ -118,6 +167,63 @@ import GRDB
                 isConfirmed: true,
                 speakerLabel: "mic"
             )
+        }
+    }
+
+    private enum DeferredRecognitionError: Error {
+        case failed
+    }
+
+    private actor DeferredRecognitionFailureGate {
+        private var continuation: CheckedContinuation<Void, Never>?
+        private(set) var didStart = false
+
+        func wait() async {
+            didStart = true
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
+
+        func release() {
+            continuation?.resume()
+            continuation = nil
+        }
+    }
+
+    private struct DeferredFailureBatchSpeechRecognizer: BatchSpeechRecognizing {
+        let gate: DeferredRecognitionFailureGate
+
+        func recognize(audioURL _: URL, locale _: Locale) async throws -> [BatchSpeechRecognition] {
+            try await failAfterRelease()
+        }
+
+        func recognize(audioSlices _: [BatchSpeechAudioSlice], locale _: Locale) async throws -> [BatchSpeechRecognition] {
+            try await failAfterRelease()
+        }
+
+        private func failAfterRelease() async throws -> [BatchSpeechRecognition] {
+            await gate.wait()
+            throw DeferredRecognitionError.failed
+        }
+    }
+
+    private actor BatchUpdateProbe {
+        private var updates: [BatchTranscriptionUpdate] = []
+
+        var hasFailure: Bool {
+            updates.contains { update in
+                switch update.state {
+                case .failed, .retranscriptionFailed:
+                    true
+                default:
+                    false
+                }
+            }
+        }
+
+        func record(_ update: BatchTranscriptionUpdate) {
+            updates.append(update)
         }
     }
 #endif

--- a/Tests/DahliaTests/BatchSpeechAnalysisWatchdogTests.swift
+++ b/Tests/DahliaTests/BatchSpeechAnalysisWatchdogTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    struct BatchSpeechAnalysisWatchdogTests {
+        @Test
+        func noProgressRunsTimeoutAction() async throws {
+            let clock = WatchdogTestClock()
+            let probe = WatchdogTimeoutProbe()
+            let watchdog = BatchSpeechAnalysisWatchdog(timeout: .seconds(60), clock: clock) {
+                await probe.recordTimeout()
+            }
+
+            await watchdog.start()
+            try await waitUntil { await clock.waiterCount == 1 }
+            await clock.advance()
+            try await waitUntil { await probe.timeoutCount == 1 }
+
+            #expect(await watchdog.didTimeOut)
+        }
+
+        @Test
+        func progressReplacesTheCurrentDeadline() async throws {
+            let clock = WatchdogTestClock()
+            let probe = WatchdogTimeoutProbe()
+            let watchdog = BatchSpeechAnalysisWatchdog(timeout: .seconds(60), clock: clock) {
+                await probe.recordTimeout()
+            }
+
+            await watchdog.start()
+            try await waitUntil { await clock.waiterCount == 1 }
+            let firstSleeperID = try #require(await clock.firstWaiterID)
+
+            await watchdog.recordProgress()
+            try await waitUntil {
+                let waiterCount = await clock.waiterCount
+                let waiterID = await clock.firstWaiterID
+                return waiterCount == 1 && waiterID != firstSleeperID
+            }
+            #expect(await probe.timeoutCount == 0)
+
+            await clock.advance()
+            try await waitUntil { await probe.timeoutCount == 1 }
+        }
+
+        @Test
+        func stopDiscardsTheDeadline() async throws {
+            let clock = WatchdogTestClock()
+            let probe = WatchdogTimeoutProbe()
+            let watchdog = BatchSpeechAnalysisWatchdog(timeout: .seconds(60), clock: clock) {
+                await probe.recordTimeout()
+            }
+
+            await watchdog.start()
+            try await waitUntil { await clock.waiterCount == 1 }
+            await watchdog.stop()
+            try await waitUntil { await clock.waiterCount == 0 }
+
+            #expect(await probe.timeoutCount == 0)
+            #expect(!(await watchdog.didTimeOut))
+        }
+
+        @Test
+        func timeoutStateRemainsResponsiveWhileTheActionIsSuspended() async throws {
+            let clock = WatchdogTestClock()
+            let action = SuspendedWatchdogAction()
+            let watchdog = BatchSpeechAnalysisWatchdog(timeout: .seconds(60), clock: clock) {
+                await action.run()
+            }
+
+            await watchdog.start()
+            try await waitUntil { await clock.waiterCount == 1 }
+            await clock.advance()
+            try await waitUntil { await action.runCount == 1 }
+
+            #expect(await watchdog.didTimeOut)
+            await watchdog.stop()
+            #expect(await action.runCount == 1)
+        }
+
+        @Test
+        func stallTimeoutValuesResolveAndFallBack() {
+            #expect(BatchTranscriptionStallTimeout.allCases.map(\.rawValue) == [1, 2, 3])
+            #expect(BatchTranscriptionStallTimeout.resolved(rawValue: 1) == .oneMinute)
+            #expect(BatchTranscriptionStallTimeout.resolved(rawValue: 2) == .twoMinutes)
+            #expect(BatchTranscriptionStallTimeout.resolved(rawValue: 3) == .threeMinutes)
+            #expect(BatchTranscriptionStallTimeout.resolved(rawValue: 0) == .oneMinute)
+            #expect(BatchTranscriptionStallTimeout.resolved(rawValue: 99) == .oneMinute)
+        }
+
+        @Test
+        func stallTimeoutStringsAreLocalizedInEnglishAndJapanese() throws {
+            let english = try #require(localizationBundle(language: "en"))
+            let japanese = try #require(localizationBundle(language: "ja"))
+
+            #expect(localizedDuration(1, bundle: english, locale: Locale(identifier: "en")) == "1 minute")
+            #expect(localizedDuration(3, bundle: english, locale: Locale(identifier: "en")) == "3 minutes")
+            #expect(localizedDuration(1, bundle: japanese, locale: Locale(identifier: "ja")) == "1分間")
+            #expect(localizedDuration(3, bundle: japanese, locale: Locale(identifier: "ja")) == "3分間")
+        }
+
+        private func localizationBundle(language: String) -> Bundle? {
+            Bundle.appModule.path(forResource: language, ofType: "lproj").flatMap(Bundle.init(path:))
+        }
+
+        private func localizedDuration(_ minutes: Int, bundle: Bundle, locale: Locale) -> String {
+            let key = minutes == 1 ? "%lld minute" : "%lld minutes"
+            return String(
+                format: bundle.localizedString(forKey: key, value: nil, table: nil),
+                locale: locale,
+                Int64(minutes)
+            )
+        }
+
+        private func waitUntil(
+            timeout: Duration = testPollTimeout,
+            condition: @escaping @Sendable () async -> Bool
+        ) async throws {
+            let completed = await pollUntil(timeout: timeout, condition)
+            #expect(completed)
+        }
+    }
+
+    private actor WatchdogTimeoutProbe {
+        private(set) var timeoutCount = 0
+
+        func recordTimeout() {
+            timeoutCount += 1
+        }
+    }
+
+    private actor SuspendedWatchdogAction {
+        private(set) var runCount = 0
+
+        func run() async {
+            runCount += 1
+            do {
+                try await Task.sleep(for: .seconds(60))
+            } catch {
+                // The watchdog owns and cancels its outstanding timeout action on stop.
+            }
+        }
+    }
+
+    private actor WatchdogTestClock: BatchSpeechWatchdogClock {
+        private struct Waiter {
+            let id: UUID
+            let continuation: CheckedContinuation<Void, Error>
+        }
+
+        private var waiters: [Waiter] = []
+
+        var waiterCount: Int { waiters.count }
+        var firstWaiterID: UUID? { waiters.first?.id }
+
+        func sleep(for _: Duration) async throws {
+            let id = UUID.v7()
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    waiters.append(Waiter(id: id, continuation: continuation))
+                }
+            } onCancel: {
+                Task { await self.cancel(id: id) }
+            }
+        }
+
+        func advance() {
+            guard !waiters.isEmpty else { return }
+            waiters.removeFirst().continuation.resume()
+        }
+
+        private func cancel(id: UUID) {
+            guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+            waiters.remove(at: index).continuation.resume(throwing: CancellationError())
+        }
+    }
+#endif

--- a/Tests/DahliaTests/BatchSpeechAnalysisWatchdogTests.swift
+++ b/Tests/DahliaTests/BatchSpeechAnalysisWatchdogTests.swift
@@ -1,3 +1,4 @@
+@preconcurrency import AVFoundation
 import Foundation
 @testable import Dahlia
 
@@ -81,6 +82,34 @@ import Foundation
         }
 
         @Test
+        func appleRecognizerStartsWatchdogBeforeAnalyzerPreparation() async throws {
+            let clock = WatchdogTestClock()
+            let preparation = SuspendedAnalyzerPreparation()
+            let audioURL = try makeAudioFile()
+            defer { try? FileManager.default.removeItem(at: audioURL) }
+            let recognizer = AppleBatchSpeechRecognizer(
+                assetPreparer: AppleSpeechAssetPreparer(prepareOperation: { _ in }),
+                stallTimeoutProvider: { .oneMinute },
+                watchdogClock: clock,
+                analyzerPreparation: { _, _ in
+                    try await preparation.run()
+                }
+            )
+
+            let recognitionTask = Task {
+                try await recognizer.recognize(audioURL: audioURL, locale: Locale(identifier: "ja_JP"))
+            }
+            try await waitUntil {
+                let didStart = await preparation.didStart
+                let waiterCount = await clock.waiterCount
+                return didStart && waiterCount == 1
+            }
+
+            recognitionTask.cancel()
+            _ = try? await recognitionTask.value
+        }
+
+        @Test
         func stallTimeoutValuesResolveAndFallBack() {
             #expect(BatchTranscriptionStallTimeout.allCases.map(\.rawValue) == [1, 2, 3])
             #expect(BatchTranscriptionStallTimeout.resolved(rawValue: 1) == .oneMinute)
@@ -114,6 +143,27 @@ import Foundation
             )
         }
 
+        private func makeAudioFile() throws -> URL {
+            let format = try #require(AVAudioFormat(
+                commonFormat: .pcmFormatInt16,
+                sampleRate: 16000,
+                channels: 1,
+                interleaved: false
+            ))
+            let url = FileManager.default.temporaryDirectory
+                .appending(path: "dahlia-watchdog-preparation-\(UUID.v7().uuidString).caf")
+            let file = try AVAudioFile(
+                forWriting: url,
+                settings: format.settings,
+                commonFormat: .pcmFormatInt16,
+                interleaved: false
+            )
+            let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 160))
+            buffer.frameLength = 160
+            try file.write(from: buffer)
+            return url
+        }
+
         private func waitUntil(
             timeout: Duration = testPollTimeout,
             condition: @escaping @Sendable () async -> Bool
@@ -141,6 +191,15 @@ import Foundation
             } catch {
                 // The watchdog owns and cancels its outstanding timeout action on stop.
             }
+        }
+    }
+
+    private actor SuspendedAnalyzerPreparation {
+        private(set) var didStart = false
+
+        func run() async throws {
+            didStart = true
+            try await Task.sleep(for: .seconds(60))
         }
     }
 

--- a/Tests/DahliaTests/BatchSpeechAnalyzerInputSequenceTests.swift
+++ b/Tests/DahliaTests/BatchSpeechAnalyzerInputSequenceTests.swift
@@ -24,6 +24,7 @@ import Speech
             }
             let readFormat = try AVAudioFile(forReading: firstURL).processingFormat
             let consumedSliceProbe = ConsumedSliceProbe()
+            let consumedBufferProbe = ConsumedBufferProbe()
             let sequence = try BatchSpeechAnalyzerInputSequence(
                 slices: [
                     BatchSpeechAudioSlice(audioURL: firstURL, startFrame: 40, frameCount: 80),
@@ -33,6 +34,9 @@ import Speech
                 analyzerFormat: readFormat,
                 onSliceConsumed: { sliceIndex in
                     await consumedSliceProbe.record(sliceIndex)
+                },
+                onBufferConsumed: {
+                    await consumedBufferProbe.record()
                 },
                 converterFactory: { _, _ in PassthroughAnalyzerInputConverter() }
             )
@@ -52,6 +56,7 @@ import Speech
             #expect(second.bufferStartTime?.seconds == 0.005)
             #expect(end == nil)
             #expect(await consumedSliceProbe.sliceIndices == [0, 1])
+            #expect(await consumedBufferProbe.count == 2)
         }
 
         @Test
@@ -133,6 +138,14 @@ import Speech
 
         func record(_ sliceIndex: Int) {
             sliceIndices.append(sliceIndex)
+        }
+    }
+
+    private actor ConsumedBufferProbe {
+        private(set) var count = 0
+
+        func record() {
+            count += 1
         }
     }
 #endif

--- a/Tests/DahliaTests/BatchTranscriptionStallPersistenceTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionStallPersistenceTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct BatchTranscriptionStallPersistenceTests {
+        @Test
+        func stalledRecognitionPersistsManualFailureAndKeepsReadyAudio() async throws {
+            let batch = try BatchAudioTestFixture(
+                name: "stalled-recognition",
+                endedAt: Date(timeIntervalSince1970: 1_776_384_001),
+                duration: 1,
+                retainAudioAfterBatch: false
+            )
+            defer { batch.removeFiles() }
+            try await batch.recordMicrophoneAudio()
+            try await batch.database.dbQueue.write { db in
+                guard var session = try RecordingSessionRecord.fetchOne(db, key: batch.session.id) else {
+                    throw CocoaError(.fileNoSuchFile)
+                }
+                session.batchSelectedLocaleIdentifier = "ja_JP"
+                try session.update(db)
+            }
+            let coordinator = BatchTranscriptionCoordinator(
+                dbQueue: batch.database.dbQueue,
+                managedRootURL: batch.managedRootURL,
+                speechRecognizer: StalledBatchSpeechRecognizer(),
+                onStateChange: { _ in }
+            )
+
+            await coordinator.enqueue(sessionId: batch.session.id)
+            #expect(await pollUntil {
+                (try? batch.database.dbQueue.read { db in
+                    try RecordingSessionRecord.fetchOne(db, key: batch.session.id)?.batchFailureKind == .transcriptionStalled
+                }) == true
+            })
+
+            let result = try await batch.database.dbQueue.read { db in
+                let session = try #require(try RecordingSessionRecord.fetchOne(db, key: batch.session.id))
+                let segment = try #require(try RecordingAudioSegmentRecord.fetchOne(db))
+                return (session, segment)
+            }
+            #expect(result.0.batchLastError == L10n.batchAnalysisStalled(minutes: 1))
+            #expect(result.0.batchFailureKind == .transcriptionStalled)
+            #expect(!BatchTranscriptionCoordinator.shouldAutomaticallyRetry(result.0))
+            #expect(result.1.state == .ready)
+            #expect(result.1.purgedAt == nil)
+            #expect(FileManager.default.fileExists(
+                atPath: batch.managedRootURL.appending(path: result.1.finalRelativePath).path
+            ))
+
+            let retryProbe = BatchRecognitionCallProbe()
+            let recoveryCoordinator = BatchTranscriptionCoordinator(
+                dbQueue: batch.database.dbQueue,
+                managedRootURL: batch.managedRootURL,
+                speechRecognizer: CountingBatchSpeechRecognizer(probe: retryProbe),
+                onStateChange: { _ in }
+            )
+            await recoveryCoordinator.recoverAndEnqueue()
+            #expect(await retryProbe.callCount == 0)
+        }
+    }
+
+    private struct StalledBatchSpeechRecognizer: BatchSpeechRecognizing {
+        func recognize(audioURL _: URL, locale _: Locale) throws -> [BatchSpeechRecognition] {
+            throw BatchSpeechTranscriberError.analysisStalled(minutes: 1)
+        }
+
+        func recognize(audioSlices _: [BatchSpeechAudioSlice], locale _: Locale) throws -> [BatchSpeechRecognition] {
+            throw BatchSpeechTranscriberError.analysisStalled(minutes: 1)
+        }
+    }
+
+    private actor BatchRecognitionCallProbe {
+        private(set) var callCount = 0
+
+        func recordCall() {
+            callCount += 1
+        }
+    }
+
+    private struct CountingBatchSpeechRecognizer: BatchSpeechRecognizing {
+        let probe: BatchRecognitionCallProbe
+
+        func recognize(audioURL _: URL, locale _: Locale) async -> [BatchSpeechRecognition] {
+            await probe.recordCall()
+            return []
+        }
+
+        func recognize(audioSlices _: [BatchSpeechAudioSlice], locale _: Locale) async -> [BatchSpeechRecognition] {
+            await probe.recordCall()
+            return []
+        }
+    }
+#endif

--- a/Tests/DahliaTests/CaptionViewModelBatchRetryTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelBatchRetryTests.swift
@@ -65,9 +65,10 @@ import GRDB
                 name: "failed-auto-retry-selection",
                 endedAt: Date(timeIntervalSince1970: 1_776_384_001),
                 duration: 1,
-                retainAudioAfterBatch: true
+                retainAudioAfterBatch: false
             )
             defer { batch.removeFiles() }
+            try await batch.recordMicrophoneAudio()
             try await markBatchFailed(batch)
 
             let viewModel = CaptionViewModel()
@@ -85,16 +86,173 @@ import GRDB
                 vaultURL: batch.vaultURL
             )
             #expect(await waitUntil {
-                if case .failed = viewModel.batchTranscriptionState { true } else { false }
+                if case .failed = viewModel.batchTranscriptionState {
+                    viewModel.canRetranscribeBatchAudio
+                } else {
+                    false
+                }
             })
+            #expect(viewModel.batchTranscriptionFailureMessage == L10n.batchLanguageDetectionFailed)
 
-            viewModel.retryBatchTranscription()
+            viewModel.presentAvailableBatchRetranscription()
 
             let confirmation = try #require(viewModel.pendingBatchTranscriptionConfirmation)
             #expect(confirmation.sessionId == batch.session.id)
             #expect(confirmation.initialLanguageSelection == .automatic)
-            #expect(confirmation.retainAudioAfterBatch)
+            #expect(!confirmation.retainAudioAfterBatch)
             #expect(confirmation.automaticLanguageCandidateSnapshot?.identifierSet == ["en", "ja"])
+        }
+
+        @Test
+        func failedRetranscriptionOffersRetryAndCanKeepCurrentTranscript() async throws {
+            let completedAt = Date(timeIntervalSince1970: 1_776_384_002)
+            let batch = try BatchAudioTestFixture(
+                name: "failed-retranscription",
+                endedAt: Date(timeIntervalSince1970: 1_776_384_001),
+                duration: 1,
+                retainAudioAfterBatch: true,
+                batchCompletedAt: completedAt
+            )
+            defer { batch.removeFiles() }
+            try await batch.recordMicrophoneAudio()
+            try await batch.database.dbQueue.write { db in
+                guard var session = try RecordingSessionRecord.fetchOne(db, key: batch.session.id) else {
+                    throw CocoaError(.fileNoSuchFile)
+                }
+                session.batchLastAttemptAt = completedAt.addingTimeInterval(1)
+                session.batchLastError = "retranscription failed"
+                try session.update(db)
+            }
+
+            let viewModel = CaptionViewModel()
+            viewModel.configureBatchTranscription(
+                dbQueue: batch.database.dbQueue,
+                managedRootURL: batch.managedRootURL,
+                recoverExistingSessions: false
+            )
+            viewModel.loadMeeting(
+                batch.meeting.id,
+                dbQueue: batch.database.dbQueue,
+                projectURL: nil,
+                projectId: nil,
+                vaultURL: batch.vaultURL
+            )
+            #expect(await waitUntil {
+                if case .retranscriptionFailed = viewModel.batchTranscriptionState {
+                    viewModel.canRetranscribeBatchAudio
+                } else {
+                    false
+                }
+            })
+
+            viewModel.presentAvailableBatchRetranscription()
+            #expect(await waitUntil { viewModel.pendingBatchTranscriptionConfirmation != nil })
+            let confirmation = try #require(viewModel.pendingBatchTranscriptionConfirmation)
+            #expect(confirmation.isRetranscription)
+            viewModel.pendingBatchTranscriptionConfirmation = nil
+
+            viewModel.cancelFailedBatchRetranscription()
+            #expect(await waitUntil { viewModel.batchTranscriptionState == nil })
+            #expect(viewModel.canRetranscribeBatchAudio)
+        }
+
+        @Test
+        func failedSessionWithNonReadyAudioDoesNotOfferRetry() async throws {
+            let batch = try BatchAudioTestFixture(
+                name: "failed-damaged-audio",
+                endedAt: Date(timeIntervalSince1970: 1_776_384_001),
+                duration: 1
+            )
+            defer { batch.removeFiles() }
+            try await batch.recordMicrophoneAudio()
+            try await markBatchFailed(batch)
+            try await batch.database.dbQueue.write { db in
+                guard var segment = try RecordingAudioSegmentRecord.fetchOne(db) else {
+                    throw CocoaError(.fileNoSuchFile)
+                }
+                segment.state = .failed
+                try segment.update(db)
+            }
+
+            let viewModel = CaptionViewModel()
+            viewModel.configureBatchTranscription(
+                dbQueue: batch.database.dbQueue,
+                managedRootURL: batch.managedRootURL,
+                recoverExistingSessions: false
+            )
+            viewModel.loadMeeting(
+                batch.meeting.id,
+                dbQueue: batch.database.dbQueue,
+                projectURL: nil,
+                projectId: nil,
+                vaultURL: batch.vaultURL
+            )
+            #expect(await waitUntil {
+                if case .failed = viewModel.batchTranscriptionState { true } else { false }
+            })
+            #expect(!viewModel.canRetranscribeBatchAudio)
+        }
+
+        @Test
+        func failedMultiSessionRetranscriptionRequiresEveryPendingAudioSession() async throws {
+            let completedAt = Date(timeIntervalSince1970: 1_776_384_002)
+            let batch = try BatchAudioTestFixture(
+                name: "failed-multi-session-retranscription",
+                endedAt: Date(timeIntervalSince1970: 1_776_384_001),
+                duration: 1,
+                retainAudioAfterBatch: true,
+                batchCompletedAt: completedAt
+            )
+            defer { batch.removeFiles() }
+            try await batch.recordMicrophoneAudio()
+
+            let unavailableSession = RecordingSessionRecord(
+                id: .v7(),
+                meetingId: batch.meeting.id,
+                startedAt: batch.now.addingTimeInterval(10),
+                endedAt: batch.now.addingTimeInterval(11),
+                duration: 1,
+                offsetSeconds: 10,
+                createdAt: batch.now,
+                updatedAt: batch.now,
+                transcriptionMode: .batch,
+                retainAudioAfterBatch: true,
+                batchCompletedAt: completedAt
+            )
+            try await batch.database.dbQueue.write { db in
+                guard var availableSession = try RecordingSessionRecord.fetchOne(db, key: batch.session.id) else {
+                    throw CocoaError(.fileNoSuchFile)
+                }
+                availableSession.batchLastAttemptAt = completedAt.addingTimeInterval(1)
+                availableSession.batchLastError = "retranscription failed"
+                try availableSession.update(db)
+
+                var unavailableSession = unavailableSession
+                unavailableSession.batchLastAttemptAt = completedAt.addingTimeInterval(1)
+                unavailableSession.batchLastError = "retranscription failed"
+                try unavailableSession.insert(db)
+            }
+
+            let viewModel = CaptionViewModel()
+            viewModel.configureBatchTranscription(
+                dbQueue: batch.database.dbQueue,
+                managedRootURL: batch.managedRootURL,
+                recoverExistingSessions: false
+            )
+            viewModel.loadMeeting(
+                batch.meeting.id,
+                dbQueue: batch.database.dbQueue,
+                projectURL: nil,
+                projectId: nil,
+                vaultURL: batch.vaultURL
+            )
+            #expect(await waitUntil {
+                if case .retranscriptionFailed = viewModel.batchTranscriptionState { true } else { false }
+            })
+
+            #expect(!viewModel.canRetranscribeBatchAudio)
+            viewModel.presentAvailableBatchRetranscription()
+            #expect(viewModel.pendingBatchTranscriptionConfirmation == nil)
         }
 
         private func markBatchFailed(_ batch: BatchAudioTestFixture) async throws {

--- a/Tests/DahliaTests/CaptionViewModelBatchRetryTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelBatchRetryTests.swift
@@ -104,6 +104,34 @@ import GRDB
         }
 
         @Test
+        func discardedFailedBatchNoLongerOffersRetranscription() async throws {
+            let batch = try BatchAudioTestFixture(
+                name: "discarded-failed-retry",
+                endedAt: Date(timeIntervalSince1970: 1_776_384_001),
+                duration: 1
+            )
+            defer { batch.removeFiles() }
+            try await batch.recordMicrophoneAudio()
+            try await markBatchFailed(batch)
+
+            let viewModel = CaptionViewModel()
+            viewModel.loadMeeting(
+                batch.meeting.id,
+                dbQueue: batch.database.dbQueue,
+                projectURL: nil,
+                projectId: nil,
+                vaultURL: batch.vaultURL
+            )
+            #expect(await waitUntil { viewModel.canRetranscribeBatchAudio })
+
+            viewModel.discardFailedBatchTranscription()
+
+            #expect(await waitUntil { viewModel.batchTranscriptionState == nil })
+            #expect(viewModel.retranscribableBatchSessionIds.isEmpty)
+            #expect(!viewModel.canRetranscribeBatchAudio)
+        }
+
+        @Test
         func failedRetranscriptionOffersRetryAndCanKeepCurrentTranscript() async throws {
             let completedAt = Date(timeIntervalSince1970: 1_776_384_002)
             let batch = try BatchAudioTestFixture(

--- a/docs/architecture/audio-transcription-data-flow.md
+++ b/docs/architecture/audio-transcription-data-flow.md
@@ -235,6 +235,12 @@ sequenceDiagram
 同じ `SpeechAnalyzer` へ順次供給する。ready CAF 自体は結合または変更せず、入力は一 buffer ずつ遅延読出しする。
 自動判定は CAF ごとの言語判定と認識の overlap を維持するため、CAF 単位の transcription のままとする。
 
+各 Apple Speech 解析には無進捗 watchdog を設ける。解析開始、論理 run 内の CAF slice 消費、認識結果の受信を進捗とし、
+解析開始時に固定した設定時間（1／2／3分、既定1分）進捗がなければ `SpeechAnalyzer` をキャンセルして失敗として保存する。
+これは総処理時間の上限ではない。停止失敗では ready CAF を保持し、startup recovery の自動再試行から除外する。
+ユーザーはミーティング詳細に復元される失敗理由と再文字起こし操作から、保持音声を明示的に再処理できる。
+再試行成功後は通常の `retainAudioAfterBatch` 方針に戻り、保持しない設定なら音声を purge する。
+
 認識途中の結果は正本へ部分反映しない。成功した全結果を `BatchTranscriptionPersistence.complete` が一つの transaction で
 反映する。再文字起こし中は以前の成功結果を利用でき、新しい一式が成功した時だけ置き換える。
 
@@ -282,6 +288,7 @@ sequenceDiagram
 | live recognition failure in batch | audio writer が健全なら正本音声を継続 | 字幕／chat を縮退し、停止後 batch を維持 |
 | realtime SQLite failure | pending event と順序を writer actor 内で保持 | exponential backoff。停止時にも flush failure を返す |
 | batch recognition failure | 旧成功 transcript と ready audio を保持 | failure state を保存し、再試行可能 |
+| Apple Speech の無進捗停止 | 旧成功 transcript と ready audio を保持 | 待機時間を含む専用 failure state を保存し、自動再試行せず手動再試行を待つ |
 | batch audio feature extraction failure | 認識済み transcript と通常の purge policy を維持 | sanitized error を報告し、該当 feature columns を `NULL` にする |
 | crash 中の partial／finalizing CAF | 既存 ready segment を変更しない | startup reconciler が DB state と file を照合 |
 | ready CAF の missing／mismatch | 自動再作成、上書き、削除をしない | `failed` と reconciliation issue を記録 |


### PR DESCRIPTION
## Summary

- add a configurable 1/2/3-minute no-progress watchdog for Apple Speech batch transcription
- persist stalled analysis as a dedicated failure, retain ready CAF audio, and require an explicit manual retry
- restore retry, discard, and keep-current-transcript actions in the meeting detail UI after relaunch
- harden retranscription recovery so failed retries cannot purge retained audio or overwrite a transcript after cancellation
- update Japanese and English localization, architecture documentation, and the app version to 0.9.0 (43)

## Root cause

Apple Speech analysis could stop producing results without completing or throwing, leaving the batch task running indefinitely. Existing recovery logic also treated a completed session's retained timestamp as sufficient for purge recovery, even while a retranscription attempt was pending.

## User impact

Batch transcription now fails with a clear message after the configured no-progress interval. When valid recorded audio remains, users can retry directly without recording another audio fragment. Failed retranscriptions preserve the last successful transcript until a complete replacement is committed.

## Validation

- `swift build`
- `swift test` — 1,377 Swift Testing tests in 210 suites and 3 XCTest tests passed
- focused watchdog, retry, and retranscription recovery tests — 14 tests in 3 suites passed after final simplification
- `CI=true ./scripts/lint.sh` — SwiftFormat reported 0/613 files requiring formatting; existing non-blocking SwiftLint baseline violations remain
- `git diff --check` and plist/localization validation
