### PR TITLE
Add original-size MCP screenshot access

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>43</string>
+    <string>44</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.8.5</string>
+    <string>0.8.6</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/DahliaMeetingAccess/DahliaMCPServer.swift
+++ b/Sources/DahliaMeetingAccess/DahliaMCPServer.swift
@@ -6,6 +6,18 @@ import GRDB
 // swiftlint:disable file_length
 // swiftlint:disable:next type_body_length
 public final class DahliaMCPServer {
+    private enum ScreenshotImageSize: String, CaseIterable {
+        case preview
+        case original
+
+        var maximumScreenshotCount: Int {
+            switch self {
+            case .preview: 10
+            case .original: 1
+            }
+        }
+    }
+
     private let store: MeetingAccessStore
     private let allowedMeetingIDs: Set<UUID>?
     private var initialized = false
@@ -185,6 +197,7 @@ public final class DahliaMCPServer {
         case "get_meeting_screenshots":
             try validate(arguments, allowedKeys: [
                 "meeting_id", "screenshot_ids", "from_elapsed_seconds", "to_elapsed_seconds", "limit", "cursor",
+                "image_size",
             ])
             let result = try getMeetingScreenshots(arguments)
             return try screenshotsToolResult(page: result.page, images: result.images)
@@ -623,6 +636,11 @@ public final class DahliaMCPServer {
         let screenshotIDs = try uuidArray(arguments, key: "screenshot_ids")
         let from = try nonnegativeDouble(arguments, key: "from_elapsed_seconds")
         let to = try nonnegativeDouble(arguments, key: "to_elapsed_seconds")
+        let rawImageSize = try string(arguments, key: "image_size") ?? ScreenshotImageSize.preview.rawValue
+        guard let imageSize = ScreenshotImageSize(rawValue: rawImageSize) else {
+            throw ParameterError("image_size must be preview or original")
+        }
+        let originalSize = imageSize == .original
         let hasRange = from != nil || to != nil
         guard (screenshotIDs != nil) != hasRange else {
             throw ParameterError("Provide either screenshot_ids or an elapsed-time range")
@@ -632,7 +650,12 @@ public final class DahliaMCPServer {
             guard arguments["limit"] == nil, arguments["cursor"] == nil else {
                 throw ParameterError("screenshot_ids cannot be combined with range or pagination parameters")
             }
-            let images = try store.screenshotImages(meetingID: meetingID, screenshotIDs: screenshotIDs)
+            try validateScreenshotCount(screenshotIDs.count, imageSize: imageSize)
+            let images = try store.screenshotImages(
+                meetingID: meetingID,
+                screenshotIDs: screenshotIDs,
+                originalSize: originalSize
+            )
             let page = try MeetingScreenshotPage(
                 vault: store.scopedVault(),
                 meetingID: meetingID,
@@ -647,7 +670,11 @@ public final class DahliaMCPServer {
         }
         try validateTimeRange(from: from, to: to)
         let limit = try integer(arguments, key: "limit") ?? 1
-        guard (1 ... 10).contains(limit) else { throw ParameterError("limit must be between 1 and 10") }
+        let maximumLimit = ScreenshotImageSize.preview.maximumScreenshotCount
+        guard (1 ... maximumLimit).contains(limit) else {
+            throw ParameterError("limit must be between 1 and \(maximumLimit)")
+        }
+        try validateScreenshotCount(limit, imageSize: imageSize)
         return try store.screenshotImages(
             meetingID: meetingID,
             query: ScreenshotQuery(
@@ -655,8 +682,15 @@ public final class DahliaMCPServer {
                 toElapsedSeconds: to,
                 limit: limit,
                 cursor: string(arguments, key: "cursor")
-            )
+            ),
+            originalSize: originalSize
         )
+    }
+
+    private func validateScreenshotCount(_ count: Int, imageSize: ScreenshotImageSize) throws {
+        guard count <= imageSize.maximumScreenshotCount else {
+            throw ParameterError("image_size original requires exactly one screenshot per call")
+        }
     }
 
     private func authorizedMeetingID(_ arguments: [String: Any]) throws -> UUID {
@@ -778,8 +812,9 @@ public final class DahliaMCPServer {
 
     private func uuidArray(_ arguments: [String: Any], key: String) throws -> [UUID]? {
         guard let value = arguments[key] else { return nil }
-        guard let values = value as? [Any], (1 ... 10).contains(values.count) else {
-            throw ParameterError("\(key) must be an array containing 1 to 10 UUID strings")
+        let maximumCount = ScreenshotImageSize.preview.maximumScreenshotCount
+        guard let values = value as? [Any], (1 ... maximumCount).contains(values.count) else {
+            throw ParameterError("\(key) must be an array containing 1 to \(maximumCount) UUID strings")
         }
         let ids = try values.map { value -> UUID in
             guard let value = value as? String, let id = UUID(uuidString: value) else {
@@ -2475,8 +2510,10 @@ private extension DahliaMCPServer {
         [
             "name": "get_meeting_screenshots",
             "title": "Get meeting screenshots",
-            "description": "Fetch resized MCP images and metadata either for 1 to 10 screenshot IDs or for a paginated "
-                + "elapsed-time range when visual evidence is needed. Original image bytes are never returned.",
+            "description": "Fetch images and metadata either for 1 to "
+                + "\(ScreenshotImageSize.preview.maximumScreenshotCount) screenshot IDs or for a paginated elapsed-time "
+                + "range when visual evidence is needed. image_size defaults to preview; use original only when the "
+                + "original resolution is required, one screenshot per call.",
             "inputSchema": [
                 "type": "object",
                 "properties": [
@@ -2485,13 +2522,24 @@ private extension DahliaMCPServer {
                         "type": "array",
                         "items": ["type": "string", "format": "uuid"],
                         "minItems": 1,
-                        "maxItems": 10,
+                        "maxItems": ScreenshotImageSize.preview.maximumScreenshotCount,
                         "uniqueItems": true,
                     ],
                     "from_elapsed_seconds": ["type": "number", "minimum": 0],
                     "to_elapsed_seconds": ["type": "number", "exclusiveMinimum": 0],
-                    "limit": ["type": "integer", "minimum": 1, "maximum": 10, "default": 1],
+                    "limit": [
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": ScreenshotImageSize.preview.maximumScreenshotCount,
+                        "default": 1,
+                    ],
                     "cursor": ["type": "string"],
+                    "image_size": [
+                        "type": "string",
+                        "enum": ScreenshotImageSize.allCases.map(\.rawValue),
+                        "default": ScreenshotImageSize.preview.rawValue,
+                        "description": "Return a resized preview or the original stored image bytes.",
+                    ],
                 ],
                 "required": ["meeting_id"],
                 "oneOf": [
@@ -2509,6 +2557,22 @@ private extension DahliaMCPServer {
                     [
                         "required": ["from_elapsed_seconds", "to_elapsed_seconds"],
                         "not": ["required": ["screenshot_ids"]],
+                    ],
+                ],
+                "allOf": [
+                    [
+                        "if": [
+                            "properties": ["image_size": ["const": ScreenshotImageSize.original.rawValue]],
+                            "required": ["image_size"],
+                        ],
+                        "then": [
+                            "properties": [
+                                "screenshot_ids": [
+                                    "maxItems": ScreenshotImageSize.original.maximumScreenshotCount,
+                                ],
+                                "limit": ["maximum": ScreenshotImageSize.original.maximumScreenshotCount],
+                            ],
+                        ],
                     ],
                 ],
                 "additionalProperties": false,

--- a/Sources/DahliaMeetingAccess/MeetingAccessModels.swift
+++ b/Sources/DahliaMeetingAccess/MeetingAccessModels.swift
@@ -343,7 +343,7 @@ public enum MeetingAccessError: Error, LocalizedError, Equatable {
         case .screenshotNotFound:
             "The screenshot was not found in the configured meeting and vault."
         case .screenshotEncodingFailed:
-            "The screenshot could not be resized for MCP access."
+            "The screenshot could not be prepared for MCP access."
         case .writeAccessRequired:
             "This dahlia-mcp process is read-only. Restart it with --write to use update tools."
         case .projectNotFound:

--- a/Sources/DahliaMeetingAccess/MeetingAccessStore.swift
+++ b/Sources/DahliaMeetingAccess/MeetingAccessStore.swift
@@ -503,10 +503,11 @@ extension MeetingAccessStore {
 
     public func screenshotImages(
         meetingID: UUID,
-        query: ScreenshotQuery
+        query: ScreenshotQuery,
+        originalSize: Bool = false
     ) throws -> (page: MeetingScreenshotPage, images: [MeetingScreenshotImage]) {
         let result = try screenshotPageData(meetingID: meetingID, query: query, includeImageData: true)
-        let images = result.payloads.compactMap(Self.encodedScreenshot)
+        let images = result.payloads.compactMap { Self.encodedScreenshot($0, originalSize: originalSize) }
         return (
             MeetingScreenshotPage(
                 vault: result.page.vault,
@@ -578,14 +579,26 @@ extension MeetingAccessStore {
         }
     }
 
-    public func screenshot(meetingID: UUID, screenshotID: UUID) throws -> MeetingScreenshotImage {
-        guard let image = try screenshotImages(meetingID: meetingID, screenshotIDs: [screenshotID]).first else {
+    public func screenshot(
+        meetingID: UUID,
+        screenshotID: UUID,
+        originalSize: Bool = false
+    ) throws -> MeetingScreenshotImage {
+        guard let image = try screenshotImages(
+            meetingID: meetingID,
+            screenshotIDs: [screenshotID],
+            originalSize: originalSize
+        ).first else {
             throw MeetingAccessError.screenshotNotFound
         }
         return image
     }
 
-    public func screenshotImages(meetingID: UUID, screenshotIDs: [UUID]) throws -> [MeetingScreenshotImage] {
+    public func screenshotImages(
+        meetingID: UUID,
+        screenshotIDs: [UUID],
+        originalSize: Bool = false
+    ) throws -> [MeetingScreenshotImage] {
         guard !screenshotIDs.isEmpty, screenshotIDs.count <= 10, Set(screenshotIDs).count == screenshotIDs.count else {
             throw MeetingAccessError.screenshotNotFound
         }
@@ -609,15 +622,21 @@ extension MeetingAccessStore {
             }
         }
         return try payloads.map { payload in
-            guard let image = Self.encodedScreenshot(payload) else {
+            guard let image = Self.encodedScreenshot(payload, originalSize: originalSize) else {
                 throw MeetingAccessError.screenshotEncodingFailed
             }
             return image
         }
     }
 
-    private static func encodedScreenshot(_ payload: ScreenshotPayload) -> MeetingScreenshotImage? {
-        guard let imageData = ImageEncoder.resizedIfPossible(payload.imageData, maxLongEdge: 1024),
+    private static func encodedScreenshot(
+        _ payload: ScreenshotPayload,
+        originalSize: Bool
+    ) -> MeetingScreenshotImage? {
+        let imageData = originalSize
+            ? payload.imageData
+            : ImageEncoder.resizedIfPossible(payload.imageData, maxLongEdge: 1024)
+        guard let imageData,
               let mimeType = ImageEncoder.mimeType(for: imageData) else {
             return nil
         }

--- a/Tests/DahliaTests/MeetingAccessStoreTests.swift
+++ b/Tests/DahliaTests/MeetingAccessStoreTests.swift
@@ -700,6 +700,20 @@ import ImageIO
             #expect(properties[kCGImagePropertyPixelWidth] as? Int == 1024)
             #expect(properties[kCGImagePropertyPixelHeight] as? Int == 256)
 
+            let original = try store.screenshot(
+                meetingID: fixture.firstMeetingID,
+                screenshotID: fixture.firstScreenshotID,
+                originalSize: true
+            )
+            #expect(original.imageData == largeData)
+            #expect(original.mimeType == ImageEncoder.mimeType(for: largeData))
+            let originalSource = try #require(CGImageSourceCreateWithData(original.imageData as CFData, nil))
+            let originalProperties = try #require(
+                CGImageSourceCopyPropertiesAtIndex(originalSource, 0, nil) as? [CFString: Any]
+            )
+            #expect(originalProperties[kCGImagePropertyPixelWidth] as? Int == 2048)
+            #expect(originalProperties[kCGImagePropertyPixelHeight] as? Int == 512)
+
             try fixture.updateFirstScreenshot(data: Data("not an image".utf8))
             #expect(throws: MeetingAccessError.screenshotEncodingFailed) {
                 try store.screenshot(meetingID: fixture.firstMeetingID, screenshotID: fixture.firstScreenshotID)
@@ -962,6 +976,21 @@ import ImageIO
             #expect(definitions.allSatisfy {
                 ($0["outputSchema"] as? [String: Any])?["additionalProperties"] as? Bool == false
             })
+            let screenshotDefinition = try #require(
+                definitions.first { $0["name"] as? String == "get_meeting_screenshots" }
+            )
+            let screenshotInputSchema = try #require(screenshotDefinition["inputSchema"] as? [String: Any])
+            let screenshotInputProperties = try #require(screenshotInputSchema["properties"] as? [String: Any])
+            let imageSizeSchema = try #require(screenshotInputProperties["image_size"] as? [String: Any])
+            #expect(imageSizeSchema["type"] as? String == "string")
+            #expect(imageSizeSchema["enum"] as? [String] == ["preview", "original"])
+            #expect(imageSizeSchema["default"] as? String == "preview")
+            let screenshotConstraints = try #require(screenshotInputSchema["allOf"] as? [[String: Any]])
+            let originalConstraint = try #require(screenshotConstraints.first)
+            let originalThen = try #require(originalConstraint["then"] as? [String: Any])
+            let originalProperties = try #require(originalThen["properties"] as? [String: Any])
+            #expect((originalProperties["screenshot_ids"] as? [String: Any])?["maxItems"] as? Int == 1)
+            #expect((originalProperties["limit"] as? [String: Any])?["maximum"] as? Int == 1)
 
             let queryCall = try Self.json(server.handleLine(#"""
             {"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"query_meetings","arguments":{"query":"planning"}}}
@@ -1043,6 +1072,76 @@ import ImageIO
             let missingVaultServer = DahliaMCPServer(store: missingVaultStore)
             let missing = try Self.json(missingVaultServer.handleLine(#"{"jsonrpc":"2.0","id":4,"method":"initialize","params":{}}"#))
             #expect((missing["error"] as? [String: Any])?["code"] as? Int == -32000)
+        }
+
+        @Test
+        func mcpScreenshotImageSizeOptionSelectsPreviewOrOriginalBytes() throws {
+            let fixture = try Fixture()
+            let largeImage = try #require(Self.makeImage(width: 2048, height: 512))
+            let largeData = try #require(ImageEncoder.encode(largeImage, quality: 0.9))
+            try fixture.updateFirstScreenshot(data: largeData)
+            let server = try DahliaMCPServer(store: fixture.store(vaultID: fixture.primaryVaultID))
+            _ = server.handleLine(#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#)
+            _ = server.handleLine(#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#)
+
+            func call(id: Int = 2, arguments: [String: Any]) throws -> [String: Any] {
+                let request: [String: Any] = [
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "method": "tools/call",
+                    "params": ["name": "get_meeting_screenshots", "arguments": arguments],
+                ]
+                let requestData = try JSONSerialization.data(withJSONObject: request)
+                let requestString = try #require(String(data: requestData, encoding: .utf8))
+                return try Self.json(server.handleLine(requestString))
+            }
+
+            func screenshotData(imageSize: String?, selectsByRange: Bool = false) throws -> Data {
+                var arguments: [String: Any] = ["meeting_id": fixture.firstMeetingID.uuidString]
+                if selectsByRange {
+                    arguments["from_elapsed_seconds"] = 15
+                    arguments["to_elapsed_seconds"] = 17
+                } else {
+                    arguments["screenshot_ids"] = [fixture.firstScreenshotID.uuidString]
+                }
+                if let imageSize {
+                    arguments["image_size"] = imageSize
+                }
+                let response = try call(arguments: arguments)
+                let result = try #require(response["result"] as? [String: Any])
+                let content = try #require(result["content"] as? [[String: Any]])
+                let image = try #require(content.first { $0["type"] as? String == "image" })
+                let encoded = try #require(image["data"] as? String)
+                return try #require(Data(base64Encoded: encoded))
+            }
+
+            #expect(try screenshotData(imageSize: nil) != largeData)
+            #expect(try screenshotData(imageSize: "preview") != largeData)
+            #expect(try screenshotData(imageSize: "original") == largeData)
+            #expect(try screenshotData(imageSize: "original", selectsByRange: true) == largeData)
+
+            let invalidResponse = try call(id: 3, arguments: [
+                "meeting_id": fixture.firstMeetingID.uuidString,
+                "screenshot_ids": [fixture.firstScreenshotID.uuidString],
+                "image_size": "large",
+            ])
+            #expect((invalidResponse["error"] as? [String: Any])?["code"] as? Int == -32602)
+
+            let multipleOriginals = try call(id: 4, arguments: [
+                "meeting_id": fixture.firstMeetingID.uuidString,
+                "screenshot_ids": [fixture.firstScreenshotID.uuidString, fixture.secondScreenshotID.uuidString],
+                "image_size": "original",
+            ])
+            #expect((multipleOriginals["error"] as? [String: Any])?["code"] as? Int == -32602)
+
+            let rangedOriginals = try call(id: 5, arguments: [
+                "meeting_id": fixture.firstMeetingID.uuidString,
+                "from_elapsed_seconds": 0,
+                "to_elapsed_seconds": 100,
+                "limit": 2,
+                "image_size": "original",
+            ])
+            #expect((rangedOriginals["error"] as? [String: Any])?["code"] as? Int == -32602)
         }
 
         @Test

--- a/docs/project-workspaces.md
+++ b/docs/project-workspaces.md
@@ -117,6 +117,10 @@ Read tools:
 - `get_meeting_transcript`
 - `get_meeting_screenshots`
 
+`get_meeting_screenshots` uses `image_size: "preview"` by default. Set `image_size` to `"original"` only when an
+external agent needs the original resolution, such as when preparing a document that must preserve screenshot detail.
+Original-size requests return one screenshot per call; use individual IDs or range pagination to retrieve more.
+
 Write tools:
 
 - `create_project`

--- a/website/index.html
+++ b/website/index.html
@@ -545,7 +545,7 @@
             </article>
             <article class="privacy-card reveal">
               <span class="privacy-icon" aria-hidden="true">⌂</span>
-              <div><h3>Scoped, read-only access</h3><p>MCP exposes only meeting search, stored summaries, confirmed original transcripts, and resized screenshots in the selected Vault.</p></div>
+              <div><h3>Scoped, read-only access</h3><p>MCP exposes only meeting search, stored summaries, confirmed original transcripts, and screenshots in the selected Vault. Screenshots are resized by default, with original-size access available on request.</p></div>
             </article>
           </div>
         </div>

--- a/website/ja/index.html
+++ b/website/ja/index.html
@@ -555,7 +555,7 @@
             </article>
             <article class="privacy-card reveal">
               <span class="privacy-icon" aria-hidden="true">⌂</span>
-              <div><h3>外部アクセスは必要な範囲だけ</h3><p>MCPが公開するのは、選択したVaultの会議検索、保存済み要約、確定済みの文字起こし、縮小したスクリーンショットだけです。</p></div>
+              <div><h3>外部アクセスは必要な範囲だけ</h3><p>MCPが公開するのは、選択したVaultの会議検索、保存済み要約、確定済みの文字起こし、スクリーンショットだけです。スクリーンショットは既定で縮小され、明示的に指定した場合のみ元サイズで取得できます。</p></div>
             </article>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- add `image_size: "preview" | "original"` to `get_meeting_screenshots`
- preserve the existing resized preview behavior by default
- return stored full-resolution image bytes when `original` is explicitly requested
- limit original-size responses to one screenshot per request to bound memory amplification

## Why

External agents such as Claude Code and Codex sometimes need full-resolution screenshots when preparing documents or other artifacts. The existing MCP tool always returned a long-edge-1024 preview, which could lose important visual detail.

## Impact

- existing callers remain on the preview path without changes
- original images can be selected by ID or elapsed-time range
- multiple originals can be retrieved with individual ID requests or range pagination
- invalid image sizes and multi-image original requests return an MCP invalid-parameters error

## Validation

- `swift test --filter MeetingAccessStoreTests` — 45 tests passed
- `swift build`
- SwiftFormat lint on changed source files
- deep review and follow-up review found no remaining actionable issues
