### PR TITLE
Improve sidebar meeting hover feedback

### DIFF
--- a/Sources/Dahlia/Views/MeetingListSidebarView.swift
+++ b/Sources/Dahlia/Views/MeetingListSidebarView.swift
@@ -725,6 +725,8 @@ private struct MeetingSidebarRow: View {
     let onCommitRename: () -> Void
     let onCancelRename: () -> Void
 
+    @State private var isHovered = false
+
     private static let timeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .none
@@ -744,8 +746,10 @@ private struct MeetingSidebarRow: View {
                         .onSubmit(onCommitRename)
                         .onExitCommand(perform: onCancelRename)
                 } else {
-                    highlightedText(displayTitle)
-                        .lineLimit(1)
+                    MeetingTitleMarquee(
+                        isHovered: isHovered,
+                        title: highlightedText(displayTitle)
+                    )
                 }
 
                 HStack(spacing: 6) {
@@ -770,8 +774,19 @@ private struct MeetingSidebarRow: View {
                     searchMatchRow(matchContext)
                 }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 3)
+        .padding(.horizontal, 5)
+        .background {
+            if isHovered {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(Color.primary.opacity(isSelected ? 0.08 : 0.06))
+            }
+        }
+        .contentShape(Rectangle())
+        .onHover { isHovered = $0 }
         .accessibilityLabel(accessibilityLabel)
     }
 

--- a/Sources/Dahlia/Views/MeetingTitleMarquee.swift
+++ b/Sources/Dahlia/Views/MeetingTitleMarquee.swift
@@ -14,41 +14,34 @@ struct MeetingTitleMarquee: View {
 
     var body: some View {
         TimelineView(.animation(paused: !isScrolling)) { timeline in
-            ScrollView(.horizontal) {
-                HStack(spacing: 0) {
+            Group {
+                if isScrolling {
+                    scrollingTitle(at: timeline.date)
+                } else {
                     title
                         .lineLimit(1)
-                        .fixedSize(horizontal: true, vertical: false)
-                        .onGeometryChange(for: CGFloat.self) { geometry in
-                            geometry.size.width
-                        } action: { width in
-                            titleWidth = width
-                            updateScrollStart()
-                        }
-
-                    Text(verbatim: " ")
-                        .fixedSize(horizontal: true, vertical: false)
-                        .onGeometryChange(for: CGFloat.self) { geometry in
-                            geometry.size.width
-                        } action: { separatorWidth = $0 }
-
-                    title
-                        .lineLimit(1)
-                        .fixedSize(horizontal: true, vertical: false)
-                        .opacity(isScrolling ? 1 : 0)
-                        .accessibilityHidden(true)
+                        .truncationMode(.tail)
                 }
-                .offset(x: horizontalOffset(at: timeline.date))
             }
-            .scrollIndicators(.hidden)
-            .scrollDisabled(true)
-            .allowsHitTesting(false)
             .onGeometryChange(for: CGFloat.self) { geometry in
                 geometry.size.width
             } action: { width in
                 viewportWidth = width
                 updateScrollStart()
             }
+        }
+        .background {
+            title
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .hidden()
+                .accessibilityHidden(true)
+                .onGeometryChange(for: CGFloat.self) { geometry in
+                    geometry.size.width
+                } action: { width in
+                    titleWidth = width
+                    updateScrollStart()
+                }
         }
         .onChange(of: isHovered) { _, _ in
             updateScrollStart()
@@ -69,6 +62,31 @@ struct MeetingTitleMarquee: View {
 
     private func updateScrollStart() {
         scrollStartedAt = isScrolling ? Date() : nil
+    }
+
+    private func scrollingTitle(at date: Date) -> some View {
+        ScrollView(.horizontal) {
+            HStack(spacing: 0) {
+                title
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+
+                Text(verbatim: " ")
+                    .fixedSize(horizontal: true, vertical: false)
+                    .onGeometryChange(for: CGFloat.self) { geometry in
+                        geometry.size.width
+                    } action: { separatorWidth = $0 }
+
+                title
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .accessibilityHidden(true)
+            }
+            .offset(x: horizontalOffset(at: date))
+        }
+        .scrollIndicators(.hidden)
+        .scrollDisabled(true)
+        .allowsHitTesting(false)
     }
 
     private func horizontalOffset(at date: Date) -> CGFloat {

--- a/Sources/Dahlia/Views/MeetingTitleMarquee.swift
+++ b/Sources/Dahlia/Views/MeetingTitleMarquee.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+struct MeetingTitleMarquee: View {
+    private static var pointsPerSecond: CGFloat { 32 }
+
+    let isHovered: Bool
+    let title: Text
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var titleWidth: CGFloat = 0
+    @State private var separatorWidth: CGFloat = 0
+    @State private var viewportWidth: CGFloat = 0
+    @State private var scrollStartedAt: Date?
+
+    var body: some View {
+        TimelineView(.animation(paused: !isScrolling)) { timeline in
+            ScrollView(.horizontal) {
+                HStack(spacing: 0) {
+                    title
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
+                        .onGeometryChange(for: CGFloat.self) { geometry in
+                            geometry.size.width
+                        } action: { width in
+                            titleWidth = width
+                            updateScrollStart()
+                        }
+
+                    Text(verbatim: " ")
+                        .fixedSize(horizontal: true, vertical: false)
+                        .onGeometryChange(for: CGFloat.self) { geometry in
+                            geometry.size.width
+                        } action: { separatorWidth = $0 }
+
+                    title
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
+                        .opacity(isScrolling ? 1 : 0)
+                        .accessibilityHidden(true)
+                }
+                .offset(x: horizontalOffset(at: timeline.date))
+            }
+            .scrollIndicators(.hidden)
+            .scrollDisabled(true)
+            .allowsHitTesting(false)
+            .onGeometryChange(for: CGFloat.self) { geometry in
+                geometry.size.width
+            } action: { width in
+                viewportWidth = width
+                updateScrollStart()
+            }
+        }
+        .onChange(of: isHovered) { _, _ in
+            updateScrollStart()
+        }
+        .onChange(of: reduceMotion) { _, _ in
+            updateScrollStart()
+        }
+        .onDisappear { scrollStartedAt = nil }
+    }
+
+    private var titleOverflowsViewport: Bool {
+        titleWidth - viewportWidth > 1
+    }
+
+    private var isScrolling: Bool {
+        isHovered && titleOverflowsViewport && !reduceMotion
+    }
+
+    private func updateScrollStart() {
+        scrollStartedAt = isScrolling ? Date() : nil
+    }
+
+    private func horizontalOffset(at date: Date) -> CGFloat {
+        guard isScrolling, let scrollStartedAt else { return 0 }
+        let travelDistance = titleWidth + separatorWidth
+        guard travelDistance > 0 else { return 0 }
+        let elapsed = max(0, date.timeIntervalSince(scrollStartedAt))
+        let distance = CGFloat(elapsed) * Self.pointsPerSecond
+        return -distance.truncatingRemainder(dividingBy: travelDistance)
+    }
+}


### PR DESCRIPTION
## Summary

- add a clear hover background to meeting rows in the sidebar
- continuously scroll truncated meeting titles at 32 points per second
- join repeated titles with one ASCII space for a seamless loop
- keep short titles static and respect the macOS Reduce Motion setting

## Why

Meeting rows previously gave no visual hover feedback, and truncated titles could not be read in full. The marquee implementation also needs to avoid duplicate short titles and stale animation offsets when hover ends.

## Impact

Sidebar meetings now provide immediate hover feedback. Long titles scroll continuously while hovered, short titles remain unchanged, and users with Reduce Motion enabled see a static title.

## Validation

- `swift build`
- SwiftFormat on the changed files
- SwiftLint on the changed files (no new violations; the existing file-length warning remains)
- `git diff --check`
- parallel deep review and post-fix re-review
