### PR TITLE
Handle empty MCP meeting filters

### DIFF
--- a/Sources/DahliaMeetingAccess/DahliaMCPServer.swift
+++ b/Sources/DahliaMeetingAccess/DahliaMCPServer.swift
@@ -594,7 +594,15 @@ public final class DahliaMCPServer {
         }
     }
 
-    private func queryMeetings(_ arguments: [String: Any]) throws -> MeetingQueryPage {
+    private func queryMeetings(_ rawArguments: [String: Any]) throws -> MeetingQueryPage {
+        let optionalStringKeys: Set = [
+            "query", "project", "project_id", "organization_id", "topic_id", "ical_uid",
+            "created_from", "created_before", "cursor",
+        ]
+        let arguments = rawArguments.filter { key, value in
+            guard optionalStringKeys.contains(key), let string = value as? String else { return true }
+            return !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
         let limit = try integer(arguments, key: "limit") ?? 25
         return try store.queryMeetings(MeetingQuery(
             query: string(arguments, key: "query"),
@@ -2444,7 +2452,8 @@ private extension DahliaMCPServer {
             "description": "Find recent meetings in the configured vault by meeting name, AI description, "
                 + "calendar title, project, or tag. Use ical_uid to find past meetings for the same calendar event, "
                 + "or exact project_id to find related meetings across different calendar events. Summary and transcript "
-                + "bodies are not searched.",
+                + "bodies are not searched. All parameters are optional filters. Omit unused properties entirely; do not "
+                + "send empty strings.",
             "inputSchema": [
                 "type": "object",
                 "properties": [

--- a/Tests/DahliaTests/MeetingAccessStoreTests.swift
+++ b/Tests/DahliaTests/MeetingAccessStoreTests.swift
@@ -2595,6 +2595,8 @@ import ImageIO
             let tools = try Self.json(server.handleLine(#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#))
             let definitions = ((tools["result"] as? [String: Any])?["tools"] as? [[String: Any]]) ?? []
             let queryDefinition = try #require(definitions.first { $0["name"] as? String == "query_meetings" })
+            let queryDescription = try #require(queryDefinition["description"] as? String)
+            #expect(queryDescription.contains("Omit unused properties entirely; do not send empty strings"))
             let inputSchema = try #require(queryDefinition["inputSchema"] as? [String: Any])
             let inputProperties = try #require(inputSchema["properties"] as? [String: Any])
             #expect(inputProperties["ical_uid"] != nil)
@@ -2646,10 +2648,23 @@ import ImageIO
             """#))
             #expect((invalidProjectID["error"] as? [String: Any])?["code"] as? Int == -32602)
 
-            let blankIcalUID = try Self.json(server.handleLine(#"""
-            {"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"query_meetings","arguments":{"ical_uid":"   "}}}
+            let blankFilters = try Self.json(server.handleLine(#"""
+            {"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"query_meetings","arguments":{
+                "created_before":"","created_from":" ","cursor":"","ical_uid":"   ",
+                "include_descendants":true,"limit":50,"organization_id":"","project":"","project_id":"",
+                "query":"","topic_id":""
+            }}}
             """#))
-            #expect((blankIcalUID["error"] as? [String: Any])?["code"] as? Int == -32602)
+            #expect(blankFilters["error"] == nil)
+            let blankFilterContent = (blankFilters["result"] as? [String: Any])?["structuredContent"] as? [String: Any]
+            #expect((blankFilterContent?["meetings"] as? [[String: Any]])?.count == 3)
+
+            for invalidTypedArguments in [#"{"limit":""}"#, #"{"include_descendants":" "}"#] {
+                let invalidTypedValue = try Self.json(server.handleLine(#"""
+                {"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"query_meetings","arguments":\#(invalidTypedArguments)}}
+                """#))
+                #expect((invalidTypedValue["error"] as? [String: Any])?["code"] as? Int == -32602)
+            }
         }
 
         private static func json(_ line: String?) throws -> [String: Any] {

--- a/docs/project-workspaces.md
+++ b/docs/project-workspaces.md
@@ -117,6 +117,10 @@ Read tools:
 - `get_meeting_transcript`
 - `get_meeting_screenshots`
 
+All `query_meetings` parameters are optional filters. Clients should omit unused properties instead of sending empty
+strings. For compatibility with clients that populate every property, the server treats empty or whitespace-only
+optional string filters as unspecified; nonblank malformed UUIDs, dates, and cursors remain errors.
+
 `get_meeting_screenshots` uses `image_size: "preview"` by default. Set `image_size` to `"original"` only when an
 external agent needs the original resolution, such as when preparing a document that must preserve screenshot detail.
 Original-size requests return one screenshot per call; use individual IDs or range pagination to retrieve more.


### PR DESCRIPTION
## Summary

- tell MCP clients to omit unused `query_meetings` properties
- treat empty or whitespace-only optional string filters as unspecified
- preserve type validation for boolean and integer parameters
- document the compatibility behavior

## Why

Some MCP clients populate every optional property with an empty string. Dahlia previously rejected those calls at UUID or date validation, preventing otherwise valid meeting queries.

## Impact

Read-only meeting queries now interoperate with those clients while nonblank malformed values and wrong types still return `-32602`.

## Validation

- `swift test --filter MCPDiscoveryContractTests` (1 test in 1 suite passed)
- `CI=true ./scripts/lint.sh` (SwiftFormat clean; SwiftLint completed with existing repository violations)
- deep review completed; the identified typed-parameter normalization issue was fixed