### PR TITLE
Refresh main navigation layout

### DIFF
--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -95,7 +95,7 @@
 "Good morning" = "おはようございます";
 "Good afternoon" = "こんにちは";
 "Good evening" = "こんばんは";
-"Meetings" = "Meetings";
+"Meetings" = "ミーティング";
 "Projects" = "Projects";
 "Project Management" = "プロジェクト管理";
 "Instructions" = "Instructions";

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -20,7 +20,12 @@ struct ContentView: View {
             MeetingListSidebarView(
                 viewModel: viewModel,
                 sidebarViewModel: sidebarViewModel,
-                recordingCoordinator: recordingCoordinator
+                recordingCoordinator: recordingCoordinator,
+                isShowingUpcomingSchedule: isShowingUpcomingSchedule,
+                onShowUpcomingSchedule: returnToCalendarSchedule,
+                onOpenProjectManagement: { openWindow(id: WindowID.projectManager) },
+                showsCustomerIntelligence: isCustomerIntelligenceBetaEnabled,
+                onOpenCustomerIntelligence: { openWindow(id: WindowID.organizationWorkspace) }
             )
             .navigationSplitViewColumnWidth(min: 240, ideal: 300, max: 420)
         } detail: {
@@ -29,42 +34,18 @@ struct ContentView: View {
         }
         .toolbar(removing: .title)
         .toolbar {
-            ToolbarItemGroup(placement: .navigation) {
+            ToolbarItem(placement: .navigation) {
                 Button(L10n.newMeeting, systemImage: "square.and.pencil") {
                     recordingCoordinator.createEmptyMeeting()
                 }
                 .labelStyle(.iconOnly)
                 .keyboardShortcut("n", modifiers: .command)
                 .help(L10n.newMeeting)
+            }
 
-                Button(L10n.showUpcomingSchedule, systemImage: "calendar", action: returnToCalendarSchedule)
-                    .labelStyle(.iconOnly)
-                    .help(L10n.showUpcomingSchedule)
+            ToolbarSpacer(.fixed, placement: .navigation)
 
-                Button {
-                    openWindow(id: WindowID.projectManager)
-                } label: {
-                    Label(L10n.manageProjects, systemImage: "folder")
-                }
-                .labelStyle(.iconOnly)
-                .help(L10n.manageProjects)
-
-                if isCustomerIntelligenceBetaEnabled {
-                    Button {
-                        openWindow(id: WindowID.organizationWorkspace)
-                    } label: {
-                        Label(L10n.customerIntelligence, systemImage: "building.2")
-                    }
-                    .labelStyle(.iconOnly)
-                    .help(L10n.openOrganizationWorkspace)
-                }
-
-                SettingsLink {
-                    Label(L10n.settingsMenuItem, systemImage: "gearshape")
-                }
-                .labelStyle(.iconOnly)
-                .help(L10n.settingsMenuItem)
-
+            ToolbarItem(placement: .navigation) {
                 Button {
                     if chatCoordinator.isFloatingVisible {
                         chatCoordinator.hideFloating()
@@ -195,6 +176,12 @@ struct ContentView: View {
             draftMeeting: draftMeeting,
             dbQueue: sidebarViewModel.dbQueue
         )
+    }
+
+    private var isShowingUpcomingSchedule: Bool {
+        sidebarViewModel.selectedMeetingIds.isEmpty
+            && !viewModel.hasDraftMeeting
+            && viewModel.currentMeetingId == nil
     }
 
     @ViewBuilder

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -344,24 +344,7 @@ struct ControlPanelView: View {
 
     @ToolbarContentBuilder
     private var detailToolbar: some ToolbarContent {
-        ToolbarSpacer(.flexible, placement: .primaryAction)
-
-        ToolbarItem(placement: .primaryAction) {
-            ShareSummaryToolbarButton(viewModel: viewModel)
-        }
-
-        ToolbarSpacer(.fixed, placement: .primaryAction)
-
-        ToolbarItem(placement: .primaryAction) {
-            GenerateSummaryToolbarButton(
-                viewModel: viewModel,
-                sidebarViewModel: sidebarViewModel
-            )
-        }
-
         if showsToolbarRecordButton {
-            ToolbarSpacer(.fixed, placement: .primaryAction)
-
             ToolbarItem(placement: .primaryAction) {
                 RecordToolbarButton(
                     viewModel: viewModel,
@@ -390,14 +373,27 @@ struct ControlPanelView: View {
     }
 
     private var summaryTabContent: some View {
-        SummaryTabContentView(
-            screenshotStore: viewModel.screenshotStore,
-            document: viewModel.currentSummaryDocument,
-            hasSummary: viewModel.hasCurrentMeetingSummary,
-            allowsTranscriptReferencePopovers: allowsTranscriptReferencePopovers,
-            openScreenshot: openSummaryScreenshot,
-            transcriptText: summaryTranscriptText
-        )
+        ZStack(alignment: .topTrailing) {
+            SummaryTabContentView(
+                screenshotStore: viewModel.screenshotStore,
+                document: viewModel.currentSummaryDocument,
+                hasSummary: viewModel.hasCurrentMeetingSummary,
+                allowsTranscriptReferencePopovers: allowsTranscriptReferencePopovers,
+                openScreenshot: openSummaryScreenshot,
+                transcriptText: summaryTranscriptText
+            )
+            .padding(.trailing, 56)
+
+            VStack(spacing: 8) {
+                ShareSummaryFloatingButton(viewModel: viewModel)
+                GenerateSummaryFloatingButton(
+                    viewModel: viewModel,
+                    sidebarViewModel: sidebarViewModel
+                )
+            }
+            .padding(.top, 12)
+            .padding(.trailing, 16)
+        }
     }
 
     private var notesTabContent: some View {

--- a/Sources/Dahlia/Views/MeetingListSidebarView.swift
+++ b/Sources/Dahlia/Views/MeetingListSidebarView.swift
@@ -6,6 +6,11 @@ struct MeetingListSidebarView: View {
     @ObservedObject var viewModel: CaptionViewModel
     var sidebarViewModel: SidebarViewModel
     let recordingCoordinator: RecordingCoordinator
+    let isShowingUpcomingSchedule: Bool
+    let onShowUpcomingSchedule: () -> Void
+    let onOpenProjectManagement: () -> Void
+    let showsCustomerIntelligence: Bool
+    let onOpenCustomerIntelligence: () -> Void
 
     @State private var searchText = ""
     @State private var searchTokens: [MeetingSearchToken] = []
@@ -27,6 +32,9 @@ struct MeetingListSidebarView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            sidebarNavigation
+            MeetingListSectionHeader()
+
             List(selection: meetingSelection) {
                 if let selectedMeeting = sidebarViewModel.selectedMeetingOutsideDisplayedItems {
                     Section(sidebarViewModel.isSearchingMeetings ? L10n.selectedMeetingOutsideResults : L10n.selectedMeeting) {
@@ -97,6 +105,55 @@ struct MeetingListSidebarView: View {
         .meetingDeletionConfirmation(request: $pendingDeletion) { meetingIds in
             sidebarViewModel.deleteMeetings(ids: meetingIds)
         }
+    }
+
+    private var sidebarNavigation: some View {
+        VStack(spacing: 2) {
+            Button(action: onShowUpcomingSchedule) {
+                sidebarActionLabel(
+                    L10n.calendarScheduleTitle,
+                    systemImage: "calendar",
+                    isSelected: isShowingUpcomingSchedule
+                )
+            }
+            .buttonStyle(.plain)
+            .help(L10n.showUpcomingSchedule)
+            .accessibilityAddTraits(isShowingUpcomingSchedule ? .isSelected : [])
+
+            Button(action: onOpenProjectManagement) {
+                sidebarActionLabel(L10n.projectManagement, systemImage: "folder")
+            }
+            .buttonStyle(.plain)
+            .help(L10n.manageProjects)
+
+            if showsCustomerIntelligence {
+                Button(action: onOpenCustomerIntelligence) {
+                    sidebarActionLabel(L10n.customerIntelligence, systemImage: "building.2")
+                }
+                .buttonStyle(.plain)
+                .help(L10n.openOrganizationWorkspace)
+            }
+
+            SettingsLink {
+                sidebarActionLabel(L10n.settings, systemImage: "gearshape")
+            }
+            .buttonStyle(.plain)
+            .help(L10n.settingsMenuItem)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+    }
+
+    private func sidebarActionLabel(
+        _ title: String,
+        systemImage: String,
+        isSelected: Bool = false
+    ) -> some View {
+        Label(title, systemImage: systemImage)
+            .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
+            .padding(.horizontal, 8)
+            .contentShape(Rectangle())
+            .modifier(SidebarNavigationRowModifier(isSelected: isSelected))
     }
 
     private var meetingListLimitMessage: String? {

--- a/Sources/Dahlia/Views/MeetingSearchComponents.swift
+++ b/Sources/Dahlia/Views/MeetingSearchComponents.swift
@@ -64,7 +64,7 @@ struct MeetingSearchTokenLabel: View {
     }
 }
 
-struct MeetingSearchDateRangePopover: View {
+struct MeetingSearchDateRangeView: View {
     @Binding var startDate: Date
     @Binding var endDate: Date
     let onCancel: () -> Void

--- a/Sources/Dahlia/Views/MeetingSidebarNavigationComponents.swift
+++ b/Sources/Dahlia/Views/MeetingSidebarNavigationComponents.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct MeetingListSectionHeader: View {
+    var body: some View {
+        Text(L10n.meetings)
+            .font(.caption.weight(.medium))
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 16)
+            .padding(.top, 6)
+            .padding(.bottom, 2)
+            .accessibilityAddTraits(.isHeader)
+    }
+}
+
+struct SidebarNavigationRowModifier: ViewModifier {
+    var isSelected = false
+    @State private var isHovered = false
+
+    func body(content: Content) -> some View {
+        content
+            .background {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(backgroundColor)
+            }
+            .animation(.easeOut(duration: 0.12), value: isHovered)
+            .onHover { isHovered = $0 }
+    }
+
+    private var backgroundColor: Color {
+        if isSelected {
+            return Color.accentColor.opacity(isHovered ? 0.22 : 0.16)
+        }
+        return Color.primary.opacity(isHovered ? 0.08 : 0)
+    }
+}

--- a/Sources/Dahlia/Views/MeetingSidebarSearchModifier.swift
+++ b/Sources/Dahlia/Views/MeetingSidebarSearchModifier.swift
@@ -8,7 +8,7 @@ struct MeetingSidebarSearchModifier: ViewModifier {
 
     @State private var customDateStart = Calendar.current.startOfDay(for: .now)
     @State private var customDateEnd = Calendar.current.startOfDay(for: .now)
-    @State private var showsCustomDatePopover = false
+    @State private var isCustomDateRangePresented = false
     @State private var isSearchInputTruncated = false
     @State private var committedTrailingQualifierText: String?
     @State private var suggestionModeOverrideText: String?
@@ -26,7 +26,7 @@ struct MeetingSidebarSearchModifier: ViewModifier {
             .searchable(
                 text: boundedSearchText,
                 tokens: $searchTokens,
-                placement: .sidebar,
+                placement: .toolbar,
                 prompt: L10n.searchMeetings
             ) { token in
                 MeetingSearchTokenLabel(
@@ -39,17 +39,13 @@ struct MeetingSidebarSearchModifier: ViewModifier {
             .searchSuggestions {
                 searchSuggestions
             }
-            .overlay(alignment: .top) {
-                Color.clear
-                    .frame(width: 1, height: 1)
-                    .popover(isPresented: $showsCustomDatePopover, arrowEdge: .top) {
-                        MeetingSearchDateRangePopover(
-                            startDate: $customDateStart,
-                            endDate: $customDateEnd,
-                            onCancel: dismissCustomDateRange,
-                            onApply: applyCustomDateRange
-                        )
-                    }
+            .sheet(isPresented: $isCustomDateRangePresented) {
+                MeetingSearchDateRangeView(
+                    startDate: $customDateStart,
+                    endDate: $customDateEnd,
+                    onCancel: dismissCustomDateRange,
+                    onApply: applyCustomDateRange
+                )
             }
             .onSubmit(of: .search) {
                 submitSearch()
@@ -58,7 +54,7 @@ struct MeetingSidebarSearchModifier: ViewModifier {
             .onChange(of: searchTokens) { _, newTokens in
                 if newTokens.isEmpty, searchText.isEmpty {
                     isSearchInputTruncated = false
-                    showsCustomDatePopover = false
+                    isCustomDateRangePresented = false
                 }
                 updateSearch()
             }
@@ -240,12 +236,12 @@ private extension MeetingSidebarSearchModifier {
             prepareCustomDateRange()
             removeTrailingQualifier()
             activeSuggestionMode = .overview
-            showsCustomDatePopover = true
+            isCustomDateRangePresented = true
         }
     }
 
     private func dismissCustomDateRange() {
-        showsCustomDatePopover = false
+        isCustomDateRangePresented = false
     }
 
     private func applyCustomDateRange() {
@@ -261,7 +257,7 @@ private extension MeetingSidebarSearchModifier {
         removeTrailingQualifier()
         activeSuggestionMode = .overview
         isSearchFocused = true
-        showsCustomDatePopover = false
+        isCustomDateRangePresented = false
     }
 
     private func replaceDateToken(_ token: MeetingSearchToken) {
@@ -335,7 +331,7 @@ private extension MeetingSidebarSearchModifier {
     private func clearSearch() {
         searchText = ""
         searchTokens.removeAll()
-        showsCustomDatePopover = false
+        isCustomDateRangePresented = false
         isSearchInputTruncated = false
         committedTrailingQualifierText = nil
         suggestionModeOverrideText = nil

--- a/Sources/Dahlia/Views/Toolbar/SessionControls.swift
+++ b/Sources/Dahlia/Views/Toolbar/SessionControls.swift
@@ -48,13 +48,17 @@ struct RecordToolbarButton: View {
     }
 }
 
-struct GenerateSummaryToolbarButton: View {
+struct GenerateSummaryFloatingButton: View {
     @ObservedObject var viewModel: CaptionViewModel
     var sidebarViewModel: SidebarViewModel
     @State private var isConfirmationPresented = false
 
     private var isGeneratingCurrentMeeting: Bool {
         viewModel.isSummaryGenerating
+    }
+
+    private var isGenerateSummaryEnabled: Bool {
+        !isGeneratingCurrentMeeting && viewModel.canGenerateSummary
     }
 
     var body: some View {
@@ -65,14 +69,15 @@ struct GenerateSummaryToolbarButton: View {
                 if isGeneratingCurrentMeeting {
                     ProgressView()
                         .controlSize(.small)
+                        .tint(.purple)
                 } else {
                     Image(systemName: "sparkles")
+                        .foregroundStyle(viewModel.canGenerateSummary ? Color.purple : .secondary)
                 }
             }
         }
-        .labelStyle(.titleAndIcon)
-        .buttonStyle(.bordered)
-        .disabled(isGeneratingCurrentMeeting || !viewModel.canGenerateSummary)
+        .modifier(FloatingSummaryButtonModifier(isEnabled: isGenerateSummaryEnabled))
+        .disabled(!isGenerateSummaryEnabled)
         .help(isGeneratingCurrentMeeting ? L10n.generatingSummary : L10n.generateSummary)
         .sheet(isPresented: $isConfirmationPresented) {
             SummaryGenerationConfirmationView(
@@ -96,7 +101,7 @@ struct GenerateSummaryToolbarButton: View {
     }
 }
 
-struct ShareSummaryToolbarButton: View {
+struct ShareSummaryFloatingButton: View {
     @ObservedObject var viewModel: CaptionViewModel
     @State private var isPopoverPresented = false
 
@@ -111,8 +116,7 @@ struct ShareSummaryToolbarButton: View {
                     .foregroundStyle(viewModel.canShareCurrentSummary ? Color.accentColor : .secondary)
             }
         }
-        .labelStyle(.titleAndIcon)
-        .buttonStyle(.bordered)
+        .modifier(FloatingSummaryButtonModifier(isEnabled: viewModel.canShareCurrentSummary))
         .disabled(!viewModel.canShareCurrentSummary)
         .help(L10n.shareSummary)
         .popover(isPresented: $isPopoverPresented, arrowEdge: .bottom) {
@@ -120,6 +124,29 @@ struct ShareSummaryToolbarButton: View {
                 isPopoverPresented = false
             }
         }
+    }
+}
+
+private struct FloatingSummaryButtonModifier: ViewModifier {
+    let isEnabled: Bool
+    @State private var isHovered = false
+
+    func body(content: Content) -> some View {
+        let respondsToHover = isHovered && isEnabled
+
+        content
+            .labelStyle(.iconOnly)
+            .buttonStyle(.bordered)
+            .buttonBorderShape(.circle)
+            .controlSize(.large)
+            .scaleEffect(respondsToHover ? 1.08 : 1)
+            .shadow(
+                color: .black.opacity(respondsToHover ? 0.18 : 0.06),
+                radius: respondsToHover ? 5 : 2,
+                y: respondsToHover ? 2 : 1
+            )
+            .animation(.easeOut(duration: 0.12), value: respondsToHover)
+            .onHover { isHovered = $0 }
     }
 }
 


### PR DESCRIPTION
## Summary

- move upcoming schedule, project management, customer intelligence, and settings into the top of the meeting sidebar
- move meeting search into the window toolbar and keep custom date selection stable with a sheet
- present share and summary generation as larger floating controls inside the summary view
- visually separate new-meeting, AI chat, recording, and search actions
- add hover feedback and a localized meeting section heading

## Why

The previous toolbar mixed navigation, utility, recording, sharing, and summary actions in one area. This change groups controls by scope, keeps meeting-specific actions near their content, and makes the meeting list easier to scan.

## Validation

- `swift build`
- `swift test --filter MeetingSidebarSearchSupportTests` — 8 tests passed
- `swift test --filter RecordingCommandStateTests` — 5 tests passed
- `swift test --filter SummaryGenerationOptionsTests` — 2 tests passed
- `CI=true ./scripts/lint.sh` — SwiftFormat clean; existing non-blocking SwiftLint violations remain

## Known unrelated failure

The full `swift test` run still fails in the pre-existing `CodexChatLiveModeSessionTests.staleSendCannotMarkANewSessionAsContextualized` test after an async timeout and index-out-of-range crash.