### PR TITLE
Fix live mode session test ordering

### DIFF
--- a/Tests/DahliaTests/CodexChatLiveModeSessionTests.swift
+++ b/Tests/DahliaTests/CodexChatLiveModeSessionTests.swift
@@ -98,8 +98,14 @@ import Foundation
             session.disableLiveMode()
             session.toggleLiveMode()
             session.receiveFinalizedLiveTranscript("New session")
-            await waitUntilAsync { await service.sentTextBlocks.count == 2 }
+            await Task.yield()
+            await Task.yield()
+
+            #expect(await service.sentTextBlocks.count == 1)
+
             await service.resumeDelayedSend()
+            await waitUntilAsync { await service.interruptCount == 1 }
+            await waitUntilAsync { await service.sentTextBlocks.count == 2 }
             await waitUntil { !session.isGenerating }
 
             let sentTextBlocks = await service.sentTextBlocks


### PR DESCRIPTION
## Summary

- update the stale live-mode send regression test to respect serialized turn cleanup
- verify the replacement transcript remains queued until the cancelled send is drained
- preserve coverage that each live-mode session sends its own context

## Root cause

PR #246 made stopped chat turns drain their active task before queued input can start. The existing test waited for the replacement send before releasing the cancellation-ignoring first send, so it could only time out under the new lifecycle contract.

## Impact

Restores the unit-test CI job without changing production code, public APIs, or the CI workflow.

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter CodexChatLiveModeSessionTests` — 3 tests passed
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` — 1420 tests in 213 suites passed
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build`
- `CI=true ./scripts/lint.sh` — SwiftFormat clean; existing non-blocking SwiftLint violations remain