### PR TITLE
Fix detail tab hit area and bump version

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>45</string>
+    <string>46</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.8.7</string>
+    <string>0.8.8</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/Sources/Dahlia/Views/DetailTabBar.swift
+++ b/Sources/Dahlia/Views/DetailTabBar.swift
@@ -47,18 +47,18 @@ struct DetailTabBar: View {
                             Text(tab.label)
                                 .font(.body.weight(isSelected ? .semibold : .regular))
                         }
+                        .padding(.horizontal, DahliaDesign.tabHorizontalPadding)
+                        .padding(.vertical, DahliaDesign.tabVerticalPadding)
+                        .contentShape(.rect)
                     }
                     .buttonStyle(.plain)
                     .foregroundStyle(isSelected ? .primary : .secondary)
-                    .padding(.horizontal, DahliaDesign.tabHorizontalPadding)
-                    .padding(.vertical, DahliaDesign.tabVerticalPadding)
                     .background {
                         if !isFolderOnly, hoveredTab == tab {
                             RoundedRectangle(cornerRadius: 6)
                                 .fill(Color.primary.opacity(0.05))
                         }
                     }
-                    .contentShape(.rect)
                     .overlay(alignment: .bottom) {
                         if isSelected {
                             Capsule()


### PR DESCRIPTION
## Summary

- make each meeting detail tab’s full padded area clickable
- keep the hover background, selection indicator, and visual spacing unchanged
- bump the app version to 0.8.8 (build 46)

## Root cause

The tab padding and content shape were applied outside the `Button` label, so the visible padded area was not part of the button’s effective hit target.

## User impact

Users can now switch tabs by clicking anywhere in the visible tab area instead of needing to click directly on the text.

## Validation

- `swift build`
- `CI=true ./scripts/lint.sh` (SwiftFormat clean; SwiftLint reports existing repository-wide violations outside this change)
- `plutil -lint Resources/Info.plist`
- `git diff --check`