### PR TITLE
Protect transcription recovery across app lifecycle

### DIFF
--- a/Sources/Dahlia/DahliaApp.swift
+++ b/Sources/Dahlia/DahliaApp.swift
@@ -205,6 +205,9 @@ struct DahliaApp: App {
         appDatabase = db
         sidebarViewModel.setAppDatabase(db)
         viewModel.configureBatchTranscription(dbQueue: db.dbQueue)
+        appDelegate.terminationHandler = { [weak viewModel] in
+            await viewModel?.prepareForTermination()
+        }
 
         let repo = MeetingRepository(dbQueue: db.dbQueue)
         if let lastVault = try? repo.fetchLastOpenedVault() {
@@ -395,6 +398,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var isWaitingForCodexShutdown = false
     private var processLock: AdvisoryFileLock?
+    @MainActor var terminationHandler: (@MainActor () async -> String?)?
 
     func applicationWillFinishLaunching(_: Notification) {
         do {
@@ -435,6 +439,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard !isWaitingForCodexShutdown else { return .terminateLater }
         isWaitingForCodexShutdown = true
         Task {
+            if let failureMessage = await terminationHandler?() {
+                isWaitingForCodexShutdown = false
+                sender.reply(toApplicationShouldTerminate: false)
+                let alert = NSAlert()
+                alert.alertStyle = .warning
+                alert.messageText = L10n.terminationPersistenceFailedTitle
+                alert.informativeText = failureMessage
+                alert.runModal()
+                return
+            }
             await CodexAppServerService.shared.shutdown()
             sender.reply(toApplicationShouldTerminate: true)
         }

--- a/Sources/Dahlia/DahliaApp.swift
+++ b/Sources/Dahlia/DahliaApp.swift
@@ -204,7 +204,9 @@ struct DahliaApp: App {
         guard let db = try? AppDatabaseManager() else { return }
         appDatabase = db
         sidebarViewModel.setAppDatabase(db)
-        viewModel.configureBatchTranscription(dbQueue: db.dbQueue)
+        viewModel.configureBatchTranscription(dbQueue: db.dbQueue) { [weak sidebarViewModel] in
+            await sidebarViewModel?.refreshUnprocessedRecordings()
+        }
         appDelegate.terminationHandler = { [weak viewModel] in
             await viewModel?.prepareForTermination()
         }

--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -238,10 +238,12 @@ final class MeetingRepository {
     @discardableResult
     func discardUnprocessedBatchSessionSafely(
         id: UUID,
+        expectedVaultId: UUID,
         managedRootURL: URL = BatchAudioStorage.managedRootURL
     ) async throws -> Bool {
         try await BatchTranscriptionDiscardService.discardUnprocessedSessionSafely(
             id: id,
+            expectedVaultId: expectedVaultId,
             dbQueue: dbQueue,
             managedRootURL: managedRootURL
         )

--- a/Sources/Dahlia/Models/BackupGeneration.swift
+++ b/Sources/Dahlia/Models/BackupGeneration.swift
@@ -36,6 +36,7 @@ struct BackupPreflightItem: Identifiable, Equatable, Sendable {
         case recording
         case awaitingConfirmation
         case processing
+        case interrupted
         case failed
     }
 
@@ -47,4 +48,38 @@ struct BackupPreflightItem: Identifiable, Equatable, Sendable {
     let startedAt: Date
     let state: State
     let failureMessage: String?
+    let canTranscribe: Bool
+
+    var canStartTranscription: Bool {
+        guard canTranscribe else { return false }
+        return switch state {
+        case .awaitingConfirmation, .interrupted, .failed:
+            true
+        case .recording, .processing:
+            false
+        }
+    }
+
+    var isWorkInProgress: Bool {
+        state == .recording || state == .processing
+    }
+
+    var canDiscard: Bool {
+        !isWorkInProgress
+    }
+
+    var hasUnavailableAudio: Bool {
+        !canTranscribe && canDiscard
+    }
+
+    var statusDescription: String {
+        if hasUnavailableAudio { return L10n.batchRecordingAudioUnavailable }
+        return switch state {
+        case .recording: L10n.recordingInProgress
+        case .awaitingConfirmation: L10n.awaitingTranscription
+        case .processing: L10n.transcriptionInProgress
+        case .interrupted: L10n.batchTranscriptionInterrupted
+        case .failed: failureMessage ?? L10n.transcriptionFailed
+        }
+    }
 }

--- a/Sources/Dahlia/Models/BackupGeneration.swift
+++ b/Sources/Dahlia/Models/BackupGeneration.swift
@@ -44,6 +44,7 @@ struct BackupPreflightItem: Identifiable, Equatable, Sendable {
 
     let sessionId: UUID
     let meetingId: UUID
+    let vaultId: UUID
     let meetingName: String
     let startedAt: Date
     let state: State

--- a/Sources/Dahlia/Models/BatchFailureKind.swift
+++ b/Sources/Dahlia/Models/BatchFailureKind.swift
@@ -1,9 +1,10 @@
 import GRDB
 
-enum BatchFailureKind: String, Codable, DatabaseValueConvertible {
+enum BatchFailureKind: String, Codable, DatabaseValueConvertible, Sendable {
     case recordingStorage
     case recordingRecovery
     case recordingAudioPermanent
     case transcription
     case transcriptionStalled
+    case transcriptionInterrupted
 }

--- a/Sources/Dahlia/Models/BatchTranscriptionRecoveryAlert.swift
+++ b/Sources/Dahlia/Models/BatchTranscriptionRecoveryAlert.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct BatchTranscriptionRecoveryAlert: Identifiable {
+    let id = UUID()
+    let message: String
+}

--- a/Sources/Dahlia/Models/BatchTranscriptionState.swift
+++ b/Sources/Dahlia/Models/BatchTranscriptionState.swift
@@ -6,6 +6,7 @@ enum BatchTranscriptionState: Equatable {
     case awaitingConfirmation(sessionId: UUID)
     case queued(sessionId: UUID)
     case running(sessionId: UUID, progress: BatchTranscriptionProgress? = nil)
+    case interrupted(sessionId: UUID, isRetranscription: Bool)
     case completed(sessionId: UUID)
     case failed(sessionId: UUID, message: String)
     case retranscriptionFailed(sessionId: UUID, message: String)
@@ -16,6 +17,7 @@ enum BatchTranscriptionState: Equatable {
              let .awaitingConfirmation(sessionId),
              let .queued(sessionId),
              let .running(sessionId, _),
+             let .interrupted(sessionId, _),
              let .completed(sessionId),
              let .failed(sessionId, _),
              let .retranscriptionFailed(sessionId, _):
@@ -25,7 +27,7 @@ enum BatchTranscriptionState: Equatable {
 
     var blocksSummaryGeneration: Bool {
         switch self {
-        case .recording, .awaitingConfirmation, .queued, .running, .failed, .retranscriptionFailed:
+        case .recording, .awaitingConfirmation, .queued, .running, .interrupted, .failed, .retranscriptionFailed:
             true
         case .completed:
             false
@@ -55,6 +57,9 @@ enum BatchTranscriptionState: Equatable {
         }
         if session.batchCompletedAt != nil, !isRetranscription {
             return .completed(sessionId: session.id)
+        }
+        if session.batchFailureKind == .transcriptionInterrupted {
+            return .interrupted(sessionId: session.id, isRetranscription: isRetranscription)
         }
         if let error = session.batchLastError?.nilIfBlank {
             return isRetranscription

--- a/Sources/Dahlia/Models/BatchTranscriptionState.swift
+++ b/Sources/Dahlia/Models/BatchTranscriptionState.swift
@@ -34,6 +34,15 @@ enum BatchTranscriptionState: Equatable {
         }
     }
 
+    var changesUnprocessedRecordingsProjection: Bool {
+        switch self {
+        case let .running(_, progress):
+            progress == nil
+        case .recording, .awaitingConfirmation, .queued, .interrupted, .completed, .failed, .retranscriptionFailed:
+            true
+        }
+    }
+
     func preferringMoreAdvancedRunningProgress(over restoredState: Self) -> Self {
         guard sessionId == restoredState.sessionId,
               case let .running(_, currentProgress?) = self,

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -720,6 +720,7 @@
 "Waiting to transcribe the recording…" = "Waiting to transcribe the recording…";
 "Creating a high-accuracy transcript…" = "Creating a high-accuracy transcript…";
 "Transcription was interrupted. The recording is safe and ready to resume." = "Transcription was interrupted. The recording is safe and ready to resume.";
+"Could not recover interrupted transcriptions" = "Could not recover interrupted transcriptions";
 "Resume Transcription" = "Resume Transcription";
 "Files completed: %lld of %lld" = "Files completed: %1$lld of %2$lld";
 "High-accuracy transcription completed." = "High-accuracy transcription completed.";

--- a/Sources/Dahlia/Resources/en.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/en.lproj/Localizable.strings
@@ -33,6 +33,7 @@
 "Restore this backup?" = "Restore this backup?";
 "The current database will be backed up first, then replaced. Dahlia will restart. Audio files and app settings are not restored." = "The current database will be backed up first, then replaced. Dahlia will restart. Audio files and app settings are not restored.";
 "Unprocessed Recordings" = "Unprocessed Recordings";
+"Recordings that need manual transcription will appear here." = "Recordings that need manual transcription will appear here.";
 "Transcribe or discard every unprocessed recording before creating or restoring a backup." = "Transcribe or discard every unprocessed recording before creating or restoring a backup.";
 "Waiting for transcription" = "Waiting for transcription";
 "Transcription in progress" = "Transcription in progress";
@@ -718,6 +719,8 @@
 "Review and Start" = "Review and Start";
 "Waiting to transcribe the recording…" = "Waiting to transcribe the recording…";
 "Creating a high-accuracy transcript…" = "Creating a high-accuracy transcript…";
+"Transcription was interrupted. The recording is safe and ready to resume." = "Transcription was interrupted. The recording is safe and ready to resume.";
+"Resume Transcription" = "Resume Transcription";
 "Files completed: %lld of %lld" = "Files completed: %1$lld of %2$lld";
 "High-accuracy transcription completed." = "High-accuracy transcription completed.";
 "Batch transcription failed: %@" = "Batch transcription failed: %@";
@@ -764,7 +767,10 @@
 "The audio writer could not keep up with the recording." = "The audio writer could not keep up with the recording.";
 "The audio writer was closed before the buffer was saved." = "The audio writer was closed before the buffer was saved.";
 "Could not save the recording: %@" = "Could not save the recording: %@";
+"Dahlia could not quit" = "Dahlia could not quit";
+"The recording could not be saved. Dahlia will remain open so you can try again." = "The recording could not be saved. Dahlia will remain open so you can try again.";
 "No compatible audio format is available." = "No compatible audio format is available.";
+"Recording audio is incomplete and cannot be transcribed." = "Recording audio is incomplete and cannot be transcribed.";
 "The recorded audio range is invalid or damaged." = "The recorded audio range is invalid or damaged.";
 "Speech analysis could not read the recorded audio." = "Speech analysis could not read the recorded audio.";
 

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -720,6 +720,7 @@
 "Waiting to transcribe the recording…" = "録音の文字起こしを待機しています…";
 "Creating a high-accuracy transcript…" = "高精度な文字起こしを作成しています…";
 "Transcription was interrupted. The recording is safe and ready to resume." = "文字起こしは中断されました。録音は保持されており、再開できます。";
+"Could not recover interrupted transcriptions" = "中断された文字起こしを復旧できませんでした";
 "Resume Transcription" = "文字起こしを再開";
 "Files completed: %lld of %lld" = "完了ファイル: %1$lld / %2$lld";
 "High-accuracy transcription completed." = "高精度な文字起こしが完了しました。";

--- a/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Dahlia/Resources/ja.lproj/Localizable.strings
@@ -33,6 +33,7 @@
 "Restore this backup?" = "このバックアップを復元しますか？";
 "The current database will be backed up first, then replaced. Dahlia will restart. Audio files and app settings are not restored." = "現在のデータベースを先に退避してから置き換え、Dahliaを再起動します。音声ファイルとアプリ設定は復元されません。";
 "Unprocessed Recordings" = "未処理の録音";
+"Recordings that need manual transcription will appear here." = "手動で文字起こしする必要がある録音がここに表示されます。";
 "Transcribe or discard every unprocessed recording before creating or restoring a backup." = "バックアップの作成または復元前に、すべての未処理録音を文字起こしするか破棄してください。";
 "Waiting for transcription" = "文字起こし待ち";
 "Transcription in progress" = "文字起こし中";
@@ -718,6 +719,8 @@
 "Review and Start" = "確認して開始";
 "Waiting to transcribe the recording…" = "録音の文字起こしを待機しています…";
 "Creating a high-accuracy transcript…" = "高精度な文字起こしを作成しています…";
+"Transcription was interrupted. The recording is safe and ready to resume." = "文字起こしは中断されました。録音は保持されており、再開できます。";
+"Resume Transcription" = "文字起こしを再開";
 "Files completed: %lld of %lld" = "完了ファイル: %1$lld / %2$lld";
 "High-accuracy transcription completed." = "高精度な文字起こしが完了しました。";
 "Batch transcription failed: %@" = "バッチ文字起こしに失敗しました: %@";
@@ -764,7 +767,10 @@
 "The audio writer could not keep up with the recording." = "音声ファイルへの書き込みが録音に追いつきませんでした。";
 "The audio writer was closed before the buffer was saved." = "音声バッファを保存する前に録音処理が終了しました。";
 "Could not save the recording: %@" = "録音を保存できませんでした: %@";
+"Dahlia could not quit" = "Dahliaを終了できませんでした";
+"The recording could not be saved. Dahlia will remain open so you can try again." = "録音を保存できませんでした。再試行できるよう、Dahliaを開いたままにします。";
 "No compatible audio format is available." = "互換性のある音声形式を利用できません。";
+"Recording audio is incomplete and cannot be transcribed." = "録音音声が不完全なため、文字起こしできません。";
 "The recorded audio range is invalid or damaged." = "録音音声の範囲が不正または破損しています。";
 "Speech analysis could not read the recorded audio." = "音声解析で録音データを読み取れませんでした。";
 

--- a/Sources/Dahlia/Services/BackupService.swift
+++ b/Sources/Dahlia/Services/BackupService.swift
@@ -102,40 +102,65 @@ actor BackupService {
         }
     }
 
-    func preflightItems() throws -> [BackupPreflightItem] {
+    func preflightItems(vaultId: UUID? = nil) throws -> [BackupPreflightItem] {
         try dbQueue.read { db in
+            var sql = """
+            SELECT recording_sessions.id AS sessionId,
+                   recording_sessions.meetingId,
+                   meetings.name AS meetingName,
+                   recording_sessions.startedAt,
+                   recording_sessions.endedAt,
+                   recording_sessions.batchLastAttemptAt,
+                   recording_sessions.batchLastError,
+                   recording_sessions.batchFailureKind,
+                   NOT EXISTS (
+                       SELECT 1 FROM recording_audio_segments AS candidate
+                       WHERE candidate.recordingSessionId = recording_sessions.id
+                         AND (
+                             candidate.state != ?
+                             OR candidate.purgedAt IS NOT NULL
+                             OR NOT EXISTS (
+                                 SELECT 1 FROM recording_audio_segment_ranges AS candidateRanges
+                                 WHERE candidateRanges.audioSegmentId = candidate.id
+                             )
+                         )
+                   ) AS hasCompleteAudio
+            FROM recording_sessions
+            JOIN meetings ON meetings.id = recording_sessions.meetingId
+            WHERE recording_sessions.transcriptionMode = ?
+              AND recording_sessions.batchCompletedAt IS NULL
+              AND recording_sessions.batchDiscardedAt IS NULL
+              AND EXISTS (
+                  SELECT 1 FROM recording_audio_segments
+                  WHERE recording_audio_segments.recordingSessionId = recording_sessions.id
+                    AND recording_audio_segments.state != ?
+              )
+            """
+            var arguments: StatementArguments = [
+                RecordingAudioSegmentState.ready.rawValue,
+                TranscriptionMode.batch.rawValue,
+                RecordingAudioSegmentState.purged.rawValue,
+            ]
+            if let vaultId {
+                sql += " AND meetings.vaultId = ?"
+                arguments += [vaultId]
+            }
+            sql += " ORDER BY recording_sessions.startedAt ASC"
             let rows = try Row.fetchAll(
                 db,
-                sql: """
-                SELECT recording_sessions.id AS sessionId,
-                       recording_sessions.meetingId,
-                       meetings.name AS meetingName,
-                       recording_sessions.startedAt,
-                       recording_sessions.endedAt,
-                       recording_sessions.batchLastAttemptAt,
-                       recording_sessions.batchLastError
-                FROM recording_sessions
-                JOIN meetings ON meetings.id = recording_sessions.meetingId
-                WHERE recording_sessions.transcriptionMode = ?
-                  AND recording_sessions.batchCompletedAt IS NULL
-                  AND recording_sessions.batchDiscardedAt IS NULL
-                  AND (
-                    EXISTS (
-                        SELECT 1 FROM recording_audio_segments
-                        WHERE recording_audio_segments.recordingSessionId = recording_sessions.id
-                          AND recording_audio_segments.state != ?
-                    )
-                  )
-                ORDER BY recording_sessions.startedAt ASC
-                """,
-                arguments: [TranscriptionMode.batch.rawValue, RecordingAudioSegmentState.purged.rawValue]
+                sql: sql,
+                arguments: arguments
             )
             return rows.map { row in
                 let endedAt: Date? = row["endedAt"]
                 let attemptedAt: Date? = row["batchLastAttemptAt"]
                 let failure: String? = row["batchLastError"]
+                let failureKind: BatchFailureKind? = row["batchFailureKind"]
+                let hasCompleteAudio: Bool = row["hasCompleteAudio"]
                 let state: BackupPreflightItem.State = if endedAt == nil {
                     .recording
+                } else if failureKind == .transcriptionInterrupted {
+                    .interrupted
                 } else if failure?.nilIfBlank != nil {
                     .failed
                 } else if attemptedAt == nil {
@@ -149,7 +174,10 @@ actor BackupService {
                     meetingName: (row["meetingName"] as String).nilIfBlank ?? L10n.untitledMeeting,
                     startedAt: row["startedAt"],
                     state: state,
-                    failureMessage: failure
+                    failureMessage: failure,
+                    canTranscribe: hasCompleteAudio
+                        && failureKind != .recordingRecovery
+                        && failureKind != .recordingAudioPermanent
                 )
             }
         }

--- a/Sources/Dahlia/Services/BackupService.swift
+++ b/Sources/Dahlia/Services/BackupService.swift
@@ -107,6 +107,7 @@ actor BackupService {
             var sql = """
             SELECT recording_sessions.id AS sessionId,
                    recording_sessions.meetingId,
+                   meetings.vaultId,
                    meetings.name AS meetingName,
                    recording_sessions.startedAt,
                    recording_sessions.endedAt,
@@ -171,6 +172,7 @@ actor BackupService {
                 return BackupPreflightItem(
                     sessionId: row["sessionId"],
                     meetingId: row["meetingId"],
+                    vaultId: row["vaultId"],
                     meetingName: (row["meetingName"] as String).nilIfBlank ?? L10n.untitledMeeting,
                     startedAt: row["startedAt"],
                     state: state,

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator+Scheduling.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator+Scheduling.swift
@@ -5,17 +5,4 @@ extension BatchTranscriptionCoordinator: BatchTranscriptionScheduling {
         await onStateChange(BatchTranscriptionUpdate(meetingId: meetingId, state: state))
     }
 
-    static func shouldAutomaticallyRetry(_ session: RecordingSessionRecord) -> Bool {
-        guard session.transcriptionMode == .batch,
-              session.batchCompletedAt == nil || session.isBatchRetranscriptionPending,
-              session.batchDiscardedAt == nil else { return false }
-        guard session.batchFailureKind != .recordingRecovery,
-              session.batchFailureKind != .recordingAudioPermanent,
-              session.batchFailureKind != .transcriptionStalled else { return false }
-        guard session.batchLastAttemptAt != nil || session.batchLastError?.nilIfBlank != nil else {
-            return false
-        }
-        guard session.batchLastError?.nilIfBlank != nil else { return true }
-        return session.batchAttemptCount < maximumAutomaticAttemptCount
-    }
 }

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -66,6 +66,8 @@ actor BatchTranscriptionCoordinator {
     private var progressNotificationTask: Task<Void, Never>?
     private var isShuttingDown = false
     private var shutdownInterruptionSessionIds: Set<UUID> = []
+    private var activeConfirmationCount = 0
+    private var confirmationDrainWaiters: [CheckedContinuation<Void, Never>] = []
 
     init(
         dbQueue: DatabaseQueue,
@@ -105,7 +107,7 @@ actor BatchTranscriptionCoordinator {
 
     func enqueue(sessionId: UUID) async {
         guard !isShuttingDown else {
-            await persistInterruptedIfPossible(sessionId: sessionId)
+            shutdownInterruptionSessionIds.insert(sessionId)
             return
         }
         guard runningSessionId != sessionId, !pendingSessionIds.contains(sessionId) else { return }
@@ -116,7 +118,7 @@ actor BatchTranscriptionCoordinator {
             return
         }
         guard !isShuttingDown else {
-            await persistInterruptedIfPossible(sessionId: sessionId)
+            shutdownInterruptionSessionIds.insert(sessionId)
             return
         }
         pendingSessionIds.append(sessionId)
@@ -172,6 +174,7 @@ actor BatchTranscriptionCoordinator {
 
     func shutdown() async throws {
         isShuttingDown = true
+        await waitForConfirmationDrain()
         shutdownInterruptionSessionIds.formUnion(pendingSessionIds)
         if let runningSessionId {
             shutdownInterruptionSessionIds.insert(runningSessionId)
@@ -195,6 +198,12 @@ actor BatchTranscriptionCoordinator {
             throw firstError
         }
     }
+
+    #if DEBUG
+        func isWaitingForConfirmationDrainForTesting() -> Bool {
+            isShuttingDown && activeConfirmationCount > 0
+        }
+    #endif
 
     private func markPreviouslyQueuedSessionsInterrupted() async throws {
         let sessionIds = try await dbQueue.write { db -> [UUID] in
@@ -244,14 +253,25 @@ actor BatchTranscriptionCoordinator {
         )
     }
 
-    private func persistInterruptedIfPossible(sessionId: UUID) async {
-        do {
-            try await persistInterrupted(sessionId: sessionId)
-        } catch {
-            ErrorReportingService.capture(
-                error,
-                context: ["source": "batchTranscriptionInterruptionPersistence"]
-            )
+    private func waitForConfirmationDrain() async {
+        guard activeConfirmationCount > 0 else { return }
+        await withCheckedContinuation { continuation in
+            confirmationDrainWaiters.append(continuation)
+        }
+    }
+
+    private func beginConfirmation() throws {
+        guard !isShuttingDown else { throw CancellationError() }
+        activeConfirmationCount += 1
+    }
+
+    private func finishConfirmation() {
+        activeConfirmationCount -= 1
+        guard activeConfirmationCount == 0 else { return }
+        let waiters = confirmationDrainWaiters
+        confirmationDrainWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
         }
     }
 
@@ -828,6 +848,8 @@ extension BatchTranscriptionCoordinator {
         retainAudioAfterBatch: Bool,
         onConfirmed: @Sendable (BatchTranscriptionConfirmationService.Result) async -> Void
     ) async throws {
+        try beginConfirmation()
+        defer { finishConfirmation() }
         let result = try await BatchTranscriptionConfirmationService.confirm(
             sessionId: sessionId,
             languageSelection: languageSelection,
@@ -849,6 +871,8 @@ extension BatchTranscriptionCoordinator {
         retainAudioAfterBatch: Bool,
         onConfirmed: @Sendable (BatchTranscriptionConfirmationService.Result) async -> Void
     ) async throws {
+        try beginConfirmation()
+        defer { finishConfirmation() }
         let result = try await BatchTranscriptionConfirmationService.confirmRetranscription(
             sessionIds: sessionIds,
             languageSelection: languageSelection,

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -191,6 +191,7 @@ actor BatchTranscriptionCoordinator {
             }
         }
         if let firstError {
+            isShuttingDown = false
             throw firstError
         }
     }

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -96,10 +96,10 @@ actor BatchTranscriptionCoordinator {
         self.onStateChange = onStateChange
     }
 
-    func recoverAndEnqueue() async {
+    func recoverAndEnqueue() async throws {
         _ = await recordingAudioStore?.reconcileStartup()
         await recoverCompletedAudioPurges()
-        await markPreviouslyQueuedSessionsInterrupted()
+        try await markPreviouslyQueuedSessionsInterrupted()
     }
 
     func enqueue(sessionId: UUID) async {
@@ -177,8 +177,8 @@ actor BatchTranscriptionCoordinator {
         }
     }
 
-    private func markPreviouslyQueuedSessionsInterrupted() async {
-        let sessionIds: [UUID] = await (try? dbQueue.write { db -> [UUID] in
+    private func markPreviouslyQueuedSessionsInterrupted() async throws {
+        let sessionIds = try await dbQueue.write { db -> [UUID] in
             let ids = try UUID.fetchAll(
                 db,
                 sql: """
@@ -207,7 +207,7 @@ actor BatchTranscriptionCoordinator {
                 arguments: updateArguments
             )
             return ids
-        }) ?? []
+        }
         for sessionId in sessionIds {
             guard let context = try? failureNotificationContext(for: sessionId) else { continue }
             await notify(

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -65,6 +65,7 @@ actor BatchTranscriptionCoordinator {
     private var pendingProgressUpdate: BatchTranscriptionUpdate?
     private var progressNotificationTask: Task<Void, Never>?
     private var isShuttingDown = false
+    private var shutdownInterruptionSessionIds: Set<UUID> = []
 
     init(
         dbQueue: DatabaseQueue,
@@ -104,7 +105,7 @@ actor BatchTranscriptionCoordinator {
 
     func enqueue(sessionId: UUID) async {
         guard !isShuttingDown else {
-            await persistInterrupted(sessionId: sessionId)
+            await persistInterruptedIfPossible(sessionId: sessionId)
             return
         }
         guard runningSessionId != sessionId, !pendingSessionIds.contains(sessionId) else { return }
@@ -115,7 +116,7 @@ actor BatchTranscriptionCoordinator {
             return
         }
         guard !isShuttingDown else {
-            await persistInterrupted(sessionId: sessionId)
+            await persistInterruptedIfPossible(sessionId: sessionId)
             return
         }
         pendingSessionIds.append(sessionId)
@@ -131,7 +132,11 @@ actor BatchTranscriptionCoordinator {
     }
 
     func recordRecordingFailure(sessionId: UUID, message: String) async {
-        await persistFailure(sessionId: sessionId, message: message, kind: .recordingStorage)
+        await persistFailureIfPossible(
+            sessionId: sessionId,
+            message: message,
+            kind: .recordingStorage
+        )
         ErrorReportingService.capture(
             BatchRecordingFailure(message: message),
             context: ["source": "batchRecording"]
@@ -165,15 +170,28 @@ actor BatchTranscriptionCoordinator {
         processorTask = nil
     }
 
-    func shutdown() async {
+    func shutdown() async throws {
         isShuttingDown = true
-        let interruptedSessionIds = Array(Set(pendingSessionIds + [runningSessionId].compactMap(\.self)))
+        shutdownInterruptionSessionIds.formUnion(pendingSessionIds)
+        if let runningSessionId {
+            shutdownInterruptionSessionIds.insert(runningSessionId)
+        }
         pendingSessionIds.removeAll()
         let task = processorTask
         task?.cancel()
         await task?.value
-        for sessionId in interruptedSessionIds {
-            await persistInterrupted(sessionId: sessionId)
+
+        var firstError: (any Error)?
+        for sessionId in Array(shutdownInterruptionSessionIds) {
+            do {
+                try await persistInterrupted(sessionId: sessionId)
+                shutdownInterruptionSessionIds.remove(sessionId)
+            } catch {
+                firstError = firstError ?? error
+            }
+        }
+        if let firstError {
+            throw firstError
         }
     }
 
@@ -217,12 +235,23 @@ actor BatchTranscriptionCoordinator {
         }
     }
 
-    private func persistInterrupted(sessionId: UUID) async {
-        await persistFailure(
+    private func persistInterrupted(sessionId: UUID) async throws {
+        try await persistFailure(
             sessionId: sessionId,
             message: L10n.batchTranscriptionInterrupted,
             kind: .transcriptionInterrupted
         )
+    }
+
+    private func persistInterruptedIfPossible(sessionId: UUID) async {
+        do {
+            try await persistInterrupted(sessionId: sessionId)
+        } catch {
+            ErrorReportingService.capture(
+                error,
+                context: ["source": "batchTranscriptionInterruptionPersistence"]
+            )
+        }
     }
 
     private func process(sessionId: UUID) async throws {
@@ -563,7 +592,7 @@ actor BatchTranscriptionCoordinator {
                 .transcription
             }
         }
-        await persistFailure(sessionId: sessionId, message: message, kind: kind)
+        await persistFailureIfPossible(sessionId: sessionId, message: message, kind: kind)
         var context = [
             "source": "batchTranscription",
             "failureKind": kind.rawValue,
@@ -577,8 +606,8 @@ actor BatchTranscriptionCoordinator {
         ErrorReportingService.capture(error, context: context)
     }
 
-    private func persistFailure(sessionId: UUID, message: String, kind: BatchFailureKind? = nil) async {
-        let didPersist = await (try? dbQueue.write { db in
+    private func persistFailure(sessionId: UUID, message: String, kind: BatchFailureKind? = nil) async throws {
+        let didPersist = try await dbQueue.write { db in
             try db.execute(
                 sql: """
                 UPDATE recording_sessions
@@ -590,7 +619,7 @@ actor BatchTranscriptionCoordinator {
                 arguments: [message, kind, Date.now, sessionId]
             )
             return db.changesCount == 1
-        }) ?? false
+        }
         if didPersist, let result = try? failureNotificationContext(for: sessionId) {
             let state: BatchTranscriptionState = if kind == .transcriptionInterrupted {
                 .interrupted(sessionId: sessionId, isRetranscription: result.isRetranscription)
@@ -600,6 +629,21 @@ actor BatchTranscriptionCoordinator {
                 .failed(sessionId: sessionId, message: message)
             }
             await notify(meetingId: result.meetingId, state: state)
+        }
+    }
+
+    private func persistFailureIfPossible(
+        sessionId: UUID,
+        message: String,
+        kind: BatchFailureKind? = nil
+    ) async {
+        do {
+            try await persistFailure(sessionId: sessionId, message: message, kind: kind)
+        } catch {
+            ErrorReportingService.capture(
+                error,
+                context: ["source": "batchTranscriptionFailurePersistence"]
+            )
         }
     }
 

--- a/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionCoordinator.swift
@@ -35,7 +35,6 @@ actor BatchTranscriptionCoordinator {
         BatchLanguageDetectionCandidateSnapshot
     ) async -> Void
 
-    static let maximumAutomaticAttemptCount = 3
     private static let signposter = OSSignposter(subsystem: "com.dahlia", category: "BatchTranscription")
 
     struct Job {
@@ -65,6 +64,7 @@ actor BatchTranscriptionCoordinator {
     private var processorTask: Task<Void, Never>?
     private var pendingProgressUpdate: BatchTranscriptionUpdate?
     private var progressNotificationTask: Task<Void, Never>?
+    private var isShuttingDown = false
 
     init(
         dbQueue: DatabaseQueue,
@@ -99,28 +99,23 @@ actor BatchTranscriptionCoordinator {
     func recoverAndEnqueue() async {
         _ = await recordingAudioStore?.reconcileStartup()
         await recoverCompletedAudioPurges()
-        let sessionIds = await (try? dbQueue.read { db in
-            try RecordingSessionRecord
-                .filter(Column("transcriptionMode") == TranscriptionMode.batch.rawValue)
-                .filter(sql: "batchCompletedAt IS NULL OR batchLastAttemptAt > batchCompletedAt")
-                .filter(Column("batchDiscardedAt") == nil)
-                .order(Column("startedAt").asc)
-                .fetchAll(db)
-                .filter(Self.shouldAutomaticallyRetry)
-                .map(\.id)
-        }) ?? []
-
-        for sessionId in sessionIds {
-            await enqueue(sessionId: sessionId)
-        }
+        await markPreviouslyQueuedSessionsInterrupted()
     }
 
     func enqueue(sessionId: UUID) async {
+        guard !isShuttingDown else {
+            await persistInterrupted(sessionId: sessionId)
+            return
+        }
         guard runningSessionId != sessionId, !pendingSessionIds.contains(sessionId) else { return }
         do {
             guard try await claimForQueue(sessionId: sessionId) else { return }
         } catch {
             ErrorReportingService.capture(error, context: ["source": "batchTranscriptionQueue"])
+            return
+        }
+        guard !isShuttingDown else {
+            await persistInterrupted(sessionId: sessionId)
             return
         }
         pendingSessionIds.append(sessionId)
@@ -145,7 +140,7 @@ actor BatchTranscriptionCoordinator {
 
     private func processQueue() async {
         repeat {
-            while !pendingSessionIds.isEmpty {
+            while !pendingSessionIds.isEmpty, !Task.isCancelled {
                 let sessionId = pendingSessionIds.removeFirst()
                 runningSessionId = sessionId
                 runningProgress = nil
@@ -156,7 +151,7 @@ actor BatchTranscriptionCoordinator {
                     try await process(sessionId: sessionId)
                     await notify(meetingId: meetingId, state: .completed(sessionId: sessionId))
                 } catch is CancellationError {
-                    // The session was completed or explicitly discarded after it was queued.
+                    // Shutdown and explicit discard persist their own terminal state.
                 } catch {
                     await recordFailure(sessionId: sessionId, error: error)
                 }
@@ -165,8 +160,69 @@ actor BatchTranscriptionCoordinator {
             }
             await languageDetector.unload()
             await speechRecognizer.unload()
+            if Task.isCancelled { break }
         } while !pendingSessionIds.isEmpty
         processorTask = nil
+    }
+
+    func shutdown() async {
+        isShuttingDown = true
+        let interruptedSessionIds = Array(Set(pendingSessionIds + [runningSessionId].compactMap(\.self)))
+        pendingSessionIds.removeAll()
+        let task = processorTask
+        task?.cancel()
+        await task?.value
+        for sessionId in interruptedSessionIds {
+            await persistInterrupted(sessionId: sessionId)
+        }
+    }
+
+    private func markPreviouslyQueuedSessionsInterrupted() async {
+        let sessionIds: [UUID] = await (try? dbQueue.write { db -> [UUID] in
+            let ids = try UUID.fetchAll(
+                db,
+                sql: """
+                SELECT id FROM recording_sessions
+                WHERE transcriptionMode = ?
+                  AND batchDiscardedAt IS NULL
+                  AND batchLastAttemptAt IS NOT NULL
+                  AND (batchCompletedAt IS NULL OR batchLastAttemptAt > batchCompletedAt)
+                  AND batchLastError IS NULL
+                """,
+                arguments: [TranscriptionMode.batch.rawValue]
+            )
+            guard !ids.isEmpty else { return ids }
+            var updateArguments: StatementArguments = [
+                L10n.batchTranscriptionInterrupted,
+                BatchFailureKind.transcriptionInterrupted.rawValue,
+                Date.now,
+            ]
+            updateArguments += StatementArguments(ids)
+            try db.execute(
+                sql: """
+                UPDATE recording_sessions
+                SET batchLastError = ?, batchFailureKind = ?, updatedAt = ?
+                WHERE id IN (\(ids.map { _ in "?" }.joined(separator: ", ")))
+                """,
+                arguments: updateArguments
+            )
+            return ids
+        }) ?? []
+        for sessionId in sessionIds {
+            guard let context = try? failureNotificationContext(for: sessionId) else { continue }
+            await notify(
+                meetingId: context.meetingId,
+                state: .interrupted(sessionId: sessionId, isRetranscription: context.isRetranscription)
+            )
+        }
+    }
+
+    private func persistInterrupted(sessionId: UUID) async {
+        await persistFailure(
+            sessionId: sessionId,
+            message: L10n.batchTranscriptionInterrupted,
+            kind: .transcriptionInterrupted
+        )
     }
 
     private func process(sessionId: UUID) async throws {
@@ -536,9 +592,13 @@ actor BatchTranscriptionCoordinator {
             return db.changesCount == 1
         }) ?? false
         if didPersist, let result = try? failureNotificationContext(for: sessionId) {
-            let state: BatchTranscriptionState = result.isRetranscription
-                ? .retranscriptionFailed(sessionId: sessionId, message: message)
-                : .failed(sessionId: sessionId, message: message)
+            let state: BatchTranscriptionState = if kind == .transcriptionInterrupted {
+                .interrupted(sessionId: sessionId, isRetranscription: result.isRetranscription)
+            } else if result.isRetranscription {
+                .retranscriptionFailed(sessionId: sessionId, message: message)
+            } else {
+                .failed(sessionId: sessionId, message: message)
+            }
             await notify(meetingId: result.meetingId, state: state)
         }
     }

--- a/Sources/Dahlia/Services/BatchTranscriptionDiscardService.swift
+++ b/Sources/Dahlia/Services/BatchTranscriptionDiscardService.swift
@@ -5,12 +5,15 @@ import GRDB
 enum BatchTranscriptionDiscardService {
     static func discardUnprocessedSessionSafely(
         id: UUID,
+        expectedVaultId: UUID,
         dbQueue: DatabaseQueue,
         managedRootURL: URL = BatchAudioStorage.managedRootURL
     ) async throws -> Bool {
         let store = try RecordingAudioStore(dbQueue: dbQueue, managedRootURL: managedRootURL)
         let claimed = try await dbQueue.write { db in
             guard var session = try RecordingSessionRecord.fetchOne(db, key: id),
+                  let meeting = try MeetingRecord.fetchOne(db, key: session.meetingId),
+                  meeting.vaultId == expectedVaultId,
                   isDiscardable(session),
                   try RecordingAudioSegmentRecord
                   .filter(Column("recordingSessionId") == id)

--- a/Sources/Dahlia/Speech/BatchTranscriptionConcurrency.swift
+++ b/Sources/Dahlia/Speech/BatchTranscriptionConcurrency.swift
@@ -2,7 +2,7 @@ import Foundation
 import Speech
 
 enum BatchTranscriptionConcurrency {
-    static let appleSpeechMaximum = 4
+    static let appleSpeechMaximum = 1
 }
 
 actor BatchTranscriptionConcurrencyLimiter {
@@ -129,7 +129,7 @@ struct SerializedBatchLanguageDetector: BatchLanguageDetecting {
     }
 }
 
-/// Uses up to four Apple Speech analyzers until the framework reports resource exhaustion, then retries serially.
+/// Serializes Apple Speech analysis and retries one transient resource-exhaustion failure.
 struct AdaptiveBatchSpeechRecognizer: BatchSpeechRecognizing {
     private let recognizer: any BatchSpeechRecognizing
     private let limiter = BatchTranscriptionConcurrencyLimiter(limit: BatchTranscriptionConcurrency.appleSpeechMaximum)

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1211,6 +1211,10 @@ enum L10n {
         localized: "Transcription was interrupted. The recording is safe and ready to resume.",
         bundle: bundle
     ) }
+    static var batchTranscriptionRecoveryFailedTitle: String {
+        String(localized: "Could not recover interrupted transcriptions", bundle: bundle)
+    }
+
     static var resumeBatchTranscription: String { String(localized: "Resume Transcription", bundle: bundle) }
     static func batchTranscriptionFileProgress(completed: Int, total: Int) -> String {
         String(localized: "Files completed: \(completed) of \(total)", bundle: bundle)

--- a/Sources/Dahlia/Utilities/L10n.swift
+++ b/Sources/Dahlia/Utilities/L10n.swift
@@ -1207,6 +1207,11 @@ enum L10n {
     static var reviewBatchTranscription: String { String(localized: "Review and Start", bundle: bundle) }
     static var batchTranscriptionQueued: String { String(localized: "Waiting to transcribe the recording…", bundle: bundle) }
     static var batchTranscriptionRunning: String { String(localized: "Creating a high-accuracy transcript…", bundle: bundle) }
+    static var batchTranscriptionInterrupted: String { String(
+        localized: "Transcription was interrupted. The recording is safe and ready to resume.",
+        bundle: bundle
+    ) }
+    static var resumeBatchTranscription: String { String(localized: "Resume Transcription", bundle: bundle) }
     static func batchTranscriptionFileProgress(completed: Int, total: Int) -> String {
         String(localized: "Files completed: \(completed) of \(total)", bundle: bundle)
     }
@@ -1350,7 +1355,19 @@ enum L10n {
         String(localized: "Could not save the recording: \(reason)", bundle: bundle)
     }
 
+    static var terminationPersistenceFailedTitle: String {
+        String(localized: "Dahlia could not quit", bundle: bundle)
+    }
+
+    static var recordingPersistenceRetryFailed: String {
+        String(localized: "The recording could not be saved. Dahlia will remain open so you can try again.", bundle: bundle)
+    }
+
     static var batchAudioFormatUnavailable: String { String(localized: "No compatible audio format is available.", bundle: bundle) }
+    static var batchRecordingAudioUnavailable: String {
+        String(localized: "Recording audio is incomplete and cannot be transcribed.", bundle: bundle)
+    }
+
     static var batchAudioRangeInvalid: String { String(localized: "The recorded audio range is invalid or damaged.", bundle: bundle) }
     static var batchAnalysisDidNotAdvance: String { String(localized: "Speech analysis could not read the recorded audio.", bundle: bundle) }
 
@@ -1532,6 +1549,10 @@ enum L10n {
     static var unprocessedRecordings: String { String(localized: "Unprocessed Recordings", bundle: bundle) }
     static var unprocessedRecordingsDescription: String { String(
         localized: "Transcribe or discard every unprocessed recording before creating or restoring a backup.",
+        bundle: bundle
+    ) }
+    static var noUnprocessedRecordingsDescription: String { String(
+        localized: "Recordings that need manual transcription will appear here.",
         bundle: bundle
     ) }
     static var awaitingTranscription: String { String(localized: "Waiting for transcription", bundle: bundle) }

--- a/Sources/Dahlia/ViewModels/BackupSettingsViewModel.swift
+++ b/Sources/Dahlia/ViewModels/BackupSettingsViewModel.swift
@@ -73,7 +73,10 @@ final class BackupSettingsViewModel {
         guard let dbQueue else { return }
         await perform {
             let discarded = try await MeetingRepository(dbQueue: dbQueue)
-                .discardUnprocessedBatchSessionSafely(id: item.sessionId)
+                .discardUnprocessedBatchSessionSafely(
+                    id: item.sessionId,
+                    expectedVaultId: item.vaultId
+                )
             guard discarded else { throw BackupServiceError.invalidBackup }
             statusMessage = L10n.unprocessedRecordingDiscarded
         }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -747,14 +747,24 @@ final class CaptionViewModel: ObservableObject {
             isTerminationRequested = false
             return errorMessage ?? L10n.recordingPersistenceRetryFailed
         }
-        await batchTranscriptionCoordinator?.shutdown()
-        return nil
+        do {
+            try await batchTranscriptionCoordinator?.shutdown()
+            return nil
+        } catch {
+            isTerminationRequested = false
+            ErrorReportingService.capture(error, context: ["source": "batchTranscriptionTerminationPersistence"])
+            return error.localizedDescription
+        }
     }
 
     #if DEBUG
         func setFailedPersistenceServiceForTesting(_ service: MeetingPersistenceService) {
             failedPersistenceService = service
             failedPersistenceMeetingId = service.meetingId
+        }
+
+        func setBatchTranscriptionCoordinatorForTesting(_ coordinator: BatchTranscriptionCoordinator) {
+            batchTranscriptionCoordinator = coordinator
         }
     #endif
 

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -817,6 +817,7 @@ final class CaptionViewModel: ObservableObject {
     }
 
     func presentAvailableBatchRetranscription() {
+        guard !isListening else { return }
         switch batchTranscriptionState {
         case .awaitingConfirmation:
             presentBatchTranscriptionConfirmation()
@@ -999,7 +1000,8 @@ final class CaptionViewModel: ObservableObject {
     }
 
     func presentBatchTranscriptionConfirmation() {
-        guard case let .awaitingConfirmation(sessionId) = batchTranscriptionState,
+        guard !isListening,
+              case let .awaitingConfirmation(sessionId) = batchTranscriptionState,
               let meetingId = currentMeetingId else { return }
         presentBatchTranscriptionConfirmation(
             sessionId: sessionId,
@@ -1023,6 +1025,7 @@ final class CaptionViewModel: ObservableObject {
         meetingId: UUID,
         dbQueue: DatabaseQueue
     ) async {
+        guard !isListening else { return }
         do {
             let snapshot = try await dbQueue.read { db -> (
                 session: RecordingSessionRecord?,
@@ -1041,6 +1044,7 @@ final class CaptionViewModel: ObservableObject {
                     .url
                 return (session, pendingRetranscriptionIds, vaultURL)
             }
+            guard !isListening else { return }
             if snapshot.session?.isBatchRetranscriptionPending == true,
                !snapshot.pendingRetranscriptionIds.isEmpty {
                 presentBatchRetranscriptionConfirmation(
@@ -1073,7 +1077,8 @@ final class CaptionViewModel: ObservableObject {
         retainAudioAfterBatch: Bool,
         summaryGenerationOptions: SummaryGenerationOptions?
     ) {
-        guard let confirmation = pendingBatchTranscriptionConfirmation,
+        guard !isListening,
+              let confirmation = pendingBatchTranscriptionConfirmation,
               let coordinator = batchTranscriptionCoordinator else { return }
         let automaticLanguageCandidates = batchTranscriptionAutomaticLanguageCandidates(
             snapshot: confirmation.automaticLanguageCandidateSnapshot

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -128,6 +128,8 @@ final class CaptionViewModel: ObservableObject {
     @Published var isPreparingAnalyzer = false
     @Published private(set) var activeTranscriptionMode: TranscriptionMode?
     @Published private(set) var batchTranscriptionState: BatchTranscriptionState?
+    @Published var batchTranscriptionRecoveryAlert: BatchTranscriptionRecoveryAlert?
+    @Published private(set) var offscreenBatchTranscriptionChangeToken: UInt64 = 0
     @Published private(set) var retranscribableBatchSessionIds: [UUID] = []
     @Published private(set) var failedPersistenceMeetingId: UUID?
     @Published var pendingBatchTranscriptionConfirmation: BatchTranscriptionConfirmation?
@@ -536,6 +538,8 @@ final class CaptionViewModel: ObservableObject {
     private var liveTranscriptRelay: FinalizedLiveTranscriptRelay?
     private var isChatLiveModeEnabled = false
     private var batchTranscriptionCoordinator: BatchTranscriptionCoordinator?
+    private var batchTranscriptionRecoveryTask: Task<Void, Never>?
+    private var onBatchTranscriptionRecoveryCompleted: (@MainActor @Sendable () async -> Void)?
     private var recordingStopTask: Task<Void, Never>?
     private var isTerminationRequested = false
     private let recordingSessionController = RecordingSessionController()
@@ -705,10 +709,28 @@ final class CaptionViewModel: ObservableObject {
             await self?.handleBatchTranscriptionUpdate(update)
         }
         batchTranscriptionCoordinator = coordinator
+        onBatchTranscriptionRecoveryCompleted = onRecoveryCompleted
         guard recoverExistingSessions else { return }
-        Task {
-            await coordinator.recoverAndEnqueue()
-            await onRecoveryCompleted?()
+        retryBatchTranscriptionRecovery()
+    }
+
+    func retryBatchTranscriptionRecovery() {
+        guard batchTranscriptionRecoveryTask == nil,
+              let coordinator = batchTranscriptionCoordinator else { return }
+        batchTranscriptionRecoveryTask = Task { [weak self] in
+            guard let self else { return }
+            defer { batchTranscriptionRecoveryTask = nil }
+            do {
+                try await coordinator.recoverAndEnqueue()
+                guard !Task.isCancelled else { return }
+                batchTranscriptionRecoveryAlert = nil
+                await onBatchTranscriptionRecoveryCompleted?()
+            } catch {
+                ErrorReportingService.capture(error, context: ["source": "batchTranscriptionStartupRecovery"])
+                batchTranscriptionRecoveryAlert = BatchTranscriptionRecoveryAlert(
+                    message: error.localizedDescription
+                )
+            }
         }
     }
 
@@ -1306,6 +1328,9 @@ final class CaptionViewModel: ObservableObject {
 
     func handleBatchTranscriptionUpdate(_ update: BatchTranscriptionUpdate) async {
         let isVisibleMeeting = currentMeetingId == update.meetingId
+        if !isVisibleMeeting, update.state.changesUnprocessedRecordingsProjection {
+            offscreenBatchTranscriptionChangeToken &+= 1
+        }
         if isVisibleMeeting,
            !(isBatchRecording && recordingMeetingId == update.meetingId) {
             batchTranscriptionState = update.state

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -203,10 +203,35 @@ final class CaptionViewModel: ObservableObject {
     var canRetranscribeBatchAudio: Bool {
         guard !retranscribableBatchSessionIds.isEmpty, !isListening else { return false }
         return switch batchTranscriptionState {
-        case nil, .failed, .retranscriptionFailed:
+        case nil, .failed, .retranscriptionFailed, .interrupted:
             true
         default:
             false
+        }
+    }
+
+    var canStartOrResumeBatchTranscription: Bool {
+        guard !isListening else { return false }
+        return switch batchTranscriptionState {
+        case .awaitingConfirmation:
+            true
+        case .failed, .retranscriptionFailed, .interrupted:
+            !retranscribableBatchSessionIds.isEmpty
+        default:
+            false
+        }
+    }
+
+    var batchTranscriptionActionTitle: String {
+        switch batchTranscriptionState {
+        case .awaitingConfirmation:
+            L10n.reviewBatchTranscription
+        case .interrupted:
+            L10n.resumeBatchTranscription
+        case .failed, .retranscriptionFailed:
+            L10n.retryBatchTranscription
+        default:
+            L10n.transcribe
         }
     }
 
@@ -511,6 +536,8 @@ final class CaptionViewModel: ObservableObject {
     private var liveTranscriptRelay: FinalizedLiveTranscriptRelay?
     private var isChatLiveModeEnabled = false
     private var batchTranscriptionCoordinator: BatchTranscriptionCoordinator?
+    private var recordingStopTask: Task<Void, Never>?
+    private var isTerminationRequested = false
     private let recordingSessionController = RecordingSessionController()
     private var activeTranscriptionPlan: TranscriptionSessionPlan?
     private var activeRecordingSessionId: UUID?
@@ -683,9 +710,33 @@ final class CaptionViewModel: ObservableObject {
         }
     }
 
+    func prepareForTermination() async -> String? {
+        isTerminationRequested = true
+        while case .starting = recordingLifecycle {
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        if case .recording = recordingLifecycle {
+            stopListening()
+        }
+        await recordingStopTask?.value
+        guard await retryFailedPersistenceIfNeeded() else {
+            isTerminationRequested = false
+            return errorMessage ?? L10n.recordingPersistenceRetryFailed
+        }
+        await batchTranscriptionCoordinator?.shutdown()
+        return nil
+    }
+
+    #if DEBUG
+        func setFailedPersistenceServiceForTesting(_ service: MeetingPersistenceService) {
+            failedPersistenceService = service
+            failedPersistenceMeetingId = service.meetingId
+        }
+    #endif
+
     func retryBatchTranscription() {
         switch batchTranscriptionState {
-        case let .failed(sessionId, _):
+        case let .failed(sessionId, _), let .interrupted(sessionId, false):
             guard canRetranscribeBatchAudio,
                   let meetingId = currentMeetingId else { return }
             presentBatchTranscriptionConfirmation(
@@ -695,18 +746,19 @@ final class CaptionViewModel: ObservableObject {
                 dbQueue: currentDbQueue,
                 vaultURL: currentVaultURL
             )
-        case let .retranscriptionFailed(sessionId, _):
+        case let .retranscriptionFailed(sessionId, _), let .interrupted(sessionId, true):
             guard let meetingId = currentMeetingId,
                   let dbQueue = currentDbQueue else { return }
+            let expectedState = batchTranscriptionState
             Task {
                 let sessionIds = await (try? Self.fetchRetryableBatchSessionIds(
                     meetingId: meetingId,
-                    state: batchTranscriptionState,
+                    state: expectedState,
                     dbQueue: dbQueue
                 )) ?? []
                 guard !sessionIds.isEmpty,
                       currentMeetingId == meetingId,
-                      case .retranscriptionFailed = batchTranscriptionState else { return }
+                      batchTranscriptionState == expectedState else { return }
                 retranscribableBatchSessionIds = sessionIds
                 presentBatchRetranscriptionConfirmation(
                     sessionId: sessionIds.contains(sessionId) ? sessionId : sessionIds[sessionIds.count - 1],
@@ -732,7 +784,9 @@ final class CaptionViewModel: ObservableObject {
 
     func presentAvailableBatchRetranscription() {
         switch batchTranscriptionState {
-        case .failed, .retranscriptionFailed:
+        case .awaitingConfirmation:
+            presentBatchTranscriptionConfirmation()
+        case .failed, .retranscriptionFailed, .interrupted:
             retryBatchTranscription()
         default:
             presentBatchRetranscriptionConfirmation()
@@ -742,23 +796,27 @@ final class CaptionViewModel: ObservableObject {
     private func presentBatchRetranscriptionConfirmation(
         sessionId: UUID,
         sessionIds: [UUID],
-        meetingId: UUID
+        meetingId: UUID,
+        dbQueue suppliedDbQueue: DatabaseQueue? = nil,
+        vaultURL suppliedVaultURL: URL? = nil
     ) {
+        let dbQueue = suppliedDbQueue ?? currentDbQueue
+        let vaultURL = suppliedVaultURL ?? currentVaultURL
         let details = makeBatchTranscriptionConfirmationDetails(
             meetingId: meetingId,
-            dbQueue: currentDbQueue
+            dbQueue: dbQueue
         )
-        if let currentDbQueue, let currentVaultURL {
+        if let dbQueue, let vaultURL {
             batchSummaryContextsBySessionId[sessionId] = BatchSummaryContext(
-                dbQueue: currentDbQueue,
-                vaultURL: currentVaultURL,
+                dbQueue: dbQueue,
+                vaultURL: vaultURL,
                 meetingName: details.meetingName
             )
         }
         let preferences = batchConfirmationPreferences(
             sessionId: sessionId,
             suggestedLocaleIdentifier: selectedLocale,
-            dbQueue: currentDbQueue
+            dbQueue: dbQueue
         )
         pendingBatchTranscriptionConfirmation = BatchTranscriptionConfirmation(
             sessionId: sessionId,
@@ -922,14 +980,54 @@ final class CaptionViewModel: ObservableObject {
         sessionId: UUID,
         meetingId: UUID,
         dbQueue: DatabaseQueue
-    ) {
-        presentBatchTranscriptionConfirmation(
-            sessionId: sessionId,
-            meetingId: meetingId,
-            suggestedLocaleIdentifier: selectedLocale,
-            dbQueue: dbQueue,
-            vaultURL: currentVaultURL
-        )
+    ) async {
+        await presentManualBatchTranscription(sessionId: sessionId, meetingId: meetingId, dbQueue: dbQueue)
+    }
+
+    func presentManualBatchTranscription(
+        sessionId: UUID,
+        meetingId: UUID,
+        dbQueue: DatabaseQueue
+    ) async {
+        do {
+            let snapshot = try await dbQueue.read { db -> (
+                session: RecordingSessionRecord?,
+                pendingRetranscriptionIds: [UUID],
+                vaultURL: URL?
+            ) in
+                let session = try RecordingSessionRecord.fetchOne(db, key: sessionId)
+                let pendingRetranscriptionIds = try RecordingSessionRecord
+                    .filter(Column("meetingId") == meetingId)
+                    .order(Column("startedAt").asc)
+                    .fetchAll(db)
+                    .filter(\.isBatchRetranscriptionPending)
+                    .map(\.id)
+                let vaultURL = try MeetingRecord.fetchOne(db, key: meetingId)
+                    .flatMap { try VaultRecord.fetchOne(db, key: $0.vaultId) }?
+                    .url
+                return (session, pendingRetranscriptionIds, vaultURL)
+            }
+            if snapshot.session?.isBatchRetranscriptionPending == true,
+               !snapshot.pendingRetranscriptionIds.isEmpty {
+                presentBatchRetranscriptionConfirmation(
+                    sessionId: sessionId,
+                    sessionIds: snapshot.pendingRetranscriptionIds,
+                    meetingId: meetingId,
+                    dbQueue: dbQueue,
+                    vaultURL: snapshot.vaultURL
+                )
+                return
+            }
+            presentBatchTranscriptionConfirmation(
+                sessionId: sessionId,
+                meetingId: meetingId,
+                suggestedLocaleIdentifier: selectedLocale,
+                dbQueue: dbQueue,
+                vaultURL: snapshot.vaultURL
+            )
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 
     func postponeBatchTranscription() {
@@ -1205,7 +1303,7 @@ final class CaptionViewModel: ObservableObject {
            !(isBatchRecording && recordingMeetingId == update.meetingId) {
             batchTranscriptionState = update.state
             switch update.state {
-            case .failed, .retranscriptionFailed:
+            case .failed, .retranscriptionFailed, .interrupted:
                 let sessionIds = await (try? Self.fetchRetryableBatchSessionIds(
                     meetingId: update.meetingId,
                     state: update.state,
@@ -1243,6 +1341,9 @@ final class CaptionViewModel: ObservableObject {
         case .completed:
             request.completedSessionIDs.insert(sessionID)
             progress = 1
+        case .interrupted:
+            failBatchTranscription(in: request.job, message: L10n.batchTranscriptionInterrupted)
+            return
         case let .failed(_, message), let .retranscriptionFailed(_, message):
             failBatchTranscription(in: request.job, message: message)
             return
@@ -1476,6 +1577,13 @@ final class CaptionViewModel: ObservableObject {
         switch state {
         case let .failed(sessionId, _):
             return eligibleSessionIdSet.contains(sessionId) ? [sessionId] : []
+        case let .interrupted(sessionId, false):
+            return eligibleSessionIdSet.contains(sessionId) ? [sessionId] : []
+        case .interrupted(_, true):
+            let pendingSessionIds = sessions.filter(\.isBatchRetranscriptionPending).map(\.id)
+            guard !pendingSessionIds.isEmpty,
+                  pendingSessionIds.allSatisfy(eligibleSessionIdSet.contains) else { return [] }
+            return pendingSessionIds
         case .retranscriptionFailed:
             let pendingSessionIds = sessions.filter(\.isBatchRetranscriptionPending).map(\.id)
             guard !pendingSessionIds.isEmpty,
@@ -2544,11 +2652,13 @@ final class CaptionViewModel: ObservableObject {
     ) async {
         guard recordingLifecycle == .idle,
               !isFinalizingRecording,
+              !isTerminationRequested,
               !AppDelegate.isBackupRestorePreparationActive else { return }
         guard await retryFailedPersistenceIfNeeded() else { return }
         await refreshDefaultInputDevice()
         guard recordingLifecycle == .idle,
               !isFinalizingRecording,
+              !isTerminationRequested,
               canStartRecording() else { return }
         let previousBatchTranscriptionState = batchTranscriptionState
 
@@ -2633,6 +2743,7 @@ final class CaptionViewModel: ObservableObject {
                 recordingSessionId: recordingSessionId
             )
             await transcriptionEventPipeline?.flushUI()
+            try ensureSessionIsActive(recordingSessionId)
 
             if let failure = pendingRealtimeRecognitionFailure {
                 throw RecordingPipelineFailure(message: failure.message)
@@ -2694,8 +2805,10 @@ final class CaptionViewModel: ObservableObject {
             recordingSessionId: persistenceService?.recordingSessionId
         )
 
-        Task {
-            await finishRecordingStop(stopContext)
+        recordingStopTask = Task { [weak self] in
+            guard let self else { return }
+            await self.finishRecordingStop(stopContext)
+            self.recordingStopTask = nil
         }
     }
 
@@ -4251,7 +4364,7 @@ final class CaptionViewModel: ObservableObject {
     // MARK: - Private Helpers
 
     private func ensureSessionIsActive(_ recordingSessionId: UUID) throws {
-        guard isSessionActive(recordingSessionId), !Task.isCancelled else {
+        guard isSessionActive(recordingSessionId), !isTerminationRequested, !Task.isCancelled else {
             throw CancellationError()
         }
     }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -694,7 +694,8 @@ final class CaptionViewModel: ObservableObject {
     func configureBatchTranscription(
         dbQueue: DatabaseQueue,
         managedRootURL: URL = BatchAudioStorage.managedRootURL,
-        recoverExistingSessions: Bool = true
+        recoverExistingSessions: Bool = true,
+        onRecoveryCompleted: (@MainActor @Sendable () async -> Void)? = nil
     ) {
         guard batchTranscriptionCoordinator == nil else { return }
         let coordinator = BatchTranscriptionCoordinator(
@@ -707,6 +708,7 @@ final class CaptionViewModel: ObservableObject {
         guard recoverExistingSessions else { return }
         Task {
             await coordinator.recoverAndEnqueue()
+            await onRecoveryCompleted?()
         }
     }
 
@@ -1246,8 +1248,13 @@ final class CaptionViewModel: ObservableObject {
     }
 
     func cancelFailedBatchRetranscription() {
-        guard case .retranscriptionFailed = batchTranscriptionState,
-              let meetingId = currentMeetingId,
+        switch batchTranscriptionState {
+        case .retranscriptionFailed, .interrupted(_, true):
+            break
+        default:
+            return
+        }
+        guard let meetingId = currentMeetingId,
               let dbQueue = currentDbQueue else { return }
         Task {
             do {

--- a/Sources/Dahlia/ViewModels/SidebarViewModel.swift
+++ b/Sources/Dahlia/ViewModels/SidebarViewModel.swift
@@ -15,7 +15,7 @@ private struct ProjectDescriptionDraft {
 @Observable
 @MainActor
 final class SidebarViewModel {
-    typealias UnprocessedRecordingDiscarder = @MainActor @Sendable (DatabaseQueue, UUID) async throws -> Bool
+    typealias UnprocessedRecordingDiscarder = @MainActor @Sendable (DatabaseQueue, UUID, UUID) async throws -> Bool
 
     nonisolated static let meetingPageSize = 50
     nonisolated static let maximumVisibleMeetings = 500
@@ -118,8 +118,11 @@ final class SidebarViewModel {
 
     init(
         settings: AppSettings = .shared,
-        unprocessedRecordingDiscarder: @escaping UnprocessedRecordingDiscarder = { dbQueue, sessionId in
-            try await MeetingRepository(dbQueue: dbQueue).discardUnprocessedBatchSessionSafely(id: sessionId)
+        unprocessedRecordingDiscarder: @escaping UnprocessedRecordingDiscarder = { dbQueue, sessionId, vaultId in
+            try await MeetingRepository(dbQueue: dbQueue).discardUnprocessedBatchSessionSafely(
+                id: sessionId,
+                expectedVaultId: vaultId
+            )
         }
     ) {
         self.settings = settings
@@ -297,11 +300,11 @@ final class SidebarViewModel {
     }
 
     func discardUnprocessedRecording(_ item: BackupPreflightItem) async {
-        guard let dbQueue, let vaultId = currentVault?.id else { return }
+        guard let dbQueue, let vaultId = currentVault?.id, item.vaultId == vaultId else { return }
         let contextGeneration = unprocessedRecordingsContextGeneration
         unprocessedRecordingsError = nil
         do {
-            _ = try await unprocessedRecordingDiscarder(dbQueue, item.sessionId)
+            _ = try await unprocessedRecordingDiscarder(dbQueue, item.sessionId, item.vaultId)
             guard isCurrentUnprocessedRecordingsContext(contextGeneration, vaultId: vaultId) else { return }
             await refreshUnprocessedRecordings()
         } catch {

--- a/Sources/Dahlia/ViewModels/SidebarViewModel.swift
+++ b/Sources/Dahlia/ViewModels/SidebarViewModel.swift
@@ -15,6 +15,8 @@ private struct ProjectDescriptionDraft {
 @Observable
 @MainActor
 final class SidebarViewModel {
+    typealias UnprocessedRecordingDiscarder = @MainActor @Sendable (DatabaseQueue, UUID) async throws -> Bool
+
     nonisolated static let meetingPageSize = 50
     nonisolated static let maximumVisibleMeetings = 500
 
@@ -65,6 +67,9 @@ final class SidebarViewModel {
     private(set) var allAvailableTags: [TagInfo] = []
     var selectedInstruction: InstructionRecord?
     var lastError: String?
+    private(set) var unprocessedRecordingItems: [BackupPreflightItem] = []
+    private(set) var unprocessedRecordingsError: String?
+    private(set) var isLoadingUnprocessedRecordings = false
 
     var selectedMeetingId: UUID? {
         selectedMeetingIds.count == 1 ? selectedMeetingIds.first : nil
@@ -73,6 +78,7 @@ final class SidebarViewModel {
     // MARK: - Active Database & Vault
 
     @ObservationIgnored private let settings: AppSettings
+    @ObservationIgnored private let unprocessedRecordingDiscarder: UnprocessedRecordingDiscarder
     @ObservationIgnored private(set) var appDatabase: AppDatabaseManager?
     var currentVault: VaultRecord? { settings.currentVault }
     var dbQueue: DatabaseQueue? { appDatabase?.dbQueue }
@@ -87,6 +93,8 @@ final class SidebarViewModel {
     @ObservationIgnored private var allTagsObservation: AnyDatabaseCancellable?
     @ObservationIgnored private var allProjectsObservation: AnyDatabaseCancellable?
     @ObservationIgnored private var projectCatalogObservationTracker = ProjectCatalogObservationTracker()
+    @ObservationIgnored private var unprocessedRecordingsContextGeneration: UInt64 = 0
+    @ObservationIgnored private var unprocessedRecordingsRefreshGeneration: UInt64 = 0
     @ObservationIgnored private var instructionsObservation: AnyDatabaseCancellable?
     @ObservationIgnored private var projectObservation: AnyDatabaseCancellable?
     @ObservationIgnored private var vaultObservation: AnyDatabaseCancellable?
@@ -108,8 +116,14 @@ final class SidebarViewModel {
     @ObservationIgnored private var projectObservationGeneration = 0
     @ObservationIgnored private var tagObservationGeneration = 0
 
-    init(settings: AppSettings = .shared) {
+    init(
+        settings: AppSettings = .shared,
+        unprocessedRecordingDiscarder: @escaping UnprocessedRecordingDiscarder = { dbQueue, sessionId in
+            try await MeetingRepository(dbQueue: dbQueue).discardUnprocessedBatchSessionSafely(id: sessionId)
+        }
+    ) {
         self.settings = settings
+        self.unprocessedRecordingDiscarder = unprocessedRecordingDiscarder
     }
 
     /// プロジェクト名から vault 内の URL を返す。
@@ -182,6 +196,8 @@ final class SidebarViewModel {
         meetingReferencesObservationGeneration &+= 1
         projectObservationGeneration &+= 1
         tagObservationGeneration &+= 1
+        unprocessedRecordingsContextGeneration &+= 1
+        unprocessedRecordingsRefreshGeneration &+= 1
         allProjectItems.removeAll()
         isProjectCatalogLoaded = false
         projectCatalogLoadFailed = false
@@ -191,6 +207,9 @@ final class SidebarViewModel {
         areSearchTagsLoaded = false
         allAvailableTags.removeAll()
         selectedInstruction = nil
+        unprocessedRecordingItems.removeAll()
+        unprocessedRecordingsError = nil
+        isLoadingUnprocessedRecordings = false
         clearMeetingSelection()
 
         guard let dbQueue = database?.dbQueue else {
@@ -225,6 +244,7 @@ final class SidebarViewModel {
         startTagsObservation(dbQueue: dbQueue)
         startProjectOverviewObservation(dbQueue: dbQueue, vaultId: vaultId)
         startInstructionsObservation(dbQueue: dbQueue, vaultId: vaultId)
+        Task { await refreshUnprocessedRecordings() }
         workspaceChangeObserver = DistributedNotificationCenter.default().addObserver(
             forName: DahliaWorkspaceChangeNotification.name(vaultID: vaultId),
             object: nil,
@@ -243,9 +263,55 @@ final class SidebarViewModel {
                 self.restartMeetingSearchIfNeeded(dbQueue: dbQueue, vaultId: vaultId)
                 self.startSelectedMeetingObservationIfNeeded()
                 self.startProjectOverviewObservation(dbQueue: dbQueue, vaultId: vaultId)
+                await self.refreshUnprocessedRecordings()
                 self.workspaceChangeToken &+= 1
             }
         }
+    }
+
+    func refreshUnprocessedRecordings() async {
+        guard let dbQueue, let vaultId = currentVault?.id else {
+            unprocessedRecordingItems = []
+            unprocessedRecordingsError = nil
+            isLoadingUnprocessedRecordings = false
+            return
+        }
+        unprocessedRecordingsRefreshGeneration &+= 1
+        let generation = unprocessedRecordingsRefreshGeneration
+        isLoadingUnprocessedRecordings = true
+        do {
+            let items = try await BackupService(dbQueue: dbQueue).preflightItems(vaultId: vaultId)
+            guard isCurrentUnprocessedRecordingsRefresh(generation, vaultId: vaultId) else { return }
+            unprocessedRecordingItems = items
+            unprocessedRecordingsError = nil
+            isLoadingUnprocessedRecordings = false
+        } catch {
+            guard isCurrentUnprocessedRecordingsRefresh(generation, vaultId: vaultId) else { return }
+            unprocessedRecordingsError = error.localizedDescription
+            isLoadingUnprocessedRecordings = false
+        }
+    }
+
+    private func isCurrentUnprocessedRecordingsRefresh(_ generation: UInt64, vaultId: UUID) -> Bool {
+        generation == unprocessedRecordingsRefreshGeneration && currentVault?.id == vaultId
+    }
+
+    func discardUnprocessedRecording(_ item: BackupPreflightItem) async {
+        guard let dbQueue, let vaultId = currentVault?.id else { return }
+        let contextGeneration = unprocessedRecordingsContextGeneration
+        unprocessedRecordingsError = nil
+        do {
+            _ = try await unprocessedRecordingDiscarder(dbQueue, item.sessionId)
+            guard isCurrentUnprocessedRecordingsContext(contextGeneration, vaultId: vaultId) else { return }
+            await refreshUnprocessedRecordings()
+        } catch {
+            guard isCurrentUnprocessedRecordingsContext(contextGeneration, vaultId: vaultId) else { return }
+            unprocessedRecordingsError = error.localizedDescription
+        }
+    }
+
+    private func isCurrentUnprocessedRecordingsContext(_ generation: UInt64, vaultId: UUID) -> Bool {
+        generation == unprocessedRecordingsContextGeneration && currentVault?.id == vaultId
     }
 
     private func startVaultObservation(dbQueue: DatabaseQueue) {

--- a/Sources/Dahlia/Views/BatchTranscriptionInfoBanner.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionInfoBanner.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct BatchTranscriptionInfoBanner: View {
+    let message: String
+    let systemImage: String
+    let showsProgress: Bool
+    let actionTitle: String?
+    let isActionEnabled: Bool
+    let onAction: () -> Void
+
+    var body: some View {
+        HStack {
+            Label(message, systemImage: systemImage)
+            if showsProgress {
+                ProgressView()
+                    .controlSize(.small)
+            }
+            Spacer()
+            if let actionTitle {
+                Button(actionTitle, action: onAction)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!isActionEnabled)
+            }
+        }
+        .padding()
+        .background(.blue.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
+        .padding(.horizontal, DahliaDesign.detailHorizontalPadding)
+        .padding(.vertical, 4)
+    }
+}

--- a/Sources/Dahlia/Views/BatchTranscriptionStatusBanner.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionStatusBanner.swift
@@ -37,15 +37,26 @@ struct BatchTranscriptionStatusBanner: View {
                 isActionEnabled: false,
                 onAction: onAction
             )
-        case .interrupted:
-            BatchTranscriptionInfoBanner(
-                message: L10n.batchTranscriptionInterrupted,
-                systemImage: "pause.circle",
-                showsProgress: false,
-                actionTitle: actionTitle,
-                isActionEnabled: canAct,
-                onAction: onAction
-            )
+        case let .interrupted(_, isRetranscription):
+            if isRetranscription {
+                BatchTranscriptionFailureBanner(
+                    message: L10n.batchTranscriptionInterrupted,
+                    canRetry: canAct,
+                    isRetranscription: true,
+                    onRetry: onAction,
+                    onDiscard: onDiscard,
+                    onKeepCurrentTranscript: onKeepCurrentTranscript
+                )
+            } else {
+                BatchTranscriptionInfoBanner(
+                    message: L10n.batchTranscriptionInterrupted,
+                    systemImage: "pause.circle",
+                    showsProgress: false,
+                    actionTitle: actionTitle,
+                    isActionEnabled: canAct,
+                    onAction: onAction
+                )
+            }
         case let .failed(_, message):
             BatchTranscriptionFailureBanner(
                 message: message,

--- a/Sources/Dahlia/Views/BatchTranscriptionStatusBanner.swift
+++ b/Sources/Dahlia/Views/BatchTranscriptionStatusBanner.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+struct BatchTranscriptionStatusBanner: View {
+    let state: BatchTranscriptionState
+    let canAct: Bool
+    let actionTitle: String
+    let onAction: () -> Void
+    let onDiscard: () -> Void
+    let onKeepCurrentTranscript: () -> Void
+
+    var body: some View {
+        switch state {
+        case .awaitingConfirmation:
+            BatchTranscriptionInfoBanner(
+                message: L10n.batchTranscriptionAwaitingConfirmation,
+                systemImage: "waveform.badge.magnifyingglass",
+                showsProgress: false,
+                actionTitle: actionTitle,
+                isActionEnabled: canAct,
+                onAction: onAction
+            )
+        case .queued:
+            BatchTranscriptionInfoBanner(
+                message: L10n.batchTranscriptionQueued,
+                systemImage: "clock",
+                showsProgress: false,
+                actionTitle: nil,
+                isActionEnabled: false,
+                onAction: onAction
+            )
+        case let .running(_, progress):
+            BatchTranscriptionInfoBanner(
+                message: runningMessage(progress),
+                systemImage: "waveform",
+                showsProgress: true,
+                actionTitle: nil,
+                isActionEnabled: false,
+                onAction: onAction
+            )
+        case .interrupted:
+            BatchTranscriptionInfoBanner(
+                message: L10n.batchTranscriptionInterrupted,
+                systemImage: "pause.circle",
+                showsProgress: false,
+                actionTitle: actionTitle,
+                isActionEnabled: canAct,
+                onAction: onAction
+            )
+        case let .failed(_, message):
+            BatchTranscriptionFailureBanner(
+                message: message,
+                canRetry: canAct,
+                isRetranscription: false,
+                onRetry: onAction,
+                onDiscard: onDiscard,
+                onKeepCurrentTranscript: onKeepCurrentTranscript
+            )
+        case let .retranscriptionFailed(_, message):
+            BatchTranscriptionFailureBanner(
+                message: message,
+                canRetry: canAct,
+                isRetranscription: true,
+                onRetry: onAction,
+                onDiscard: onDiscard,
+                onKeepCurrentTranscript: onKeepCurrentTranscript
+            )
+        case .recording, .completed:
+            EmptyView()
+        }
+    }
+
+    private func runningMessage(_ progress: BatchTranscriptionProgress?) -> String {
+        guard let progress else { return L10n.batchTranscriptionRunning }
+        return "\(L10n.batchTranscriptionRunning) \(L10n.batchTranscriptionFileProgress(completed: progress.completedFileCount, total: progress.totalFileCount))"
+    }
+
+}

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -92,7 +92,8 @@ struct ContentView: View {
         .task(id: sidebarViewModel.currentVault?.id) {
             await sidebarViewModel.refreshUnprocessedRecordings()
         }
-        .onChange(of: viewModel.batchTranscriptionState) { _, _ in
+        .onChange(of: viewModel.batchTranscriptionState) { _, state in
+            guard state?.changesUnprocessedRecordingsProjection != false else { return }
             Task { await sidebarViewModel.refreshUnprocessedRecordings() }
         }
         .onChange(of: viewModel.offscreenBatchTranscriptionChangeToken) { _, _ in

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -95,6 +95,17 @@ struct ContentView: View {
         .onChange(of: viewModel.batchTranscriptionState) { _, _ in
             Task { await sidebarViewModel.refreshUnprocessedRecordings() }
         }
+        .onChange(of: viewModel.offscreenBatchTranscriptionChangeToken) { _, _ in
+            Task { await sidebarViewModel.refreshUnprocessedRecordings() }
+        }
+        .alert(item: $viewModel.batchTranscriptionRecoveryAlert) { alert in
+            Alert(
+                title: Text(L10n.batchTranscriptionRecoveryFailedTitle),
+                message: Text(alert.message),
+                primaryButton: .default(Text(L10n.retry), action: viewModel.retryBatchTranscriptionRecovery),
+                secondaryButton: .cancel()
+            )
+        }
         .sheet(item: $viewModel.pendingBatchTranscriptionConfirmation) { confirmation in
             BatchTranscriptionConfirmationView(
                 locales: viewModel.batchTranscriptionLocaleOptions(

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -14,6 +14,7 @@ struct ContentView: View {
     private var permissionGuidePresentationVersion = 0
     @AppStorage(AppSettings.customerIntelligenceBetaEnabledUserDefaultsKey)
     private var isCustomerIntelligenceBetaEnabled = AppSettings.defaultCustomerIntelligenceBetaEnabled
+    @State private var isShowingUnprocessedRecordings = false
 
     var body: some View {
         NavigationSplitView {
@@ -24,6 +25,8 @@ struct ContentView: View {
                 isShowingUpcomingSchedule: isShowingUpcomingSchedule,
                 onShowUpcomingSchedule: returnToCalendarSchedule,
                 onOpenProjectManagement: { openWindow(id: WindowID.projectManager) },
+                isShowingUnprocessedRecordings: isShowingUnprocessedRecordings,
+                onShowUnprocessedRecordings: showUnprocessedRecordings,
                 showsCustomerIntelligence: isCustomerIntelligenceBetaEnabled,
                 onOpenCustomerIntelligence: { openWindow(id: WindowID.organizationWorkspace) }
             )
@@ -86,6 +89,12 @@ struct ContentView: View {
         .task {
             presentPermissionGuideIfNeeded()
         }
+        .task(id: sidebarViewModel.currentVault?.id) {
+            await sidebarViewModel.refreshUnprocessedRecordings()
+        }
+        .onChange(of: viewModel.batchTranscriptionState) { _, _ in
+            Task { await sidebarViewModel.refreshUnprocessedRecordings() }
+        }
         .sheet(item: $viewModel.pendingBatchTranscriptionConfirmation) { confirmation in
             BatchTranscriptionConfirmationView(
                 locales: viewModel.batchTranscriptionLocaleOptions(
@@ -120,6 +129,9 @@ struct ContentView: View {
         }
         .onChange(of: sidebarViewModel.selectedMeetingIds) { oldValue, newValue in
             guard oldValue != newValue else { return }
+            if !newValue.isEmpty {
+                isShowingUnprocessedRecordings = false
+            }
             handleMeetingSelectionChange(newValue)
             syncChatContext()
         }
@@ -182,11 +194,18 @@ struct ContentView: View {
         sidebarViewModel.selectedMeetingIds.isEmpty
             && !viewModel.hasDraftMeeting
             && viewModel.currentMeetingId == nil
+            && !isShowingUnprocessedRecordings
     }
 
     @ViewBuilder
     private var detailView: some View {
-        if sidebarViewModel.selectedMeetingIds.count > 1 {
+        if isShowingUnprocessedRecordings {
+            UnprocessedRecordingsView(
+                items: sidebarViewModel.unprocessedRecordingItems,
+                captionViewModel: viewModel,
+                sidebarViewModel: sidebarViewModel
+            )
+        } else if sidebarViewModel.selectedMeetingIds.count > 1 {
             MultipleMeetingSelectionView(
                 viewModel: viewModel,
                 sidebarViewModel: sidebarViewModel
@@ -217,10 +236,18 @@ struct ContentView: View {
     }
 
     private func returnToCalendarSchedule() {
+        isShowingUnprocessedRecordings = false
         if viewModel.hasDraftMeeting || sidebarViewModel.selectedMeetingIds.isEmpty {
             viewModel.clearCurrentMeeting()
         }
         sidebarViewModel.clearMeetingSelection()
+    }
+
+    private func showUnprocessedRecordings() {
+        viewModel.clearCurrentMeeting()
+        sidebarViewModel.clearMeetingSelection()
+        isShowingUnprocessedRecordings = true
+        Task { await sidebarViewModel.refreshUnprocessedRecordings() }
     }
 
     private func handleMeetingSelection(_ meetingId: UUID) {

--- a/Sources/Dahlia/Views/ControlPanelView.swift
+++ b/Sources/Dahlia/Views/ControlPanelView.swift
@@ -253,12 +253,12 @@ struct ControlPanelView: View {
                 Rectangle().fill(tabContentBackgroundColor)
             }
 
-            if let failureMessage = viewModel.batchTranscriptionFailureMessage {
-                BatchTranscriptionFailureBanner(
-                    message: failureMessage,
-                    canRetry: viewModel.canRetranscribeBatchAudio,
-                    isRetranscription: viewModel.isBatchRetranscriptionFailure,
-                    onRetry: viewModel.presentAvailableBatchRetranscription,
+            if let batchTranscriptionState = viewModel.batchTranscriptionState {
+                BatchTranscriptionStatusBanner(
+                    state: batchTranscriptionState,
+                    canAct: viewModel.canStartOrResumeBatchTranscription,
+                    actionTitle: viewModel.batchTranscriptionActionTitle,
+                    onAction: viewModel.presentAvailableBatchRetranscription,
                     onDiscard: viewModel.discardFailedBatchTranscription,
                     onKeepCurrentTranscript: viewModel.cancelFailedBatchRetranscription
                 )

--- a/Sources/Dahlia/Views/MeetingDetailNavigationBar.swift
+++ b/Sources/Dahlia/Views/MeetingDetailNavigationBar.swift
@@ -17,7 +17,13 @@ private struct MeetingActionsMenu: View {
                 SummaryOpenMenu(viewModel: viewModel)
             }
 
-            if viewModel.canRetranscribeBatchAudio {
+            if viewModel.canStartOrResumeBatchTranscription {
+                Button(
+                    viewModel.batchTranscriptionActionTitle,
+                    systemImage: "waveform",
+                    action: viewModel.presentAvailableBatchRetranscription
+                )
+            } else if viewModel.canRetranscribeBatchAudio {
                 Button(
                     L10n.retranscribe,
                     systemImage: "arrow.clockwise",

--- a/Sources/Dahlia/Views/MeetingListSidebarView.swift
+++ b/Sources/Dahlia/Views/MeetingListSidebarView.swift
@@ -9,6 +9,8 @@ struct MeetingListSidebarView: View {
     let isShowingUpcomingSchedule: Bool
     let onShowUpcomingSchedule: () -> Void
     let onOpenProjectManagement: () -> Void
+    let isShowingUnprocessedRecordings: Bool
+    let onShowUnprocessedRecordings: () -> Void
     let showsCustomerIntelligence: Bool
     let onOpenCustomerIntelligence: () -> Void
 
@@ -125,6 +127,24 @@ struct MeetingListSidebarView: View {
             }
             .buttonStyle(.plain)
             .help(L10n.manageProjects)
+
+            Button(action: onShowUnprocessedRecordings) {
+                HStack {
+                    sidebarActionLabel(
+                        L10n.unprocessedRecordings,
+                        systemImage: "waveform.badge.exclamationmark",
+                        isSelected: isShowingUnprocessedRecordings
+                    )
+                    if !sidebarViewModel.unprocessedRecordingItems.isEmpty {
+                        Text(sidebarViewModel.unprocessedRecordingItems.count, format: .number)
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+            .help(L10n.unprocessedRecordings)
+            .accessibilityAddTraits(isShowingUnprocessedRecordings ? .isSelected : [])
 
             if showsCustomerIntelligence {
                 Button(action: onOpenCustomerIntelligence) {

--- a/Sources/Dahlia/Views/Settings/BackupSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/BackupSettingsView.swift
@@ -16,16 +16,13 @@ struct BackupSettingsView: View {
 
     private let dbQueue: DatabaseQueue?
     @ObservedObject private var captionViewModel: CaptionViewModel
-    private let sidebarViewModel: SidebarViewModel
 
     init(
         dbQueue: DatabaseQueue?,
-        captionViewModel: CaptionViewModel,
-        sidebarViewModel: SidebarViewModel
+        captionViewModel: CaptionViewModel
     ) {
         self.dbQueue = dbQueue
         _captionViewModel = ObservedObject(wrappedValue: captionViewModel)
-        self.sidebarViewModel = sidebarViewModel
         _model = State(initialValue: BackupSettingsViewModel(dbQueue: dbQueue))
     }
 
@@ -152,22 +149,24 @@ struct BackupSettingsView: View {
             ForEach(model.preflightItems) { item in
                 LabeledContent {
                     HStack {
-                        if item.state == .awaitingConfirmation || item.state == .failed {
+                        if item.canStartTranscription {
                             Button(L10n.transcribe) {
-                                resolveByTranscribing(item)
+                                Task { await resolveByTranscribing(item) }
                             }
+                        } else if item.isWorkInProgress {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        if item.canDiscard {
                             Button(L10n.discardRecording, role: .destructive) {
                                 pendingDiscardItem = item
                             }
-                        } else {
-                            ProgressView()
-                                .controlSize(.small)
                         }
                     }
                 } label: {
                     Text(item.meetingName)
                     Text(item.startedAt.formatted(date: .abbreviated, time: .shortened))
-                    Text(preflightStateLabel(item))
+                    Text(item.statusDescription)
                 }
             }
         } header: {
@@ -211,35 +210,14 @@ struct BackupSettingsView: View {
         }
     }
 
-    private func preflightStateLabel(_ item: BackupPreflightItem) -> String {
-        switch item.state {
-        case .recording: L10n.recordingInProgress
-        case .awaitingConfirmation: L10n.awaitingTranscription
-        case .processing: L10n.transcriptionInProgress
-        case .failed: item.failureMessage ?? L10n.transcriptionFailed
-        }
-    }
-
-    private func resolveByTranscribing(_ item: BackupPreflightItem) {
+    private func resolveByTranscribing(_ item: BackupPreflightItem) async {
         guard let dbQueue else { return }
-        sidebarViewModel.selectMeeting(item.meetingId)
         MainWindowOpener.shared.openMainWindow()
-        switch item.state {
-        case .awaitingConfirmation:
-            captionViewModel.presentBatchTranscriptionConfirmation(
-                sessionId: item.sessionId,
-                meetingId: item.meetingId,
-                dbQueue: dbQueue
-            )
-        case .failed:
-            captionViewModel.presentBatchTranscriptionConfirmation(
-                sessionId: item.sessionId,
-                meetingId: item.meetingId,
-                dbQueue: dbQueue
-            )
-        case .recording, .processing:
-            break
-        }
+        await captionViewModel.presentManualBatchTranscription(
+            sessionId: item.sessionId,
+            meetingId: item.meetingId,
+            dbQueue: dbQueue
+        )
     }
 
     private func importBackup() {

--- a/Sources/Dahlia/Views/Settings/SettingsDetailView.swift
+++ b/Sources/Dahlia/Views/Settings/SettingsDetailView.swift
@@ -16,8 +16,7 @@ struct SettingsDetailView: View {
             case .backups:
                 BackupSettingsView(
                     dbQueue: sidebarViewModel.dbQueue,
-                    captionViewModel: captionViewModel,
-                    sidebarViewModel: sidebarViewModel
+                    captionViewModel: captionViewModel
                 )
             case .transcription:
                 TranscriptionSettingsView()

--- a/Sources/Dahlia/Views/UnprocessedRecordingsView.swift
+++ b/Sources/Dahlia/Views/UnprocessedRecordingsView.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+struct UnprocessedRecordingsView: View {
+    let items: [BackupPreflightItem]
+    @ObservedObject var captionViewModel: CaptionViewModel
+    let sidebarViewModel: SidebarViewModel
+    @State private var pendingDiscardItem: BackupPreflightItem?
+
+    var body: some View {
+        Group {
+            if items.isEmpty {
+                emptyContent
+            } else {
+                List(items) { item in
+                    LabeledContent {
+                        actions(for: item)
+                    } label: {
+                        Text(item.meetingName)
+                        Text(item.startedAt, format: .dateTime.year().month().day().hour().minute())
+                        Text(item.statusDescription)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .safeAreaInset(edge: .top) {
+                    if let error = sidebarViewModel.unprocessedRecordingsError {
+                        errorBanner(error)
+                    }
+                }
+            }
+        }
+        .navigationTitle(L10n.unprocessedRecordings)
+        .confirmationDialog(
+            L10n.discardUnprocessedRecordingConfirmation,
+            isPresented: Binding(
+                get: { pendingDiscardItem != nil },
+                set: { if !$0 { pendingDiscardItem = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button(L10n.discardRecording, role: .destructive) {
+                guard let item = pendingDiscardItem else { return }
+                pendingDiscardItem = nil
+                Task { await sidebarViewModel.discardUnprocessedRecording(item) }
+            }
+            Button(L10n.cancel, role: .cancel) { pendingDiscardItem = nil }
+        } message: {
+            Text(L10n.discardUnprocessedRecordingDescription)
+        }
+    }
+
+    @ViewBuilder
+    private var emptyContent: some View {
+        if sidebarViewModel.isLoadingUnprocessedRecordings {
+            ProgressView()
+        } else if let error = sidebarViewModel.unprocessedRecordingsError {
+            ContentUnavailableView {
+                Label(L10n.unprocessedRecordings, systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(error)
+            } actions: {
+                Button(L10n.retry) {
+                    Task { await sidebarViewModel.refreshUnprocessedRecordings() }
+                }
+            }
+        } else {
+            ContentUnavailableView(
+                L10n.unprocessedRecordings,
+                systemImage: "waveform.badge.checkmark",
+                description: Text(L10n.noUnprocessedRecordingsDescription)
+            )
+        }
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack {
+            Label(message, systemImage: "exclamationmark.triangle")
+            Spacer()
+            Button(L10n.retry) {
+                Task { await sidebarViewModel.refreshUnprocessedRecordings() }
+            }
+        }
+        .padding(.horizontal, DahliaDesign.detailHorizontalPadding)
+        .padding(.vertical, 8)
+        .background(.orange.opacity(0.1))
+    }
+
+    private func actions(for item: BackupPreflightItem) -> some View {
+        HStack {
+            if item.canStartTranscription {
+                Button(item.state == .interrupted ? L10n.resumeBatchTranscription : L10n.transcribe) {
+                    beginTranscription(item)
+                }
+                .buttonStyle(.borderedProminent)
+            } else if item.isWorkInProgress {
+                ProgressView()
+                    .controlSize(.small)
+            }
+            Button(L10n.discardRecording, role: .destructive) {
+                pendingDiscardItem = item
+            }
+            .disabled(!item.canDiscard)
+        }
+    }
+
+    private func beginTranscription(_ item: BackupPreflightItem) {
+        guard let dbQueue = sidebarViewModel.dbQueue else { return }
+        sidebarViewModel.selectMeeting(item.meetingId)
+        Task {
+            await captionViewModel.presentManualBatchTranscription(
+                sessionId: item.sessionId,
+                meetingId: item.meetingId,
+                dbQueue: dbQueue
+            )
+        }
+    }
+}

--- a/Tests/DahliaTests/BackupServiceTests.swift
+++ b/Tests/DahliaTests/BackupServiceTests.swift
@@ -128,6 +128,12 @@ import GRDB
             let items = try await service.preflightItems()
             #expect(items.count == 1)
             #expect(items.first?.state == .awaitingConfirmation)
+            #expect(items.first?.canTranscribe == false)
+            #expect(items.first?.canStartTranscription == false)
+            #expect(items.first?.isWorkInProgress == false)
+            #expect(items.first?.canDiscard == true)
+            #expect(items.first?.hasUnavailableAudio == true)
+            #expect(items.first?.statusDescription == L10n.batchRecordingAudioUnavailable)
             await #expect(throws: BackupServiceError.unresolvedAudio(1)) {
                 try await service.createGeneration()
             }
@@ -151,7 +157,7 @@ import GRDB
                     """,
                     arguments: [
                         UUID.v7(), fixture.session.id, RecordingAudioSource.microphone.rawValue,
-                        "legacy/microphone.caf", 16_000, 1, fixture.now, 160,
+                        "legacy/microphone.caf", 16000, 1, fixture.now, 160,
                         fixture.now, fixture.now, RecordingAudioStorageLocation.vault.rawValue,
                     ]
                 )
@@ -287,11 +293,11 @@ import GRDB
             let oldQueue = try DatabaseQueue(path: oldURL.path)
             try AppDatabaseManager.migrator.migrate(oldQueue, upTo: migrationIdentifier)
             let vault = makeVault(name: "Preserved old vault", path: rootURL.appending(path: "Vault").path)
-            let metadata = BackupMetadata(
+            let metadata = try BackupMetadata(
                 formatVersion: BackupMetadata.currentFormatVersion,
                 generationId: .v7(),
                 createdAt: .now,
-                schemaVersion: try #require(AppDatabaseManager.schemaVersion(from: migrationIdentifier)),
+                schemaVersion: #require(AppDatabaseManager.schemaVersion(from: migrationIdentifier)),
                 migrationIdentifier: migrationIdentifier,
                 appVersion: "0.9.0",
                 appBuild: "9",
@@ -331,10 +337,10 @@ import GRDB
                 .appending(path: marker.stagedFilename)
             let staged = try DatabaseQueue(path: stagedURL.path)
             let result = try await staged.read { db in
-                (
-                    try AppDatabaseManager.migrator.hasCompletedMigrations(db),
-                    try AppDatabaseManager.hasExpectedCurrentSchema(db),
-                    try String.fetchOne(db, sql: "SELECT name FROM vaults WHERE id = ?", arguments: [vault.id])
+                try (
+                    AppDatabaseManager.migrator.hasCompletedMigrations(db),
+                    AppDatabaseManager.hasExpectedCurrentSchema(db),
+                    String.fetchOne(db, sql: "SELECT name FROM vaults WHERE id = ?", arguments: [vault.id])
                 )
             }
             #expect(result.0)
@@ -352,7 +358,7 @@ import GRDB
                 state: .ready,
                 partialRelativePath: "session/microphone/0.partial.caf",
                 finalRelativePath: "session/microphone/0.caf",
-                sampleRate: 16_000,
+                sampleRate: 16000,
                 channelCount: 1,
                 sealedFrameCount: 160,
                 sessionStartOffsetSeconds: 0,

--- a/Tests/DahliaTests/BatchRetranscriptionRecoveryTests.swift
+++ b/Tests/DahliaTests/BatchRetranscriptionRecoveryTests.swift
@@ -87,7 +87,7 @@ import GRDB
                 managedRootURL: fixture.managedRootURL,
                 onStateChange: { _ in }
             )
-            await coordinator.recoverAndEnqueue()
+            try await coordinator.recoverAndEnqueue()
             let segments = try await fixture.database.dbQueue.read { db in
                 try RecordingAudioSegmentRecord
                     .filter(Column("recordingSessionId") == fixture.session.id)
@@ -149,7 +149,8 @@ import GRDB
             }
             #expect(session.batchLastError == nil)
             #expect(BatchTranscriptionState.derive(from: session) == .completed(sessionId: fixture.session.id))
-            #expect(!(await updateProbe.hasFailure))
+            let hasFailure = await updateProbe.hasFailure
+            #expect(!hasFailure)
         }
 
         private func makeTranscriptRecord(

--- a/Tests/DahliaTests/BatchTranscriptionConcurrencyTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionConcurrencyTests.swift
@@ -57,7 +57,7 @@ import Speech
         }
 
         @Test
-        func appleRecognitionAllowsFourConcurrentRequests() async throws {
+        func appleRecognitionSerializesConcurrentRequests() async throws {
             let recognizer = SuspendingSpeechRecognizer()
             defer { Task { await recognizer.resumeAll() } }
             let adaptive = AdaptiveBatchSpeechRecognizer(recognizer: recognizer)
@@ -69,12 +69,11 @@ import Speech
             async let fourth = adaptive.recognize(audioURL: URL(fileURLWithPath: "/tmp/fourth.caf"), locale: locale)
             async let fifth = adaptive.recognize(audioURL: URL(fileURLWithPath: "/tmp/fifth.caf"), locale: locale)
 
-            try await waitUntil { await recognizer.callCount == 4 }
-            #expect(await recognizer.maximumActiveCount == 4)
-            await recognizer.resumeNext()
-            try await waitUntil { await recognizer.callCount == 5 }
-            #expect(await recognizer.maximumActiveCount == 4)
-            await recognizer.resumeAll()
+            for expectedCallCount in 1 ... 5 {
+                try await waitUntil { await recognizer.callCount == expectedCallCount }
+                #expect(await recognizer.maximumActiveCount == 1)
+                await recognizer.resumeNext()
+            }
             _ = try await (first, second, third, fourth, fifth)
         }
 
@@ -104,54 +103,6 @@ import Speech
                 )
             }
             #expect(await recognizer.callCount == 2)
-        }
-
-        @Test
-        func insufficientResourcesWaitsForInflightRecognitionThenKeepsSerialLimit() async throws {
-            let recognizer = ConcurrentResourceLimitedSpeechRecognizer()
-            defer { Task { await recognizer.resumeAll() } }
-            let adaptive = AdaptiveBatchSpeechRecognizer(recognizer: recognizer)
-            let locale = Locale(identifier: "ja_JP")
-
-            let held = Task {
-                try await adaptive.recognize(
-                    audioURL: URL(fileURLWithPath: "/tmp/held.caf"),
-                    locale: locale
-                )
-            }
-            try await waitUntil { await recognizer.activeCount == 1 }
-            let fallback = Task {
-                try await adaptive.recognize(
-                    audioURL: URL(fileURLWithPath: "/tmp/fallback.caf"),
-                    locale: locale
-                )
-            }
-            try await waitUntil { await recognizer.didReturnResourceFailure }
-            await Task.yield()
-            #expect(await recognizer.callCount == 2)
-
-            await recognizer.resumeNext()
-            _ = try await held.value
-            _ = try await fallback.value
-            #expect(await recognizer.callCount == 3)
-            #expect(await adaptive.currentConcurrencyLimit() == 1)
-
-            let nextA = Task {
-                try await adaptive.recognize(audioURL: URL(fileURLWithPath: "/tmp/next-a.caf"), locale: locale)
-            }
-            let nextB = Task {
-                try await adaptive.recognize(audioURL: URL(fileURLWithPath: "/tmp/next-b.caf"), locale: locale)
-            }
-            try await waitUntil { await recognizer.callCount == 4 }
-            #expect(await recognizer.activeCount == 1)
-            await recognizer.resumeNext()
-            try await waitUntil { await recognizer.callCount == 5 }
-            #expect(await recognizer.activeCount == 1)
-            await recognizer.resumeNext()
-            _ = try await (nextA.value, nextB.value)
-
-            await adaptive.unload()
-            #expect(await adaptive.currentConcurrencyLimit() == 4)
         }
 
         @Test

--- a/Tests/DahliaTests/BatchTranscriptionConfirmationServiceTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionConfirmationServiceTests.swift
@@ -211,7 +211,7 @@ import GRDB
                 managedRootURL: fixture.managedRootURL,
                 onStateChange: { _ in }
             )
-            await coordinator.recoverAndEnqueue()
+            try await coordinator.recoverAndEnqueue()
             let segmentStates = try await fixture.database.dbQueue.read { db in
                 try RecordingAudioSegmentRecord
                     .filter(Column("recordingSessionId") == fixture.session.id)

--- a/Tests/DahliaTests/BatchTranscriptionConfirmationServiceTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionConfirmationServiceTests.swift
@@ -311,7 +311,7 @@ import GRDB
 
         @Test(arguments: [
             0,
-            BatchTranscriptionCoordinator.maximumAutomaticAttemptCount,
+            3,
         ])
         func automaticConfirmationPreservesLocaleAndFailedRetryBecomesRecoverableManual(
             failedAttemptCount: Int
@@ -386,7 +386,6 @@ import GRDB
             #expect(retrySession.batchFailureKind == nil)
             #expect(retrySession.batchAttemptCount == failedAttemptCount)
             #expect(retrySession.batchLastAttemptAt != nil)
-            #expect(BatchTranscriptionCoordinator.shouldAutomaticallyRetry(retrySession))
             #expect(retryResult.1.map(\.localeIdentifier) == ["en_US"])
         }
 

--- a/Tests/DahliaTests/BatchTranscriptionCoordinatorLanguageDetectionTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionCoordinatorLanguageDetectionTests.swift
@@ -42,7 +42,7 @@ import GRDB
         }
 
         @Test
-        func nextLanguageDetectionOverlapsPreviousSpeechRecognition() async throws {
+        func languageDetectionAndSpeechRecognitionRunSerially() async throws {
             let fixture = try BatchAudioTestFixture(
                 name: "AutomaticLanguagePipeline",
                 endedAt: Date(timeIntervalSince1970: 1_776_384_001),
@@ -52,7 +52,6 @@ import GRDB
             defer { fixture.removeFiles() }
             try await createSegmentedRecording(fixture: fixture)
             let probe = BatchPipelineProbe()
-            defer { Task { await probe.releaseSecondDetection() } }
             let coordinator = BatchTranscriptionCoordinator(
                 dbQueue: fixture.database.dbQueue,
                 managedRootURL: fixture.managedRootURL,
@@ -65,10 +64,6 @@ import GRDB
             )
 
             await coordinator.enqueue(sessionId: fixture.session.id)
-            try await waitUntil { await probe.secondDetectionIsActive }
-            try await waitUntil { await probe.recognitionCallCount > 0 }
-            #expect(await probe.recognitionStartedDuringSecondDetection)
-            await probe.releaseSecondDetection()
             try await waitUntil {
                 (try? fixture.database.dbQueue.read { db in
                     try RecordingSessionRecord.fetchOne(db, key: fixture.session.id)?.batchCompletedAt != nil
@@ -82,6 +77,12 @@ import GRDB
                     .fetchAll(db)
             }
             #expect(transcripts.count == 2)
+            #expect(await probe.events == [
+                "detection-1",
+                "recognition-1",
+                "detection-2",
+                "recognition-2",
+            ])
         }
 
         @Test
@@ -337,7 +338,6 @@ import GRDB
             #expect(failed.0.batchLastError == L10n.batchLanguageModelPreparationFailed)
             #expect(failed.0.batchFailureKind == .transcription)
             #expect(failed.0.batchAttemptCount == 1)
-            #expect(BatchTranscriptionCoordinator.shouldAutomaticallyRetry(failed.0))
             #expect(failed.1 == 0)
             for segment in context.audioSegments {
                 #expect(FileManager.default.fileExists(
@@ -510,39 +510,15 @@ import GRDB
     }
 
     private actor BatchPipelineProbe {
-        private var secondDetectionContinuation: CheckedContinuation<Void, Never>?
-        private var recognitionWaiters: [CheckedContinuation<Void, Never>] = []
-        private(set) var secondDetectionIsActive = false
-        private(set) var recognitionStartedDuringSecondDetection = false
-        private(set) var recognitionCallCount = 0
+        private(set) var events: [String] = []
 
-        func holdSecondDetection() async {
-            secondDetectionIsActive = true
-            let waiters = recognitionWaiters
-            recognitionWaiters.removeAll()
-            for waiter in waiters {
-                waiter.resume()
-            }
-            await withCheckedContinuation { continuation in
-                secondDetectionContinuation = continuation
-            }
-            secondDetectionIsActive = false
+        func recordDetection(_ callCount: Int) {
+            events.append("detection-\(callCount)")
         }
 
-        func recordRecognitionStart() async {
-            recognitionCallCount += 1
-            guard recognitionCallCount == 1 else { return }
-            if !secondDetectionIsActive {
-                await withCheckedContinuation { continuation in
-                    recognitionWaiters.append(continuation)
-                }
-            }
-            recognitionStartedDuringSecondDetection = secondDetectionIsActive
-        }
-
-        func releaseSecondDetection() {
-            secondDetectionContinuation?.resume()
-            secondDetectionContinuation = nil
+        func recordRecognitionStart() {
+            let recognitionCount = events.count(where: { $0.hasPrefix("recognition-") }) + 1
+            events.append("recognition-\(recognitionCount)")
         }
     }
 
@@ -559,11 +535,8 @@ import GRDB
             allowedLanguageIdentifiers _: Set<String>?
         ) async -> BatchLanguageDetectionOutcome {
             callCount += 1
-            if callCount == 2 {
-                await probe.holdSecondDetection()
-                return .confidentDetection("en")
-            }
-            return .confidentDetection("ja")
+            await probe.recordDetection(callCount)
+            return .confidentDetection(callCount == 1 ? "ja" : "en")
         }
 
         func unload() async {}

--- a/Tests/DahliaTests/BatchTranscriptionDiscardTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionDiscardTests.swift
@@ -25,7 +25,7 @@ import GRDB
                 state: .ready,
                 partialRelativePath: "session/mic/0.partial.caf",
                 finalRelativePath: "session/mic/0.caf",
-                sampleRate: 16_000,
+                sampleRate: 16000,
                 channelCount: 1,
                 sealedFrameCount: 160,
                 sessionStartOffsetSeconds: 0,
@@ -49,6 +49,7 @@ import GRDB
             let discarded = try await MeetingRepository(dbQueue: fixture.database.dbQueue)
                 .discardUnprocessedBatchSessionSafely(
                     id: fixture.session.id,
+                    expectedVaultId: fixture.meeting.vaultId,
                     managedRootURL: fixture.managedRootURL
                 )
 
@@ -63,6 +64,30 @@ import GRDB
             #expect(result.0?.batchDiscardedAt != nil)
             #expect(result.1?.id == fixture.meeting.id)
             #expect(result.2?.state == .purged)
+        }
+
+        @Test
+        func discardRejectsSessionFromAnotherVault() async throws {
+            let fixture = try BatchAudioTestFixture(
+                name: "DiscardVaultMismatch",
+                endedAt: Date(timeIntervalSince1970: 1_776_384_010),
+                duration: 10
+            )
+            defer { fixture.removeFiles() }
+            try await fixture.recordMicrophoneAudio()
+
+            let discarded = try await MeetingRepository(dbQueue: fixture.database.dbQueue)
+                .discardUnprocessedBatchSessionSafely(
+                    id: fixture.session.id,
+                    expectedVaultId: .v7(),
+                    managedRootURL: fixture.managedRootURL
+                )
+
+            let session = try await fixture.database.dbQueue.read { db in
+                try RecordingSessionRecord.fetchOne(db, key: fixture.session.id)
+            }
+            #expect(!discarded)
+            #expect(session?.batchDiscardedAt == nil)
         }
 
         @Test
@@ -97,7 +122,7 @@ import GRDB
                 targetSegmentDuration: .seconds(60),
                 maximumFinalizingSegmentCountPerSource: 2,
                 maximumActiveSegmentDuration: .seconds(600),
-                maximumActiveSegmentByteCount: 64 * 1_024 * 1_024,
+                maximumActiveSegmentByteCount: 64 * 1024 * 1024,
                 minimumAvailableCapacity: 0,
                 capacityCheckInterval: .seconds(5)
             )
@@ -174,7 +199,7 @@ import GRDB
                 state: .ready,
                 partialRelativePath: "session/mic/0.partial.caf",
                 finalRelativePath: "session/mic/0.caf",
-                sampleRate: 16_000,
+                sampleRate: 16000,
                 channelCount: 1,
                 sealedFrameCount: 160,
                 sessionStartOffsetSeconds: 0,
@@ -206,6 +231,7 @@ import GRDB
             async let enqueue: Void = coordinator.enqueue(sessionId: fixture.session.id)
             async let discard = repository.discardUnprocessedBatchSessionSafely(
                 id: fixture.session.id,
+                expectedVaultId: fixture.meeting.vaultId,
                 managedRootURL: fixture.managedRootURL
             )
             await enqueue

--- a/Tests/DahliaTests/BatchTranscriptionStallPersistenceTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionStallPersistenceTests.swift
@@ -161,9 +161,13 @@ import GRDB
             }
             #expect(await pollUntil { await confirmationGate.isWaiting })
 
-            try await coordinator.shutdown()
+            let shutdownTask = Task {
+                try await coordinator.shutdown()
+            }
+            #expect(await pollUntil { await coordinator.isWaitingForConfirmationDrainForTesting() })
             await confirmationGate.release()
             try await confirmationTask.value
+            try await shutdownTask.value
 
             let session = try await batch.database.dbQueue.read { db in
                 try #require(try RecordingSessionRecord.fetchOne(db, key: batch.session.id))

--- a/Tests/DahliaTests/BatchTranscriptionStallPersistenceTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionStallPersistenceTests.swift
@@ -70,7 +70,7 @@ import GRDB
             await coordinator.enqueue(sessionId: batch.session.id)
             #expect(await pollUntil { await recognizer.didStart })
 
-            await coordinator.shutdown()
+            try await coordinator.shutdown()
 
             let session = try await batch.database.dbQueue.read { db in
                 try #require(try RecordingSessionRecord.fetchOne(db, key: batch.session.id))
@@ -80,6 +80,55 @@ import GRDB
                 sessionId: batch.session.id,
                 isRetranscription: false
             ))
+        }
+
+        @Test
+        func terminationIsRejectedUntilBatchInterruptionPersists() async throws {
+            let batch = try BatchAudioTestFixture(
+                name: "shutdown-persistence-retry",
+                endedAt: Date(timeIntervalSince1970: 1_776_384_001),
+                duration: 1
+            )
+            defer { batch.removeFiles() }
+            try await batch.recordMicrophoneAudio()
+            try await batch.database.dbQueue.write { db in
+                guard var session = try RecordingSessionRecord.fetchOne(db, key: batch.session.id) else {
+                    throw CocoaError(.fileNoSuchFile)
+                }
+                session.batchSelectedLocaleIdentifier = "ja_JP"
+                try session.update(db)
+            }
+            let recognizer = ShutdownSpeechRecognizer()
+            let coordinator = BatchTranscriptionCoordinator(
+                dbQueue: batch.database.dbQueue,
+                managedRootURL: batch.managedRootURL,
+                speechRecognizer: recognizer,
+                onStateChange: { _ in }
+            )
+            await coordinator.enqueue(sessionId: batch.session.id)
+            #expect(await pollUntil { await recognizer.didStart })
+            try await batch.database.dbQueue.write { db in
+                try db.execute(sql: """
+                CREATE TRIGGER fail_batch_interruption_persistence
+                BEFORE UPDATE OF batchLastError ON recording_sessions
+                BEGIN
+                    SELECT RAISE(ABORT, 'forced interruption persistence failure');
+                END
+                """)
+            }
+            let viewModel = CaptionViewModel()
+            viewModel.setBatchTranscriptionCoordinatorForTesting(coordinator)
+
+            #expect(await viewModel.prepareForTermination() != nil)
+
+            try await batch.database.dbQueue.write { db in
+                try db.execute(sql: "DROP TRIGGER fail_batch_interruption_persistence")
+            }
+            #expect(await viewModel.prepareForTermination() == nil)
+            let session = try await batch.database.dbQueue.read { db in
+                try #require(try RecordingSessionRecord.fetchOne(db, key: batch.session.id))
+            }
+            #expect(session.batchFailureKind == .transcriptionInterrupted)
         }
 
         @Test
@@ -110,7 +159,7 @@ import GRDB
             }
             #expect(await pollUntil { await confirmationGate.isWaiting })
 
-            await coordinator.shutdown()
+            try await coordinator.shutdown()
             await confirmationGate.release()
             try await confirmationTask.value
 

--- a/Tests/DahliaTests/BatchTranscriptionStallPersistenceTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionStallPersistenceTests.swift
@@ -124,6 +124,8 @@ import GRDB
             try await batch.database.dbQueue.write { db in
                 try db.execute(sql: "DROP TRIGGER fail_batch_interruption_persistence")
             }
+            await coordinator.enqueue(sessionId: batch.session.id)
+            #expect(await pollUntil { await recognizer.startCount == 2 })
             #expect(await viewModel.prepareForTermination() == nil)
             let session = try await batch.database.dbQueue.read { db in
                 try #require(try RecordingSessionRecord.fetchOne(db, key: batch.session.id))
@@ -268,7 +270,8 @@ import GRDB
 
     private actor ShutdownSpeechRecognizer: BatchSpeechRecognizing {
         private var continuation: CheckedContinuation<[BatchSpeechRecognition], Error>?
-        private(set) var didStart = false
+        private(set) var startCount = 0
+        var didStart: Bool { startCount > 0 }
 
         func recognize(audioURL _: URL, locale _: Locale) async throws -> [BatchSpeechRecognition] {
             try await suspendUntilCancelled()
@@ -279,7 +282,7 @@ import GRDB
         }
 
         private func suspendUntilCancelled() async throws -> [BatchSpeechRecognition] {
-            didStart = true
+            startCount += 1
             return try await withTaskCancellationHandler {
                 try await withCheckedThrowingContinuation { continuation in
                     if Task.isCancelled {

--- a/Tests/DahliaTests/BatchTranscriptionStallPersistenceTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionStallPersistenceTests.swift
@@ -31,7 +31,7 @@ import GRDB
                 onStateChange: { _ in }
             )
 
-            await coordinator.recoverAndEnqueue()
+            try await coordinator.recoverAndEnqueue()
 
             let session = try await batch.database.dbQueue.read { db in
                 try #require(try RecordingSessionRecord.fetchOne(db, key: batch.session.id))
@@ -176,7 +176,7 @@ import GRDB
                 speechRecognizer: CountingBatchSpeechRecognizer(probe: retryProbe),
                 onStateChange: { _ in }
             )
-            await recoveryCoordinator.recoverAndEnqueue()
+            try await recoveryCoordinator.recoverAndEnqueue()
             #expect(await retryProbe.callCount == 0)
         }
     }

--- a/Tests/DahliaTests/BatchTranscriptionStallPersistenceTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionStallPersistenceTests.swift
@@ -8,6 +8,124 @@ import GRDB
     @MainActor
     struct BatchTranscriptionStallPersistenceTests {
         @Test
+        func startupMarksConfirmedWorkInterruptedWithoutStartingSpeech() async throws {
+            let batch = try BatchAudioTestFixture(
+                name: "startup-manual-resume",
+                endedAt: Date(timeIntervalSince1970: 1_776_384_001),
+                duration: 1
+            )
+            defer { batch.removeFiles() }
+            try await batch.recordMicrophoneAudio()
+            _ = try await BatchTranscriptionConfirmationService.confirm(
+                sessionId: batch.session.id,
+                languageSelection: .manual(localeIdentifier: "ja_JP"),
+                automaticLanguageCandidates: nil,
+                retainAudioAfterBatch: true,
+                dbQueue: batch.database.dbQueue
+            )
+            let retryProbe = BatchRecognitionCallProbe()
+            let coordinator = BatchTranscriptionCoordinator(
+                dbQueue: batch.database.dbQueue,
+                managedRootURL: batch.managedRootURL,
+                speechRecognizer: CountingBatchSpeechRecognizer(probe: retryProbe),
+                onStateChange: { _ in }
+            )
+
+            await coordinator.recoverAndEnqueue()
+
+            let session = try await batch.database.dbQueue.read { db in
+                try #require(try RecordingSessionRecord.fetchOne(db, key: batch.session.id))
+            }
+            #expect(await retryProbe.callCount == 0)
+            #expect(session.batchFailureKind == .transcriptionInterrupted)
+            #expect(BatchTranscriptionState.derive(from: session) == .interrupted(
+                sessionId: batch.session.id,
+                isRetranscription: false
+            ))
+        }
+
+        @Test
+        func shutdownCancelsRecognitionAndPersistsManualResumeState() async throws {
+            let batch = try BatchAudioTestFixture(
+                name: "shutdown-manual-resume",
+                endedAt: Date(timeIntervalSince1970: 1_776_384_001),
+                duration: 1
+            )
+            defer { batch.removeFiles() }
+            try await batch.recordMicrophoneAudio()
+            try await batch.database.dbQueue.write { db in
+                guard var session = try RecordingSessionRecord.fetchOne(db, key: batch.session.id) else {
+                    throw CocoaError(.fileNoSuchFile)
+                }
+                session.batchSelectedLocaleIdentifier = "ja_JP"
+                try session.update(db)
+            }
+            let recognizer = ShutdownSpeechRecognizer()
+            let coordinator = BatchTranscriptionCoordinator(
+                dbQueue: batch.database.dbQueue,
+                managedRootURL: batch.managedRootURL,
+                speechRecognizer: recognizer,
+                onStateChange: { _ in }
+            )
+            await coordinator.enqueue(sessionId: batch.session.id)
+            #expect(await pollUntil { await recognizer.didStart })
+
+            await coordinator.shutdown()
+
+            let session = try await batch.database.dbQueue.read { db in
+                try #require(try RecordingSessionRecord.fetchOne(db, key: batch.session.id))
+            }
+            #expect(session.batchFailureKind == .transcriptionInterrupted)
+            #expect(BatchTranscriptionState.derive(from: session) == .interrupted(
+                sessionId: batch.session.id,
+                isRetranscription: false
+            ))
+        }
+
+        @Test
+        func confirmationFinishingAfterShutdownDoesNotStartSpeech() async throws {
+            let batch = try BatchAudioTestFixture(
+                name: "shutdown-during-confirmation",
+                endedAt: Date(timeIntervalSince1970: 1_776_384_001),
+                duration: 1
+            )
+            defer { batch.removeFiles() }
+            try await batch.recordMicrophoneAudio()
+            let recognitionProbe = BatchRecognitionCallProbe()
+            let confirmationGate = BatchConfirmationGate()
+            let coordinator = BatchTranscriptionCoordinator(
+                dbQueue: batch.database.dbQueue,
+                managedRootURL: batch.managedRootURL,
+                speechRecognizer: CountingBatchSpeechRecognizer(probe: recognitionProbe),
+                onStateChange: { _ in }
+            )
+            let confirmationTask = Task {
+                try await coordinator.confirmAndEnqueue(
+                    sessionId: batch.session.id,
+                    languageSelection: .manual(localeIdentifier: "ja_JP"),
+                    automaticLanguageCandidates: nil,
+                    retainAudioAfterBatch: true,
+                    onConfirmed: { _ in await confirmationGate.wait() }
+                )
+            }
+            #expect(await pollUntil { await confirmationGate.isWaiting })
+
+            await coordinator.shutdown()
+            await confirmationGate.release()
+            try await confirmationTask.value
+
+            let session = try await batch.database.dbQueue.read { db in
+                try #require(try RecordingSessionRecord.fetchOne(db, key: batch.session.id))
+            }
+            #expect(await recognitionProbe.callCount == 0)
+            #expect(session.batchFailureKind == .transcriptionInterrupted)
+            #expect(BatchTranscriptionState.derive(from: session) == .interrupted(
+                sessionId: batch.session.id,
+                isRetranscription: false
+            ))
+        }
+
+        @Test
         func stalledRecognitionPersistsManualFailureAndKeepsReadyAudio() async throws {
             let batch = try BatchAudioTestFixture(
                 name: "stalled-recognition",
@@ -45,7 +163,6 @@ import GRDB
             }
             #expect(result.0.batchLastError == L10n.batchAnalysisStalled(minutes: 1))
             #expect(result.0.batchFailureKind == .transcriptionStalled)
-            #expect(!BatchTranscriptionCoordinator.shouldAutomaticallyRetry(result.0))
             #expect(result.1.state == .ready)
             #expect(result.1.purgedAt == nil)
             #expect(FileManager.default.fileExists(
@@ -79,6 +196,57 @@ import GRDB
 
         func recordCall() {
             callCount += 1
+        }
+    }
+
+    private actor BatchConfirmationGate {
+        private var continuation: CheckedContinuation<Void, Never>?
+        private(set) var isWaiting = false
+
+        func wait() async {
+            isWaiting = true
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
+
+        func release() {
+            continuation?.resume()
+            continuation = nil
+            isWaiting = false
+        }
+    }
+
+    private actor ShutdownSpeechRecognizer: BatchSpeechRecognizing {
+        private var continuation: CheckedContinuation<[BatchSpeechRecognition], Error>?
+        private(set) var didStart = false
+
+        func recognize(audioURL _: URL, locale _: Locale) async throws -> [BatchSpeechRecognition] {
+            try await suspendUntilCancelled()
+        }
+
+        func recognize(audioSlices _: [BatchSpeechAudioSlice], locale _: Locale) async throws -> [BatchSpeechRecognition] {
+            try await suspendUntilCancelled()
+        }
+
+        private func suspendUntilCancelled() async throws -> [BatchSpeechRecognition] {
+            didStart = true
+            return try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    if Task.isCancelled {
+                        continuation.resume(throwing: CancellationError())
+                    } else {
+                        self.continuation = continuation
+                    }
+                }
+            } onCancel: {
+                Task { await self.cancel() }
+            }
+        }
+
+        private func cancel() {
+            continuation?.resume(throwing: CancellationError())
+            continuation = nil
         }
     }
 

--- a/Tests/DahliaTests/BatchTranscriptionStateTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionStateTests.swift
@@ -92,6 +92,22 @@ import Foundation
         }
 
         @Test
+        func progressFramesDoNotChangeTheUnprocessedRecordingsProjection() {
+            let sessionId = UUID.v7()
+
+            #expect(BatchTranscriptionState.running(
+                sessionId: sessionId
+            ).changesUnprocessedRecordingsProjection)
+            #expect(!BatchTranscriptionState.running(
+                sessionId: sessionId,
+                progress: BatchTranscriptionProgress(completedFileCount: 1, totalFileCount: 2)
+            ).changesUnprocessedRecordingsProjection)
+            #expect(BatchTranscriptionState.completed(
+                sessionId: sessionId
+            ).changesUnprocessedRecordingsProjection)
+        }
+
+        @Test
         func interruptedAttemptRequiresManualResume() {
             let now = Date(timeIntervalSince1970: 1_776_384_000)
             var session = RecordingSessionRecord(

--- a/Tests/DahliaTests/BatchTranscriptionStateTests.swift
+++ b/Tests/DahliaTests/BatchTranscriptionStateTests.swift
@@ -92,7 +92,7 @@ import Foundation
         }
 
         @Test
-        func automaticRetryStopsAfterThreeRecordedFailures() {
+        func interruptedAttemptRequiresManualResume() {
             let now = Date(timeIntervalSince1970: 1_776_384_000)
             var session = RecordingSessionRecord(
                 id: .v7(),
@@ -104,30 +104,16 @@ import Foundation
                 createdAt: now,
                 updatedAt: now,
                 transcriptionMode: .batch,
-                batchLastError: "damaged",
-                batchAttemptCount: 2
+                batchLastError: L10n.batchTranscriptionInterrupted,
+                batchAttemptCount: 1
             )
-
-            #expect(BatchTranscriptionCoordinator.shouldAutomaticallyRetry(session))
-
-            session.batchFailureKind = .recordingRecovery
-            #expect(!BatchTranscriptionCoordinator.shouldAutomaticallyRetry(session))
-            session.batchFailureKind = .recordingAudioPermanent
-            #expect(!BatchTranscriptionCoordinator.shouldAutomaticallyRetry(session))
-            session.batchFailureKind = nil
-
-            session.batchAttemptCount = BatchTranscriptionCoordinator.maximumAutomaticAttemptCount
-            #expect(!BatchTranscriptionCoordinator.shouldAutomaticallyRetry(session))
-
-            // 実行中クラッシュでエラーが記録されなかったセッションは、回数にかかわらず復旧対象にする。
-            session.batchLastError = nil
             session.batchLastAttemptAt = now.addingTimeInterval(11)
-            #expect(BatchTranscriptionCoordinator.shouldAutomaticallyRetry(session))
+            session.batchFailureKind = .transcriptionInterrupted
 
-            // 停止後にまだ確認されていないセッションは、再起動しても自動実行しない。
-            session.batchLastAttemptAt = nil
-            session.batchAttemptCount = 0
-            #expect(!BatchTranscriptionCoordinator.shouldAutomaticallyRetry(session))
+            #expect(BatchTranscriptionState.derive(from: session) == .interrupted(
+                sessionId: session.id,
+                isRetranscription: false
+            ))
         }
     }
 #endif

--- a/Tests/DahliaTests/CaptionViewModelBatchRetryTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelBatchRetryTests.swift
@@ -185,6 +185,56 @@ import GRDB
         }
 
         @Test
+        func interruptedRetranscriptionOffersResumeConfirmation() async throws {
+            let completedAt = Date(timeIntervalSince1970: 1_776_384_002)
+            let batch = try BatchAudioTestFixture(
+                name: "interrupted-retranscription",
+                endedAt: Date(timeIntervalSince1970: 1_776_384_001),
+                duration: 1,
+                retainAudioAfterBatch: true,
+                batchCompletedAt: completedAt
+            )
+            defer { batch.removeFiles() }
+            try await batch.recordMicrophoneAudio()
+            try await batch.database.dbQueue.write { db in
+                guard var session = try RecordingSessionRecord.fetchOne(db, key: batch.session.id) else {
+                    throw CocoaError(.fileNoSuchFile)
+                }
+                session.batchLastAttemptAt = completedAt.addingTimeInterval(1)
+                session.batchLastError = L10n.batchTranscriptionInterrupted
+                session.batchFailureKind = .transcriptionInterrupted
+                try session.update(db)
+            }
+
+            let viewModel = CaptionViewModel()
+            viewModel.configureBatchTranscription(
+                dbQueue: batch.database.dbQueue,
+                managedRootURL: batch.managedRootURL,
+                recoverExistingSessions: false
+            )
+            viewModel.loadMeeting(
+                batch.meeting.id,
+                dbQueue: batch.database.dbQueue,
+                projectURL: nil,
+                projectId: nil,
+                vaultURL: batch.vaultURL
+            )
+            #expect(await waitUntil {
+                viewModel.batchTranscriptionState == .interrupted(
+                    sessionId: batch.session.id,
+                    isRetranscription: true
+                ) && viewModel.canRetranscribeBatchAudio
+            })
+
+            viewModel.presentAvailableBatchRetranscription()
+
+            #expect(await waitUntil { viewModel.pendingBatchTranscriptionConfirmation != nil })
+            let confirmation = try #require(viewModel.pendingBatchTranscriptionConfirmation)
+            #expect(confirmation.isRetranscription)
+            #expect(confirmation.sessionId == batch.session.id)
+        }
+
+        @Test
         func failedSessionWithNonReadyAudioDoesNotOfferRetry() async throws {
             let batch = try BatchAudioTestFixture(
                 name: "failed-damaged-audio",

--- a/Tests/DahliaTests/CaptionViewModelBatchRetryTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelBatchRetryTests.swift
@@ -108,6 +108,51 @@ import GRDB
         }
 
         @Test
+        func manualBatchTranscriptionCannotStartWhileRecording() async throws {
+            let batch = try BatchAudioTestFixture(
+                name: "manual-batch-during-recording",
+                endedAt: Date(timeIntervalSince1970: 1_776_384_001),
+                duration: 1
+            )
+            defer { batch.removeFiles() }
+            try await batch.recordMicrophoneAudio()
+            let viewModel = CaptionViewModel()
+            viewModel.configureBatchTranscription(
+                dbQueue: batch.database.dbQueue,
+                managedRootURL: batch.managedRootURL,
+                recoverExistingSessions: false
+            )
+
+            viewModel.isListening = true
+            await viewModel.presentManualBatchTranscription(
+                sessionId: batch.session.id,
+                meetingId: batch.meeting.id,
+                dbQueue: batch.database.dbQueue
+            )
+            #expect(viewModel.pendingBatchTranscriptionConfirmation == nil)
+
+            viewModel.isListening = false
+            await viewModel.presentManualBatchTranscription(
+                sessionId: batch.session.id,
+                meetingId: batch.meeting.id,
+                dbQueue: batch.database.dbQueue
+            )
+            #expect(viewModel.pendingBatchTranscriptionConfirmation != nil)
+
+            viewModel.isListening = true
+            viewModel.confirmBatchTranscription(
+                languageSelection: .manual(localeIdentifier: "ja_JP"),
+                retainAudioAfterBatch: false,
+                summaryGenerationOptions: nil
+            )
+            #expect(viewModel.pendingBatchTranscriptionConfirmation != nil)
+            let session = try await batch.database.dbQueue.read { db in
+                try #require(try RecordingSessionRecord.fetchOne(db, key: batch.session.id))
+            }
+            #expect(session.batchLastAttemptAt == nil)
+        }
+
+        @Test
         func failedAutomaticBatchRetryPresentsLanguageSelection() async throws {
             let batch = try BatchAudioTestFixture(
                 name: "failed-auto-retry-selection",

--- a/Tests/DahliaTests/CaptionViewModelBatchRetryTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelBatchRetryTests.swift
@@ -22,6 +22,13 @@ import GRDB
                 }
                 session.batchLastAttemptAt = batch.now
                 try session.update(db)
+                try db.execute(sql: """
+                CREATE TRIGGER fail_startup_batch_recovery
+                BEFORE UPDATE OF batchLastError ON recording_sessions
+                BEGIN
+                    SELECT RAISE(ABORT, 'forced startup recovery failure');
+                END
+                """)
             }
             var recoveredState: BackupPreflightItem.State?
             let viewModel = CaptionViewModel()
@@ -36,7 +43,16 @@ import GRDB
                     .state
             }
 
+            #expect(await waitUntil { viewModel.batchTranscriptionRecoveryAlert != nil })
+            #expect(recoveredState == nil)
+            try await batch.database.dbQueue.write { db in
+                try db.execute(sql: "DROP TRIGGER fail_startup_batch_recovery")
+            }
+
+            viewModel.retryBatchTranscriptionRecovery()
+
             #expect(await waitUntil { recoveredState == .interrupted })
+            #expect(viewModel.batchTranscriptionRecoveryAlert == nil)
         }
 
         @Test

--- a/Tests/DahliaTests/CaptionViewModelBatchRetryTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelBatchRetryTests.swift
@@ -8,6 +8,38 @@ import GRDB
     @MainActor
     struct CaptionViewModelBatchRetryTests {
         @Test
+        func startupRecoveryRefreshesOffscreenUnprocessedRecordings() async throws {
+            let batch = try BatchAudioTestFixture(
+                name: "offscreen-startup-recovery",
+                endedAt: Date(timeIntervalSince1970: 1_776_384_001),
+                duration: 1
+            )
+            defer { batch.removeFiles() }
+            try await batch.recordMicrophoneAudio()
+            try await batch.database.dbQueue.write { db in
+                guard var session = try RecordingSessionRecord.fetchOne(db, key: batch.session.id) else {
+                    throw CocoaError(.fileNoSuchFile)
+                }
+                session.batchLastAttemptAt = batch.now
+                try session.update(db)
+            }
+            var recoveredState: BackupPreflightItem.State?
+            let viewModel = CaptionViewModel()
+
+            viewModel.configureBatchTranscription(
+                dbQueue: batch.database.dbQueue,
+                managedRootURL: batch.managedRootURL
+            ) {
+                recoveredState = try? await BackupService(dbQueue: batch.database.dbQueue)
+                    .preflightItems(vaultId: batch.meeting.vaultId)
+                    .first?
+                    .state
+            }
+
+            #expect(await waitUntil { recoveredState == .interrupted })
+        }
+
+        @Test
         func retainedCompletedAudioOffersRetranscription() async throws {
             let batch = try BatchAudioTestFixture(
                 name: "retained-completed-audio",
@@ -232,6 +264,11 @@ import GRDB
             let confirmation = try #require(viewModel.pendingBatchTranscriptionConfirmation)
             #expect(confirmation.isRetranscription)
             #expect(confirmation.sessionId == batch.session.id)
+            viewModel.pendingBatchTranscriptionConfirmation = nil
+
+            viewModel.cancelFailedBatchRetranscription()
+
+            #expect(await waitUntil { viewModel.batchTranscriptionState == nil })
         }
 
         @Test

--- a/Tests/DahliaTests/CaptionViewModelBatchUpdateTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelBatchUpdateTests.swift
@@ -47,6 +47,41 @@ import GRDB
         }
 
         @Test
+        func offscreenBatchUpdatesSignalProjectionChangesWithoutSignalingProgress() async {
+            let viewModel = CaptionViewModel()
+            let meetingId = UUID()
+            let sessionId = UUID()
+            let initialToken = viewModel.offscreenBatchTranscriptionChangeToken
+
+            await viewModel.handleBatchTranscriptionUpdate(
+                BatchTranscriptionUpdate(
+                    meetingId: meetingId,
+                    state: .running(sessionId: sessionId)
+                )
+            )
+            #expect(viewModel.offscreenBatchTranscriptionChangeToken == initialToken &+ 1)
+
+            await viewModel.handleBatchTranscriptionUpdate(
+                BatchTranscriptionUpdate(
+                    meetingId: meetingId,
+                    state: .running(
+                        sessionId: sessionId,
+                        progress: BatchTranscriptionProgress(completedFileCount: 1, totalFileCount: 2)
+                    )
+                )
+            )
+            #expect(viewModel.offscreenBatchTranscriptionChangeToken == initialToken &+ 1)
+
+            await viewModel.handleBatchTranscriptionUpdate(
+                BatchTranscriptionUpdate(
+                    meetingId: meetingId,
+                    state: .completed(sessionId: sessionId)
+                )
+            )
+            #expect(viewModel.offscreenBatchTranscriptionChangeToken == initialToken &+ 2)
+        }
+
+        @Test
         func completedBatchReloadsVisibleMeetingWhileAnotherMeetingIsRecording() async throws {
             let prepared = try makeFixture(name: "visible-batch")
             let batch = prepared.batch

--- a/Tests/DahliaTests/CaptionViewModelSummaryGenerationTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelSummaryGenerationTests.swift
@@ -143,7 +143,7 @@ import GRDB
             try repository.upsertSummary(SummaryRecord(
                 meetingId: fixture.first.id,
                 title: "Old summary",
-                document: try SummaryDocument(title: "Old summary", sections: []).databaseJSONString(),
+                document: SummaryDocument(title: "Old summary", sections: []).databaseJSONString(),
                 createdAt: .now
             ))
             try repository.updateSummaryVaultRelativePath(
@@ -169,13 +169,13 @@ import GRDB
         }
 
         @Test
-        func batchConfirmationWithoutPersistenceContextDoesNotBlockTranscription() throws {
+        func batchConfirmationWithoutPersistenceContextDoesNotBlockTranscription() async throws {
             let fixture = try SummaryGenerationFixture()
             defer { fixture.removeFiles() }
             let viewModel = CaptionViewModel()
             let sessionID = try fixture.insertRecordingSession(for: fixture.first, offset: 0)
 
-            viewModel.presentBatchTranscriptionConfirmation(
+            await viewModel.presentBatchTranscriptionConfirmation(
                 sessionId: sessionID,
                 meetingId: fixture.first.id,
                 dbQueue: fixture.database.dbQueue
@@ -624,7 +624,7 @@ import GRDB
             )
             await original.select(original.first, in: viewModel, note: "original")
             let sessionID = try original.insertRecordingSession(for: original.first, offset: 0)
-            viewModel.presentBatchTranscriptionConfirmation(
+            await viewModel.presentBatchTranscriptionConfirmation(
                 sessionId: sessionID,
                 meetingId: original.first.id,
                 dbQueue: original.database.dbQueue
@@ -667,7 +667,7 @@ import GRDB
         }
 
         private func waitUntil(
-            attempts: Int = 10_000,
+            attempts: Int = 10000,
             condition: @escaping @MainActor () -> Bool
         ) async -> Bool {
             for _ in 0 ..< attempts {

--- a/Tests/DahliaTests/MeetingPersistenceStopTests.swift
+++ b/Tests/DahliaTests/MeetingPersistenceStopTests.swift
@@ -73,6 +73,40 @@ import GRDB
         }
 
         @Test
+        func terminationIsRejectedUntilFailedPersistenceRecovers() async throws {
+            let fixture = try makeDatabase()
+            let store = TranscriptStore()
+            store.recordingStartTime = Date(timeIntervalSince1970: 1_776_384_000)
+            let service = try await MeetingPersistenceService.createNew(
+                store: store,
+                dbQueue: fixture.database.dbQueue,
+                vaultId: fixture.vault.id,
+                projectId: nil,
+                initialName: "Termination persistence failure"
+            )
+            try await fixture.database.dbQueue.write { db in
+                try db.execute(sql: """
+                CREATE TRIGGER fail_termination_persistence
+                BEFORE UPDATE OF endedAt ON recording_sessions
+                BEGIN
+                    SELECT RAISE(ABORT, 'forced termination failure');
+                END
+                """)
+            }
+            let viewModel = CaptionViewModel()
+            viewModel.setFailedPersistenceServiceForTesting(service)
+
+            let failureMessage = await viewModel.prepareForTermination()
+            #expect(failureMessage != nil)
+            #expect(failureMessage == viewModel.errorMessage)
+
+            try await fixture.database.dbQueue.write { db in
+                try db.execute(sql: "DROP TRIGGER fail_termination_persistence")
+            }
+            #expect(await viewModel.prepareForTermination() == nil)
+        }
+
+        @Test
         func appendStopDoesNotAssignLegacySegmentsToNewSession() async throws {
             let fixture = try makeDatabase()
             let meetingId = UUID.v7()

--- a/Tests/DahliaTests/RecordingAudioStoreTests.swift
+++ b/Tests/DahliaTests/RecordingAudioStoreTests.swift
@@ -429,7 +429,6 @@ import GRDB
             #expect(session?.endedAt == endedAt)
             #expect(session?.batchFailureKind == .recordingRecovery)
             #expect(session?.batchLastError?.nilIfBlank != nil)
-            #expect(session.map(BatchTranscriptionCoordinator.shouldAutomaticallyRetry) == false)
         }
 
         @Test

--- a/Tests/DahliaTests/SidebarViewModelMeetingListTests.swift
+++ b/Tests/DahliaTests/SidebarViewModelMeetingListTests.swift
@@ -172,7 +172,7 @@ import GRDB
                     try insertMeeting(
                         vaultId: fixture.vault.id,
                         name: "Recent \(index)",
-                        createdAt: start.addingTimeInterval(1_000 + TimeInterval(index)),
+                        createdAt: start.addingTimeInterval(1000 + TimeInterval(index)),
                         in: db
                     )
                 }
@@ -379,7 +379,7 @@ import GRDB
     }
 
     @MainActor
-    private final class SidebarViewModelMeetingListFixture {
+    final class SidebarViewModelMeetingListFixture {
         let manager: AppDatabaseManager
         let vault: VaultRecord
 

--- a/Tests/DahliaTests/SidebarViewModelUnprocessedRecordingsTests.swift
+++ b/Tests/DahliaTests/SidebarViewModelUnprocessedRecordingsTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import GRDB
+@testable import Dahlia
+
+#if canImport(Testing)
+    import Testing
+
+    @MainActor
+    struct SidebarViewModelUnprocessedRecordingsTests {
+        @Test
+        func refreshSurfacesDatabaseFailure() async throws {
+            let fixture = try SidebarViewModelMeetingListFixture()
+            defer { fixture.stop() }
+            let viewModel = fixture.makeViewModel()
+            defer { viewModel.setAppDatabase(nil) }
+            try await fixture.manager.dbQueue.write { db in
+                try db.execute(sql: "DROP TABLE recording_audio_segment_ranges")
+            }
+
+            await viewModel.refreshUnprocessedRecordings()
+
+            #expect(viewModel.unprocessedRecordingItems.isEmpty)
+            #expect(viewModel.unprocessedRecordingsError != nil)
+            #expect(!viewModel.isLoadingUnprocessedRecordings)
+        }
+
+        @Test
+        func staleDiscardFailureDoesNotAppearAfterVaultChanges() async throws {
+            let fixture = try SidebarViewModelMeetingListFixture()
+            defer { fixture.stop() }
+            let settings = AppSettings()
+            settings.currentVault = fixture.vault
+            let gate = SidebarDiscardGate()
+            let viewModel = SidebarViewModel(settings: settings) { _, _ in
+                await gate.wait()
+                throw SidebarDiscardTestError.failed
+            }
+            viewModel.setAppDatabase(fixture.manager)
+            defer { viewModel.setAppDatabase(nil) }
+
+            let discardTask = Task { await viewModel.discardUnprocessedRecording(Self.discardItem) }
+            #expect(await gate.waitUntilBlocked())
+            settings.currentVault = nil
+            viewModel.setAppDatabase(nil)
+            await gate.release()
+            await discardTask.value
+
+            #expect(viewModel.unprocessedRecordingsError == nil)
+        }
+
+        @Test
+        func successfulDiscardRefreshesAfterOverlappingSameVaultRefresh() async throws {
+            let fixture = try SidebarViewModelMeetingListFixture()
+            defer { fixture.stop() }
+            let settings = AppSettings()
+            settings.currentVault = fixture.vault
+            let gate = SidebarDiscardGate()
+            let viewModel = SidebarViewModel(settings: settings) { _, _ in
+                await gate.wait()
+                return true
+            }
+            viewModel.setAppDatabase(fixture.manager)
+            defer { viewModel.setAppDatabase(nil) }
+
+            let discardTask = Task { await viewModel.discardUnprocessedRecording(Self.discardItem) }
+            #expect(await gate.waitUntilBlocked())
+            await viewModel.refreshUnprocessedRecordings()
+            try await fixture.manager.dbQueue.write { db in
+                try db.execute(sql: "DROP TABLE recording_audio_segment_ranges")
+            }
+            await gate.release()
+            await discardTask.value
+
+            #expect(viewModel.unprocessedRecordingsError != nil)
+        }
+
+        private static let discardItem = BackupPreflightItem(
+            sessionId: .v7(),
+            meetingId: .v7(),
+            meetingName: "Discard",
+            startedAt: .now,
+            state: .failed,
+            failureMessage: "damaged",
+            canTranscribe: false
+        )
+    }
+
+    private enum SidebarDiscardTestError: Error {
+        case failed
+    }
+
+    private actor SidebarDiscardGate {
+        private var continuation: CheckedContinuation<Void, Never>?
+        private var isBlocked = false
+
+        func wait() async {
+            isBlocked = true
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
+
+        func waitUntilBlocked() async -> Bool {
+            await pollUntil { self.isBlocked }
+        }
+
+        func release() {
+            continuation?.resume()
+            continuation = nil
+            isBlocked = false
+        }
+    }
+#endif

--- a/Tests/DahliaTests/SidebarViewModelUnprocessedRecordingsTests.swift
+++ b/Tests/DahliaTests/SidebarViewModelUnprocessedRecordingsTests.swift
@@ -31,19 +31,46 @@ import GRDB
             let settings = AppSettings()
             settings.currentVault = fixture.vault
             let gate = SidebarDiscardGate()
-            let viewModel = SidebarViewModel(settings: settings) { _, _ in
+            let viewModel = SidebarViewModel(settings: settings) { _, _, _ in
                 await gate.wait()
                 throw SidebarDiscardTestError.failed
             }
             viewModel.setAppDatabase(fixture.manager)
             defer { viewModel.setAppDatabase(nil) }
 
-            let discardTask = Task { await viewModel.discardUnprocessedRecording(Self.discardItem) }
+            let discardTask = Task {
+                await viewModel.discardUnprocessedRecording(Self.discardItem(vaultId: fixture.vault.id))
+            }
             #expect(await gate.waitUntilBlocked())
             settings.currentVault = nil
             viewModel.setAppDatabase(nil)
             await gate.release()
             await discardTask.value
+
+            #expect(viewModel.unprocessedRecordingsError == nil)
+        }
+
+        @Test
+        func staleVaultItemIsRejectedBeforeDiscardStarts() async throws {
+            let fixture = try SidebarViewModelMeetingListFixture()
+            defer { fixture.stop() }
+            let settings = AppSettings()
+            settings.currentVault = fixture.vault
+            let viewModel = SidebarViewModel(settings: settings) { _, _, _ in
+                Issue.record("Discard must not start for an item from another Vault")
+                return true
+            }
+            viewModel.setAppDatabase(fixture.manager)
+            defer { viewModel.setAppDatabase(nil) }
+            settings.currentVault = VaultRecord(
+                id: .v7(),
+                path: fixture.vault.path,
+                name: "Other",
+                createdAt: .now,
+                lastOpenedAt: .now
+            )
+
+            await viewModel.discardUnprocessedRecording(Self.discardItem(vaultId: fixture.vault.id))
 
             #expect(viewModel.unprocessedRecordingsError == nil)
         }
@@ -55,14 +82,16 @@ import GRDB
             let settings = AppSettings()
             settings.currentVault = fixture.vault
             let gate = SidebarDiscardGate()
-            let viewModel = SidebarViewModel(settings: settings) { _, _ in
+            let viewModel = SidebarViewModel(settings: settings) { _, _, _ in
                 await gate.wait()
                 return true
             }
             viewModel.setAppDatabase(fixture.manager)
             defer { viewModel.setAppDatabase(nil) }
 
-            let discardTask = Task { await viewModel.discardUnprocessedRecording(Self.discardItem) }
+            let discardTask = Task {
+                await viewModel.discardUnprocessedRecording(Self.discardItem(vaultId: fixture.vault.id))
+            }
             #expect(await gate.waitUntilBlocked())
             await viewModel.refreshUnprocessedRecordings()
             try await fixture.manager.dbQueue.write { db in
@@ -74,15 +103,18 @@ import GRDB
             #expect(viewModel.unprocessedRecordingsError != nil)
         }
 
-        private static let discardItem = BackupPreflightItem(
-            sessionId: .v7(),
-            meetingId: .v7(),
-            meetingName: "Discard",
-            startedAt: .now,
-            state: .failed,
-            failureMessage: "damaged",
-            canTranscribe: false
-        )
+        private static func discardItem(vaultId: UUID) -> BackupPreflightItem {
+            BackupPreflightItem(
+                sessionId: .v7(),
+                meetingId: .v7(),
+                vaultId: vaultId,
+                meetingName: "Discard",
+                startedAt: .now,
+                state: .failed,
+                failureMessage: "damaged",
+                canTranscribe: false
+            )
+        }
     }
 
     private enum SidebarDiscardTestError: Error {

--- a/docs/architecture/audio-transcription-data-flow.md
+++ b/docs/architecture/audio-transcription-data-flow.md
@@ -233,12 +233,13 @@ sequenceDiagram
 
 固定言語では、同一音源、同一形式、同一 locale で session time が連続する verified CAF range を一つの論理 run として
 同じ `SpeechAnalyzer` へ順次供給する。ready CAF 自体は結合または変更せず、入力は一 buffer ずつ遅延読出しする。
-自動判定は CAF ごとの言語判定と認識の overlap を維持するため、CAF 単位の transcription のままとする。
+自動判定は CAF ごとの言語判定結果を使うため、CAF 単位の transcription のままとし、一つずつ処理する。
 
 各 Apple Speech 解析には無進捗 watchdog を設ける。解析開始、論理 run 内の CAF slice 消費、認識結果の受信を進捗とし、
 解析開始時に固定した設定時間（1／2／3分、既定1分）進捗がなければ `SpeechAnalyzer` をキャンセルして失敗として保存する。
-これは総処理時間の上限ではない。停止失敗では ready CAF を保持し、startup recovery の自動再試行から除外する。
-ユーザーはミーティング詳細に復元される失敗理由と再文字起こし操作から、保持音声を明示的に再処理できる。
+これは総処理時間の上限ではない。ready CAF は保持し、起動時は音声整合性の復旧だけを行って batch recognition を自動再開しない。
+前プロセスで queued／running だった処理は中断状態へ移し、ユーザーはミーティング詳細または未処理録音一覧から
+保持音声を明示的に再処理できる。複数の batch recognition は一つずつ直列実行する。
 再試行成功後は通常の `retainAudioAfterBatch` 方針に戻り、保持しない設定なら音声を purge する。
 
 認識途中の結果は正本へ部分反映しない。成功した全結果を `BatchTranscriptionPersistence.complete` が一つの transaction で
@@ -277,6 +278,8 @@ sequenceDiagram
 
 この順序により、capture 停止前に受理した callback、router、recognition、audio writer、transcript persistence を
 それぞれの owner が drain する。batch transcription の enqueue はこの停止処理に含めず、音声確定とユーザー確認の後に行う。
+アプリ終了時はこの録音停止と永続化を待ち、進行中の batch recognition をキャンセルして中断状態を保存してから終了する。
+文字起こしの永続化を完了できない場合は終了を承認せず、エラーを表示して保存の再試行を可能にする。
 
 ## Failure と recovery
 
@@ -287,7 +290,7 @@ sequenceDiagram
 | live recognition failure in realtime | 正本文字起こしを継続できない | fatal runtime failure として停止へ進む |
 | live recognition failure in batch | audio writer が健全なら正本音声を継続 | 字幕／chat を縮退し、停止後 batch を維持 |
 | realtime SQLite failure | pending event と順序を writer actor 内で保持 | exponential backoff。停止時にも flush failure を返す |
-| batch recognition failure | 旧成功 transcript と ready audio を保持 | failure state を保存し、再試行可能 |
+| batch recognition failure／アプリ終了による中断 | 旧成功 transcript と ready audio を保持 | failure／interrupted state を保存し、手動再試行を待つ |
 | Apple Speech の無進捗停止 | 旧成功 transcript と ready audio を保持 | 待機時間を含む専用 failure state を保存し、自動再試行せず手動再試行を待つ |
 | batch audio feature extraction failure | 認識済み transcript と通常の purge policy を維持 | sanitized error を報告し、該当 feature columns を `NULL` にする |
 | crash 中の partial／finalizing CAF | 既存 ready segment を変更しない | startup reconciler が DB state と file を照合 |


### PR DESCRIPTION
## Summary

- serialize Apple Speech batch transcription and preserve interrupted work across quit, restart, and update boundaries
- prevent recording startup and shutdown races, and keep Dahlia open with a visible error when final persistence cannot complete
- add manual transcribe, resume, retry, and discard actions for unresolved recording audio
- scope unresolved recording refreshes and actions to the correct Vault
- add regression coverage and document the lifecycle guarantees

## Why

An app termination or update could overlap recording startup, realtime persistence, batch queue admission, or Apple Speech work. This could leave transcription work in an ambiguous state, retry automatically at startup, or present unresolved audio without a manual recovery action.

## User impact

Recording data is preserved before termination, interrupted batch work is explicitly marked for manual recovery, and users can transcribe or discard unresolved recordings from the app. Batch transcription now runs serially to match the virtual single-file workflow.

## Validation

- `swift build`
- `swift test`: 1438 tests in 215 suites passed
- targeted BackupService and unprocessed-recording tests: 10 passed
- SwiftFormat: 0 of 632 files require formatting
- `git diff --check`
- deep-review follow-up: no remaining findings

SwiftLint completed in the repository configured non-blocking mode; existing repository-wide length and style debt remains.