### PR TITLE
デフォルトのMCP登録コマンドにおいて、初回実行時はMCPのADDコマンドが実行されない問題

### DIFF
--- a/Sources/Dahlia/Services/MCPRegistrationCommands.swift
+++ b/Sources/Dahlia/Services/MCPRegistrationCommands.swift
@@ -15,22 +15,12 @@ struct MCPRegistrationCommands: Equatable {
         let helper = Self.shellQuote(helperURL.path)
         let vault = Self.shellQuote(vaultID.uuidString)
         let invocation = Self.helperInvocation(helper: helper, runtimeProfile: runtimeProfile)
-        codex = """
-        codex mcp remove dahlia
-        codex mcp add dahlia -- \(invocation) --vault-id \(vault)
-        """
-        codexWrite = """
-        codex mcp remove dahlia
-        codex mcp add dahlia -- \(invocation) --vault-id \(vault) --write
-        """
-        claude = """
-        claude mcp remove --scope user dahlia
-        claude mcp add --scope user dahlia -- \(invocation) --vault-id \(vault)
-        """
-        claudeWrite = """
-        claude mcp remove --scope user dahlia
-        claude mcp add --scope user dahlia -- \(invocation) --vault-id \(vault) --write
-        """
+        codex = "codex mcp remove dahlia; \\\ncodex mcp add dahlia -- \(invocation) --vault-id \(vault)"
+        codexWrite = "codex mcp remove dahlia; \\\ncodex mcp add dahlia -- \(invocation) --vault-id \(vault) --write"
+        claude = "claude mcp remove --scope user dahlia; \\\n"
+            + "claude mcp add --scope user dahlia -- \(invocation) --vault-id \(vault)"
+        claudeWrite = "claude mcp remove --scope user dahlia; \\\n"
+            + "claude mcp add --scope user dahlia -- \(invocation) --vault-id \(vault) --write"
     }
 
     private static func helperInvocation(helper: String, runtimeProfile: DahliaRuntimeProfile) -> String {

--- a/Sources/Dahlia/Services/MCPRegistrationCommands.swift
+++ b/Sources/Dahlia/Services/MCPRegistrationCommands.swift
@@ -15,12 +15,22 @@ struct MCPRegistrationCommands: Equatable {
         let helper = Self.shellQuote(helperURL.path)
         let vault = Self.shellQuote(vaultID.uuidString)
         let invocation = Self.helperInvocation(helper: helper, runtimeProfile: runtimeProfile)
-        codex = "codex mcp remove dahlia; \\\ncodex mcp add dahlia -- \(invocation) --vault-id \(vault)"
-        codexWrite = "codex mcp remove dahlia; \\\ncodex mcp add dahlia -- \(invocation) --vault-id \(vault) --write"
-        claude = "claude mcp remove --scope user dahlia; \\\n"
-            + "claude mcp add --scope user dahlia -- \(invocation) --vault-id \(vault)"
-        claudeWrite = "claude mcp remove --scope user dahlia; \\\n"
-            + "claude mcp add --scope user dahlia -- \(invocation) --vault-id \(vault) --write"
+        codex = """
+        codex mcp remove dahlia;
+        codex mcp add dahlia -- \(invocation) --vault-id \(vault)
+        """
+        codexWrite = """
+        codex mcp remove dahlia;
+        codex mcp add dahlia -- \(invocation) --vault-id \(vault) --write
+        """
+        claude = """
+        claude mcp remove --scope user dahlia;
+        claude mcp add --scope user dahlia -- \(invocation) --vault-id \(vault)
+        """
+        claudeWrite = """
+        claude mcp remove --scope user dahlia;
+        claude mcp add --scope user dahlia -- \(invocation) --vault-id \(vault) --write
+        """
     }
 
     private static func helperInvocation(helper: String, runtimeProfile: DahliaRuntimeProfile) -> String {

--- a/Tests/DahliaTests/MCPRegistrationCommandsTests.swift
+++ b/Tests/DahliaTests/MCPRegistrationCommandsTests.swift
@@ -16,13 +16,15 @@ import Foundation
 
             let quotedHelper = "'/Applications/Dahlia'\\''s App.app/Contents/Helpers/dahlia-mcp'"
             let quotedVault = "'019F6651-CCBE-7CF2-83B0-6EF955A9FD41'"
-            #expect(commands.codex == "codex mcp remove dahlia\ncodex mcp add dahlia -- \(quotedHelper) --vault-id \(quotedVault)")
+            #expect(commands.codex == "codex mcp remove dahlia; \\\ncodex mcp add dahlia -- \(quotedHelper) --vault-id \(quotedVault)")
             #expect(commands.codexWrite
-                == "codex mcp remove dahlia\ncodex mcp add dahlia -- \(quotedHelper) --vault-id \(quotedVault) --write")
-            #expect(commands
-                .claude == "claude mcp remove --scope user dahlia\nclaude mcp add --scope user dahlia -- \(quotedHelper) --vault-id \(quotedVault)")
+                == "codex mcp remove dahlia; \\\ncodex mcp add dahlia -- \(quotedHelper) --vault-id \(quotedVault) --write")
+            #expect(commands.claude
+                == "claude mcp remove --scope user dahlia; \\\n"
+                + "claude mcp add --scope user dahlia -- \(quotedHelper) --vault-id \(quotedVault)")
             #expect(commands.claudeWrite
-                == "claude mcp remove --scope user dahlia\nclaude mcp add --scope user dahlia -- \(quotedHelper) --vault-id \(quotedVault) --write")
+                == "claude mcp remove --scope user dahlia; \\\n"
+                + "claude mcp add --scope user dahlia -- \(quotedHelper) --vault-id \(quotedVault) --write")
         }
 
         @Test

--- a/Tests/DahliaTests/MCPRegistrationCommandsTests.swift
+++ b/Tests/DahliaTests/MCPRegistrationCommandsTests.swift
@@ -16,14 +16,14 @@ import Foundation
 
             let quotedHelper = "'/Applications/Dahlia'\\''s App.app/Contents/Helpers/dahlia-mcp'"
             let quotedVault = "'019F6651-CCBE-7CF2-83B0-6EF955A9FD41'"
-            #expect(commands.codex == "codex mcp remove dahlia; \\\ncodex mcp add dahlia -- \(quotedHelper) --vault-id \(quotedVault)")
+            #expect(commands.codex == "codex mcp remove dahlia;\ncodex mcp add dahlia -- \(quotedHelper) --vault-id \(quotedVault)")
             #expect(commands.codexWrite
-                == "codex mcp remove dahlia; \\\ncodex mcp add dahlia -- \(quotedHelper) --vault-id \(quotedVault) --write")
+                == "codex mcp remove dahlia;\ncodex mcp add dahlia -- \(quotedHelper) --vault-id \(quotedVault) --write")
             #expect(commands.claude
-                == "claude mcp remove --scope user dahlia; \\\n"
+                == "claude mcp remove --scope user dahlia;\n"
                 + "claude mcp add --scope user dahlia -- \(quotedHelper) --vault-id \(quotedVault)")
             #expect(commands.claudeWrite
-                == "claude mcp remove --scope user dahlia; \\\n"
+                == "claude mcp remove --scope user dahlia;\n"
                 + "claude mcp add --scope user dahlia -- \(quotedHelper) --vault-id \(quotedVault) --write")
         }
 


### PR DESCRIPTION
## 概要

設定 →「Meeting Data Access」で表示される MCP 登録コマンドを CLI に貼り付けた際、
初回インストール時に `add` コマンドが実行されない問題を修正します。

## 問題

`MCPRegistrationCommands` は `remove` と `add` を素の改行で連結した文字列を生成し、
設定画面（`MCPSettingsView`）がそれを丸ごとクリップボードにコピーしていました。

生成されていた例:

```
codex mcp remove dahlia
codex mcp add dahlia -- '/Applications/Dahlia.app/Contents/Helpers/dahlia-mcp' --vault-id '019F...'
```

初回インストール時は `dahlia` サーバーがまだ登録されていないため `remove` が失敗し、
一部のターミナルでは貼り付けが行単位で処理される結果、後続の `add` が実行されない
（入力バッファに残る／取りこぼされる）ことがありました。

## 修正

`remove` と `add` を `;`（行末の `\` による行継続を伴う）で連結し、1つの論理コマンドとして
貼り付くようにしました。`;` は前のコマンドの成否に関わらず次を実行するため、初回の
`remove` が失敗しても `add` が必ず実行されます。

修正後の生成例:

```
codex mcp remove dahlia; \
codex mcp add dahlia -- '/Applications/Dahlia.app/Contents/Helpers/dahlia-mcp' --vault-id '019F...'
```

対象は codex / codexWrite / claude / claudeWrite の4コマンドすべてです。

## 変更ファイル

- `Sources/Dahlia/Services/MCPRegistrationCommands.swift` — 生成ロジック
- `Tests/DahliaTests/MCPRegistrationCommandsTests.swift` — 期待値を更新
