### PR TITLE
Add Vault controls to the sidebar footer

### DIFF
--- a/Sources/Dahlia/DahliaApp.swift
+++ b/Sources/Dahlia/DahliaApp.swift
@@ -219,11 +219,7 @@ struct DahliaApp: App {
     }
 
     private func openVault(_ vault: VaultRecord) {
-        guard let db = appDatabase else { return }
-
-        if viewModel.isListening {
-            viewModel.stopListening()
-        }
+        guard viewModel.canSwitchVault, let db = appDatabase else { return }
 
         try? FileManager.default.createDirectory(at: vault.url, withIntermediateDirectories: true)
 

--- a/Sources/Dahlia/DahliaApp.swift
+++ b/Sources/Dahlia/DahliaApp.swift
@@ -79,7 +79,10 @@ struct DahliaApp: App {
         Window(L10n.dahlia, id: WindowID.main) {
             Group {
                 if showVaultPicker {
-                    VaultPickerView(appDatabase: appDatabase) { vault in
+                    VaultPickerView(
+                        appDatabase: appDatabase,
+                        canSwitchVault: viewModel.canSwitchVault
+                    ) { vault in
                         openVault(vault)
                     }
                 } else {
@@ -136,7 +139,10 @@ struct DahliaApp: App {
         .restorationBehavior(.disabled)
 
         Window(L10n.vault, id: WindowID.vaultManager) {
-            VaultPickerView(appDatabase: appDatabase) { vault in
+            VaultPickerView(
+                appDatabase: appDatabase,
+                canSwitchVault: viewModel.canSwitchVault
+            ) { vault in
                 openVault(vault)
             }
         }

--- a/Sources/Dahlia/ViewModels/CaptionViewModel.swift
+++ b/Sources/Dahlia/ViewModels/CaptionViewModel.swift
@@ -124,6 +124,7 @@ final class CaptionViewModel: ObservableObject {
     }
 
     @Published private(set) var canBeginRecording = true
+    @Published private(set) var isRecordingStartPending = false
     @Published var analyzerReady = false
     @Published var isPreparingAnalyzer = false
     @Published private(set) var activeTranscriptionMode: TranscriptionMode?
@@ -453,6 +454,12 @@ final class CaptionViewModel: ObservableObject {
 
     /// 少なくとも 1 つの音声ソースが有効か。
     var hasEnabledAudioSource: Bool { isMicEnabled || isSystemAudioEnabled }
+
+    var canSwitchVault: Bool {
+        !isRecordingStartPending
+            && recordingLifecycle == .idle
+            && !isFinalizingRecording
+    }
 
     private var enabledRecordingAudioSources: Set<RecordingAudioSource> {
         var sources: Set<RecordingAudioSource> = []
@@ -2705,9 +2712,12 @@ final class CaptionViewModel: ObservableObject {
         appendingTo existingMeetingId: UUID? = nil
     ) async {
         guard recordingLifecycle == .idle,
+              !isRecordingStartPending,
               !isFinalizingRecording,
               !isTerminationRequested,
               !AppDelegate.isBackupRestorePreparationActive else { return }
+        isRecordingStartPending = true
+        defer { isRecordingStartPending = false }
         guard await retryFailedPersistenceIfNeeded() else { return }
         await refreshDefaultInputDevice()
         guard recordingLifecycle == .idle,

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -28,7 +28,8 @@ struct ContentView: View {
                     onShowUpcomingSchedule: returnToCalendarSchedule,
                     onShowUnprocessedRecordings: showUnprocessedRecordings,
                     showsCustomerIntelligence: isCustomerIntelligenceBetaEnabled,
-                    onOpenCustomerIntelligence: { openWindow(id: WindowID.organizationWorkspace) }
+                    onOpenCustomerIntelligence: { openWindow(id: WindowID.organizationWorkspace) },
+                    onSelectVault: onSelectVault
                 )
             } else {
                 NavigationSplitView {
@@ -42,7 +43,8 @@ struct ContentView: View {
                         isShowingUnprocessedRecordings: isShowingUnprocessedRecordings,
                         onShowUnprocessedRecordings: showUnprocessedRecordings,
                         showsCustomerIntelligence: isCustomerIntelligenceBetaEnabled,
-                        onOpenCustomerIntelligence: { openWindow(id: WindowID.organizationWorkspace) }
+                        onOpenCustomerIntelligence: { openWindow(id: WindowID.organizationWorkspace) },
+                        onSelectVault: onSelectVault
                     )
                     .navigationSplitViewColumnWidth(min: 240, ideal: 300, max: 420)
                 } detail: {

--- a/Sources/Dahlia/Views/MainSidebarFooterView.swift
+++ b/Sources/Dahlia/Views/MainSidebarFooterView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+struct MainSidebarFooterView: View {
+    static let verticalPadding: CGFloat = 8
+
+    let vaults: [VaultRecord]
+    let currentVault: VaultRecord?
+    let onSelectVault: (VaultRecord) -> Void
+
+    @State private var isVaultHovered = false
+    @State private var isSettingsHovered = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Menu {
+                ForEach(vaults) { vault in
+                    Button(action: { onSelectVault(vault) }, label: {
+                        if vault.id == currentVault?.id {
+                            Label(vault.name, systemImage: "checkmark")
+                        } else {
+                            Text(vault.name)
+                        }
+                    })
+                    .disabled(vault.id == currentVault?.id)
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Label(currentVault?.name ?? L10n.noVaultSelected, systemImage: "externaldrive")
+                        .lineLimit(1)
+
+                    Spacer(minLength: 0)
+
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 5)
+                .background(
+                    isVaultHovered ? Color.primary.opacity(0.08) : .clear,
+                    in: RoundedRectangle(cornerRadius: 6)
+                )
+                .contentShape(RoundedRectangle(cornerRadius: 6))
+                .onContinuousHover { phase in
+                    isVaultHovered = phase != .ended
+                }
+            }
+            .menuStyle(.borderlessButton)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .help(L10n.currentVaultDescription)
+            .accessibilityLabel("\(L10n.currentVault), \(currentVault?.name ?? L10n.noVaultSelected)")
+
+            SettingsLink {
+                Label(L10n.settings, systemImage: "gearshape")
+                    .labelStyle(.iconOnly)
+                    .padding(7)
+                    .background(isSettingsHovered ? Color.primary.opacity(0.08) : .clear, in: Circle())
+                    .contentShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .help(L10n.settingsMenuItem)
+            .accessibilityLabel(L10n.settings)
+            .onHover { isSettingsHovered = $0 }
+        }
+        .padding(2)
+        .background(Color(nsColor: .controlBackgroundColor), in: Capsule())
+        .overlay {
+            Capsule()
+                .strokeBorder(Color(nsColor: .separatorColor), lineWidth: 1)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, Self.verticalPadding)
+    }
+}

--- a/Sources/Dahlia/Views/MainSidebarNavigationView.swift
+++ b/Sources/Dahlia/Views/MainSidebarNavigationView.swift
@@ -63,12 +63,6 @@ struct MainSidebarNavigationView: View {
                 .buttonStyle(.plain)
                 .help(L10n.openOrganizationWorkspace)
             }
-
-            SettingsLink {
-                MainSidebarNavigationLabel(title: L10n.settings, systemImage: "gearshape")
-            }
-            .buttonStyle(.plain)
-            .help(L10n.settingsMenuItem)
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)

--- a/Sources/Dahlia/Views/MeetingListSidebarView.swift
+++ b/Sources/Dahlia/Views/MeetingListSidebarView.swift
@@ -13,6 +13,7 @@ struct MeetingListSidebarView: View {
     let onShowUnprocessedRecordings: () -> Void
     let showsCustomerIntelligence: Bool
     let onOpenCustomerIntelligence: () -> Void
+    let onSelectVault: (VaultRecord) -> Void
 
     @State private var searchText = ""
     @State private var searchTokens: [MeetingSearchToken] = []
@@ -20,6 +21,7 @@ struct MeetingListSidebarView: View {
     @State private var editingMeetingId: UUID?
     @State private var editingMeetingName = ""
     @State private var pendingDeletion: MeetingDeletionRequest?
+    @State private var sidebarFooterHeight: CGFloat = 0
     @FocusState private var isRenameFieldFocused: Bool
 
     private var meetingSelection: Binding<Set<UUID>> {
@@ -30,6 +32,10 @@ struct MeetingListSidebarView: View {
                 sidebarViewModel.selectedMeetingIds = selection
             }
         )
+    }
+
+    private var showsSidebarFooter: Bool {
+        !viewModel.isListening && !viewModel.isFinalizingRecording
     }
 
     var body: some View {
@@ -77,6 +83,11 @@ struct MeetingListSidebarView: View {
                 )
             }
             .listStyle(.sidebar)
+            .contentMargins(
+                .bottom,
+                showsSidebarFooter ? sidebarFooterHeight : 0,
+                for: .scrollContent
+            )
             .overlay {
                 MeetingListStatusOverlay(
                     isLoaded: sidebarViewModel.isDisplayedMeetingListLoaded,
@@ -91,6 +102,12 @@ struct MeetingListSidebarView: View {
                 contextMenu(for: selection)
             }
 
+            if showsSidebarFooter {
+                Color.clear
+                    .frame(height: MainSidebarFooterView.verticalPadding)
+                    .accessibilityHidden(true)
+            }
+
             if viewModel.isListening {
                 RecordingStatusBar(
                     viewModel: viewModel,
@@ -98,6 +115,21 @@ struct MeetingListSidebarView: View {
                     recordingCoordinator: recordingCoordinator
                 )
                 .padding(8)
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if showsSidebarFooter {
+                MainSidebarFooterView(
+                    vaults: sidebarViewModel.allVaults,
+                    currentVault: sidebarViewModel.currentVault,
+                    onSelectVault: onSelectVault
+                )
+                .frame(maxWidth: .infinity)
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.height
+                } action: { height in
+                    sidebarFooterHeight = height
+                }
             }
         }
         .meetingSidebarSearch(

--- a/Sources/Dahlia/Views/MeetingListSidebarView.swift
+++ b/Sources/Dahlia/Views/MeetingListSidebarView.swift
@@ -35,7 +35,7 @@ struct MeetingListSidebarView: View {
     }
 
     private var showsSidebarFooter: Bool {
-        !viewModel.isListening && !viewModel.isFinalizingRecording
+        viewModel.canSwitchVault
     }
 
     var body: some View {

--- a/Sources/Dahlia/Views/ProjectManagementView.swift
+++ b/Sources/Dahlia/Views/ProjectManagementView.swift
@@ -10,6 +10,7 @@ struct ProjectManagementView: View {
     let onShowUnprocessedRecordings: () -> Void
     let showsCustomerIntelligence: Bool
     let onOpenCustomerIntelligence: () -> Void
+    let onSelectVault: (VaultRecord) -> Void
 
     @State private var isShowingProjectCreation = false
     @State private var projectCreationParentId: UUID?
@@ -67,6 +68,12 @@ struct ProjectManagementView: View {
                         recordingCoordinator: recordingCoordinator
                     )
                     .padding(8)
+                } else if !captionViewModel.isFinalizingRecording {
+                    MainSidebarFooterView(
+                        vaults: sidebarViewModel.allVaults,
+                        currentVault: sidebarViewModel.currentVault,
+                        onSelectVault: onSelectVault
+                    )
                 }
             }
             .navigationSplitViewColumnWidth(min: 240, ideal: sidebarWidth, max: 420)

--- a/Sources/Dahlia/Views/ProjectManagementView.swift
+++ b/Sources/Dahlia/Views/ProjectManagementView.swift
@@ -68,7 +68,7 @@ struct ProjectManagementView: View {
                         recordingCoordinator: recordingCoordinator
                     )
                     .padding(8)
-                } else if !captionViewModel.isFinalizingRecording {
+                } else if captionViewModel.canSwitchVault {
                     MainSidebarFooterView(
                         vaults: sidebarViewModel.allVaults,
                         currentVault: sidebarViewModel.currentVault,

--- a/Sources/Dahlia/Views/Settings/GeneralSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/GeneralSettingsView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct GeneralSettingsView: View {
     var sidebarViewModel: SidebarViewModel
     var mainWindowNavigation: MainWindowNavigation
+    let canSwitchVault: Bool
     var onSelectVault: (VaultRecord) -> Void = { _ in }
 
     @Environment(\.openWindow) private var openWindow
@@ -20,6 +21,7 @@ struct GeneralSettingsView: View {
                             }
                         }
                     }
+                    .disabled(!canSwitchVault)
                 } label: {
                     Text(L10n.currentVault)
                     Text(L10n.currentVaultDescription)

--- a/Sources/Dahlia/Views/Settings/SettingsDetailView.swift
+++ b/Sources/Dahlia/Views/Settings/SettingsDetailView.swift
@@ -14,6 +14,7 @@ struct SettingsDetailView: View {
                 GeneralSettingsView(
                     sidebarViewModel: sidebarViewModel,
                     mainWindowNavigation: mainWindowNavigation,
+                    canSwitchVault: captionViewModel.canSwitchVault,
                     onSelectVault: onSelectVault
                 )
             case .permissions:

--- a/Sources/Dahlia/Views/SettingsView.swift
+++ b/Sources/Dahlia/Views/SettingsView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// 設定画面（Cmd+, で表示）。
 struct SettingsView: View {
-    var captionViewModel: CaptionViewModel
+    @ObservedObject var captionViewModel: CaptionViewModel
     var sidebarViewModel: SidebarViewModel
     var mainWindowNavigation: MainWindowNavigation
     var onSelectVault: (VaultRecord) -> Void = { _ in }

--- a/Sources/Dahlia/Views/VaultDetailView.swift
+++ b/Sources/Dahlia/Views/VaultDetailView.swift
@@ -4,6 +4,7 @@ struct VaultDetailView: View {
     let vault: VaultRecord?
     let hasRegisteredVaults: Bool
     let isCurrentVault: Bool
+    let canSwitchVault: Bool
     let onOpen: () -> Void
     let onAdd: () -> Void
 
@@ -33,7 +34,7 @@ struct VaultDetailView: View {
                 Section {
                     Button(L10n.openVault, systemImage: "folder", action: onOpen)
                         .buttonStyle(.borderedProminent)
-                        .disabled(isCurrentVault)
+                        .disabled(isCurrentVault || !canSwitchVault)
                 } footer: {
                     Text(L10n.openVaultDescription)
                 }

--- a/Sources/Dahlia/Views/VaultPickerView.swift
+++ b/Sources/Dahlia/Views/VaultPickerView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// 保管庫の登録・選択・登録解除を行う画面。
 struct VaultPickerView: View {
     let appDatabase: AppDatabaseManager?
+    let canSwitchVault: Bool
     let onVaultSelected: (VaultRecord) -> Void
 
     @Environment(\.dismissWindow) private var dismissWindow
@@ -42,6 +43,7 @@ struct VaultPickerView: View {
                 vault: selectedVault,
                 hasRegisteredVaults: !vaults.isEmpty,
                 isCurrentVault: selectedVault?.id == settings.currentVault?.id,
+                canSwitchVault: canSwitchVault,
                 onOpen: openSelectedVault,
                 onAdd: showFolderPicker
             )
@@ -158,6 +160,7 @@ struct VaultPickerView: View {
     }
 
     private func openVault(_ vault: VaultRecord) {
+        guard canSwitchVault else { return }
         onVaultSelected(vault)
         openWindow(id: WindowID.main)
         dismissWindow(id: WindowID.vaultManager)

--- a/Tests/DahliaTests/CaptionViewModelTests.swift
+++ b/Tests/DahliaTests/CaptionViewModelTests.swift
@@ -273,6 +273,17 @@ import GRDB
         }
 
         @Test
+        func vaultSwitchingIsDisabledWhileFinalizingRecording() {
+            let viewModel = CaptionViewModel()
+
+            #expect(viewModel.canSwitchVault)
+
+            viewModel.isFinalizingRecording = true
+
+            #expect(!viewModel.canSwitchVault)
+        }
+
+        @Test
         func canGenerateSummaryRemainsEnabledWhileAnotherMeetingSummaryIsGenerating() {
             let viewModel = summaryReadyViewModel()
             let currentMeetingID = viewModel.currentMeetingId


### PR DESCRIPTION
## Summary

- add a shared pill-shaped sidebar footer with the active Vault switcher and Settings button
- use the footer in meeting and project sidebars while preserving the recording status panel
- keep meeting rows behind the footer but clipped at the pill's lower edge
- hide Vault switching while recording is active or finalization is still in progress

## Why

Vault switching and app settings were difficult to discover in the existing sidebar layout. Moving both controls to a consistent footer makes their scope and relationship clearer while keeping recording controls prominent.

## Validation

- `swift build`
- `scripts/run-swiftformat.sh --cache ignore --lint` for all changed Swift files
- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter CaptionViewModelTests` — 27 tests in 2 suites passed
- manual verification in meeting and project sidebars, including inactive-window background rendering
- `CI=true ./scripts/lint.sh` — SwiftFormat passed; SwiftLint reported existing repository-wide violations unrelated to this change
