### PR TITLE
Align unprocessed recording sidebar highlight

### DIFF
--- a/Sources/Dahlia/Views/MainSidebarNavigationLabel.swift
+++ b/Sources/Dahlia/Views/MainSidebarNavigationLabel.swift
@@ -3,13 +3,28 @@ import SwiftUI
 struct MainSidebarNavigationLabel: View {
     let title: String
     let systemImage: String
+    var badgeCount = 0
     var isSelected = false
 
     var body: some View {
-        Label(title, systemImage: systemImage)
-            .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
-            .padding(.horizontal, 8)
-            .contentShape(Rectangle())
-            .modifier(SidebarNavigationRowModifier(isSelected: isSelected))
+        HStack {
+            Label(title, systemImage: systemImage)
+
+            Spacer(minLength: 8)
+
+            if badgeCount > 0 {
+                Text(badgeCount, format: .number)
+                    .font(.caption)
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 1)
+                    .background(.quaternary, in: Capsule())
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
+        .padding(.horizontal, 8)
+        .contentShape(Rectangle())
+        .modifier(SidebarNavigationRowModifier(isSelected: isSelected))
     }
 }

--- a/Sources/Dahlia/Views/MainSidebarNavigationView.swift
+++ b/Sources/Dahlia/Views/MainSidebarNavigationView.swift
@@ -36,18 +36,12 @@ struct MainSidebarNavigationView: View {
             .accessibilityAddTraits(isShowingProjectManagement ? .isSelected : [])
 
             Button(action: onShowUnprocessedRecordings) {
-                HStack {
-                    MainSidebarNavigationLabel(
-                        title: L10n.unprocessedRecordings,
-                        systemImage: "waveform.badge.exclamationmark",
-                        isSelected: isShowingUnprocessedRecordings
-                    )
-                    if unprocessedRecordingCount > 0 {
-                        Text(unprocessedRecordingCount, format: .number)
-                            .monospacedDigit()
-                            .foregroundStyle(.secondary)
-                    }
-                }
+                MainSidebarNavigationLabel(
+                    title: L10n.unprocessedRecordings,
+                    systemImage: "waveform.badge.exclamationmark",
+                    badgeCount: unprocessedRecordingCount,
+                    isSelected: isShowingUnprocessedRecordings
+                )
             }
             .buttonStyle(.plain)
             .help(L10n.unprocessedRecordings)


### PR DESCRIPTION
## Summary

- extend the unprocessed-recording navigation highlight across the full sidebar row
- present the unprocessed recording count as a compact trailing badge
- keep the badge hidden when the count is zero

## Why

The count was rendered outside `MainSidebarNavigationLabel`, so hover and selection backgrounds stopped before the count and appeared shorter than adjacent sidebar rows.

## Impact

The unprocessed-recording row now has consistent hover and selection geometry while preserving its existing navigation behavior and count visibility.

## Validation

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build`
- `CI=true ./scripts/lint.sh` (SwiftFormat passed; SwiftLint reported only existing repository violations and no new violations in the changed files)
- `git diff --check`
- parallel deep review covering SwiftUI/accessibility, security/performance, and tests/documentation; no actionable findings