### PR TITLE
Highlight upcoming calendar events on hover

### DIFF
--- a/Sources/Dahlia/Views/CalendarScheduleView.swift
+++ b/Sources/Dahlia/Views/CalendarScheduleView.swift
@@ -384,6 +384,8 @@ private struct CalendarScheduleEventRow: View {
     let onSelect: () -> Void
     let onJoin: (() -> Void)?
 
+    @State private var isHovered = false
+
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
             Button(action: onSelect) {
@@ -420,11 +422,15 @@ private struct CalendarScheduleEventRow: View {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)
+        .background(Color.primary.opacity(isHovered ? 0.08 : 0), in: RoundedRectangle(cornerRadius: 8))
         .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
         .overlay {
             RoundedRectangle(cornerRadius: 8)
                 .stroke(Color(nsColor: .separatorColor).opacity(0.4), lineWidth: 1)
         }
+        .contentShape(Rectangle())
+        .animation(.easeOut(duration: 0.12), value: isHovered)
+        .onHover { isHovered = $0 }
     }
 
     private var subtitle: String {


### PR DESCRIPTION
## Summary

- highlight upcoming calendar event rows while the pointer is hovering
- preserve the existing calendar card styling and join action behavior
- animate the hover transition for clearer visual feedback

## Root cause

Upcoming calendar event rows did not track hover state, so interactive events had no visual acknowledgement when the pointer moved over them.

## Validation

- `swift build --disable-sandbox`
- SwiftLint on `Sources/Dahlia/Views/CalendarScheduleView.swift`
- `git diff --check`
- Claude Code review (`medium`, `opus`): no findings
