### PR TITLE
Bump version to 0.8.10

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.dahlia.app</string>
     <key>CFBundleVersion</key>
-    <string>47</string>
+    <string>48</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.8.9</string>
+    <string>0.8.10</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>


### PR DESCRIPTION
## What changed

- Bumped the marketing version from `0.8.9` to `0.8.10`.
- Increased the build number from `47` to `48`.

## Why

Prepares the next patch release.

## Impact

The app reports the new release and build version.

## Validation

- `plutil -lint Resources/Info.plist`
- `git diff --check`