### PR TITLE
Reorder sidebar navigation items

### DIFF
--- a/Sources/Dahlia/Views/MainSidebarNavigationView.swift
+++ b/Sources/Dahlia/Views/MainSidebarNavigationView.swift
@@ -35,6 +35,17 @@ struct MainSidebarNavigationView: View {
             .help(L10n.manageProjects)
             .accessibilityAddTraits(isShowingProjectManagement ? .isSelected : [])
 
+            if showsCustomerIntelligence {
+                Button(action: onOpenCustomerIntelligence) {
+                    MainSidebarNavigationLabel(
+                        title: L10n.customerIntelligence,
+                        systemImage: "building.2"
+                    )
+                }
+                .buttonStyle(.plain)
+                .help(L10n.openOrganizationWorkspace)
+            }
+
             Button(action: onShowUnprocessedRecordings) {
                 MainSidebarNavigationLabel(
                     title: L10n.unprocessedRecordings,
@@ -46,17 +57,6 @@ struct MainSidebarNavigationView: View {
             .buttonStyle(.plain)
             .help(L10n.unprocessedRecordings)
             .accessibilityAddTraits(isShowingUnprocessedRecordings ? .isSelected : [])
-
-            if showsCustomerIntelligence {
-                Button(action: onOpenCustomerIntelligence) {
-                    MainSidebarNavigationLabel(
-                        title: L10n.customerIntelligence,
-                        systemImage: "building.2"
-                    )
-                }
-                .buttonStyle(.plain)
-                .help(L10n.openOrganizationWorkspace)
-            }
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)


### PR DESCRIPTION
## Summary

- move Customer Intelligence above Unprocessed Recordings in the main sidebar
- preserve the existing navigation actions, selection state, and unprocessed-recording badge

## Why

The sidebar order should place the organization workspace before the unprocessed recordings entry.

## Impact

This is a presentation-only change to the main sidebar. Navigation behavior and recording data are unchanged.

## Validation

- `swift build`
- `CI=true ./scripts/lint.sh` (SwiftFormat passed; SwiftLint reported only existing violations outside the edited file)
- `git diff --check`
