### PR TITLE
Add main window navigation history

### DIFF
--- a/Sources/Dahlia/Database/MeetingRepository.swift
+++ b/Sources/Dahlia/Database/MeetingRepository.swift
@@ -189,7 +189,7 @@ final class MeetingRepository {
         }
     }
 
-    func fetchMeeting(id: UUID) throws -> MeetingRecord? {
+    nonisolated func fetchMeeting(id: UUID) throws -> MeetingRecord? {
         try dbQueue.read { db in
             try MeetingRecord.fetchOne(db, key: id)
         }

--- a/Sources/Dahlia/Utilities/MainWindowNavigation.swift
+++ b/Sources/Dahlia/Utilities/MainWindowNavigation.swift
@@ -95,6 +95,12 @@ final class MainWindowNavigation {
         section = location.section
     }
 
+    func recordUpcomingScheduleIfVisible(_ isVisible: Bool) {
+        guard isVisible, section == .meetings,
+              case .meeting = currentLocation else { return }
+        recordNavigation(to: .upcomingSchedule)
+    }
+
     func resetNavigationHistory(to location: MainWindowLocation) {
         hasInitializedNavigationHistory = true
         navigationGeneration += 1

--- a/Sources/Dahlia/Utilities/MainWindowNavigation.swift
+++ b/Sources/Dahlia/Utilities/MainWindowNavigation.swift
@@ -1,17 +1,46 @@
 import Foundation
 import Observation
 
+enum MainWindowLocation: Equatable {
+    case upcomingSchedule
+    case unprocessedRecordings
+    case meeting(UUID)
+    case project(UUID?)
+
+    var section: MainWindowSection {
+        switch self {
+        case .upcomingSchedule, .unprocessedRecordings, .meeting:
+            .meetings
+        case .project:
+            .projects
+        }
+    }
+}
+
 @MainActor
 @Observable
 final class MainWindowNavigation {
+    private enum HistoryDirection {
+        case backward
+        case forward
+    }
+
     static let shared = MainWindowNavigation()
 
+    private static let historyLimit = 50
+
     private(set) var section: MainWindowSection = .meetings
+    private(set) var currentLocation: MainWindowLocation = .upcomingSchedule
+    private(set) var isNavigatingHistory = false
+    private(set) var hasInitializedNavigationHistory = false
     var selectedProjectId: UUID?
     var projectSearchText = ""
     var expandedProjectIds: Set<UUID> = []
 
     private var projectVaultId: UUID?
+    private var navigationGeneration = 0
+    private var backHistory: [MainWindowLocation] = []
+    private var forwardHistory: [MainWindowLocation] = []
 
     private let openMainWindow: @MainActor () -> Void
     private let openMainWindowWithoutActivation: @MainActor () -> Void
@@ -35,6 +64,7 @@ final class MainWindowNavigation {
     }
 
     func openProjects() {
+        recordNavigation(to: .project(selectedProjectId))
         showProjects()
         openMainWindow()
     }
@@ -49,6 +79,74 @@ final class MainWindowNavigation {
         openMainWindowWithoutActivation()
     }
 
+    var canGoBack: Bool { !backHistory.isEmpty && !isNavigatingHistory }
+    var canGoForward: Bool { !forwardHistory.isEmpty && !isNavigatingHistory }
+
+    func recordNavigation(to location: MainWindowLocation) {
+        hasInitializedNavigationHistory = true
+        cancelHistoryNavigation()
+        guard currentLocation != location else {
+            section = location.section
+            return
+        }
+        appendToHistory(&backHistory, location: currentLocation)
+        currentLocation = location
+        forwardHistory = []
+        section = location.section
+    }
+
+    func resetNavigationHistory(to location: MainWindowLocation) {
+        hasInitializedNavigationHistory = true
+        navigationGeneration += 1
+        isNavigatingHistory = false
+        currentLocation = location
+        backHistory = []
+        forwardHistory = []
+        section = location.section
+    }
+
+    func initializeNavigationHistoryIfNeeded(to location: MainWindowLocation) {
+        guard !hasInitializedNavigationHistory else { return }
+        resetNavigationHistory(to: location)
+    }
+
+    func changeVault(to vaultId: UUID?) {
+        projectVaultId = vaultId
+        selectedProjectId = nil
+        projectSearchText = ""
+        expandedProjectIds = []
+        let location: MainWindowLocation = if section == .projects {
+            .project(nil)
+        } else if currentLocation == .unprocessedRecordings {
+            .unprocessedRecordings
+        } else {
+            .upcomingSchedule
+        }
+        resetNavigationHistory(to: location)
+    }
+
+    func goBack(
+        validatingWith validate: (MainWindowLocation) async -> Bool,
+        restoringWith restore: (MainWindowLocation) -> Void
+    ) async {
+        guard canGoBack else { return }
+        await navigate(.backward, validatingWith: validate, restoringWith: restore)
+    }
+
+    func goForward(
+        validatingWith validate: (MainWindowLocation) async -> Bool,
+        restoringWith restore: (MainWindowLocation) -> Void
+    ) async {
+        guard canGoForward else { return }
+        await navigate(.forward, validatingWith: validate, restoringWith: restore)
+    }
+
+    func cancelHistoryNavigation() {
+        guard isNavigatingHistory else { return }
+        navigationGeneration += 1
+        isNavigatingHistory = false
+    }
+
     func reconcileProjectCatalog(
         vaultId: UUID?,
         projects: [ProjectOverviewItem]
@@ -59,9 +157,76 @@ final class MainWindowNavigation {
             projectSearchText = ""
             expandedProjectIds.removeAll()
         }
-        selectedProjectId = ProjectManagementSelection.reconciled(
+        let reconciledProjectId = ProjectManagementSelection.reconciled(
             selectedProjectId: selectedProjectId,
             projects: projects
         )
+        selectedProjectId = reconciledProjectId
+        if section == .projects {
+            currentLocation = .project(reconciledProjectId)
+        }
+    }
+
+    private func navigate(
+        _ direction: HistoryDirection,
+        validatingWith validate: (MainWindowLocation) async -> Bool,
+        restoringWith restore: (MainWindowLocation) -> Void
+    ) async {
+        navigationGeneration += 1
+        let generation = navigationGeneration
+        isNavigatingHistory = true
+        defer {
+            if generation == navigationGeneration {
+                isNavigatingHistory = false
+            }
+        }
+
+        while let location = nextLocation(for: direction) {
+            let canRestore = await validate(location)
+            guard generation == navigationGeneration else { return }
+            removeNextLocation(for: direction)
+            if canRestore {
+                switch direction {
+                case .backward:
+                    appendToHistory(&forwardHistory, location: currentLocation)
+                case .forward:
+                    appendToHistory(&backHistory, location: currentLocation)
+                }
+                currentLocation = location
+                section = location.section
+                restore(location)
+                return
+            }
+        }
+    }
+
+    private func nextLocation(for direction: HistoryDirection) -> MainWindowLocation? {
+        switch direction {
+        case .backward:
+            backHistory.last
+        case .forward:
+            forwardHistory.last
+        }
+    }
+
+    private func removeNextLocation(for direction: HistoryDirection) {
+        switch direction {
+        case .backward:
+            backHistory.removeLast()
+        case .forward:
+            forwardHistory.removeLast()
+        }
+    }
+
+    private func appendToHistory(
+        _ history: inout [MainWindowLocation],
+        location: MainWindowLocation
+    ) {
+        if history.last != location {
+            history.append(location)
+        }
+        if history.count > Self.historyLimit {
+            history.removeFirst(history.count - Self.historyLimit)
+        }
     }
 }

--- a/Sources/Dahlia/Utilities/MainWindowNavigation.swift
+++ b/Sources/Dahlia/Utilities/MainWindowNavigation.swift
@@ -164,6 +164,7 @@ final class MainWindowNavigation {
         selectedProjectId = reconciledProjectId
         if section == .projects {
             currentLocation = .project(reconciledProjectId)
+            reconcileProjectHistory(with: projects)
         }
     }
 
@@ -228,5 +229,26 @@ final class MainWindowNavigation {
         if history.count > Self.historyLimit {
             history.removeFirst(history.count - Self.historyLimit)
         }
+    }
+
+    private func reconcileProjectHistory(with projects: [ProjectOverviewItem]) {
+        if !projects.isEmpty {
+            let availableProjectIds = Set(projects.map(\.projectId))
+            backHistory.removeAll { $0.referencesUnavailableProject(in: availableProjectIds) }
+            forwardHistory.removeAll { $0.referencesUnavailableProject(in: availableProjectIds) }
+        }
+        while backHistory.last == currentLocation {
+            backHistory.removeLast()
+        }
+        while forwardHistory.last == currentLocation {
+            forwardHistory.removeLast()
+        }
+    }
+}
+
+private extension MainWindowLocation {
+    func referencesUnavailableProject(in availableProjectIds: Set<UUID>) -> Bool {
+        guard case let .project(projectId?) = self else { return false }
+        return !availableProjectIds.contains(projectId)
     }
 }

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -176,6 +176,9 @@ struct ContentView: View {
                 mainWindowNavigation.recordNavigation(to: .meeting(meetingID))
             }
             handleMeetingSelectionChange(newValue)
+            if newValue.isEmpty {
+                mainWindowNavigation.recordUpcomingScheduleIfVisible(isShowingUpcomingSchedule)
+            }
             syncChatContext()
         }
         .onChange(of: viewModel.currentMeetingId) { oldId, newId in

--- a/Sources/Dahlia/Views/ContentView.swift
+++ b/Sources/Dahlia/Views/ContentView.swift
@@ -55,6 +55,13 @@ struct ContentView: View {
         }
         .toolbar(removing: .title)
         .toolbar {
+            MainWindowNavigationToolbar(
+                canGoBack: canGoBack,
+                canGoForward: canGoForward,
+                onGoBack: goBack,
+                onGoForward: goForward
+            )
+
             ToolbarItem(placement: .navigation) {
                 if mainWindowNavigation.section == .meetings {
                     Button(L10n.newMeeting, systemImage: "square.and.pencil") {
@@ -165,6 +172,9 @@ struct ContentView: View {
                 mainWindowNavigation.showMeetings()
                 isShowingUnprocessedRecordings = false
             }
+            if newValue.count == 1, let meetingID = newValue.first {
+                mainWindowNavigation.recordNavigation(to: .meeting(meetingID))
+            }
             handleMeetingSelectionChange(newValue)
             syncChatContext()
         }
@@ -178,10 +188,15 @@ struct ContentView: View {
         .onChange(of: viewModel.draftMeeting) {
             syncChatContext()
         }
-        .onChange(of: sidebarViewModel.currentVault?.id) { _, _ in
+        .onChange(of: sidebarViewModel.currentVault?.id) { _, vaultID in
             sidebarViewModel.clearMeetingSelection()
             viewModel.clearCurrentMeeting()
+            mainWindowNavigation.changeVault(to: vaultID)
             syncChatContext()
+        }
+        .onChange(of: mainWindowNavigation.selectedProjectId) { _, projectID in
+            guard mainWindowNavigation.section == .projects else { return }
+            mainWindowNavigation.recordNavigation(to: .project(projectID))
         }
         .onChange(of: mainWindowNavigation.section) { _, section in
             if section == .projects {
@@ -252,6 +267,20 @@ private extension ContentView {
             && !isShowingUnprocessedRecordings
     }
 
+    private var canGoBack: Bool {
+        mainWindowNavigation.canGoBack && canNavigateHistory
+    }
+
+    private var canGoForward: Bool {
+        mainWindowNavigation.canGoForward && canNavigateHistory
+    }
+
+    private var canNavigateHistory: Bool {
+        !viewModel.hasDraftMeeting
+            && !viewModel.isRecordingStartPending
+            && !viewModel.isFinalizingRecording
+    }
+
     @ViewBuilder
     private var detailView: some View {
         if isShowingUnprocessedRecordings {
@@ -291,6 +320,16 @@ private extension ContentView {
     }
 
     private func returnToCalendarSchedule() {
+        mainWindowNavigation.recordNavigation(to: .upcomingSchedule)
+        displayUpcomingSchedule()
+    }
+
+    private func showUnprocessedRecordings() {
+        mainWindowNavigation.recordNavigation(to: .unprocessedRecordings)
+        displayUnprocessedRecordings()
+    }
+
+    private func displayUpcomingSchedule() {
         mainWindowNavigation.showMeetings()
         isShowingUnprocessedRecordings = false
         if viewModel.hasDraftMeeting || sidebarViewModel.selectedMeetingIds.isEmpty {
@@ -299,7 +338,7 @@ private extension ContentView {
         sidebarViewModel.clearMeetingSelection()
     }
 
-    private func showUnprocessedRecordings() {
+    private func displayUnprocessedRecordings() {
         mainWindowNavigation.showMeetings()
         viewModel.clearCurrentMeeting()
         sidebarViewModel.clearMeetingSelection()
@@ -308,6 +347,7 @@ private extension ContentView {
     }
 
     private func showProjectManagement() {
+        mainWindowNavigation.recordNavigation(to: .project(mainWindowNavigation.selectedProjectId))
         mainWindowNavigation.showProjects()
     }
 
@@ -319,8 +359,15 @@ private extension ContentView {
     }
 
     private func prepareInitialPresentation() {
+        if mainWindowNavigation.hasInitializedNavigationHistory {
+            restoreCurrentPresentation()
+            return
+        }
         if mainWindowNavigation.section == .projects {
             prepareProjectManagement()
+            mainWindowNavigation.initializeNavigationHistoryIfNeeded(
+                to: .project(mainWindowNavigation.selectedProjectId)
+            )
             return
         }
         if sidebarViewModel.selectedMeetingIds.count == 1,
@@ -328,7 +375,94 @@ private extension ContentView {
            viewModel.currentMeetingId != meetingId {
             handleMeetingSelection(meetingId)
         }
+        let initialLocation = sidebarViewModel.selectedMeetingId.map(MainWindowLocation.meeting)
+            ?? .upcomingSchedule
+        mainWindowNavigation.initializeNavigationHistoryIfNeeded(to: initialLocation)
         syncChatContext()
+    }
+
+    private func restoreCurrentPresentation() {
+        if viewModel.hasDraftMeeting || sidebarViewModel.selectedMeetingIds.count > 1 {
+            mainWindowNavigation.showMeetings()
+            isShowingUnprocessedRecordings = false
+            syncChatContext()
+            return
+        }
+
+        restoreNavigation(mainWindowNavigation.currentLocation)
+        syncChatContext()
+    }
+
+    private func goBack() {
+        guard canNavigateHistory else { return }
+        Task {
+            await mainWindowNavigation.goBack(
+                validatingWith: validateNavigation,
+                restoringWith: restoreNavigation
+            )
+        }
+    }
+
+    private func goForward() {
+        guard canNavigateHistory else { return }
+        Task {
+            await mainWindowNavigation.goForward(
+                validatingWith: validateNavigation,
+                restoringWith: restoreNavigation
+            )
+        }
+    }
+
+    private func validateNavigation(_ location: MainWindowLocation) async -> Bool {
+        switch location {
+        case .upcomingSchedule, .unprocessedRecordings:
+            return true
+        case let .meeting(meetingID):
+            let selectedMeetingIds = sidebarViewModel.selectedMeetingIds
+            let draftMeeting = viewModel.draftMeeting
+            let currentMeetingID = viewModel.currentMeetingId
+            let isRecordingStartPending = viewModel.isRecordingStartPending
+            let isFinalizingRecording = viewModel.isFinalizingRecording
+            let exists = await meetingExists(meetingID)
+            guard canNavigateHistory,
+                  sidebarViewModel.selectedMeetingIds == selectedMeetingIds,
+                  viewModel.draftMeeting == draftMeeting,
+                  viewModel.currentMeetingId == currentMeetingID,
+                  viewModel.isRecordingStartPending == isRecordingStartPending,
+                  viewModel.isFinalizingRecording == isFinalizingRecording else {
+                mainWindowNavigation.cancelHistoryNavigation()
+                return false
+            }
+            return exists
+        case let .project(projectID):
+            return projectID == nil
+                || sidebarViewModel.allProjectItems.contains(where: { $0.projectId == projectID })
+        }
+    }
+
+    private func restoreNavigation(_ location: MainWindowLocation) {
+        switch location {
+        case .upcomingSchedule:
+            displayUpcomingSchedule()
+        case .unprocessedRecordings:
+            displayUnprocessedRecordings()
+        case let .meeting(meetingID):
+            mainWindowNavigation.showMeetings()
+            isShowingUnprocessedRecordings = false
+            sidebarViewModel.selectMeeting(meetingID)
+        case let .project(projectID):
+            mainWindowNavigation.showProjects()
+            mainWindowNavigation.selectedProjectId = projectID
+        }
+    }
+
+    private func meetingExists(_ meetingID: UUID) async -> Bool {
+        guard let dbQueue = sidebarViewModel.dbQueue,
+              let vaultID = sidebarViewModel.currentVault?.id else { return false }
+        let existsInVault = await Task.detached(priority: .userInitiated) {
+            try? MeetingRepository(dbQueue: dbQueue).fetchMeeting(id: meetingID)?.vaultId == vaultID
+        }.value == true
+        return existsInVault && sidebarViewModel.currentVault?.id == vaultID
     }
 
     private func handleMeetingSelection(_ meetingId: UUID) {

--- a/Sources/Dahlia/Views/CustomerIntelligenceWorkspaceView.swift
+++ b/Sources/Dahlia/Views/CustomerIntelligenceWorkspaceView.swift
@@ -104,6 +104,7 @@ struct OrganizationWorkspaceView: View {
                     onOpenTopic: { id in Task { await model.openTopic(id) } },
                     onOpenInsight: { id in Task { await model.openInsight(id) } },
                     onOpenMeetings: {
+                        mainWindowNavigation.recordNavigation(to: .upcomingSchedule)
                         mainWindowNavigation.openMeetings()
                     },
                     onOpenMeeting: { openMeeting($0) }

--- a/Sources/Dahlia/Views/MainWindowNavigationToolbar.swift
+++ b/Sources/Dahlia/Views/MainWindowNavigationToolbar.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct MainWindowNavigationToolbar: ToolbarContent {
+    let canGoBack: Bool
+    let canGoForward: Bool
+    let onGoBack: () -> Void
+    let onGoForward: () -> Void
+
+    var body: some ToolbarContent {
+        ToolbarItemGroup(placement: .navigation) {
+            Button(L10n.back, systemImage: "chevron.backward", action: onGoBack)
+                .labelStyle(.iconOnly)
+                .disabled(!canGoBack)
+                .keyboardShortcut("[", modifiers: .command)
+                .help(L10n.back)
+            Button(L10n.forward, systemImage: "chevron.forward", action: onGoForward)
+                .labelStyle(.iconOnly)
+                .disabled(!canGoForward)
+                .keyboardShortcut("]", modifiers: .command)
+                .help(L10n.forward)
+        }
+    }
+}

--- a/Tests/DahliaTests/MainWindowNavigationTests.swift
+++ b/Tests/DahliaTests/MainWindowNavigationTests.swift
@@ -19,6 +19,228 @@ struct MainWindowNavigationTests {
     }
 
     @Test
+    func navigatesBackwardAndForwardThroughMainLocations() async {
+        let navigation = MainWindowNavigation(openMainWindow: {})
+        let meetingId = UUID.v7()
+        let projectId = UUID.v7()
+        navigation.recordNavigation(to: .meeting(meetingId))
+        navigation.recordNavigation(to: .project(projectId))
+        navigation.recordNavigation(to: .unprocessedRecordings)
+
+        await navigateBack(navigation)
+        #expect(navigation.currentLocation == .project(projectId))
+        #expect(navigation.section == .projects)
+
+        await navigateBack(navigation)
+        #expect(navigation.currentLocation == .meeting(meetingId))
+
+        await navigateBack(navigation)
+        #expect(navigation.currentLocation == .upcomingSchedule)
+        #expect(!navigation.canGoBack)
+
+        await navigateForward(navigation)
+        await navigateForward(navigation)
+        await navigateForward(navigation)
+        #expect(navigation.currentLocation == .unprocessedRecordings)
+        #expect(!navigation.canGoForward)
+    }
+
+    @Test
+    func duplicateNavigationDoesNotAddHistory() async {
+        let navigation = MainWindowNavigation(openMainWindow: {})
+        let meetingId = UUID.v7()
+
+        navigation.recordNavigation(to: .meeting(meetingId))
+        navigation.recordNavigation(to: .meeting(meetingId))
+        await navigateBack(navigation)
+
+        #expect(navigation.currentLocation == .upcomingSchedule)
+        #expect(!navigation.canGoBack)
+    }
+
+    @Test
+    func repeatedInitializationKeepsExistingBackAndForwardHistory() async {
+        let navigation = MainWindowNavigation(openMainWindow: {})
+        let meetingId = UUID.v7()
+        navigation.initializeNavigationHistoryIfNeeded(to: .upcomingSchedule)
+        navigation.recordNavigation(to: .meeting(meetingId))
+        navigation.recordNavigation(to: .project(.v7()))
+        await navigateBack(navigation)
+
+        navigation.initializeNavigationHistoryIfNeeded(to: .unprocessedRecordings)
+
+        #expect(navigation.currentLocation == .meeting(meetingId))
+        #expect(navigation.canGoBack)
+        #expect(navigation.canGoForward)
+    }
+
+    @Test
+    func newNavigationAfterGoingBackClearsForwardHistory() async {
+        let navigation = MainWindowNavigation(openMainWindow: {})
+        navigation.recordNavigation(to: .meeting(.v7()))
+        navigation.recordNavigation(to: .project(.v7()))
+
+        await navigateBack(navigation)
+        #expect(navigation.canGoForward)
+
+        navigation.recordNavigation(to: .unprocessedRecordings)
+
+        #expect(!navigation.canGoForward)
+    }
+
+    @Test
+    func resettingHistoryForVaultChangeClearsBothDirections() async {
+        let navigation = MainWindowNavigation(openMainWindow: {})
+        let vaultId = UUID.v7()
+        navigation.recordNavigation(to: .meeting(.v7()))
+        navigation.recordNavigation(to: .project(.v7()))
+        navigation.recordNavigation(to: .unprocessedRecordings)
+        navigation.projectSearchText = "customer"
+        navigation.expandedProjectIds = [.v7()]
+        await navigateBack(navigation)
+
+        navigation.changeVault(to: vaultId)
+
+        #expect(navigation.currentLocation == .project(nil))
+        #expect(!navigation.canGoBack)
+        #expect(!navigation.canGoForward)
+        #expect(navigation.selectedProjectId == nil)
+        #expect(navigation.projectSearchText.isEmpty)
+        #expect(navigation.expandedProjectIds.isEmpty)
+    }
+
+    @Test
+    func changingVaultKeepsUnprocessedRecordingsAsCurrentLocation() {
+        let navigation = MainWindowNavigation(openMainWindow: {})
+        navigation.recordNavigation(to: .unprocessedRecordings)
+
+        navigation.changeVault(to: .v7())
+
+        #expect(navigation.currentLocation == .unprocessedRecordings)
+        #expect(!navigation.canGoBack)
+        #expect(!navigation.canGoForward)
+    }
+
+    @Test
+    func unavailableHistoryEntriesAreDiscarded() async {
+        let navigation = MainWindowNavigation(openMainWindow: {})
+        let availableMeetingId = UUID.v7()
+        let unavailableMeetingId = UUID.v7()
+        navigation.recordNavigation(to: .meeting(availableMeetingId))
+        navigation.recordNavigation(to: .meeting(unavailableMeetingId))
+        navigation.recordNavigation(to: .project(.v7()))
+
+        await navigation.goBack(
+            validatingWith: { location in
+                location != .meeting(unavailableMeetingId)
+            },
+            restoringWith: { _ in }
+        )
+
+        #expect(navigation.currentLocation == .meeting(availableMeetingId))
+    }
+
+    @Test
+    func unavailableEntryDoesNotPublishItsSectionOrChangeCurrentLocation() async {
+        let navigation = MainWindowNavigation(openMainWindow: {})
+        let missingProjectId = UUID.v7()
+        let meetingId = UUID.v7()
+        navigation.resetNavigationHistory(to: .project(missingProjectId))
+        navigation.recordNavigation(to: .meeting(meetingId))
+        var restoredLocation: MainWindowLocation?
+
+        await navigation.goBack(
+            validatingWith: { _ in
+                #expect(navigation.section == .meetings)
+                return false
+            },
+            restoringWith: { restoredLocation = $0 }
+        )
+
+        #expect(restoredLocation == nil)
+        #expect(navigation.currentLocation == .meeting(meetingId))
+        #expect(navigation.section == .meetings)
+    }
+
+    @Test
+    func normalNavigationCancelsSuspendedHistoryWithoutDiscardingIt() async {
+        let navigation = MainWindowNavigation(openMainWindow: {})
+        let meetingId = UUID.v7()
+        let projectId = UUID.v7()
+        let gate = NavigationValidationGate()
+        navigation.recordNavigation(to: .meeting(meetingId))
+        navigation.recordNavigation(to: .project(projectId))
+
+        let traversal = Task {
+            await navigation.goBack(
+                validatingWith: { _ in
+                    await gate.wait()
+                    return true
+                },
+                restoringWith: { _ in }
+            )
+        }
+        while !navigation.isNavigatingHistory {
+            await Task.yield()
+        }
+
+        navigation.recordNavigation(to: .unprocessedRecordings)
+        await gate.release()
+        await traversal.value
+
+        #expect(navigation.currentLocation == .unprocessedRecordings)
+        await navigateBack(navigation)
+        #expect(navigation.currentLocation == .project(projectId))
+    }
+
+    @Test
+    func resettingHistoryCancelsSuspendedNavigation() async {
+        let navigation = MainWindowNavigation(openMainWindow: {})
+        let gate = NavigationValidationGate()
+        navigation.recordNavigation(to: .meeting(.v7()))
+
+        let traversal = Task {
+            await navigation.goBack(
+                validatingWith: { _ in
+                    await gate.wait()
+                    return true
+                },
+                restoringWith: { _ in }
+            )
+        }
+        while !navigation.isNavigatingHistory {
+            await Task.yield()
+        }
+
+        navigation.resetNavigationHistory(to: .unprocessedRecordings)
+        await gate.release()
+        await traversal.value
+
+        #expect(!navigation.isNavigatingHistory)
+        #expect(navigation.currentLocation == .unprocessedRecordings)
+        #expect(!navigation.canGoBack)
+        #expect(!navigation.canGoForward)
+    }
+
+    @Test
+    func historyRetainsOnlyTheMostRecentFiftyLocations() async {
+        let navigation = MainWindowNavigation(openMainWindow: {})
+        for _ in 0 ..< 51 {
+            navigation.recordNavigation(to: .meeting(.v7()))
+        }
+
+        var restoredCount = 0
+        while navigation.canGoBack {
+            await navigation.goBack(
+                validatingWith: { _ in true },
+                restoringWith: { _ in restoredCount += 1 }
+            )
+        }
+
+        #expect(restoredCount == 50)
+    }
+
+    @Test
     func openingProjectsSetsSectionBeforeOpeningMainWindow() {
         var observedSection: MainWindowSection?
         var navigation: MainWindowNavigation?
@@ -26,6 +248,8 @@ struct MainWindowNavigationTests {
             observedSection = navigation?.section
         }
         navigation = subject
+        subject.resetNavigationHistory(to: .project(.v7()))
+        subject.showMeetings()
 
         subject.openProjects()
 
@@ -114,6 +338,34 @@ struct MainWindowNavigationTests {
         #expect(navigation.selectedProjectId == first.projectId)
     }
 
+    @Test
+    func automaticProjectSelectionReplacesCurrentLocationWithoutAddingHistory() {
+        let navigation = MainWindowNavigation(openMainWindow: {})
+        let vaultId = UUID.v7()
+        let first = project(named: "First")
+        navigation.resetNavigationHistory(to: .project(nil))
+
+        navigation.reconcileProjectCatalog(vaultId: vaultId, projects: [first])
+
+        #expect(navigation.selectedProjectId == first.projectId)
+        #expect(navigation.currentLocation == .project(first.projectId))
+        #expect(!navigation.canGoBack)
+    }
+
+    private func navigateBack(_ navigation: MainWindowNavigation) async {
+        await navigation.goBack(
+            validatingWith: { _ in true },
+            restoringWith: { _ in }
+        )
+    }
+
+    private func navigateForward(_ navigation: MainWindowNavigation) async {
+        await navigation.goForward(
+            validatingWith: { _ in true },
+            restoringWith: { _ in }
+        )
+    }
+
     private func project(named name: String) -> ProjectOverviewItem {
         ProjectOverviewItem(
             projectId: .v7(),
@@ -129,6 +381,22 @@ struct MainWindowNavigationTests {
             meetingCount: 0,
             latestMeetingDate: nil
         )
+    }
+}
+
+private actor NavigationValidationGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isReleased = false
+
+    func wait() async {
+        if isReleased { return }
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func release() {
+        isReleased = true
+        continuation?.resume()
+        continuation = nil
     }
 }
 #endif

--- a/Tests/DahliaTests/MainWindowNavigationTests.swift
+++ b/Tests/DahliaTests/MainWindowNavigationTests.swift
@@ -384,6 +384,27 @@ struct MainWindowNavigationTests {
     }
 }
 
+extension MainWindowNavigationTests {
+    @Test
+    func deletingSelectedProjectRemovesRedundantAndUnavailableHistory() {
+        let navigation = MainWindowNavigation(openMainWindow: {})
+        let vaultId = UUID.v7()
+        let first = project(named: "First")
+        let selected = project(named: "Selected")
+        let unavailable = project(named: "Unavailable")
+        navigation.resetNavigationHistory(to: .project(first.projectId))
+        navigation.recordNavigation(to: .project(unavailable.projectId))
+        navigation.recordNavigation(to: .project(selected.projectId))
+        navigation.selectedProjectId = selected.projectId
+
+        navigation.reconcileProjectCatalog(vaultId: vaultId, projects: [first])
+
+        #expect(navigation.currentLocation == .project(first.projectId))
+        #expect(!navigation.canGoBack)
+        #expect(!navigation.canGoForward)
+    }
+}
+
 private actor NavigationValidationGate {
     private var continuation: CheckedContinuation<Void, Never>?
     private var isReleased = false

--- a/Tests/DahliaTests/MainWindowNavigationTests.swift
+++ b/Tests/DahliaTests/MainWindowNavigationTests.swift
@@ -17,7 +17,9 @@ struct MainWindowNavigationTests {
         navigation.showMeetings()
         #expect(navigation.section == .meetings)
     }
+}
 
+extension MainWindowNavigationTests {
     @Test
     func navigatesBackwardAndForwardThroughMainLocations() async {
         let navigation = MainWindowNavigation(openMainWindow: {})
@@ -385,6 +387,30 @@ struct MainWindowNavigationTests {
 }
 
 extension MainWindowNavigationTests {
+    @Test
+    func clearingMeetingSelectionRecordsVisibleUpcomingSchedule() async {
+        let navigation = MainWindowNavigation(openMainWindow: {})
+        let meetingId = UUID.v7()
+        navigation.recordNavigation(to: .meeting(meetingId))
+
+        navigation.recordUpcomingScheduleIfVisible(true)
+
+        #expect(navigation.currentLocation == .upcomingSchedule)
+        await navigateBack(navigation)
+        #expect(navigation.currentLocation == .meeting(meetingId))
+    }
+
+    @Test
+    func programmaticSelectionClearKeepsRecordedDestination() {
+        let navigation = MainWindowNavigation(openMainWindow: {})
+        navigation.recordNavigation(to: .meeting(.v7()))
+        navigation.recordNavigation(to: .unprocessedRecordings)
+
+        navigation.recordUpcomingScheduleIfVisible(true)
+
+        #expect(navigation.currentLocation == .unprocessedRecordings)
+    }
+
     @Test
     func deletingSelectedProjectRemovesRedundantAndUnavailableHistory() {
         let navigation = MainWindowNavigation(openMainWindow: {})


### PR DESCRIPTION
## Summary

- add browser-style back and forward history for main-window meeting and project destinations
- place the controls in the standard macOS navigation toolbar with Command-[ and Command-] shortcuts
- reset history across vault changes and safely skip deleted or otherwise unavailable destinations
- keep drafts, multi-selection, and recording transitions outside history restoration

## Why

Moving among the upcoming schedule, unprocessed recordings, meetings, and projects previously required navigating through the sidebar again. This adds predictable back and forward navigation while preserving recording state and vault isolation.

The history restoration path validates destinations before publishing UI changes and cancels stale asynchronous restoration when newer user navigation occurs.

## Validation

- `swift build`
- `swift test --filter MainWindowNavigationTests` — 18 tests passed
- `swift test` — 1,472 tests in 219 suites passed
- `CI=true ./scripts/lint.sh` — SwiftFormat passed; SwiftLint reported only existing non-blocking repository violations
- `git diff --check`
