### PR TITLE
Optimize calendar refresh rendering

### DIFF
--- a/Sources/Dahlia/DahliaApp.swift
+++ b/Sources/Dahlia/DahliaApp.swift
@@ -104,12 +104,7 @@ struct DahliaApp: App {
                 initializeAppIfNeeded()
                 let settings = AppSettings.shared
                 async let driveRestore: Void = GoogleDriveStore.shared.restoreSessionIfNeeded()
-                if settings.isCalendarSourceEnabled(.google) {
-                    await GoogleCalendarStore.shared.restoreSessionIfNeeded()
-                }
-                if settings.isCalendarSourceEnabled(.macOS) {
-                    await MacCalendarStore.shared.refreshIfNeeded()
-                }
+                await CalendarSourceCoordinator.shared.refreshEnabledSources(settings.enabledCalendarSources)
                 await driveRestore
             }
         }

--- a/Sources/Dahlia/Models/MenuBarCalendarAgenda.swift
+++ b/Sources/Dahlia/Models/MenuBarCalendarAgenda.swift
@@ -9,32 +9,21 @@ struct MenuBarCalendarAgenda: Equatable {
     let hasEventsExcludedByFilter: Bool
 
     init(
-        googleEvents: [CalendarEvent],
-        macEvents: [CalendarEvent],
-        enabledSources: Set<CalendarSource>,
+        events: [CalendarEvent],
         filter: CalendarEventFilter,
         now: Date,
         calendar: Calendar = .autoupdatingCurrent
     ) {
-        var sourceEvents: [CalendarEvent] = []
-        if enabledSources.contains(.google) {
-            sourceEvents.append(contentsOf: googleEvents)
-        }
-        if enabledSources.contains(.macOS) {
-            sourceEvents.append(contentsOf: macEvents)
-        }
-
         let tomorrow = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now)) ?? now
-        let currentEvents = sourceEvents
-            .deduplicatedAcrossSources()
+        let currentEvents = events
             .filter { $0.endDate > now && $0.startDate < tomorrow }
 
-        events = currentEvents
+        self.events = currentEvents
             .filter(filter.includes)
             .sorted(by: Self.sortEvents)
-        hasEventsExcludedByFilter = events.isEmpty && !currentEvents.isEmpty
+        hasEventsExcludedByFilter = self.events.isEmpty && !currentEvents.isEmpty
 
-        let timedEvents = events.filter { !$0.isAllDay }
+        let timedEvents = self.events.filter { !$0.isAllDay }
         if let ongoingEvent = timedEvents
             .filter({ $0.startDate <= now && $0.endDate > now })
             .max(by: Self.compareOngoingEvents) {

--- a/Sources/Dahlia/Services/CalendarSourceCoordinator.swift
+++ b/Sources/Dahlia/Services/CalendarSourceCoordinator.swift
@@ -1,0 +1,106 @@
+import Combine
+import Foundation
+
+@MainActor
+protocol CalendarEventSourceStore: AnyObject, Sendable {
+    var source: CalendarSource { get }
+    var upcomingEvents: [CalendarEvent] { get }
+    var isLoaded: Bool { get }
+    var upcomingEventsPublisher: AnyPublisher<[CalendarEvent], Never> { get }
+    var statePublisher: AnyPublisher<Bool, Never> { get }
+
+    func refreshIfNeeded(force: Bool) async
+}
+
+@MainActor
+final class CalendarSourceCoordinator: ObservableObject {
+    static let shared = CalendarSourceCoordinator(stores: [GoogleCalendarStore.shared, MacCalendarStore.shared])
+
+    @Published private(set) var eventsBySource: [CalendarSource: [CalendarEvent]]
+    @Published private(set) var loadedSources: Set<CalendarSource>
+
+    private let storesBySource: [CalendarSource: any CalendarEventSourceStore]
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(stores: [any CalendarEventSourceStore]) {
+        storesBySource = Dictionary(uniqueKeysWithValues: stores.map { ($0.source, $0) })
+        eventsBySource = Dictionary(uniqueKeysWithValues: stores.map { ($0.source, $0.upcomingEvents) })
+        loadedSources = Set(stores.filter(\.isLoaded).map(\.source))
+
+        for store in stores {
+            store.upcomingEventsPublisher
+                .sink { [weak self] events in
+                    self?.updateEvents(events, for: store.source)
+                }
+                .store(in: &cancellables)
+
+            store.statePublisher
+                .sink { [weak self] isLoaded in
+                    self?.updateLoadedState(isLoaded, for: store.source)
+                }
+                .store(in: &cancellables)
+        }
+    }
+
+    func refreshEnabledSources(_ enabledSources: Set<CalendarSource>, force: Bool = false) async {
+        await withTaskGroup(of: Void.self) { group in
+            for source in CalendarSource.allCases where enabledSources.contains(source) {
+                guard let store = storesBySource[source] else { continue }
+                group.addTask {
+                    await store.refreshIfNeeded(force: force)
+                }
+            }
+        }
+    }
+
+    func events(for enabledSources: Set<CalendarSource>, requiringLoadedSources: Bool = false) -> [CalendarEvent] {
+        CalendarSource.allCases
+            .filter { enabledSources.contains($0) && (!requiringLoadedSources || loadedSources.contains($0)) }
+            .flatMap { eventsBySource[$0] ?? [] }
+            .deduplicatedAcrossSources()
+    }
+
+    static func allSourcesAreLoaded(
+        _ enabledSources: Set<CalendarSource>,
+        loadedSources: Set<CalendarSource>
+    ) -> Bool {
+        !enabledSources.isEmpty && enabledSources.isSubset(of: loadedSources)
+    }
+
+    private func updateEvents(_ events: [CalendarEvent], for source: CalendarSource) {
+        guard eventsBySource[source] != events else { return }
+        eventsBySource[source] = events
+    }
+
+    private func updateLoadedState(_ isLoaded: Bool, for source: CalendarSource) {
+        var updatedSources = loadedSources
+        if isLoaded {
+            updatedSources.insert(source)
+        } else {
+            updatedSources.remove(source)
+        }
+        guard updatedSources != loadedSources else {
+            objectWillChange.send()
+            return
+        }
+        loadedSources = updatedSources
+    }
+}
+
+extension GoogleCalendarStore: CalendarEventSourceStore {
+    var source: CalendarSource { .google }
+    var isLoaded: Bool { state == .loaded }
+    var upcomingEventsPublisher: AnyPublisher<[CalendarEvent], Never> { $upcomingEvents.eraseToAnyPublisher() }
+    var statePublisher: AnyPublisher<Bool, Never> {
+        $state.map { $0 == .loaded }.eraseToAnyPublisher()
+    }
+}
+
+extension MacCalendarStore: CalendarEventSourceStore {
+    var source: CalendarSource { .macOS }
+    var isLoaded: Bool { state == .loaded }
+    var upcomingEventsPublisher: AnyPublisher<[CalendarEvent], Never> { $upcomingEvents.eraseToAnyPublisher() }
+    var statePublisher: AnyPublisher<Bool, Never> {
+        $state.map { $0 == .loaded }.eraseToAnyPublisher()
+    }
+}

--- a/Sources/Dahlia/Services/GoogleCalendarStore.swift
+++ b/Sources/Dahlia/Services/GoogleCalendarStore.swift
@@ -50,6 +50,8 @@ final class GoogleCalendarStore: ObservableObject {
     private var isLoadingAccountData = false
     private var authChangeTask: Task<Void, Never>?
     private var refreshGeneration: UInt64 = 0
+    private var refreshTask: Task<Void, Never>?
+    private var refreshTaskID: UUID?
 
     init(
         signInProvider: any GoogleSignInProviding = GoogleSignInAdapter(sessionKind: .calendar),
@@ -162,6 +164,31 @@ final class GoogleCalendarStore: ObservableObject {
     }
 
     func refreshIfNeeded(force: Bool = false) async {
+        if !force, let refreshTask, !refreshTask.isCancelled {
+            if lastRefreshAt == nil {
+                await refreshTask.value
+            }
+            return
+        }
+
+        let taskID = UUID.v7()
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await performRefresh(force: force)
+        }
+        refreshTaskID = taskID
+        refreshTask = task
+        await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+        guard refreshTaskID == taskID else { return }
+        refreshTask = nil
+        refreshTaskID = nil
+    }
+
+    private func performRefresh(force: Bool) async {
         guard !isDisconnecting, !isLoadingAccountData else { return }
         guard isConfigured else {
             transitionToUnconfiguredState()
@@ -201,7 +228,7 @@ final class GoogleCalendarStore: ObservableObject {
 
         refreshGeneration &+= 1
         let generation = refreshGeneration
-        beginLoading()
+        beginLoadingIfNeeded()
         do {
             guard let session = try await signInProvider.refreshCurrentSession() ?? currentSession else {
                 guard isCurrentRefresh(generation) else { return }
@@ -212,7 +239,7 @@ final class GoogleCalendarStore: ObservableObject {
             guard isCurrentRefresh(generation) else { return }
 
             currentSession = session
-            account = session.account
+            if account != session.account { account = session.account }
             let selectedCalendars = availableCalendars.filter { selectedCalendarIDs.contains($0.id) }
             let events = try await apiClient.fetchUpcomingEvents(
                 accessToken: session.accessToken,
@@ -221,9 +248,12 @@ final class GoogleCalendarStore: ObservableObject {
                 daysAhead: daysAhead
             )
             guard isCurrentRefresh(generation) else { return }
-            upcomingEvents = events
+            if upcomingEvents != events { upcomingEvents = events }
             lastRefreshAt = now()
-            lastErrorMessage = nil
+            if lastErrorMessage != nil { lastErrorMessage = nil }
+            recomputeState()
+        } catch is CancellationError {
+            guard isCurrentRefresh(generation) else { return }
             recomputeState()
         } catch {
             guard isCurrentRefresh(generation) else { return }
@@ -260,8 +290,8 @@ final class GoogleCalendarStore: ObservableObject {
     ) async throws {
         guard isCurrentRefresh(generation) else { return }
         currentSession = session
-        account = session.account
-        lastErrorMessage = nil
+        if account != session.account { account = session.account }
+        if lastErrorMessage != nil { lastErrorMessage = nil }
 
         guard session.hasScopes(GoogleOAuthScope.calendar) else {
             if !availableCalendars.isEmpty { availableCalendars = [] }
@@ -273,7 +303,7 @@ final class GoogleCalendarStore: ObservableObject {
 
         let calendars = try await apiClient.fetchCalendarList(accessToken: session.accessToken)
         guard isCurrentRefresh(generation) else { return }
-        availableCalendars = calendars
+        if availableCalendars != calendars { availableCalendars = calendars }
         pruneSelectedCalendars()
         isLoadingAccountData = false
 
@@ -291,8 +321,13 @@ final class GoogleCalendarStore: ObservableObject {
     }
 
     private func beginLoading() {
-        lastErrorMessage = nil
-        state = .loading
+        if lastErrorMessage != nil { lastErrorMessage = nil }
+        if state != .loading { state = .loading }
+    }
+
+    private func beginLoadingIfNeeded() {
+        guard lastRefreshAt == nil || state == .failed else { return }
+        beginLoading()
     }
 
     private func beginAccountDataLoad() -> UInt64 {
@@ -366,6 +401,7 @@ final class GoogleCalendarStore: ObservableObject {
         } else {
             availableIDs.isEmpty ? ids : ids.intersection(availableIDs)
         }
+        guard selectedCalendarIDs != filtered else { return }
         selectedCalendarIDs = filtered
         Self.persistSelectedCalendarIDs(filtered, to: userDefaults)
     }

--- a/Sources/Dahlia/Services/MacCalendarStore.swift
+++ b/Sources/Dahlia/Services/MacCalendarStore.swift
@@ -64,6 +64,8 @@ final class MacCalendarStore: ObservableObject {
     private var lastRefreshAt: Date?
     private var storeChangedTask: Task<Void, Never>?
     private var refreshGeneration: UInt64 = 0
+    private var refreshTask: Task<Void, Never>?
+    private var refreshTaskID: UUID?
 
     init(
         eventStoreProvider: any MacCalendarEventStoreProviding = EventKitMacCalendarEventStore(),
@@ -114,23 +116,48 @@ final class MacCalendarStore: ObservableObject {
     }
 
     func refreshIfNeeded(force: Bool = false) async {
+        if !force, let refreshTask, !refreshTask.isCancelled {
+            if lastRefreshAt == nil {
+                await refreshTask.value
+            }
+            return
+        }
+
+        let taskID = UUID.v7()
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await performRefresh(force: force)
+        }
+        refreshTaskID = taskID
+        refreshTask = task
+        await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+        guard refreshTaskID == taskID else { return }
+        refreshTask = nil
+        refreshTaskID = nil
+    }
+
+    private func performRefresh(force: Bool) async {
         guard await prepareRefresh(force: force) else { return }
 
         refreshGeneration &+= 1
         let generation = refreshGeneration
-        beginLoading()
+        beginLoadingIfNeeded()
         do {
             let calendars = try await eventStoreProvider.fetchCalendarList()
             try Task.checkCancellation()
             guard isCurrentRefresh(generation) else { return }
-            availableCalendars = calendars
+            if availableCalendars != calendars { availableCalendars = calendars }
             initializeSelectionIfNeeded()
             pruneSelectedCalendars()
 
             guard !selectedCalendarIDs.isEmpty else {
                 if !upcomingEvents.isEmpty { upcomingEvents = [] }
-                lastRefreshAt = nil
-                lastErrorMessage = nil
+                lastRefreshAt = now()
+                if lastErrorMessage != nil { lastErrorMessage = nil }
                 recomputeState()
                 return
             }
@@ -143,9 +170,9 @@ final class MacCalendarStore: ObservableObject {
             )
             try Task.checkCancellation()
             guard isCurrentRefresh(generation) else { return }
-            upcomingEvents = events
+            if upcomingEvents != events { upcomingEvents = events }
             lastRefreshAt = now()
-            lastErrorMessage = nil
+            if lastErrorMessage != nil { lastErrorMessage = nil }
             recomputeState()
         } catch is CancellationError {
             guard isCurrentRefresh(generation) else { return }
@@ -160,7 +187,9 @@ final class MacCalendarStore: ObservableObject {
     private func prepareRefresh(force: Bool) async -> Bool {
         let refreshedAuthorizationStatus = await eventStoreProvider.authorizationStatus()
         guard !Task.isCancelled else { return false }
-        authorizationStatus = refreshedAuthorizationStatus
+        if authorizationStatus != refreshedAuthorizationStatus {
+            authorizationStatus = refreshedAuthorizationStatus
+        }
         guard authorizationStatus.canReadEvents else {
             invalidateCurrentRefresh()
             clearRuntimeState()
@@ -201,8 +230,13 @@ final class MacCalendarStore: ObservableObject {
     }
 
     private func beginLoading() {
-        lastErrorMessage = nil
-        state = .loading
+        if lastErrorMessage != nil { lastErrorMessage = nil }
+        if state != .loading { state = .loading }
+    }
+
+    private func beginLoadingIfNeeded() {
+        guard lastRefreshAt == nil || state == .failed else { return }
+        beginLoading()
     }
 
     private func handle(_ error: Error) {
@@ -250,6 +284,7 @@ final class MacCalendarStore: ObservableObject {
         } else {
             availableIDs.isEmpty ? ids : ids.intersection(availableIDs)
         }
+        guard selectedCalendarIDs != filtered else { return }
         selectedCalendarIDs = filtered
         Self.persistSelectedCalendarIDs(filtered, to: userDefaults)
     }

--- a/Sources/Dahlia/Services/MeetingDetectionService.swift
+++ b/Sources/Dahlia/Services/MeetingDetectionService.swift
@@ -36,6 +36,7 @@ final class MeetingDetectionService: ObservableObject {
     private var isMeetingAudioMonitoringRunning = false
     private let notificationService: MeetingNotificationService
     private let calendarAutoRecordingStore: CalendarAutoRecordingStore
+    private let calendarSourceCoordinator: CalendarSourceCoordinator
     private let meetingAudioActivityMonitor: MeetingAudioActivityMonitor
     private let meetingWindowDetectionWorker: MeetingWindowDetectionWorker
     private let now: () -> Date
@@ -43,12 +44,14 @@ final class MeetingDetectionService: ObservableObject {
     init(
         notificationService: MeetingNotificationService = .shared,
         calendarAutoRecordingStore: CalendarAutoRecordingStore = .shared,
+        calendarSourceCoordinator: CalendarSourceCoordinator = .shared,
         meetingAudioActivityMonitor: MeetingAudioActivityMonitor = MeetingAudioActivityMonitor(),
         meetingWindowDetectionWorker: MeetingWindowDetectionWorker = MeetingWindowDetectionWorker(),
         now: @escaping () -> Date = { .now }
     ) {
         self.notificationService = notificationService
         self.calendarAutoRecordingStore = calendarAutoRecordingStore
+        self.calendarSourceCoordinator = calendarSourceCoordinator
         self.meetingAudioActivityMonitor = meetingAudioActivityMonitor
         self.meetingWindowDetectionWorker = meetingWindowDetectionWorker
         self.now = now
@@ -112,9 +115,8 @@ final class MeetingDetectionService: ObservableObject {
     }
 
     private func observeCalendarEvents() {
-        Publishers.CombineLatest3(
-            GoogleCalendarStore.shared.$upcomingEvents,
-            MacCalendarStore.shared.$upcomingEvents,
+        Publishers.CombineLatest(
+            calendarSourceCoordinator.$eventsBySource,
             calendarAutoRecordingStore.$selections
         )
         .debounce(for: .milliseconds(250), scheduler: DispatchQueue.main)
@@ -125,16 +127,13 @@ final class MeetingDetectionService: ObservableObject {
         }
         .store(in: &lifecycleCancellables)
 
-        Publishers.Merge(
-            GoogleCalendarStore.shared.$state.map { _ in },
-            MacCalendarStore.shared.$state.map { _ in }
-        )
-        .sink { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.rescheduleAutomaticRecording()
+        calendarSourceCoordinator.$loadedSources
+            .sink { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.rescheduleAutomaticRecording()
+                }
             }
-        }
-        .store(in: &lifecycleCancellables)
+            .store(in: &lifecycleCancellables)
     }
 
     private func reconcileSettings() {
@@ -252,20 +251,11 @@ final class MeetingDetectionService: ObservableObject {
         calendarAutoRecordingTask?.cancel()
         calendarAutoRecordingTask = nil
 
-        var refreshedEvents: [CalendarEvent] = []
-        if settings.isCalendarSourceEnabled(.google) {
-            await GoogleCalendarStore.shared.refreshIfNeeded(force: force)
-            if GoogleCalendarStore.shared.state == .loaded {
-                refreshedEvents.append(contentsOf: GoogleCalendarStore.shared.upcomingEvents)
-            }
-        }
-        if settings.isCalendarSourceEnabled(.macOS) {
-            await MacCalendarStore.shared.refreshIfNeeded(force: force)
-            if MacCalendarStore.shared.state == .loaded {
-                refreshedEvents.append(contentsOf: MacCalendarStore.shared.upcomingEvents)
-            }
-        }
-        return refreshedEvents.deduplicatedAcrossSources()
+        await calendarSourceCoordinator.refreshEnabledSources(settings.enabledCalendarSources, force: force)
+        return calendarSourceCoordinator.events(
+            for: settings.enabledCalendarSources,
+            requiringLoadedSources: true
+        )
     }
 
     private func observeCalendarPowerEvents() {
@@ -597,30 +587,13 @@ final class MeetingDetectionService: ObservableObject {
     }
 
     private var selectedUpcomingEvents: [CalendarEvent] {
-        var events: [CalendarEvent] = []
-        let settings = AppSettings.shared
-
-        if settings.isCalendarSourceEnabled(.google) {
-            events.append(contentsOf: GoogleCalendarStore.shared.upcomingEvents)
-        }
-        if settings.isCalendarSourceEnabled(.macOS) {
-            events.append(contentsOf: MacCalendarStore.shared.upcomingEvents)
-        }
-
-        return events.deduplicatedAcrossSources()
+        calendarSourceCoordinator.events(for: AppSettings.shared.enabledCalendarSources)
     }
 
     private var automaticRecordingEvents: [CalendarEvent] {
-        var events: [CalendarEvent] = []
-        let settings = AppSettings.shared
-
-        if settings.isCalendarSourceEnabled(.google), GoogleCalendarStore.shared.state == .loaded {
-            events.append(contentsOf: GoogleCalendarStore.shared.upcomingEvents)
-        }
-        if settings.isCalendarSourceEnabled(.macOS), MacCalendarStore.shared.state == .loaded {
-            events.append(contentsOf: MacCalendarStore.shared.upcomingEvents)
-        }
-
-        return events.deduplicatedAcrossSources()
+        calendarSourceCoordinator.events(
+            for: AppSettings.shared.enabledCalendarSources,
+            requiringLoadedSources: true
+        )
     }
 }

--- a/Sources/Dahlia/ViewModels/MenuBarCalendarViewModel.swift
+++ b/Sources/Dahlia/ViewModels/MenuBarCalendarViewModel.swift
@@ -9,45 +9,32 @@ final class MenuBarCalendarViewModel {
     private(set) var agenda: MenuBarCalendarAgenda
 
     private let settings: AppSettings
-    private let googleCalendarStore: GoogleCalendarStore
-    private let macCalendarStore: MacCalendarStore
+    private let calendarSourceCoordinator: CalendarSourceCoordinator
+    private var loadedSources: Set<CalendarSource>
     private var cancellables: Set<AnyCancellable> = []
 
     var allEnabledSourcesAreLoaded: Bool {
-        Self.allEnabledSourcesAreLoaded(
+        CalendarSourceCoordinator.allSourcesAreLoaded(
             settings.enabledCalendarSources,
-            googleIsLoaded: googleCalendarStore.state == .loaded,
-            macOSIsLoaded: macCalendarStore.state == .loaded
+            loadedSources: loadedSources
         )
     }
 
     init(
         settings: AppSettings = .shared,
-        googleCalendarStore: GoogleCalendarStore = .shared,
-        macCalendarStore: MacCalendarStore = .shared
+        calendarSourceCoordinator: CalendarSourceCoordinator = .shared
     ) {
         let now = Date.now
         self.settings = settings
-        self.googleCalendarStore = googleCalendarStore
-        self.macCalendarStore = macCalendarStore
+        self.calendarSourceCoordinator = calendarSourceCoordinator
         self.currentDate = now
+        self.loadedSources = calendarSourceCoordinator.loadedSources
         self.agenda = Self.makeAgenda(
             settings: settings,
-            googleEvents: googleCalendarStore.upcomingEvents,
-            macEvents: macCalendarStore.upcomingEvents,
+            events: calendarSourceCoordinator.events(for: settings.enabledCalendarSources),
             now: now
         )
         observeCalendarInputs()
-    }
-
-    static func allEnabledSourcesAreLoaded(
-        _ enabledSources: Set<CalendarSource>,
-        googleIsLoaded: Bool,
-        macOSIsLoaded: Bool
-    ) -> Bool {
-        guard !enabledSources.isEmpty else { return false }
-        return (!enabledSources.contains(.google) || googleIsLoaded)
-            && (!enabledSources.contains(.macOS) || macOSIsLoaded)
     }
 
     func runRefreshLoop() async {
@@ -67,13 +54,13 @@ final class MenuBarCalendarViewModel {
     }
 
     private func observeCalendarInputs() {
-        googleCalendarStore.$upcomingEvents
+        calendarSourceCoordinator.$eventsBySource
             .dropFirst()
             .sink { [weak self] _ in self?.scheduleAgendaRebuild() }
             .store(in: &cancellables)
-        macCalendarStore.$upcomingEvents
+        calendarSourceCoordinator.$loadedSources
             .dropFirst()
-            .sink { [weak self] _ in self?.scheduleAgendaRebuild() }
+            .sink { [weak self] loadedSources in self?.loadedSources = loadedSources }
             .store(in: &cancellables)
         settings.objectWillChange
             .sink { [weak self] _ in self?.scheduleAgendaRebuild() }
@@ -90,8 +77,7 @@ final class MenuBarCalendarViewModel {
     private func rebuildAgenda() {
         agenda = Self.makeAgenda(
             settings: settings,
-            googleEvents: googleCalendarStore.upcomingEvents,
-            macEvents: macCalendarStore.upcomingEvents,
+            events: calendarSourceCoordinator.events(for: settings.enabledCalendarSources),
             now: currentDate
         )
     }
@@ -107,25 +93,17 @@ final class MenuBarCalendarViewModel {
 
     private static func makeAgenda(
         settings: AppSettings,
-        googleEvents: [CalendarEvent],
-        macEvents: [CalendarEvent],
+        events: [CalendarEvent],
         now: Date
     ) -> MenuBarCalendarAgenda {
         MenuBarCalendarAgenda(
-            googleEvents: googleEvents,
-            macEvents: macEvents,
-            enabledSources: settings.enabledCalendarSources,
+            events: events,
             filter: settings.calendarEventFilter,
             now: now
         )
     }
 
     private func refreshEnabledSources() async {
-        if settings.isCalendarSourceEnabled(.google) {
-            await googleCalendarStore.refreshIfNeeded()
-        }
-        if settings.isCalendarSourceEnabled(.macOS) {
-            await macCalendarStore.refreshIfNeeded()
-        }
+        await calendarSourceCoordinator.refreshEnabledSources(settings.enabledCalendarSources)
     }
 }

--- a/Sources/Dahlia/Views/CalendarScheduleView.swift
+++ b/Sources/Dahlia/Views/CalendarScheduleView.swift
@@ -3,9 +3,10 @@ import SwiftUI
 /// ミーティング未選択時に表示するカレンダーの予定一覧。
 struct CalendarScheduleView: View {
     @ObservedObject private var settings = AppSettings.shared
-    @ObservedObject private var googleCalendarStore = GoogleCalendarStore.shared
-    @ObservedObject private var macCalendarStore = MacCalendarStore.shared
+    @ObservedObject private var calendarSourceCoordinator = CalendarSourceCoordinator.shared
     @ObservedObject private var calendarAutoRecordingStore = CalendarAutoRecordingStore.shared
+    private let googleCalendarStore = GoogleCalendarStore.shared
+    private let macCalendarStore = MacCalendarStore.shared
     @Environment(\.openSettings) private var openSettings
     @Environment(\.openURL) private var openURL
 
@@ -244,15 +245,7 @@ struct CalendarScheduleView: View {
     }
 
     private var upcomingEventsFromEnabledSources: [CalendarEvent] {
-        var events: [CalendarEvent] = []
-        if settings.isCalendarSourceEnabled(.google) {
-            events.append(contentsOf: googleCalendarStore.upcomingEvents)
-        }
-        if settings.isCalendarSourceEnabled(.macOS) {
-            events.append(contentsOf: macCalendarStore.upcomingEvents)
-        }
-
-        return events.deduplicatedAcrossSources()
+        calendarSourceCoordinator.events(for: settings.enabledCalendarSources)
     }
 
     private var visibleUpcomingEvents: [CalendarEvent] {
@@ -291,13 +284,7 @@ struct CalendarScheduleView: View {
     }
 
     private func refreshEnabledSources(force: Bool = false) async {
-        if settings.isCalendarSourceEnabled(.google) {
-            await googleCalendarStore.refreshIfNeeded(force: force)
-        }
-
-        if settings.isCalendarSourceEnabled(.macOS) {
-            await macCalendarStore.refreshIfNeeded(force: force)
-        }
+        await calendarSourceCoordinator.refreshEnabledSources(settings.enabledCalendarSources, force: force)
     }
 
     private func statusCard(

--- a/Sources/Dahlia/Views/Settings/CalendarSettingsView.swift
+++ b/Sources/Dahlia/Views/Settings/CalendarSettingsView.swift
@@ -4,6 +4,7 @@ struct CalendarSettingsView: View {
     @ObservedObject private var settings = AppSettings.shared
     @ObservedObject private var googleCalendarStore = GoogleCalendarStore.shared
     @ObservedObject private var macCalendarStore = MacCalendarStore.shared
+    private let calendarSourceCoordinator = CalendarSourceCoordinator.shared
     @State private var googleOAuthConsent = GoogleOAuthConsentState()
 
     var body: some View {
@@ -304,13 +305,7 @@ struct CalendarSettingsView: View {
     }
 
     private func refreshEnabledSources(force: Bool = false) async {
-        if settings.isCalendarSourceEnabled(.google) {
-            await googleCalendarStore.refreshIfNeeded(force: force)
-        }
-
-        if settings.isCalendarSourceEnabled(.macOS) {
-            await macCalendarStore.refreshIfNeeded(force: force)
-        }
+        await calendarSourceCoordinator.refreshEnabledSources(settings.enabledCalendarSources, force: force)
     }
 }
 

--- a/Tests/DahliaTests/CalendarRefreshCancellationTestSupport.swift
+++ b/Tests/DahliaTests/CalendarRefreshCancellationTestSupport.swift
@@ -1,0 +1,99 @@
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+@MainActor
+final class CancellationAwareGoogleCalendarAPIClient: GoogleCalendarAPIClientProviding {
+    private let calendar: CalendarListItem
+    private let initialEvents: [CalendarEvent]
+    private(set) var fetchEventsCallCount = 0
+    private(set) var cancellationObserved = false
+
+    init(calendar: CalendarListItem, initialEvents: [CalendarEvent]) {
+        self.calendar = calendar
+        self.initialEvents = initialEvents
+    }
+
+    func fetchCalendarList(accessToken _: String) async throws -> [CalendarListItem] {
+        [calendar]
+    }
+
+    func fetchUpcomingEvents(
+        accessToken _: String,
+        calendars _: [CalendarListItem],
+        now _: Date,
+        daysAhead _: Int
+    ) async throws -> [CalendarEvent] {
+        fetchEventsCallCount += 1
+        guard fetchEventsCallCount > 1 else { return initialEvents }
+        do {
+            try await Task.sleep(for: .seconds(60))
+            return []
+        } catch is CancellationError {
+            cancellationObserved = true
+            throw CancellationError()
+        }
+    }
+
+    func waitForFetchEventsCallCount(_ expectedCount: Int) async {
+        while fetchEventsCallCount < expectedCount {
+            await Task.yield()
+        }
+    }
+}
+
+actor CancellationAwareMacCalendarEventStore: MacCalendarEventStoreProviding {
+    nonisolated let initialAuthorizationStatus: MacCalendarAuthorizationStatus = .fullAccess
+    private let calendar: CalendarListItem
+    private let initialEvents: [CalendarEvent]
+    private var fetchEventsCallCount = 0
+    private var cancellationObserved = false
+
+    init(calendar: CalendarListItem, initialEvents: [CalendarEvent]) {
+        self.calendar = calendar
+        self.initialEvents = initialEvents
+    }
+
+    func authorizationStatus() -> MacCalendarAuthorizationStatus {
+        .fullAccess
+    }
+
+    func requestFullAccessToEvents() async throws -> Bool {
+        true
+    }
+
+    func fetchCalendarList() async throws -> [CalendarListItem] {
+        [calendar]
+    }
+
+    func fetchUpcomingEvents(
+        calendars _: [CalendarListItem],
+        now _: Date,
+        daysAhead _: Int
+    ) async throws -> [CalendarEvent] {
+        fetchEventsCallCount += 1
+        guard fetchEventsCallCount > 1 else { return initialEvents }
+        do {
+            try await Task.sleep(for: .seconds(60))
+            return []
+        } catch is CancellationError {
+            cancellationObserved = true
+            throw CancellationError()
+        }
+    }
+
+    func waitForFetchEventsCallCount(_ expectedCount: Int) async {
+        while fetchEventsCallCount < expectedCount {
+            await Task.yield()
+        }
+    }
+
+    func didObserveCancellation() -> Bool {
+        cancellationObserved
+    }
+}
+
+enum CalendarRefreshTestError: Error {
+    case requestFailed
+}
+#endif

--- a/Tests/DahliaTests/CalendarSourceCoordinatorTests.swift
+++ b/Tests/DahliaTests/CalendarSourceCoordinatorTests.swift
@@ -1,0 +1,140 @@
+import Combine
+import Foundation
+@testable import Dahlia
+
+#if canImport(Testing)
+import Testing
+
+@MainActor
+struct CalendarSourceCoordinatorTests {
+    @Test
+    func refreshesOnlyEnabledSourcesAndAggregatesTheirEvents() async {
+        let googleEvent = event(id: "google", platform: CalendarEventPlatform.googleCalendar, icalUid: "shared")
+        let macEvent = event(id: "mac", platform: CalendarEventPlatform.macOSCalendar)
+        let duplicateMacEvent = event(id: "mac-duplicate", platform: CalendarEventPlatform.macOSCalendar, icalUid: "shared")
+        let googleStore = FakeCalendarEventSourceStore(source: .google, events: [googleEvent])
+        let macStore = FakeCalendarEventSourceStore(source: .macOS, events: [duplicateMacEvent, macEvent])
+        let coordinator = CalendarSourceCoordinator(stores: [googleStore, macStore])
+
+        await coordinator.refreshEnabledSources([.google])
+
+        #expect(googleStore.refreshCallCount == 1)
+        #expect(macStore.refreshCallCount == 0)
+        #expect(coordinator.events(for: [.google]) == [googleEvent])
+        #expect(coordinator.events(for: [.google, .macOS]) == [googleEvent, macEvent])
+    }
+
+    @Test
+    func updatesOnlyWhenASourcePublishesChangedEvents() {
+        let originalEvent = event(id: "original", platform: CalendarEventPlatform.googleCalendar)
+        let updatedEvent = event(id: "updated", platform: CalendarEventPlatform.googleCalendar)
+        let store = FakeCalendarEventSourceStore(source: .google, events: [originalEvent])
+        let coordinator = CalendarSourceCoordinator(stores: [store])
+        var publicationCount = 0
+        let cancellable = coordinator.$eventsBySource.dropFirst().sink { _ in publicationCount += 1 }
+
+        store.replaceEvents([originalEvent])
+        store.replaceEvents([updatedEvent])
+
+        #expect(publicationCount == 1)
+        #expect(coordinator.events(for: [.google]) == [updatedEvent])
+        withExtendedLifetime(cancellable) {}
+    }
+
+    @Test
+    func refreshesEnabledSourcesConcurrently() async {
+        let blockedStore = FakeCalendarEventSourceStore(source: .google, events: [], blocksRefresh: true)
+        let otherStore = FakeCalendarEventSourceStore(source: .macOS, events: [])
+        let coordinator = CalendarSourceCoordinator(stores: [blockedStore, otherStore])
+
+        let refresh = Task { await coordinator.refreshEnabledSources([.google, .macOS]) }
+        await blockedStore.waitUntilRefreshStarts()
+        await otherStore.waitUntilRefreshStarts()
+
+        #expect(otherStore.refreshCallCount == 1)
+        blockedStore.resumeRefresh()
+        await refresh.value
+    }
+
+    @Test
+    func tracksLoadedStateWithoutAnEventChange() {
+        let store = FakeCalendarEventSourceStore(source: .google, events: [], isLoaded: false)
+        let coordinator = CalendarSourceCoordinator(stores: [store])
+        var publicationCount = 0
+        let cancellable = coordinator.$loadedSources.dropFirst().sink { _ in publicationCount += 1 }
+
+        store.setLoaded(true)
+
+        #expect(coordinator.loadedSources == [.google])
+        #expect(publicationCount == 1)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    private func event(id: String, platform: String, icalUid: String? = nil) -> CalendarEvent {
+        CalendarEvent(
+            id: id,
+            calendarID: "calendar",
+            calendarName: "Calendar",
+            calendarColorHex: nil,
+            platform: platform,
+            platformId: id,
+            title: id,
+            description: "",
+            icalUid: icalUid,
+            startDate: Date(timeIntervalSince1970: 1_776_387_600),
+            endDate: Date(timeIntervalSince1970: 1_776_391_200),
+            isAllDay: false,
+            conferenceURI: nil
+        )
+    }
+}
+
+@MainActor
+private final class FakeCalendarEventSourceStore: CalendarEventSourceStore {
+    let source: CalendarSource
+    @Published private(set) var upcomingEvents: [CalendarEvent]
+    @Published private(set) var isLoaded: Bool
+    private(set) var refreshCallCount = 0
+    private let blocksRefresh: Bool
+    private var refreshStartWaiter: CheckedContinuation<Void, Never>?
+    private var refreshContinuation: CheckedContinuation<Void, Never>?
+
+    var upcomingEventsPublisher: AnyPublisher<[CalendarEvent], Never> { $upcomingEvents.eraseToAnyPublisher() }
+    var statePublisher: AnyPublisher<Bool, Never> { $isLoaded.eraseToAnyPublisher() }
+
+    init(source: CalendarSource, events: [CalendarEvent], isLoaded: Bool = true, blocksRefresh: Bool = false) {
+        self.source = source
+        upcomingEvents = events
+        self.isLoaded = isLoaded
+        self.blocksRefresh = blocksRefresh
+    }
+
+    func refreshIfNeeded(force _: Bool) async {
+        refreshCallCount += 1
+        refreshStartWaiter?.resume()
+        refreshStartWaiter = nil
+        if blocksRefresh {
+            await withCheckedContinuation { refreshContinuation = $0 }
+        }
+    }
+
+    func replaceEvents(_ events: [CalendarEvent]) {
+        guard upcomingEvents != events else { return }
+        upcomingEvents = events
+    }
+
+    func setLoaded(_ isLoaded: Bool) {
+        self.isLoaded = isLoaded
+    }
+
+    func waitUntilRefreshStarts() async {
+        guard refreshCallCount == 0 else { return }
+        await withCheckedContinuation { refreshStartWaiter = $0 }
+    }
+
+    func resumeRefresh() {
+        refreshContinuation?.resume()
+        refreshContinuation = nil
+    }
+}
+#endif

--- a/Tests/DahliaTests/GoogleCalendarStoreTests.swift
+++ b/Tests/DahliaTests/GoogleCalendarStoreTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import Foundation
 @testable import Dahlia
 
@@ -78,6 +79,102 @@ struct GoogleCalendarStoreTests {
         await olderRefresh.value
 
         #expect(store.upcomingEvents == [newerEvent])
+        #expect(store.state == .loaded)
+    }
+
+    @Test
+    func identicalBackgroundRefreshKeepsLoadedStateAndCoalescesRequests() async {
+        let defaults = isolatedUserDefaults()
+        seedSelectedCalendars(["primary"], defaults: defaults)
+        let apiClient = ControllableGoogleCalendarAPIClient(initialEvents: [fixtureEvent])
+        let store = GoogleCalendarStore(
+            signInProvider: MockGoogleCalendarSignInProvider(
+                hasPreviousSignIn: true,
+                restoreResult: .success(fixtureSession),
+                refreshResult: .success(fixtureSession)
+            ),
+            apiClient: apiClient,
+            userDefaults: defaults,
+            now: { fixtureNow },
+            refreshInterval: 0
+        )
+        await store.restoreSessionIfNeeded()
+
+        var eventPublicationCount = 0
+        let cancellable = store.$upcomingEvents.dropFirst().sink { _ in eventPublicationCount += 1 }
+        let firstRefresh = Task { await store.refreshIfNeeded() }
+        await apiClient.waitForFetchEventsCallCount(2)
+        let coalescedRefresh = Task { await store.refreshIfNeeded() }
+        await Task.yield()
+
+        #expect(store.state == .loaded)
+        #expect(store.upcomingEvents == [fixtureEvent])
+        #expect(apiClient.fetchEventsCallCount == 2)
+
+        apiClient.resumePendingRequest(at: 0, with: [fixtureEvent])
+        await firstRefresh.value
+        await coalescedRefresh.value
+
+        #expect(eventPublicationCount == 0)
+        #expect(store.state == .loaded)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    @Test
+    func cancellingRefreshCancelsTheInFlightRequest() async {
+        let defaults = isolatedUserDefaults()
+        seedSelectedCalendars(["primary"], defaults: defaults)
+        let apiClient = CancellationAwareGoogleCalendarAPIClient(calendar: primaryCalendar, initialEvents: [fixtureEvent])
+        let store = GoogleCalendarStore(
+            signInProvider: MockGoogleCalendarSignInProvider(
+                hasPreviousSignIn: true,
+                restoreResult: .success(fixtureSession),
+                refreshResult: .success(fixtureSession)
+            ),
+            apiClient: apiClient,
+            userDefaults: defaults,
+            now: { fixtureNow }
+        )
+        await store.restoreSessionIfNeeded()
+
+        let refresh = Task { await store.refreshIfNeeded(force: true) }
+        await apiClient.waitForFetchEventsCallCount(2)
+        refresh.cancel()
+        await refresh.value
+
+        #expect(apiClient.cancellationObserved)
+        #expect(store.state == .loaded)
+    }
+
+    @Test
+    func retryAfterCachedRefreshFailureShowsLoading() async {
+        let defaults = isolatedUserDefaults()
+        seedSelectedCalendars(["primary"], defaults: defaults)
+        let apiClient = ControllableGoogleCalendarAPIClient(initialEvents: [fixtureEvent])
+        let store = GoogleCalendarStore(
+            signInProvider: MockGoogleCalendarSignInProvider(
+                hasPreviousSignIn: true,
+                restoreResult: .success(fixtureSession),
+                refreshResult: .success(fixtureSession)
+            ),
+            apiClient: apiClient,
+            userDefaults: defaults,
+            now: { fixtureNow }
+        )
+        await store.restoreSessionIfNeeded()
+
+        let failedRefresh = Task { await store.refreshIfNeeded(force: true) }
+        await apiClient.waitForFetchEventsCallCount(2)
+        apiClient.failPendingRequest(at: 0)
+        await failedRefresh.value
+        #expect(store.state == .failed)
+
+        let retry = Task { await store.refreshIfNeeded(force: true) }
+        await apiClient.waitForFetchEventsCallCount(3)
+        #expect(store.state == .loading)
+        apiClient.resumePendingRequest(at: 0, with: [fixtureEvent])
+        await retry.value
+
         #expect(store.state == .loaded)
     }
 
@@ -705,6 +802,10 @@ private final class ControllableGoogleCalendarAPIClient: GoogleCalendarAPIClient
 
     func resumePendingRequest(at index: Int, with events: [CalendarEvent]) {
         pendingRequests.remove(at: index).resume(returning: events)
+    }
+
+    func failPendingRequest(at index: Int) {
+        pendingRequests.remove(at: index).resume(throwing: CalendarRefreshTestError.requestFailed)
     }
 }
 

--- a/Tests/DahliaTests/MacCalendarStoreTests.swift
+++ b/Tests/DahliaTests/MacCalendarStoreTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 @testable import Dahlia
 
@@ -83,10 +84,18 @@ struct MacCalendarStoreTests {
 
         await store.refreshIfNeeded()
 
+        var publicationCount = 0
+        let cancellable = store.objectWillChange.sink { publicationCount += 1 }
+        await store.refreshIfNeeded()
+        let providerSnapshot = await provider.snapshot()
+
         #expect(store.state == .needsCalendarSelection)
         #expect(store.selectedCalendarIDs.isEmpty)
         #expect(store.upcomingEvents.isEmpty)
-        #expect(await provider.snapshot().fetchEventsCallCount == 0)
+        #expect(providerSnapshot.fetchCalendarsCallCount == 1)
+        #expect(providerSnapshot.fetchEventsCallCount == 0)
+        #expect(publicationCount == 0)
+        withExtendedLifetime(cancellable) {}
     }
 
     @Test
@@ -161,6 +170,82 @@ struct MacCalendarStoreTests {
         #expect(await provider.eventFetchCount() == 2)
         #expect(store.state == .loaded)
         #expect(!store.upcomingEvents.isEmpty)
+    }
+
+    @Test
+    func identicalBackgroundRefreshKeepsLoadedStateAndCoalescesRequests() async {
+        let provider = OverlappingMacCalendarEventStore(blockedFetchNumber: 2)
+        let store = MacCalendarStore(
+            eventStoreProvider: provider,
+            userDefaults: isolatedUserDefaults(),
+            now: { fixtureNow },
+            refreshInterval: 0,
+            storeChangedNotification: nil
+        )
+        await store.refreshIfNeeded(force: true)
+        let initialEvents = store.upcomingEvents
+
+        var eventPublicationCount = 0
+        let cancellable = store.$upcomingEvents.dropFirst().sink { _ in eventPublicationCount += 1 }
+        let firstRefresh = Task { await store.refreshIfNeeded() }
+        await provider.waitUntilBlockedEventFetchStarts()
+        let coalescedRefresh = Task { await store.refreshIfNeeded() }
+        await Task.yield()
+
+        #expect(store.state == .loaded)
+        #expect(store.upcomingEvents == initialEvents)
+        #expect(await provider.eventFetchCount() == 2)
+
+        await provider.resumeBlockedEventFetch()
+        await firstRefresh.value
+        await coalescedRefresh.value
+
+        #expect(eventPublicationCount == 0)
+        #expect(store.state == .loaded)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    @Test
+    func cancellingRefreshCancelsTheInFlightRequest() async {
+        let provider = CancellationAwareMacCalendarEventStore(calendar: primaryCalendar, initialEvents: [fixtureEvent])
+        let store = MacCalendarStore(
+            eventStoreProvider: provider,
+            userDefaults: isolatedUserDefaults(),
+            now: { fixtureNow },
+            storeChangedNotification: nil
+        )
+        await store.refreshIfNeeded(force: true)
+
+        let refresh = Task { await store.refreshIfNeeded(force: true) }
+        await provider.waitForFetchEventsCallCount(2)
+        refresh.cancel()
+        await refresh.value
+
+        #expect(await provider.didObserveCancellation())
+        #expect(store.state == .loaded)
+    }
+
+    @Test
+    func retryAfterCachedRefreshFailureShowsLoading() async {
+        let provider = OverlappingMacCalendarEventStore(blockedFetchNumber: 3, failedFetchNumber: 2)
+        let store = MacCalendarStore(
+            eventStoreProvider: provider,
+            userDefaults: isolatedUserDefaults(),
+            now: { fixtureNow },
+            storeChangedNotification: nil
+        )
+        await store.refreshIfNeeded(force: true)
+
+        await store.refreshIfNeeded(force: true)
+        #expect(store.state == .failed)
+
+        let retry = Task { await store.refreshIfNeeded(force: true) }
+        await provider.waitUntilBlockedEventFetchStarts()
+        #expect(store.state == .loading)
+        await provider.resumeBlockedEventFetch()
+        await retry.value
+
+        #expect(store.state == .loaded)
     }
 
     @Test
@@ -267,6 +352,7 @@ private let fixtureEvent = CalendarEvent(
 private actor MockMacCalendarEventStore: MacCalendarEventStoreProviding {
     struct Snapshot: Sendable {
         let requestAccessCallCount: Int
+        let fetchCalendarsCallCount: Int
         let fetchEventsCallCount: Int
         let requestedCalendars: [CalendarListItem]
     }
@@ -277,6 +363,7 @@ private actor MockMacCalendarEventStore: MacCalendarEventStoreProviding {
     var calendarsResult: Result<[CalendarListItem], Error>
     var eventsResult: Result<[CalendarEvent], Error>
     private(set) var requestAccessCallCount = 0
+    private(set) var fetchCalendarsCallCount = 0
     private(set) var fetchEventsCallCount = 0
     private(set) var requestedCalendars: [CalendarListItem] = []
 
@@ -305,7 +392,8 @@ private actor MockMacCalendarEventStore: MacCalendarEventStoreProviding {
     }
 
     func fetchCalendarList() throws -> [CalendarListItem] {
-        try calendarsResult.get()
+        fetchCalendarsCallCount += 1
+        return try calendarsResult.get()
     }
 
     func fetchUpcomingEvents(calendars: [CalendarListItem], now _: Date, daysAhead _: Int) throws -> [CalendarEvent] {
@@ -317,6 +405,7 @@ private actor MockMacCalendarEventStore: MacCalendarEventStoreProviding {
     func snapshot() -> Snapshot {
         Snapshot(
             requestAccessCallCount: requestAccessCallCount,
+            fetchCalendarsCallCount: fetchCalendarsCallCount,
             fetchEventsCallCount: fetchEventsCallCount,
             requestedCalendars: requestedCalendars
         )
@@ -326,12 +415,14 @@ private actor MockMacCalendarEventStore: MacCalendarEventStoreProviding {
 private actor OverlappingMacCalendarEventStore: MacCalendarEventStoreProviding {
     nonisolated let initialAuthorizationStatus: MacCalendarAuthorizationStatus = .fullAccess
     private let blockedFetchNumber: Int
+    private let failedFetchNumber: Int?
     private var fetchCount = 0
     private var fetchCountWaiters: [CheckedContinuation<Void, Never>] = []
     private var blockedFetchContinuation: CheckedContinuation<Void, Never>?
 
-    init(blockedFetchNumber: Int = 1) {
+    init(blockedFetchNumber: Int = 1, failedFetchNumber: Int? = nil) {
         self.blockedFetchNumber = blockedFetchNumber
+        self.failedFetchNumber = failedFetchNumber
     }
 
     func authorizationStatus() -> MacCalendarAuthorizationStatus {
@@ -352,6 +443,9 @@ private actor OverlappingMacCalendarEventStore: MacCalendarEventStoreProviding {
         daysAhead _: Int
     ) async throws -> [CalendarEvent] {
         fetchCount += 1
+        if fetchCount == failedFetchNumber {
+            throw CalendarRefreshTestError.requestFailed
+        }
         if fetchCount == blockedFetchNumber {
             let waiters = fetchCountWaiters
             fetchCountWaiters.removeAll()

--- a/Tests/DahliaTests/MenuBarCalendarAgendaTests.swift
+++ b/Tests/DahliaTests/MenuBarCalendarAgendaTests.swift
@@ -19,7 +19,7 @@ import Foundation
             let upcoming = event(id: "upcoming", start: 3_600, end: 7_200)
             let tomorrow = event(id: "tomorrow", start: 46_800, end: 50_400)
 
-            let agenda = agenda(googleEvents: [ended, overnight, upcoming, tomorrow])
+            let agenda = agenda(events: [ended, overnight, upcoming, tomorrow])
 
             #expect(agenda.events.map(\.id) == [overnight.id, upcoming.id])
             #expect(agenda.featuredEvent?.id == overnight.id)
@@ -27,7 +27,7 @@ import Foundation
         }
 
         @Test
-        func appliesEnabledSourcesFiltersAndCrossSourceDeduplication() {
+        func appliesEventFilters() {
             let googleEvent = event(
                 id: "google",
                 platform: CalendarEventPlatform.googleCalendar,
@@ -35,19 +35,10 @@ import Foundation
                 start: 3_600,
                 end: 7_200
             )
-            let duplicateMacEvent = event(
-                id: "mac-duplicate",
-                platform: CalendarEventPlatform.macOSCalendar,
-                icalUid: "shared",
-                start: 3_600,
-                end: 7_200
-            )
             let declined = event(id: "declined", start: 7_200, end: 10_800, isDeclined: true)
 
             let agenda = MenuBarCalendarAgenda(
-                googleEvents: [googleEvent, declined],
-                macEvents: [duplicateMacEvent],
-                enabledSources: [.google, .macOS],
+                events: [googleEvent, declined],
                 filter: CalendarEventFilter(includesDeclinedEvents: false),
                 now: now,
                 calendar: calendar
@@ -61,14 +52,12 @@ import Foundation
             let declined = event(id: "declined", start: 3_600, end: 7_200, isDeclined: true)
 
             let filteredAgenda = MenuBarCalendarAgenda(
-                googleEvents: [declined],
-                macEvents: [],
-                enabledSources: [.google],
+                events: [declined],
                 filter: CalendarEventFilter(includesDeclinedEvents: false),
                 now: now,
                 calendar: calendar
             )
-            let emptyAgenda = agenda(googleEvents: [])
+            let emptyAgenda = agenda(events: [])
 
             #expect(filteredAgenda.events.isEmpty)
             #expect(filteredAgenda.hasEventsExcludedByFilter)
@@ -80,7 +69,7 @@ import Foundation
             let attending = event(id: "attending", start: -1_800, end: 3_600, isAttending: true)
             let laterUnconfirmed = event(id: "unconfirmed", start: -600, end: 1_800)
 
-            let agenda = agenda(googleEvents: [laterUnconfirmed, attending])
+            let agenda = agenda(events: [laterUnconfirmed, attending])
 
             #expect(agenda.featuredEvent?.id == attending.id)
             #expect(agenda.featuredEventIsOngoing)
@@ -92,8 +81,8 @@ import Foundation
             let laterOngoing = event(id: "later", start: -600, end: 1_800)
             let next = event(id: "next", start: 3_600, end: 7_200)
 
-            let ongoingAgenda = agenda(googleEvents: [next, earlierOngoing, laterOngoing])
-            let upcomingAgenda = agenda(googleEvents: [next])
+            let ongoingAgenda = agenda(events: [next, earlierOngoing, laterOngoing])
+            let upcomingAgenda = agenda(events: [next])
 
             #expect(ongoingAgenda.featuredEvent?.id == laterOngoing.id)
             #expect(ongoingAgenda.featuredEventIsOngoing)
@@ -113,7 +102,7 @@ import Foundation
                 isAllDay: true
             )
 
-            let agenda = agenda(googleEvents: [allDay])
+            let agenda = agenda(events: [allDay])
 
             #expect(agenda.events == [allDay])
             #expect(agenda.featuredEvent == nil)
@@ -132,15 +121,13 @@ import Foundation
             )
             let declined = event(id: "declined", start: 3_600, end: 7_200, isDeclined: true)
             let filteredAgenda = MenuBarCalendarAgenda(
-                googleEvents: [declined],
-                macEvents: [],
-                enabledSources: [.google],
+                events: [declined],
                 filter: CalendarEventFilter(includesDeclinedEvents: false),
                 now: now,
                 calendar: calendar
             )
 
-            for emptyAgenda in [agenda(googleEvents: []), agenda(googleEvents: [allDay]), filteredAgenda] {
+            for emptyAgenda in [agenda(events: []), agenda(events: [allDay]), filteredAgenda] {
                 #expect(emptyAgenda.labelText(showsTitle: true, showsCountdown: true, now: now) == L10n.menuBarNoEvents)
                 #expect(emptyAgenda.accessibilityLabel(now: now) == L10n.menuBarNoEvents)
             }
@@ -150,14 +137,14 @@ import Foundation
         func keepsDahliaFallbackWhenAllCalendarLabelDetailsAreDisabled() {
             let upcoming = event(id: "upcoming", start: 3_600, end: 7_200)
 
-            #expect(agenda(googleEvents: [upcoming]).labelText(showsTitle: false, showsCountdown: false, now: now) == nil)
-            #expect(agenda(googleEvents: []).labelText(showsTitle: false, showsCountdown: false, now: now) == nil)
+            #expect(agenda(events: [upcoming]).labelText(showsTitle: false, showsCountdown: false, now: now) == nil)
+            #expect(agenda(events: []).labelText(showsTitle: false, showsCountdown: false, now: now) == nil)
         }
 
         @Test
         func roundsCountdownUpAndHonorsLabelSettings() {
             let upcoming = event(id: "upcoming", title: "Planning", start: 3_601, end: 7_200)
-            let agenda = agenda(googleEvents: [upcoming])
+            let agenda = agenda(events: [upcoming])
 
             #expect(MenuBarCalendarAgenda.remainingMinutes(from: now, to: upcoming.startDate) == 61)
             #expect(agenda.labelText(showsTitle: true, showsCountdown: false, now: now) == "Planning")
@@ -170,7 +157,7 @@ import Foundation
         func truncatesLongMenuBarTitlesWithoutTruncatingAccessibilityText() {
             let title = "Office Hours for Japan PS/DSA/Training [Weekly]"
             let upcoming = event(id: "upcoming", title: title, start: 3_600, end: 7_200)
-            let agenda = agenda(googleEvents: [upcoming])
+            let agenda = agenda(events: [upcoming])
 
             #expect(agenda.labelText(showsTitle: true, showsCountdown: false, now: now) == "Office Hours for Japan P…")
             #expect(agenda.accessibilityLabel(now: now)?.hasPrefix(title) == true)
@@ -181,15 +168,13 @@ import Foundation
             let startingSoon = event(id: "starting", start: 59, end: 3_600)
             let endingSoon = event(id: "ending", start: -3_600, end: 59)
 
-            #expect(agenda(googleEvents: [startingSoon]).countdownText(now: now) == L10n.menuBarStartingSoon)
-            #expect(agenda(googleEvents: [endingSoon]).countdownText(now: now) == L10n.menuBarEndingSoon)
+            #expect(agenda(events: [startingSoon]).countdownText(now: now) == L10n.menuBarStartingSoon)
+            #expect(agenda(events: [endingSoon]).countdownText(now: now) == L10n.menuBarEndingSoon)
         }
 
-        private func agenda(googleEvents: [CalendarEvent]) -> MenuBarCalendarAgenda {
+        private func agenda(events: [CalendarEvent]) -> MenuBarCalendarAgenda {
             MenuBarCalendarAgenda(
-                googleEvents: googleEvents,
-                macEvents: [],
-                enabledSources: [.google],
+                events: events,
                 filter: CalendarEventFilter(includesAllDayEvents: true),
                 now: now,
                 calendar: calendar

--- a/Tests/DahliaTests/MenuBarCalendarViewModelTests.swift
+++ b/Tests/DahliaTests/MenuBarCalendarViewModelTests.swift
@@ -20,10 +20,12 @@ import Foundation
             google: Bool,
             macOS: Bool
         ) -> Bool {
-            MenuBarCalendarViewModel.allEnabledSourcesAreLoaded(
+            var loadedSources: Set<CalendarSource> = []
+            if google { loadedSources.insert(.google) }
+            if macOS { loadedSources.insert(.macOS) }
+            return CalendarSourceCoordinator.allSourcesAreLoaded(
                 enabledSources,
-                googleIsLoaded: google,
-                macOSIsLoaded: macOS
+                loadedSources: loadedSources
             )
         }
     }


### PR DESCRIPTION
## Summary

- centralize Google Calendar and macOS Calendar refresh orchestration behind a shared source coordinator
- coalesce concurrent refreshes, preserve the last rendered snapshot while refreshing, and avoid publishing unchanged event lists
- refresh enabled sources in parallel and keep cancellation behavior consistent across calendar providers
- add coverage for refresh deduplication, cancellation, loaded state, and unchanged agenda rendering

## Why

Opening or redrawing the schedule could trigger calendar refresh work and republish equivalent state. Even when event content had not changed, SwiftUI could rebuild the visible agenda, which looked like a brief refresh or flicker. Refresh behavior also lived in several consumers, making it harder to extend consistently to additional calendar sources.

## Impact

The schedule and menu bar retain their current content during background refreshes and only update when the resulting calendar snapshot changes. Google Calendar and macOS Calendar now follow the same refresh lifecycle, providing a common path for future calendar sources.

## Validation

- targeted calendar tests: 47 tests in 5 suites passed
- full test suite: 1,531 tests in 224 suites passed
- SwiftFormat: no files require formatting
- `git diff --check`: passed
- SwiftLint: only pre-existing repository violations remain
